### PR TITLE
do not allow pruning exception to fail queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -805,7 +805,13 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       int numTotalSelectedSegments = selectedSegments.size();
       if (!selectedSegments.isEmpty()) {
         for (SegmentPruner segmentPruner : _segmentPruners) {
-          selectedSegments = segmentPruner.prune(brokerRequest, selectedSegments);
+          try {
+            selectedSegments = segmentPruner.prune(brokerRequest, selectedSegments);
+          } catch (Exception e) {
+            // Pruning errors should get logged, but they shouldn't outright fail the query.
+            LOGGER.error("Caught exception while pruning segments for table: {} with pruner: {}", _tableNameWithType,
+                segmentPruner.getClass().getName(), e);
+          }
         }
       }
       int numPrunedSegments = numTotalSelectedSegments - selectedSegments.size();


### PR DESCRIPTION
This is a `bugfix` addressing a portion of #12721. Failing to Prune should not fail the query itself. Instead we log the table, the pruner, and the stack trace leading to the error.

This is tested on an internal QA cluster where I was able to replicate and not fail the query
```
ERROR [BrokerRoutingManager] [jersey-server-managed-async-executor-3:17] Caught exception while pruning segments for table: <table_name> with pruner: org.apache.pinot.broker.routing.segmentpruner.TimeSegmentPruner
[2024-03-26 22:41:34.099479] java.lang.NumberFormatException: Character array is missing "e" notation exponential mark.
```