### PR TITLE
Set column major segment builder to be on by default

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -62,7 +62,7 @@ public class IndexingConfig extends BaseJsonConfig {
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _aggregateMetrics;
   private boolean _nullHandlingEnabled;
-  private boolean _columnMajorSegmentBuilderEnabled = false;
+  private boolean _columnMajorSegmentBuilderEnabled = true;
 
   /**
    * If `optimizeDictionary` enabled, dictionary is not created for the high-cardinality

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -35,7 +35,7 @@ public class StreamIngestionConfig extends BaseJsonConfig {
   private final List<Map<String, String>> _streamConfigMaps;
 
   @JsonPropertyDescription("Whether to use column major mode when creating the segment.")
-  private boolean _columnMajorSegmentBuilderEnabled;
+  private boolean _columnMajorSegmentBuilderEnabled = true;
 
   @JsonCreator
   public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -100,7 +100,7 @@ public class TableConfigBuilder {
   private Map<String, String> _streamConfigs;
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _nullHandlingEnabled;
-  private boolean _columnMajorSegmentBuilderEnabled;
+  private boolean _columnMajorSegmentBuilderEnabled = true;
   private List<String> _varLengthDictionaryColumns;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private List<String> _jsonIndexColumns;


### PR DESCRIPTION
This enables the faster Column Major segment builder to be on by default. This feature has been in the wild for several months and since it's purpose is to speed up segment building it makes sense to enable it by default.

Effect:
1. Any new table will be configured to use column major segment building.
2. I believe any existing table will continue to use row major segment building unless the config is updated manually.

Testing:
1. Ran locally to verify that tables used column major segment building.
3. Ran unit tests to make sure they all passed.
