### PR TITLE
Delete database API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResource.java
@@ -18,23 +18,31 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,5 +66,76 @@ public class PinotDatabaseRestletResource {
   @ApiOperation(value = "List all database names", notes = "Lists all database names")
   public List<String> listDatabaseNames() {
     return _pinotHelixResourceManager.getDatabaseNames();
+  }
+
+  @DELETE
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/databases/{databaseName}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DELETE_DATABASE)
+  @ApiOperation(value = "Delete all tables in given database name", notes = "Delete all tables in given database name")
+  public DeleteDatabaseResponse deleteTablesInDatabase(
+      @ApiParam(value = "Database name", required = true) @PathParam("databaseName") String databaseName,
+      @ApiParam(value = "Run in dryRun mode initially to know the list of tables that will be deleted in actual run. "
+          + "No tables will be deleted when dryRun=true", required = true)
+      @QueryParam("dryRun") boolean dryRun) {
+    List<String> tablesInDatabase = _pinotHelixResourceManager.getAllTables(databaseName);
+    List<String> deletedTables = new ArrayList<>(tablesInDatabase.size());
+    if (dryRun) {
+      deletedTables = tablesInDatabase;
+    } else {
+      for (String table : tablesInDatabase) {
+        boolean isSchemaDeleted = false;
+        try {
+          TableType tableType = TableNameBuilder.getTableTypeFromTableName(table);
+          String rawTableName = TableNameBuilder.extractRawTableName(table);
+          _pinotHelixResourceManager.deleteSchema(rawTableName);
+          LOGGER.info("Deleted schema: {}", rawTableName);
+          isSchemaDeleted = true;
+          _pinotHelixResourceManager.deleteTable(table, tableType, null);
+          LOGGER.info("Deleted table: {}", table);
+          deletedTables.add(table);
+        } catch (Exception e) {
+          if (isSchemaDeleted) {
+            LOGGER.error("Failed to delete table {}", table);
+          } else {
+            LOGGER.error("Failed to delete table and schema for {}", table);
+          }
+        }
+      }
+    }
+    return new DeleteDatabaseResponse(tablesInDatabase, deletedTables, dryRun);
+  }
+}
+
+class DeleteDatabaseResponse {
+  private final List<String> _tablesInDatabase;
+  private final List<String> _deletedTables;
+  private final boolean _partiallyDeleted;
+  private final boolean _dryRun;
+
+  public DeleteDatabaseResponse(List<String> tablesInDatabase, List<String> deletedTables, boolean dryRun) {
+    _tablesInDatabase = tablesInDatabase;
+    _deletedTables = deletedTables;
+    _dryRun = dryRun;
+    _partiallyDeleted = tablesInDatabase.size() != deletedTables.size();
+  }
+
+  @JsonProperty("tablesInDatabase")
+  public List<String> getTablesInDatabase() {
+    return _tablesInDatabase;
+  }
+
+  @JsonProperty("deletedTables")
+  public List<String> getDeletedTables() {
+    return _deletedTables;
+  }
+
+  public boolean isDryRun() {
+    return _dryRun;
+  }
+
+  @JsonProperty("partiallyDeleted")
+  public boolean isPartiallyDeleted() {
+    return _partiallyDeleted;
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResourceTest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotDatabaseRestletResourceTest {
+  private static final String DATABASE = "db";
+  private static final List<String> TABLES = Lists.newArrayList("a_REALTIME", "b_OFFLINE", "c_REALTIME", "d_OFFLINE");
+
+  @Mock
+  PinotHelixResourceManager _resourceManager;
+  @InjectMocks
+  PinotDatabaseRestletResource _resource;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(_resourceManager.getAllTables(DATABASE)).thenReturn(TABLES);
+    doNothing().when(_resourceManager).deleteTable(anyString(), any(TableType.class), any());
+    when(_resourceManager.deleteSchema(anyString())).thenReturn(true);
+  }
+
+  @Test
+  public void successfulDatabaseDeletionDryRunTest() {
+    successfulDatabaseDeletionCheck(true);
+  }
+
+  @Test
+  public void successfulDatabaseDeletionTest() {
+    successfulDatabaseDeletionCheck(false);
+  }
+
+  private void successfulDatabaseDeletionCheck(boolean dryRun) {
+    DeleteDatabaseResponse response = _resource.deleteTablesInDatabase(DATABASE, dryRun);
+    assertEquals(response.isDryRun(), dryRun);
+    assertFalse(response.isPartiallyDeleted());
+    assertEquals(response.getTablesInDatabase(), TABLES);
+    assertEquals(response.getDeletedTables(), TABLES);
+  }
+
+  @Test
+  public void partialDatabaseDeletionWithDeleteTableFailureTest() {
+    int failureTableIdx = TABLES.size() / 2;
+    doThrow(new RuntimeException()).when(_resourceManager)
+        .deleteTable(TABLES.get(failureTableIdx), TableType.REALTIME, null);
+    partialDatabaseDeletionCheck(failureTableIdx);
+  }
+
+  @Test
+  public void partialDatabaseDeletionWithDeleteSchemaFailureTest() {
+    int failureSchemaIdx = TABLES.size() / 2;
+    doThrow(new RuntimeException()).when(_resourceManager)
+        .deleteSchema(TableNameBuilder.extractRawTableName(TABLES.get(failureSchemaIdx)));
+    partialDatabaseDeletionCheck(failureSchemaIdx);
+  }
+
+  private void partialDatabaseDeletionCheck(int idx) {
+    DeleteDatabaseResponse response = _resource.deleteTablesInDatabase(DATABASE, false);
+    List<String> resultList = new ArrayList<>(TABLES);
+    resultList.remove(idx);
+    assertFalse(response.isDryRun());
+    assertTrue(response.isPartiallyDeleted());
+    assertEquals(response.getTablesInDatabase(), TABLES);
+    assertEquals(response.getDeletedTables(), resultList);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -40,6 +40,7 @@ public class Actions {
     public static final String DELETE_TENANT = "DeleteTenant";
     public static final String DELETE_USER = "DeleteUser";
     public static final String DELETE_ZNODE = "DeleteZnode";
+    public static final String DELETE_DATABASE = "DeleteDatabase";
     public static final String ESTIMATE_UPSERT_MEMORY = "EstimateUpsertMemory";
     public static final String EXECUTE_TASK = "ExecuteTask";
     public static final String GET_ADMIN_INFO = "GetAdminInfo";


### PR DESCRIPTION
# Description
API to delete the given database which effectively deletes all the tables under the given database.
The API has a sync behaviour which means partial database deletion is possible in case of failures.
Server side failures are handled silently and further table deletion is resumed. The response will have appropriate information regarding the partial database deletion.

**Endpoint** : `/databases/<databaseName>`
**Query param** : `dryRun` , _required_ = `true`
**Method** : `DELETE`
**Sample output** : 
```
{
  "dryRun": false,
  "tablesInDatabase": [
    "db1.table1_REALTIME",
    "db1.table2_OFFLINE"
  ],
  "deletedTables": [
    "db1.table1_REALTIME"
  ],
  "partiallyDeleted": true
}
```
As the API is of idempotent nature client can repeatedly call the API in-case the deletion has occurred partially
 
# labels
`feature` `release-notes`

# release-notes
API to delete database and all its underlying tables
