### PR TITLE
Use ArrayList instead of LinkedList in SortOperator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
 import javax.annotation.Nullable;
@@ -129,16 +128,19 @@ public class SortOperator extends MultiStageOperator {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
     } else {
-      LinkedList<Object[]> rows = new LinkedList<>();
-      while (_priorityQueue.size() > _offset) {
-        Object[] row = _priorityQueue.poll();
-        rows.addFirst(row);
-      }
-      if (rows.size() == 0) {
+      int resultSize = _priorityQueue.size() - _offset;
+      if (resultSize == 0) {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      } else {
-        return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
       }
+      ArrayList<Object[]> rows = new ArrayList<>(resultSize);
+      for (int i = 0; i < resultSize; i++) {
+        rows.add(null);
+      }
+      for (int i = resultSize - 1; i >= 0; i--) {
+        Object[] row = _priorityQueue.poll();
+        rows.set(i, row);
+      }
+      return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.PriorityQueue;
 import javax.annotation.Nullable;
@@ -129,18 +130,15 @@ public class SortOperator extends MultiStageOperator {
       }
     } else {
       int resultSize = _priorityQueue.size() - _offset;
-      if (resultSize == 0) {
+      if (resultSize <= 0) {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
-      ArrayList<Object[]> rows = new ArrayList<>(resultSize);
-      for (int i = 0; i < resultSize; i++) {
-        rows.add(null);
-      }
+      Object[][] rowsArr = new Object[resultSize][];
       for (int i = resultSize - 1; i >= 0; i--) {
         Object[] row = _priorityQueue.poll();
-        rows.set(i, row);
+        rowsArr[i] = row;
       }
-      return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
+      return new TransferableBlock(Arrays.asList(rowsArr), _dataSchema, DataBlock.Type.ROW);
     }
   }
 


### PR DESCRIPTION
A small PR that changes SortOperator to buffer entries in an ArrayList instead of a LinkedList.

In general LinkedList performance is horrible, even in cases when theoretically (by Big-O) they are fine, usually the performance cost is worse than ArrayList due to memory amplification and cache issues. In the specific case this PR is changing, there was no actual reason to use LinkedList apart from a slightly nicer code. But given the size of the final result is well know, it was very easy to change it to an ArrayList implementation where the ArrayList is initialized to all values being null and then set values in the reverse direction. Amortized BigO cost is still linear, but locallity and allocation should be quite better in this implementation.

A secondary but difficult to prove improvement is related to megamorphic calls. As we mostly always use ArrayList in our code, the JIT can generate code that assumes that. Sometimes we need to use different lists, but if we can avoid that we theoretically can produce better code.

Probably the performance cost will be negligible in most cases and some of the actual cases (like the megamorphic calls) cannot be easilly benchmarked with JMH, so I'm not adding these benchmarks in this PR.