### PR TITLE
BugFix: Fix merge result from more than one server

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -391,6 +391,8 @@ public class DistinctCountCPCSketchAggregationFunction
     if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
+    intermediateResult1.setLgNominalEntries(_lgNominalEntries);
+    intermediateResult1.setThreshold(_accumulatorThreshold);
     intermediateResult1.merge(intermediateResult2);
     return intermediateResult1;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -997,6 +997,8 @@ public class DistinctCountThetaSketchAggregationFunction
         mergedAccumulators.add(thetaSketchAccumulator1);
         continue;
       }
+      thetaSketchAccumulator1.setSetOperationBuilder(_setOperationBuilder);
+      thetaSketchAccumulator1.setThreshold(_accumulatorThreshold);
       thetaSketchAccumulator1.merge(thetaSketchAccumulator2);
       mergedAccumulators.add(thetaSketchAccumulator1);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -250,6 +250,7 @@ public class IntegerTupleSketchAggregationFunction
     if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
+    intermediateResult1.setThreshold(_accumulatorThreshold);
     intermediateResult1.setNominalEntries(_nominalEntries);
     intermediateResult1.setSetOperations(_setOps);
     intermediateResult1.merge(intermediateResult2);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -250,6 +250,8 @@ public class IntegerTupleSketchAggregationFunction
     if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
+    intermediateResult1.setNominalEntries(_nominalEntries);
+    intermediateResult1.setSetOperations(_setOps);
     intermediateResult1.merge(intermediateResult2);
     return intermediateResult1;
   }


### PR DESCRIPTION
Summary
---------

The merge operation results in a null reference error when the set operations is not set properly for Tuple Sketches.

Description
------------
When more than one server returns an intermediate result to the broker, the custom object accumulators need to perform a merge.  When some of the state on the object accumulator is not re-initialised, this can lead to unpredictable behaviour.  

The serialisation on these custom objects (for sketches) is somewhat cumbersome.  Ideally, we would encode the fields in binary together with the underlying sketch payload.  I came across a test case where sketches were fetched directly from the servers and I'm not sure as to whether there are users in the community who expect results to conform directly to a sketch for these server responses.

Finally, I was not able to find a good way to test multiple server responses with an aggregation function - please let me know if there is a good example.

Tags
-----

`bugfix` .
