### PR TITLE
Fix the time segment pruner on TIMESTAMP data type

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -221,8 +221,7 @@ public class SchemaTest {
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime0", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
         .addDateTime("dateTime1", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
-        .addDateTime("dateTime2", FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
-        .build();
+        .addDateTime("dateTime2", FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS").build();
 
     // Test method which fetches the DateTimeFieldSpec given the timeColumnName
     // Test is on TIME
@@ -254,7 +253,7 @@ public class SchemaTest {
     Assert.assertEquals(dateTimeFieldSpec.getDataType(), FieldSpec.DataType.TIMESTAMP);
     Assert.assertTrue(dateTimeFieldSpec.isSingleValueField());
     Assert.assertEquals(dateTimeFieldSpec.getDefaultNullValue(), 0L);
-    Assert.assertEquals(dateTimeFieldSpec.getFormat(), "1:MILLISECONDS:EPOCH");
+    Assert.assertEquals(dateTimeFieldSpec.getFormat(), "TIMESTAMP");
     Assert.assertEquals(dateTimeFieldSpec.getGranularity(), "1:MILLISECONDS");
 
     dateTimeFieldSpec = schema.getSpecForTimeColumn("dateTime2");
@@ -326,15 +325,10 @@ public class SchemaTest {
   @Test
   public void testSerializeDeserializeOptions()
       throws IOException {
-    String json = "{\n"
-        + "  \"primaryKeyColumns\" : null,\n"
-        + "  \"timeFieldSpec\" : null,\n"
-        + "  \"schemaName\" : null,\n"
-        + "  \"enableColumnBasedNullHandling\" : true,\n"
-        + "  \"dimensionFieldSpecs\" : [ ],\n"
-        + "  \"metricFieldSpecs\" : [ ],\n"
-        + "  \"dateTimeFieldSpecs\" : [ ]\n"
-        + "}";
+    String json =
+        "{\n" + "  \"primaryKeyColumns\" : null,\n" + "  \"timeFieldSpec\" : null,\n" + "  \"schemaName\" : null,\n"
+            + "  \"enableColumnBasedNullHandling\" : true,\n" + "  \"dimensionFieldSpecs\" : [ ],\n"
+            + "  \"metricFieldSpecs\" : [ ],\n" + "  \"dateTimeFieldSpecs\" : [ ]\n" + "}";
     JsonNode expectedNode = JsonUtils.stringToJsonNode(json);
 
     Schema schema = JsonUtils.jsonNodeToObject(expectedNode, Schema.class);
@@ -361,6 +355,17 @@ public class SchemaTest {
     Schema schemaFromJson = Schema.fromString(jsonSchema);
     Assert.assertEquals(schemaFromJson, schema);
     Assert.assertEquals(schemaFromJson.hashCode(), schema.hashCode());
+  }
+
+  @Test
+  public void testTimestampFormatOverride()
+      throws Exception {
+    URL resourceUrl = getClass().getClassLoader().getResource("schemaTest.schema");
+    Assert.assertNotNull(resourceUrl);
+    Schema schema = Schema.fromFile(new File(resourceUrl.getFile()));
+    DateTimeFieldSpec fieldSpec = schema.getDateTimeSpec("dateTime3");
+    Assert.assertNotNull(fieldSpec);
+    Assert.assertEquals(fieldSpec.getFormat(), "TIMESTAMP");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.EqualityUtils;
 
+
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class DateTimeFieldSpec extends FieldSpec {
@@ -74,6 +75,10 @@ public final class DateTimeFieldSpec extends FieldSpec {
       @Nullable Object sampleValue) {
     super(name, dataType, true);
 
+    // Override format to be "TIMESTAMP" for TIMESTAMP data type because the format is implicit
+    if (dataType == DataType.TIMESTAMP) {
+      format = TimeFormat.TIMESTAMP.name();
+    }
     _format = format;
     _granularity = granularity;
     _formatSpec = new DateTimeFormatSpec(format);
@@ -119,13 +124,23 @@ public final class DateTimeFieldSpec extends FieldSpec {
     Preconditions.checkArgument(isSingleValueField, "Unsupported multi-value for date time field.");
   }
 
+  @Override
+  public void setDataType(DataType dataType) {
+    super.setDataType(dataType);
+    if (dataType == DataType.TIMESTAMP) {
+      _format = TimeFormat.TIMESTAMP.name();
+    }
+  }
+
   public String getFormat() {
     return _format;
   }
 
   // Required by JSON de-serializer. DO NOT REMOVE.
   public void setFormat(String format) {
-    _format = format;
+    if (_dataType != DataType.TIMESTAMP) {
+      _format = format;
+    }
   }
 
   @JsonIgnore


### PR DESCRIPTION
Fix #12721 

When data type is TIMESTAMP, fix the format to be "TIMESTAMP" because the time format is already implicit from the data type.