### PR TITLE
Emit table size related metrics only in lead pinot-controller

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -65,6 +65,7 @@ import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.restlet.resources.SegmentServerDebugInfo;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.debug.TableDebugInfo;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -122,6 +123,9 @@ public class DebugResource {
 
   @Inject
   ControllerConf _controllerConf;
+
+  @Inject
+  LeadControllerManager _leadControllerManager;
 
   @GET
   @Path("tables/{tableName}")
@@ -238,7 +242,8 @@ public class DebugResource {
 
   private TableDebugInfo.TableSizeSummary getTableSize(String tableNameWithType) {
     TableSizeReader tableSizeReader =
-        new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
+        new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager,
+            _leadControllerManager);
     TableSizeReader.TableSizeDetails tableSizeDetails;
     try {
       tableSizeDetails = tableSizeReader

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -363,7 +363,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       }
       SegmentValidationUtils.checkStorageQuota(segmentName, untarredSegmentSizeInBytes, tableConfig,
           _pinotHelixResourceManager, _controllerConf, _controllerMetrics, _connectionManager, _executor,
-          _leadControllerManager.isLeaderForTable(tableNameWithType));
+          _leadControllerManager);
 
       // Encrypt segment
       String crypterNameInTableConfig = tableConfig.getValidationConfig().getCrypterClassName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
@@ -70,6 +71,9 @@ public class TableSize {
   @Inject
   ControllerMetrics _controllerMetrics;
 
+  @Inject
+  LeadControllerManager _leadControllerManager;
+
   @GET
   @Path("/tables/{tableName}/size")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SIZE)
@@ -84,7 +88,8 @@ public class TableSize {
       @ApiParam(value = "Table name without type", required = true, example = "myTable | myTable_OFFLINE")
       @PathParam("tableName") String tableName) {
     TableSizeReader tableSizeReader =
-        new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
+        new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager,
+            _leadControllerManager);
     TableSizeReader.TableSizeDetails tableSizeDetails = null;
     try {
       tableSizeDetails =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.Response;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
@@ -65,12 +66,13 @@ public class SegmentValidationUtils {
 
   public static void checkStorageQuota(String segmentName, long segmentSizeInBytes, TableConfig tableConfig,
       PinotHelixResourceManager resourceManager, ControllerConf controllerConf, ControllerMetrics controllerMetrics,
-      HttpClientConnectionManager connectionManager, Executor executor, boolean isLeaderForTable) {
+      HttpClientConnectionManager connectionManager, Executor executor, LeadControllerManager leadControllerManager) {
     if (!controllerConf.getEnableStorageQuotaCheck()) {
       return;
     }
+    boolean isLeaderForTable = leadControllerManager.isLeaderForTable(tableConfig.getTableName());
     TableSizeReader tableSizeReader =
-        new TableSizeReader(executor, connectionManager, controllerMetrics, resourceManager);
+        new TableSizeReader(executor, connectionManager, controllerMetrics, resourceManager, leadControllerManager);
     StorageQuotaChecker quotaChecker =
         new StorageQuotaChecker(tableConfig, tableSizeReader, controllerMetrics, isLeaderForTable, resourceManager);
     StorageQuotaChecker.QuotaCheckerResponse response;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -94,7 +94,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _tableSizeReader =
         new TableSizeReader(executorService, new PoolingHttpClientConnectionManager(), _controllerMetrics,
-            _pinotHelixResourceManager);
+            _pinotHelixResourceManager, leadControllerManager);
   }
 
   @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metrics.MetricValueUtils;
 import org.apache.pinot.common.restlet.resources.SegmentSizeInfo;
 import org.apache.pinot.common.restlet.resources.TableSizeInfo;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.controller.utils.FakeHttpServer;
@@ -79,10 +80,12 @@ public class TableSizeReaderTest {
       new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
   private final Map<String, FakeSizeServer> _serverMap = new HashMap<>();
   private PinotHelixResourceManager _helix;
+  private LeadControllerManager _leadControllerManager;
 
   @BeforeClass
   public void setUp() throws IOException {
     _helix = mock(PinotHelixResourceManager.class);
+    _leadControllerManager = mock(LeadControllerManager.class);
 
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setNumReplicas(NUM_REPLICAS).build();
@@ -103,6 +106,7 @@ public class TableSizeReaderTest {
 
     when(_helix.getPropertyStore()).thenReturn(mockPropertyStore);
     when(_helix.getNumReplicas(ArgumentMatchers.eq(tableConfig))).thenReturn(NUM_REPLICAS);
+    when(_leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
 
     int counter = 0;
     // server0
@@ -218,8 +222,10 @@ public class TableSizeReaderTest {
   }
 
   @Test
-  public void testNoSuchTable() throws InvalidConfigException {
-    TableSizeReader reader = new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _helix);
+  public void testNoSuchTable()
+      throws InvalidConfigException {
+    TableSizeReader reader =
+        new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _helix, _leadControllerManager);
     assertNull(reader.getTableSizeDetails("mytable", 5000));
   }
 
@@ -239,7 +245,8 @@ public class TableSizeReaderTest {
       }
     });
 
-    TableSizeReader reader = new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _helix);
+    TableSizeReader reader = new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _helix,
+        _leadControllerManager);
     return reader.getTableSizeDetails(table, TIMEOUT_MSEC);
   }
 


### PR DESCRIPTION
This PR is to address the issue in https://github.com/apache/pinot/issues/12746.
Basically it should only be the lead pinot-controller that is able to update the table size related metrics for the given Pinot table.