### PR TITLE
Fix some resource leak in tests

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
@@ -78,10 +78,5 @@ public class PercentileSmartTDigestAggregationFunctionTest {
     String expectedAggrWithoutNull90(Scenario scenario) {
       return "7.100000000000001";
     }
-
-    @Override
-    String expectedAggrWithoutNull100(Scenario scenario) {
-      return super.expectedAggrWithoutNull100(scenario);
-    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -480,6 +480,8 @@ public class MutableSegmentImplIngestionAggregationTest {
     Assert.assertThrows(IllegalArgumentException.class, () -> {
       mutableSegmentImpl.index(row, defaultMetadata);
     });
+
+    mutableSegmentImpl.destroy();
   }
 
   private BigDecimal generateRandomBigDecimal(Random random, int maxPrecision, int scale) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterTest.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunk
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -90,8 +90,8 @@ public class VarByteChunkSVForwardIndexWriterTest {
         writer.putStringMV(array);
       }
     }
-    try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(
-        PinotDataBuffer.loadBigEndianFile(file), FieldSpec.DataType.STRING);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.loadBigEndianFile(file);
+        VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(dataBuffer, DataType.STRING);
         ChunkReaderContext context = reader.createContext()) {
       for (int i = 0; i < arrays.size(); i++) {
         String[] array = arrays.get(i);
@@ -125,8 +125,8 @@ public class VarByteChunkSVForwardIndexWriterTest {
         writer.putBytesMV(Arrays.stream(array).map(str -> str.getBytes(UTF_8)).toArray(byte[][]::new));
       }
     }
-    try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(
-        PinotDataBuffer.loadBigEndianFile(file), FieldSpec.DataType.BYTES);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.loadBigEndianFile(file);
+        VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(dataBuffer, DataType.BYTES);
         ChunkReaderContext context = reader.createContext()) {
       for (int i = 0; i < arrays.size(); i++) {
         String[] array = arrays.get(i);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -29,22 +29,20 @@ import java.util.stream.Stream;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.segment.spi.ColumnMetadata;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.partition.BoundedColumnValuePartitionFunction;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -140,8 +138,7 @@ public class ColumnMetadataTest {
     driver.build();
 
     // Load segment metadata.
-    IndexSegment segment = ImmutableSegmentLoader.load(INDEX_DIR.listFiles()[0], ReadMode.mmap);
-    SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
+    SegmentMetadata segmentMetadata = new SegmentMetadataImpl(INDEX_DIR.listFiles()[0]);
     verifySegmentAfterLoading(segmentMetadata);
 
     // Make sure we got the creator name as well.
@@ -159,8 +156,7 @@ public class ColumnMetadataTest {
     driver.build();
 
     // Load segment metadata.
-    IndexSegment segment = ImmutableSegmentLoader.load(INDEX_DIR.listFiles()[0], ReadMode.mmap);
-    SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
+    SegmentMetadata segmentMetadata = new SegmentMetadataImpl(INDEX_DIR.listFiles()[0]);
     verifySegmentAfterLoading(segmentMetadata);
 
     // Make sure we get null for creator name.
@@ -177,9 +173,8 @@ public class ColumnMetadataTest {
     driver.build();
 
     // Load segment metadata.
-    IndexSegment segment = ImmutableSegmentLoader.load(INDEX_DIR.listFiles()[0], ReadMode.mmap);
-    SegmentMetadata metadata = segment.getSegmentMetadata();
-    verifySegmentAfterLoading(metadata);
+    SegmentMetadata segmentMetadata = new SegmentMetadataImpl(INDEX_DIR.listFiles()[0]);
+    verifySegmentAfterLoading(segmentMetadata);
   }
 
   @Test
@@ -198,8 +193,7 @@ public class ColumnMetadataTest {
     driver.build();
 
     // Load segment metadata.
-    IndexSegment segment = ImmutableSegmentLoader.load(INDEX_DIR.listFiles()[0], ReadMode.mmap);
-    SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
+    SegmentMetadata segmentMetadata = new SegmentMetadataImpl(INDEX_DIR.listFiles()[0]);
     verifySegmentAfterLoading(segmentMetadata);
     // Make sure we get null for creator name.
     Assert.assertNull(segmentMetadata.getCreatorName());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
@@ -126,14 +126,15 @@ public class MultiValueVarByteRawIndexCreatorTest {
     }
 
     //read
-    final PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
-    ForwardIndexReader reader = ForwardIndexReaderFactory.createRawIndexReader(buffer, DataType.STRING, false);
-    final ForwardIndexReaderContext context = reader.createContext();
-    String[] values = new String[maxElements];
-    for (int i = 0; i < numDocs; i++) {
-      int length = reader.getStringMV(i, values, context);
-      String[] readValue = Arrays.copyOf(values, length);
-      Assert.assertEquals(inputs.get(i), readValue);
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
+        ForwardIndexReader reader = ForwardIndexReaderFactory.createRawIndexReader(buffer, DataType.STRING, false);
+        ForwardIndexReaderContext context = reader.createContext()) {
+      String[] values = new String[maxElements];
+      for (int i = 0; i < numDocs; i++) {
+        int length = reader.getStringMV(i, values, context);
+        String[] readValue = Arrays.copyOf(values, length);
+        Assert.assertEquals(inputs.get(i), readValue);
+      }
     }
   }
 
@@ -177,15 +178,16 @@ public class MultiValueVarByteRawIndexCreatorTest {
     }
 
     //read
-    final PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
-    ForwardIndexReader reader = ForwardIndexReaderFactory.createRawIndexReader(buffer, DataType.BYTES, false);
-    final ForwardIndexReaderContext context = reader.createContext();
-    byte[][] values = new byte[maxElements][];
-    for (int i = 0; i < numDocs; i++) {
-      int length = reader.getBytesMV(i, values, context);
-      byte[][] readValue = Arrays.copyOf(values, length);
-      for (int j = 0; j < length; j++) {
-        Assert.assertTrue(Arrays.equals(inputs.get(i)[j], readValue[j]));
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
+        ForwardIndexReader reader = ForwardIndexReaderFactory.createRawIndexReader(buffer, DataType.BYTES, false);
+        ForwardIndexReaderContext context = reader.createContext()) {
+      byte[][] values = new byte[maxElements][];
+      for (int i = 0; i < numDocs; i++) {
+        int length = reader.getBytesMV(i, values, context);
+        byte[][] readValue = Arrays.copyOf(values, length);
+        for (int j = 0; j < length; j++) {
+          Assert.assertTrue(Arrays.equals(inputs.get(i)[j], readValue[j]));
+        }
       }
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/DirectMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/DirectMemory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.spi.memory.unsafe;
 
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,15 +54,10 @@ public class DirectMemory implements Memory {
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public synchronized void close() {
     if (!_closed) {
-      synchronized (this) {
-        if (!_closed) {
-          Unsafer.UNSAFE.freeMemory(_address);
-          _closed = true;
-        }
-      }
+      Unsafer.UNSAFE.freeMemory(_address);
+      _closed = true;
     }
   }
 
@@ -71,7 +65,7 @@ public class DirectMemory implements Memory {
   protected void finalize()
       throws Throwable {
     if (!_closed) {
-      LOGGER.warn("Mmap section of " + _size + " wasn't explicitly closed");
+      LOGGER.warn("Direct memory of size: {} wasn't explicitly closed", _size);
       close();
     }
     super.finalize();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -98,16 +98,11 @@ public class MmapMemory implements Memory {
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public synchronized void close() {
     try {
       if (!_closed) {
-        synchronized (this) {
-          if (!_closed) {
-            _section._unmapFun.unmap();
-            _closed = true;
-          }
-        }
+        _section._unmapFun.unmap();
+        _closed = true;
       }
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new RuntimeException("Error while calling unmap", e);
@@ -118,7 +113,7 @@ public class MmapMemory implements Memory {
   protected void finalize()
       throws Throwable {
     if (!_closed) {
-      LOGGER.warn("Mmap section of " + _size + " wasn't explicitly closed");
+      LOGGER.warn("Mmap section of size: {} wasn't explicitly closed", _size);
       close();
     }
     super.finalize();


### PR DESCRIPTION
Under topic #12793 

- Fix the warning message of resource leak in `DirectMemory`
- Make resource leak warning more clear
- Fix resource leak in some tests (not all)