### PR TITLE
upgrade maven-shade-plugin version to 3.5.2

### DIFF
--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -47,5 +47,6 @@ if [ "$RUN_TEST_SET" == "2" ]; then
     -pl '!pinot-core' \
     -pl '!pinot-query-planner' \
     -pl '!pinot-query-runtime' \
+    -pl '!:pinot-yammer' \
     -P github-actions,no-integration-tests || exit 1
 fi

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -33,6 +33,7 @@ if [ "$RUN_TEST_SET" == "1" ]; then
       -pl 'pinot-spi' \
       -pl 'pinot-segment-spi' \
       -pl 'pinot-common' \
+      -pl ':pinot-yammer' \
       -pl 'pinot-core' \
       -pl 'pinot-query-planner' \
       -pl 'pinot-query-runtime' \

--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <build>
     <resources>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <build>
     <resources>
@@ -81,37 +82,4 @@
       <artifactId>jsr305</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <transformers>
-                    <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                  </transformers>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -95,7 +95,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>package</phase>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <build>
@@ -355,43 +356,6 @@
     </dependency>
   </dependencies>
   <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common.base</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common.base</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.common.cache</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common.cache</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.apache.http</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>profile-buildthrift</id>
       <activation>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -179,39 +179,4 @@
     </dependency>
     <!-- Lucene dependencies end -->
   </dependencies>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common.base</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common.base</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.apache.http</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -34,6 +34,7 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmss'Z'</maven.build.timestamp.format>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>
@@ -143,64 +144,6 @@
             <algorithm>SHA-512</algorithm>
           </algorithms>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <transformers combine.self="override">
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Multi-Release>true</Multi-Release>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-              <!--
-              Usually in hadoop environment, there are multiple jars with different versions.
-              Most of the NoSuchMethodExceptions are caused by class loading conflicts.
-              Class relocation ensures the reference of certain packages/classes in Pinot code to
-              shaded libs, e.g. jackson or guava.
-              Ref: https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html
-              -->
-              <relocations>
-                <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.http</pattern>
-                  <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>software.amazon</pattern>
-                  <shadedPattern>${shade.prefix}.software.amazon</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.reflections</pattern>
-                  <shadedPattern>${shade.prefix}.org.reflections</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>${shade.prefix}.io.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.parquet</pattern>
-                  <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -214,7 +214,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <!-- Run shade goal on package phase -->
           <execution>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
@@ -35,6 +35,5 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>none</phase.prop>
   </properties>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
     <scala.major.version>2.11</scala.major.version>
     <spark.version>2.4.6</spark.version>
     <scala.minor.version>2.11.11</scala.minor.version>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
     <spark.version>3.5.1</spark.version>
   </properties>
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -33,7 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -33,7 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -79,7 +79,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <s3mock.version>2.12.2</s3mock.version>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -65,54 +65,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>${phase.prop}</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <transformers>
-                    <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                  </transformers>
-                  <!--
-                  Usually in hadoop environment, there are multiple jars with different versions.
-                  Most of the NoSuchMethodExceptions are caused by class loading conflicts.
-                  Class relocation ensures the reference of certain packages/classes in Pinot code to
-                  shaded libs, e.g. jackson or guava.
-                  Ref: https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html
-                  -->
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.fasterxml.jackson</pattern>
-                      <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.8.1</kafka.lib.version>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <repositories>
     <repository>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -34,6 +34,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -37,7 +37,7 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.8.1</kafka.lib.version>
     <testcontainers.version>1.19.7</testcontainers.version>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <repositories>
     <repository>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -34,7 +34,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
@@ -34,7 +34,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>none</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
+++ b/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
@@ -35,7 +35,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>none</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
@@ -35,7 +35,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>none</phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.8.1</kafka.lib.version>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
     <reactive.version>1.0.2</reactive.version>
     <localstack-utils.version>0.2.23</localstack-utils.version>
   </properties>
@@ -133,68 +133,4 @@
     </dependency>
 
   </dependencies>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>${phase.prop}</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <!-- combine.self="override" needs to be specified as without this attribute child pom appears to merge
-                   shade plugin configurations in its parents pom.Notably the shade plugin configuration in the root pom declares a mainClass which 
-                   causes the build to fail - https://github.com/apache/pinot/blob/master/pom.xml#L1880
-                   The build will fail with the message "Unable to parse configuration of mojo org.apache.maven.plugins:maven-shade-plugin:3.2.1:shade 
-                   for parameter mainClass: Cannot find 'mainClass' in class org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" error
-                   Adding "combine.self" attribute in the child pom's configuration will allow maven to execute the shade plugin independently from the
-                   parent pom. For more details please see https://github.com/stevenschlansker/maven-configure-transformer-bug & 
-                   https://mail-archives.apache.org/mod_mbox/maven-issues/201605.mbox/%3CJIRA.12964833.1462316804000.103574.1462316952817@Atlassian.JIRA%3E
-                   -->
-                  <transformers combine.self="override">
-                    <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                    <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                  </transformers>
-                  <!--
-                  Usually in hadoop environment, there are multiple jars with different versions.
-                  Most of the NoSuchMethodExceptions are caused by class loading conflicts.
-                  Class relocation ensures the reference of certain packages/classes in Pinot code to
-                  shaded libs, e.g. jackson or guava.
-                  Ref: https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html
-                  -->
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.fasterxml.jackson</pattern>
-                      <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>software.amazon</pattern>
-                      <shadedPattern>${shade.prefix}.software.amazon</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -146,7 +146,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
 
   <properties>
-    <phase.prop>package</phase.prop>
+    <shade.phase.prop>package</shade.phase.prop>
     <pinot.root>${basedir}/../../..</pinot.root>
     <simpleclient_common.version>0.16.0</simpleclient_common.version>
     <grpc-context.version>1.63.0</grpc-context.version>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <plugin.type/>
-    <phase.prop>none</phase.prop>
     <hadoop.dependencies.scope>compile</hadoop.dependencies.scope>
   </properties>
 
@@ -82,77 +81,6 @@
       <properties>
         <hadoop.dependencies.scope>provided</hadoop.dependencies.scope>
       </properties>
-    </profile>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>${phase.prop}</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <transformers>
-                    <transformer
-                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                  </transformers>
-                  <!--
-                  Usually in hadoop environment, there are multiple jars with different versions.
-                  Most of the NoSuchMethodExceptions are caused by class loading conflicts.
-                  Class relocation ensures the reference of certain packages/classes in Pinot code to
-                  shaded libs, e.g. jackson or guava.
-                  Ref: https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html
-                  -->
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.fasterxml.jackson</pattern>
-                      <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.apache.http</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>software.amazon</pattern>
-                      <shadedPattern>${shade.prefix}.software.amazon</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.reflections</pattern>
-                      <shadedPattern>${shade.prefix}.org.reflections</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>io.netty</pattern>
-                      <shadedPattern>${shade.prefix}.io.netty</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.apache.parquet</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.apache.kafka</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.kafka</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -95,7 +95,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -179,39 +179,4 @@
       <artifactId>reflections</artifactId>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <relocations>
-                    <relocation>
-                      <pattern>com.google.common.base</pattern>
-                      <shadedPattern>${shade.prefix}.com.google.common.base</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.fasterxml.jackson</pattern>
-                      <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
-                    </relocation>
-                  </relocations>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2209,6 +2209,9 @@
             <!-- Exclude build targets -->
             <exclude>**/target/**</exclude>
 
+            <!-- Exclude Maven plugin generated files -->
+            <exclude>**/dependency-reduced-pom.xml</exclude>
+
             <!-- Text and log files -->
             <exclude>**/*.txt</exclude>
             <exclude>**/*.log</exclude>
@@ -2299,10 +2302,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.2</version>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
           <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>${mainClass}</mainClass>
@@ -2323,6 +2328,40 @@
               </excludes>
             </filter>
           </filters>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.netty</pattern>
+              <shadedPattern>${shade.prefix}.io.netty</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.http</pattern>
+              <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.kafka</pattern>
+              <shadedPattern>${shade.prefix}.org.apache.kafka</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.parquet</pattern>
+              <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.reflections</pattern>
+              <shadedPattern>${shade.prefix}.org.reflections</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>software.amazon</pattern>
+              <shadedPattern>${shade.prefix}.software.amazon</shadedPattern>
+            </relocation>
+          </relocations>
         </configuration>
       </plugin>
       <!-- Include apache LICENSE, NOTICE files for jar resource bundle -->

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,8 @@
     <!-- Configuration for Packaging -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
     <maven-jar-plugin.version>3.4.0</maven-jar-plugin.version>
+    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
+    <shade.phase.prop>none</shade.phase.prop>
 
     <avro.version>1.11.3</avro.version>
     <parquet.version>1.13.1</parquet.version>
@@ -2302,7 +2304,15 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>${shade.phase.prop}</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <createDependencyReducedPom>false</createDependencyReducedPom>


### PR DESCRIPTION
Upgrade maven-shade-plugin version from 3.2.x to 3.5.2.
By default, modules are not building the shaded jar.
For the modules require shaded jars, users can specify `<shade.phase.prop>package</shade.phase.prop>` in the `pom.xml` file `properties` section.