### PR TITLE
Bugfix for multiple values of a key in a Config file - apache#9102, apache#12689 

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -21,7 +21,6 @@ package org.apache.pinot.spi.env;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -161,10 +160,10 @@ public class CommonsConfigurationUtils {
   }
 
   private static Object mapValue(String key, Configuration configuration) {
-    // For multi-value config, convert it to a single comma connected string value.
+    // For multi-value config, override it with the last seen value
     // For single-value config, return its raw property, unless it needs interpolation.
     return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 1)
-        .<Object>map(values -> Arrays.stream(values).collect(Collectors.joining(","))).orElseGet(() -> {
+        .<Object>map(values -> values[values.length - 1]).orElseGet(() -> {
           Object rawProperty = configuration.getProperty(key);
           if (!needInterpolate(rawProperty)) {
             return rawProperty;


### PR DESCRIPTION
Overriding the existing values with the last value in the list instead of adding them as a list of values in Config File.


<img width="961" alt="fix" src="https://github.com/apache/pinot/assets/45308220/b94b2fda-6296-4713-8478-9a27120ea29a">
.