### PR TITLE
upgrade to jackson 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <orc.version>1.5.9</orc.version>
     <helix.version>1.3.1</helix.version>
     <zkclient.version>0.11</zkclient.version>
-    <jackson.version>2.12.7.20221012</jackson.version>
+    <jackson.version>2.17.0</jackson.version>
     <zookeeper.version>3.9.2</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.42</jersey.version>


### PR DESCRIPTION

Jackson 2.17.0 was released on March 12, 2024

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.17


