### PR TITLE
Deprecate PinotHelixResourceManager#getAllTables() in favour of getAllTables(String databaseName)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -720,6 +720,7 @@ public class PinotHelixResourceManager {
    *
    * @return List of table names in default database
    */
+  @Deprecated
   public List<String> getAllTables() {
     return getAllTables(null);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
@@ -138,9 +138,12 @@ public class StaleInstancesCleanupTask extends BasePeriodicTask {
 
   private Set<String> getServerInstancesInUse() {
     Set<String> serverInstancesInUse = new HashSet<>();
-    _pinotHelixResourceManager.getAllTables().forEach(tableName -> serverInstancesInUse.addAll(
-        Optional.ofNullable(_pinotHelixResourceManager.getTableIdealState(tableName))
-            .map(is -> is.getInstanceSet(tableName)).orElse(Collections.emptySet())));
+    _pinotHelixResourceManager.getDatabaseNames().stream()
+        .map(_pinotHelixResourceManager::getAllTables)
+        .flatMap(List::stream)
+        .forEach(tableName -> serverInstancesInUse.addAll(
+          Optional.ofNullable(_pinotHelixResourceManager.getTableIdealState(tableName))
+              .map(is -> is.getInstanceSet(tableName)).orElse(Collections.emptySet())));
     return serverInstancesInUse;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -70,7 +70,10 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
       String propTableNameWithType = (String) periodicTaskProperties.get(PeriodicTask.PROPERTY_KEY_TABLE_NAME);
       // Process the tables that are managed by this controller
       List<String> allTables = propTableNameWithType == null
-          ? _pinotHelixResourceManager.getAllTables()
+          ? _pinotHelixResourceManager.getDatabaseNames().stream()
+            .map(_pinotHelixResourceManager::getAllTables)
+            .flatMap(List::stream)
+            .collect(Collectors.toList())
           : Collections.singletonList(propTableNameWithType);
 
       Set<String> currentLeaderOfTables = allTables.stream()

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -92,7 +93,9 @@ public class RealtimeConsumerMonitorTest {
       ZkHelixPropertyStore<ZNRecord> helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(helixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
       when(helixResourceManager.getPropertyStore()).thenReturn(helixPropertyStore);
-      when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(helixResourceManager.getTableExternalView(tableName)).thenReturn(externalView);
       ZNRecord znRecord = new ZNRecord("0");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -55,6 +55,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -113,7 +114,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(externalView);
@@ -217,7 +220,9 @@ public class SegmentStatusCheckerTest {
       _helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(_helixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
       when(_helixResourceManager.getPropertyStore()).thenReturn(_helixPropertyStore);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(externalView);
       ZNRecord znRecord = new ZNRecord("0");
@@ -320,7 +325,9 @@ public class SegmentStatusCheckerTest {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
       _helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(_helixResourceManager.getPropertyStore()).thenReturn(_helixPropertyStore);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(offlineTableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(offlineTableName)).thenReturn(externalView);
       when(_helixResourceManager.getSegmentZKMetadata(offlineTableName, "myTable_3"))
@@ -381,7 +388,9 @@ public class SegmentStatusCheckerTest {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
       _helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(_helixResourceManager.getPropertyStore()).thenReturn(_helixPropertyStore);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }
@@ -426,7 +435,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(null);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }
@@ -516,7 +527,9 @@ public class SegmentStatusCheckerTest {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
       _helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(_helixResourceManager.getPropertyStore()).thenReturn(_helixPropertyStore);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(offlineTableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(offlineTableName)).thenReturn(externalView);
       when(_helixResourceManager.getSegmentZKMetadata(offlineTableName, "myTable_0"))
@@ -577,7 +590,9 @@ public class SegmentStatusCheckerTest {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
       _helixPropertyStore = mock(ZkHelixPropertyStore.class);
       when(_helixResourceManager.getPropertyStore()).thenReturn(_helixPropertyStore);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }
@@ -633,7 +648,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }
@@ -676,7 +693,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }
@@ -738,7 +757,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(externalView);
@@ -793,7 +814,9 @@ public class SegmentStatusCheckerTest {
 
     {
       _helixResourceManager = mock(PinotHelixResourceManager.class);
-      when(_helixResourceManager.getAllTables()).thenReturn(allTableNames);
+      when(_helixResourceManager.getDatabaseNames())
+          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+      when(_helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
       when(_helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
       when(_helixResourceManager.getTableExternalView(tableName)).thenReturn(null);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.periodictask;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,6 +35,7 @@ import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -87,7 +89,9 @@ public class ControllerPeriodicTaskTest {
   public void beforeTest() {
     List<String> tables = new ArrayList<>(_numTables);
     IntStream.range(0, _numTables).forEach(i -> tables.add("table_" + i + " _OFFLINE"));
-    when(_resourceManager.getAllTables()).thenReturn(tables);
+    when(_resourceManager.getDatabaseNames())
+        .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+    when(_resourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(tables);
     when(_leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -49,6 +49,7 @@ import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -161,7 +162,9 @@ public class RetentionManagerTest {
   private void setupPinotHelixResourceManager(TableConfig tableConfig, final List<String> removedSegments,
       PinotHelixResourceManager resourceManager, LeadControllerManager leadControllerManager) {
     final String tableNameWithType = tableConfig.getTableName();
-    when(resourceManager.getAllTables()).thenReturn(Collections.singletonList(tableNameWithType));
+    when(resourceManager.getDatabaseNames())
+        .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
+    when(resourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(Collections.singletonList(tableNameWithType));
 
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     when(resourceManager.getPropertyStore()).thenReturn(propertyStore);


### PR DESCRIPTION
# Description

- Deprecating `PinotHelixResourceManager#getAllTables()` in favour of `PinotHelixResourceManager#getAllTables(String databaseName)` as `getAllTables()` only works for `default` database. 
- Callers which actually need all the tables across all databases are updated to iterate over all databases and fetch all the tables

# labels
`release-notes`

# release-notes
Deprecating `PinotHelixResourceManager#getAllTables()` in favour of `PinotHelixResourceManager#getAllTables(String databaseName)`