### PR TITLE
upgrade lmax disruptor to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@
       <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
-        <version>3.3.4</version>
+        <version>4.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.asynchttpclient</groupId>


### PR DESCRIPTION
lmax disruptor 4.0.0 was releated in September 2023

https://mvnrepository.com/artifact/com.lmax/disruptor

