### PR TITLE
Fetch the query quota capacity utilization rate  broker metric in a callback function

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HitCounter.java
@@ -83,10 +83,20 @@ public class HitCounter {
 
   @VisibleForTesting
   int getHitCount(long timestamp) {
+    return getHitCount(timestamp, _bucketCount);
+  }
+
+  /**
+   * Get the hit count within the valid number of buckets.
+   * @param timestamp the current timestamp
+   * @param validBucketCount the valid number of buckets
+   * @return the number of hits within the valid bucket count
+   */
+  int getHitCount(long timestamp, int validBucketCount) {
     long numTimeUnits = timestamp / _timeBucketWidthMs;
     int count = 0;
     for (int i = 0; i < _bucketCount; i++) {
-      if (numTimeUnits - _bucketStartTime.get(i) < _bucketCount) {
+      if (numTimeUnits - _bucketStartTime.get(i) < validBucketCount) {
         count += _bucketHitCount.get(i);
       }
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/MaxHitRateTracker.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/MaxHitRateTracker.java
@@ -34,6 +34,7 @@ public class MaxHitRateTracker extends HitCounter {
   private static final int ONE_SECOND_BUCKET_WIDTH_MS = 1000;
   private static final int MAX_TIME_RANGE_FACTOR = 2;
 
+  private final int _validBucketCount;
   private final long _maxTimeRangeMs;
   private final long _defaultTimeRangeMs;
   private volatile long _lastAccessTimestamp;
@@ -44,6 +45,7 @@ public class MaxHitRateTracker extends HitCounter {
 
   private MaxHitRateTracker(int defaultTimeRangeInSeconds, int maxTimeRangeInSeconds) {
     super(maxTimeRangeInSeconds, (int) (maxTimeRangeInSeconds * 1000L / ONE_SECOND_BUCKET_WIDTH_MS));
+    _validBucketCount = (int) (defaultTimeRangeInSeconds * 1000L / ONE_SECOND_BUCKET_WIDTH_MS);
     _defaultTimeRangeMs = defaultTimeRangeInSeconds * 1000L;
     _maxTimeRangeMs = maxTimeRangeInSeconds * 1000L;
   }
@@ -79,5 +81,15 @@ public class MaxHitRateTracker extends HitCounter {
     // Update the last access timestamp
     _lastAccessTimestamp = now;
     return maxCount;
+  }
+
+  @VisibleForTesting
+  @Override
+  int getHitCount(long now) {
+    return super.getHitCount(now, _validBucketCount);
+  }
+
+  public long getDefaultTimeRangeMs() {
+    return _defaultTimeRangeMs;
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/MaxHitRateTrackerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/MaxHitRateTrackerTest.java
@@ -37,24 +37,29 @@ public class MaxHitRateTrackerTest {
     long latestTimeStamp = currentTimestamp + (timeInSec - 1) * 1000;
     Assert.assertNotNull(hitCounter);
     Assert.assertEquals(5, hitCounter.getMaxCountPerBucket(latestTimeStamp));
+    Assert.assertEquals(5 * 60, hitCounter.getHitCount(latestTimeStamp));
 
     // 2 seconds have passed, the hit counter should return 5 as well since the count in the last bucket could increase.
     latestTimeStamp = latestTimeStamp + 2000L;
     Assert.assertEquals(5, hitCounter.getMaxCountPerBucket(latestTimeStamp));
+    Assert.assertEquals(5 * (60 - 2), hitCounter.getHitCount(latestTimeStamp));
 
     // This time it should return 0 as the internal lastAccessTimestamp has already been updated and there is no more
     // hits between the gap.
     latestTimeStamp = latestTimeStamp + 2000L;
     Assert.assertEquals(0, hitCounter.getMaxCountPerBucket(latestTimeStamp));
+    Assert.assertEquals(5 * (60 - 4), hitCounter.getHitCount(latestTimeStamp));
 
     // Increment the hit in this second and we should see the result becomes 1.
     hitCounter.hit(latestTimeStamp);
     latestTimeStamp = latestTimeStamp + 2000L;
     Assert.assertEquals(1, hitCounter.getMaxCountPerBucket(latestTimeStamp));
+    Assert.assertEquals(5 * (60 - 6) + 1, hitCounter.getHitCount(latestTimeStamp));
 
     // More than a time range period has passed and the hit counter should return 0 as there is no hits.
     hitCounter.hit(latestTimeStamp);
     latestTimeStamp = latestTimeStamp + timeInSec * 2 * 1000L + 2000L;
     Assert.assertEquals(0, hitCounter.getMaxCountPerBucket(latestTimeStamp));
+    Assert.assertEquals(0, hitCounter.getHitCount(latestTimeStamp));
   }
 }


### PR DESCRIPTION
This PR fetches the query quota capacity utilization rate broker metric in a callback function.
Related issue: https://github.com/apache/pinot/issues/12768

The reason is that this broker metric is a gauge metric. If there is no incoming query, the gauge value would remain the same without any updates. In addition, if the total query quota is less than the number of brokers, meaning if the per-broker rate is less than 1, the metric value would always be > 100. So even there is only 1 incoming query for a while, the metric value would still be > 100.