### PR TITLE
Bugfix. Correct wrong method call from scheduleTask() to scheduleTaskForDatabase()

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -624,7 +624,7 @@ public class PinotTaskRestletResource {
       // Schedule task for the given task type
       List<String> taskNames = tableName != null
           ? _pinotTaskManager.scheduleTask(taskType, DatabaseUtils.translateTableName(tableName, headers))
-          : _pinotTaskManager.scheduleTask(taskType, database);
+          : _pinotTaskManager.scheduleTaskForDatabase(taskType, database);
       return Collections.singletonMap(taskType, taskNames == null ? null : StringUtils.join(taskNames, ','));
     } else {
       // Schedule tasks for all task types

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -484,6 +484,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * It might be called from the non-leader controller.
    * Returns a map from the task type to the list of tasks scheduled.
    */
+  @Deprecated
   public synchronized Map<String, List<String>> scheduleTasks() {
     return scheduleTasks(_pinotHelixResourceManager.getAllTables(CommonConstants.DEFAULT_DATABASE), false);
   }


### PR DESCRIPTION
Bug introduced in #12766
Also revert the deprecated annotation removed by #12459
# labels
`bugfix`