### PR TITLE
upgrade redis version in superset pinot docker image

### DIFF
--- a/docker/images/pinot-superset/requirements-db.txt
+++ b/docker/images/pinot-superset/requirements-db.txt
@@ -17,4 +17,4 @@
 # under the License.
 #
 pinotdb>=0.4.5
-redis==4.5.4
+redis>=4.6.0,<5.0


### PR DESCRIPTION
New superset requires redis version >4.6.0,<5.0
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 615, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 952, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 813, in resolve
    dist = self._resolve_dist(
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 859, in _resolve_dist
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (redis 4.5.4 (/usr/local/lib/python3.10/site-packages), Requirement.parse('redis<5.0,>=4.6.0'), {'apache-superset'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/superset", line 33, in <module>
    sys.exit(load_entry_point('apache-superset', 'console_scripts', 'superset')())
  File "/usr/local/bin/superset", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/superset/cli/main.py", line 28, in <module>
    from superset.cli.lib import normalize_token
  File "/app/superset/cli/lib.py", line 20, in <module>
    from superset import config
  File "/app/superset/config.py", line 39, in <module>
    import pkg_resources
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3304, in <module>
    def _initialize_master_working_set():
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3278, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3316, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 617, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 630, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 813, in resolve
    dist = self._resolve_dist(
  File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 854, in _resolve_dist
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'redis<5.0,>=4.6.0' distribution was not found and is required by apache-superset
```