### PR TITLE
Keep get tables API with and without database

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -201,8 +201,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _helixClusterName = _config.getHelixClusterName();
     ServiceStartableUtils.applyClusterConfig(_config, _helixZkURL, _helixClusterName, ServiceRole.CONTROLLER);
 
-    PinotInsecureMode.setPinotInInsecureMode(
-        Boolean.valueOf(_config.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE,
+    PinotInsecureMode.setPinotInInsecureMode(Boolean.valueOf(
+        _config.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE,
             CommonConstants.DEFAULT_PINOT_INSECURE_MODE)));
 
     setupHelixSystemProperties();
@@ -531,8 +531,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       if (tableConfig != null) {
         Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
         try {
-          StreamConfig.validateConsumerType(
-              streamConfigMap.getOrDefault(StreamConfigProperties.STREAM_TYPE, "kafka"), streamConfigMap);
+          StreamConfig.validateConsumerType(streamConfigMap.getOrDefault(StreamConfigProperties.STREAM_TYPE, "kafka"),
+              streamConfigMap);
         } catch (Exception e) {
           existingHlcTables.add(rt);
         }
@@ -587,66 +587,63 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     AtomicInteger failedToUpdateTableConfigCount = new AtomicInteger();
     ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
 
-    _helixResourceManager.getDatabaseNames().stream()
-        .map(_helixResourceManager::getAllTables)
-        .flatMap(List::stream)
-        .forEach(tableNameWithType -> {
-          Pair<TableConfig, Integer> tableConfigWithVersion =
-              ZKMetadataProvider.getTableConfigWithVersion(propertyStore, tableNameWithType);
-          if (tableConfigWithVersion == null) {
-            // This might due to table deletion, just log it here.
-            LOGGER.warn("Failed to find table config for table: {}, the table likely already got deleted",
-                tableNameWithType);
-            return;
-          }
-          TableConfig tableConfig = tableConfigWithVersion.getLeft();
-          String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-          String schemaPath = ZKMetadataProvider.constructPropertyStorePathForSchema(rawTableName);
-          boolean schemaExists = propertyStore.exists(schemaPath, AccessOption.PERSISTENT);
-          String existSchemaName = tableConfig.getValidationConfig().getSchemaName();
-          if (existSchemaName == null || existSchemaName.equals(rawTableName)) {
-            // Although the table config is valid, we still need to ensure the schema exists
-            if (!schemaExists) {
-              LOGGER.warn("Failed to find schema for table: {}", tableNameWithType);
-              tableWithoutSchemaCount.getAndIncrement();
-              return;
-            }
-            // Table config is already in good status
-            return;
-          }
-          misconfiguredTableCount.getAndIncrement();
-          if (schemaExists) {
-            // If a schema named `rawTableName` already exists, then likely this is a misconfiguration.
-            // Reset schema name in table config to null to let the table point to the existing schema.
-            LOGGER.warn("Schema: {} already exists, fix the schema name in table config from {} to null", rawTableName,
-                existSchemaName);
-          } else {
-            // Copy the schema current table referring to to `rawTableName` if it does not exist
-            Schema schema = _helixResourceManager.getSchema(existSchemaName);
-            if (schema == null) {
-              LOGGER.warn("Failed to find schema: {} for table: {}", existSchemaName, tableNameWithType);
-              tableWithoutSchemaCount.getAndIncrement();
-              return;
-            }
-            schema.setSchemaName(rawTableName);
-            if (propertyStore.create(schemaPath, SchemaUtils.toZNRecord(schema), AccessOption.PERSISTENT)) {
-              LOGGER.info("Copied schema: {} to {}", existSchemaName, rawTableName);
-            } else {
-              LOGGER.warn("Failed to copy schema: {} to {}", existSchemaName, rawTableName);
-              failedToCopySchemaCount.getAndIncrement();
-              return;
-            }
-          }
-          // Update table config to remove schema name
-          tableConfig.getValidationConfig().setSchemaName(null);
-          if (ZKMetadataProvider.setTableConfig(propertyStore, tableConfig, tableConfigWithVersion.getRight())) {
-            LOGGER.info("Removed schema name from table config for table: {}", tableNameWithType);
-            fixedSchemaTableCount.getAndIncrement();
-          } else {
-            LOGGER.warn("Failed to update table config for table: {}", tableNameWithType);
-            failedToUpdateTableConfigCount.getAndIncrement();
-          }
-        });
+    _helixResourceManager.getAllTables().forEach(tableNameWithType -> {
+      Pair<TableConfig, Integer> tableConfigWithVersion =
+          ZKMetadataProvider.getTableConfigWithVersion(propertyStore, tableNameWithType);
+      if (tableConfigWithVersion == null) {
+        // This might due to table deletion, just log it here.
+        LOGGER.warn("Failed to find table config for table: {}, the table likely already got deleted",
+            tableNameWithType);
+        return;
+      }
+      TableConfig tableConfig = tableConfigWithVersion.getLeft();
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      String schemaPath = ZKMetadataProvider.constructPropertyStorePathForSchema(rawTableName);
+      boolean schemaExists = propertyStore.exists(schemaPath, AccessOption.PERSISTENT);
+      String existSchemaName = tableConfig.getValidationConfig().getSchemaName();
+      if (existSchemaName == null || existSchemaName.equals(rawTableName)) {
+        // Although the table config is valid, we still need to ensure the schema exists
+        if (!schemaExists) {
+          LOGGER.warn("Failed to find schema for table: {}", tableNameWithType);
+          tableWithoutSchemaCount.getAndIncrement();
+          return;
+        }
+        // Table config is already in good status
+        return;
+      }
+      misconfiguredTableCount.getAndIncrement();
+      if (schemaExists) {
+        // If a schema named `rawTableName` already exists, then likely this is a misconfiguration.
+        // Reset schema name in table config to null to let the table point to the existing schema.
+        LOGGER.warn("Schema: {} already exists, fix the schema name in table config from {} to null", rawTableName,
+            existSchemaName);
+      } else {
+        // Copy the schema current table referring to to `rawTableName` if it does not exist
+        Schema schema = _helixResourceManager.getSchema(existSchemaName);
+        if (schema == null) {
+          LOGGER.warn("Failed to find schema: {} for table: {}", existSchemaName, tableNameWithType);
+          tableWithoutSchemaCount.getAndIncrement();
+          return;
+        }
+        schema.setSchemaName(rawTableName);
+        if (propertyStore.create(schemaPath, SchemaUtils.toZNRecord(schema), AccessOption.PERSISTENT)) {
+          LOGGER.info("Copied schema: {} to {}", existSchemaName, rawTableName);
+        } else {
+          LOGGER.warn("Failed to copy schema: {} to {}", existSchemaName, rawTableName);
+          failedToCopySchemaCount.getAndIncrement();
+          return;
+        }
+      }
+      // Update table config to remove schema name
+      tableConfig.getValidationConfig().setSchemaName(null);
+      if (ZKMetadataProvider.setTableConfig(propertyStore, tableConfig, tableConfigWithVersion.getRight())) {
+        LOGGER.info("Removed schema name from table config for table: {}", tableNameWithType);
+        fixedSchemaTableCount.getAndIncrement();
+      } else {
+        LOGGER.warn("Failed to update table config for table: {}", tableNameWithType);
+        failedToUpdateTableConfigCount.getAndIncrement();
+      }
+    });
     LOGGER.info(
         "Found {} tables misconfigured, {} tables without schema. Successfully fixed schema for {} tables, failed to "
             + "fix {} tables due to copy schema failure, failed to fix {} tables due to update table config failure.",

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
@@ -127,10 +127,8 @@ public class PinotBrokerRestletResource {
   @ApiOperation(value = "List tables to brokers mappings", notes = "List tables to brokers mappings")
   public Map<String, List<String>> getTablesToBrokersMapping(
       @ApiParam(value = "ONLINE|OFFLINE") @QueryParam("state") String state, @Context HttpHeaders headers) {
-    Map<String, List<String>> resultMap = new HashMap<>();
-    _pinotHelixResourceManager.getAllRawTables(headers.getHeaderString(DATABASE))
-        .forEach(table -> resultMap.put(table, getBrokersForTable(table, null, state, headers)));
-    return resultMap;
+    return _pinotHelixResourceManager.getAllRawTables(headers.getHeaderString(DATABASE)).stream()
+        .collect(Collectors.toMap(table -> table, table -> getBrokersForTable(table, null, state, headers)));
   }
 
   @GET
@@ -201,11 +199,8 @@ public class PinotBrokerRestletResource {
   @ApiOperation(value = "List tables to brokers mappings", notes = "List tables to brokers mappings")
   public Map<String, List<InstanceInfo>> getTablesToBrokersMappingV2(
       @ApiParam(value = "ONLINE|OFFLINE") @QueryParam("state") String state, @Context HttpHeaders headers) {
-    Map<String, List<InstanceInfo>> resultMap = new HashMap<>();
-    String databaseName = headers.getHeaderString(DATABASE);
-    _pinotHelixResourceManager.getAllRawTables(databaseName).stream()
-        .forEach(table -> resultMap.put(table, getBrokersForTableV2(table, null, state, headers)));
-    return resultMap;
+    return _pinotHelixResourceManager.getAllRawTables(headers.getHeaderString(DATABASE)).stream()
+        .collect(Collectors.toMap(table -> table, table -> getBrokersForTableV2(table, null, state, headers)));
   }
 
   @GET

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
@@ -109,8 +109,7 @@ public class PinotLeadControllerRestletResource {
     }
 
     // Assigns all the tables to the relevant partitions.
-    List<String> tableNames = _pinotHelixResourceManager.getAllTables(
-        headers.getHeaderString(DATABASE));
+    List<String> tableNames = _pinotHelixResourceManager.getAllTables(headers.getHeaderString(DATABASE));
     for (String tableName : tableNames) {
       String rawTableName = TableNameBuilder.extractRawTableName(tableName);
       int partitionId = LeadControllerUtils.getPartitionIdForTable(rawTableName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -716,13 +716,12 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Get all table names (with type suffix) in default database.
+   * Get all table names (with type suffix) in all databases.
    *
-   * @return List of table names in default database
+   * @return List of table names
    */
-  @Deprecated
   public List<String> getAllTables() {
-    return getAllTables(null);
+    return getAllResources().stream().filter(TableNameBuilder::isTableResource).collect(Collectors.toList());
   }
 
   /**
@@ -732,23 +731,18 @@ public class PinotHelixResourceManager {
    * @return List of table names in provided database name
    */
   public List<String> getAllTables(@Nullable String databaseName) {
-    List<String> tableNames = new ArrayList<>();
-    for (String resourceName : getAllResources()) {
-      if (TableNameBuilder.isTableResource(resourceName)
-          && DatabaseUtils.isPartOfDatabase(resourceName, databaseName)) {
-        tableNames.add(resourceName);
-      }
-    }
-    return tableNames;
+    return getAllResources().stream().filter(
+        resourceName -> TableNameBuilder.isTableResource(resourceName) && DatabaseUtils.isPartOfDatabase(resourceName,
+            databaseName)).collect(Collectors.toList());
   }
 
   /**
-   * Get all offline table names from default database.
+   * Get all offline table names from all databases.
    *
-   * @return List of offline table names in default database
+   * @return List of offline table names
    */
   public List<String> getAllOfflineTables() {
-    return getAllOfflineTables(null);
+    return getAllResources().stream().filter(TableNameBuilder::isOfflineTableResource).collect(Collectors.toList());
   }
 
   /**
@@ -758,23 +752,18 @@ public class PinotHelixResourceManager {
    * @return List of offline table names in provided database name
    */
   public List<String> getAllOfflineTables(@Nullable String databaseName) {
-    List<String> offlineTableNames = new ArrayList<>();
-    for (String resourceName : getAllResources()) {
-      if (DatabaseUtils.isPartOfDatabase(resourceName, databaseName)
-          && TableNameBuilder.isOfflineTableResource(resourceName)) {
-        offlineTableNames.add(resourceName);
-      }
-    }
-    return offlineTableNames;
+    return getAllResources().stream().filter(
+        resourceName -> TableNameBuilder.isOfflineTableResource(resourceName) && DatabaseUtils.isPartOfDatabase(
+            resourceName, databaseName)).collect(Collectors.toList());
   }
 
   /**
-   * Get all dimension table names from default database.
+   * Get all dimension table names from all databases.
    *
-   * @return List of dimension table names in default database
+   * @return List of dimension table names
    */
   public List<String> getAllDimensionTables() {
-    return getAllDimensionTables(null);
+    return _tableCache.getAllDimensionTables();
   }
 
   /**
@@ -785,17 +774,16 @@ public class PinotHelixResourceManager {
    */
   public List<String> getAllDimensionTables(@Nullable String databaseName) {
     return _tableCache.getAllDimensionTables().stream()
-        .filter(table -> DatabaseUtils.isPartOfDatabase(table, databaseName))
-        .collect(Collectors.toList());
+        .filter(table -> DatabaseUtils.isPartOfDatabase(table, databaseName)).collect(Collectors.toList());
   }
 
   /**
-   * Get all realtime table names from default database.
+   * Get all realtime table names from all databases.
    *
-   * @return List of realtime table names in default database
+   * @return List of realtime table names
    */
   public List<String> getAllRealtimeTables() {
-    return getAllRealtimeTables(null);
+    return getAllResources().stream().filter(TableNameBuilder::isRealtimeTableResource).collect(Collectors.toList());
   }
 
   /**
@@ -805,23 +793,19 @@ public class PinotHelixResourceManager {
    * @return List of realtime table names in provided database name
    */
   public List<String> getAllRealtimeTables(@Nullable String databaseName) {
-    List<String> realtimeTableNames = new ArrayList<>();
-    for (String resourceName : getAllResources()) {
-      if (DatabaseUtils.isPartOfDatabase(resourceName, databaseName)
-          && TableNameBuilder.isRealtimeTableResource(resourceName)) {
-        realtimeTableNames.add(resourceName);
-      }
-    }
-    return realtimeTableNames;
+    return getAllResources().stream().filter(
+        resourceName -> TableNameBuilder.isRealtimeTableResource(resourceName) && DatabaseUtils.isPartOfDatabase(
+            resourceName, databaseName)).collect(Collectors.toList());
   }
 
   /**
-   * Get all raw table names in default database.
+   * Get all raw table names in all databases.
    *
-   * @return List of raw table names in default database
+   * @return List of raw table names
    */
   public List<String> getAllRawTables() {
-    return getAllRawTables(null);
+    return getAllResources().stream().filter(TableNameBuilder::isTableResource)
+        .map(TableNameBuilder::extractRawTableName).distinct().collect(Collectors.toList());
   }
 
   /**
@@ -831,14 +815,9 @@ public class PinotHelixResourceManager {
    * @return List of raw table names in provided database name
    */
   public List<String> getAllRawTables(@Nullable String databaseName) {
-    Set<String> rawTableNames = new HashSet<>();
-    for (String resourceName : getAllResources()) {
-      if (TableNameBuilder.isTableResource(resourceName)
-          && DatabaseUtils.isPartOfDatabase(resourceName, databaseName)) {
-        rawTableNames.add(TableNameBuilder.extractRawTableName(resourceName));
-      }
-    }
-    return new ArrayList<>(rawTableNames);
+    return getAllResources().stream().filter(
+        resourceName -> TableNameBuilder.isTableResource(resourceName) && DatabaseUtils.isPartOfDatabase(resourceName,
+            databaseName)).map(TableNameBuilder::extractRawTableName).distinct().collect(Collectors.toList());
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
@@ -138,12 +138,9 @@ public class StaleInstancesCleanupTask extends BasePeriodicTask {
 
   private Set<String> getServerInstancesInUse() {
     Set<String> serverInstancesInUse = new HashSet<>();
-    _pinotHelixResourceManager.getDatabaseNames().stream()
-        .map(_pinotHelixResourceManager::getAllTables)
-        .flatMap(List::stream)
-        .forEach(tableName -> serverInstancesInUse.addAll(
-          Optional.ofNullable(_pinotHelixResourceManager.getTableIdealState(tableName))
-              .map(is -> is.getInstanceSet(tableName)).orElse(Collections.emptySet())));
+    _pinotHelixResourceManager.getAllTables().forEach(tableName -> serverInstancesInUse.addAll(
+        Optional.ofNullable(_pinotHelixResourceManager.getTableIdealState(tableName))
+            .map(is -> is.getInstanceSet(tableName)).orElse(Collections.emptySet())));
     return serverInstancesInUse;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -20,7 +20,6 @@ package org.apache.pinot.controller.helix.core.periodictask;
 
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -69,12 +68,8 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
       // Check if we have a specific table against which this task needs to be run.
       String propTableNameWithType = (String) periodicTaskProperties.get(PeriodicTask.PROPERTY_KEY_TABLE_NAME);
       // Process the tables that are managed by this controller
-      List<String> allTables = propTableNameWithType == null
-          ? _pinotHelixResourceManager.getDatabaseNames().stream()
-            .map(_pinotHelixResourceManager::getAllTables)
-            .flatMap(List::stream)
-            .collect(Collectors.toList())
-          : Collections.singletonList(propTableNameWithType);
+      List<String> allTables =
+          propTableNameWithType != null ? List.of(propTableNameWithType) : _pinotHelixResourceManager.getAllTables();
 
       Set<String> currentLeaderOfTables = allTables.stream()
           .filter(_leadControllerManager::isLeaderForTable)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.controller.helix;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -43,15 +40,14 @@ import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 
 public class RealtimeConsumerMonitorTest {
@@ -59,17 +55,16 @@ public class RealtimeConsumerMonitorTest {
   @Test
   public void realtimeBasicTest()
       throws Exception {
-    final String tableName = "myTable_REALTIME";
-    final String rawTableName = TableNameBuilder.extractRawTableName(tableName);
-    List<String> allTableNames = new ArrayList<String>();
-    allTableNames.add(tableName);
+    String rawTableName = "myTable";
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(tableName).setTimeColumnName("timeColumn")
+        new TableConfigBuilder(TableType.REALTIME).setTableName(rawTableName).setTimeColumnName("timeColumn")
             .setNumReplicas(2).setStreamConfigs(getStreamConfigMap()).build();
+
     LLCSegmentName segmentPartition1Seq0 = new LLCSegmentName(rawTableName, 1, 0, System.currentTimeMillis());
     LLCSegmentName segmentPartition1Seq1 = new LLCSegmentName(rawTableName, 1, 1, System.currentTimeMillis());
     LLCSegmentName segmentPartition2Seq0 = new LLCSegmentName(rawTableName, 2, 0, System.currentTimeMillis());
-    IdealState idealState = new IdealState(tableName);
+    IdealState idealState = new IdealState(realtimeTableName);
     idealState.setPartitionState(segmentPartition1Seq0.getSegmentName(), "pinot1", "ONLINE");
     idealState.setPartitionState(segmentPartition1Seq0.getSegmentName(), "pinot2", "ONLINE");
     idealState.setPartitionState(segmentPartition1Seq1.getSegmentName(), "pinot1", "CONSUMING");
@@ -79,7 +74,7 @@ public class RealtimeConsumerMonitorTest {
     idealState.setReplicas("3");
     idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
 
-    ExternalView externalView = new ExternalView(tableName);
+    ExternalView externalView = new ExternalView(realtimeTableName);
     externalView.setState(segmentPartition1Seq0.getSegmentName(), "pinot1", "ONLINE");
     externalView.setState(segmentPartition1Seq0.getSegmentName(), "pinot2", "ONLINE");
     externalView.setState(segmentPartition1Seq1.getSegmentName(), "pinot1", "CONSUMING");
@@ -91,13 +86,11 @@ public class RealtimeConsumerMonitorTest {
     {
       helixResourceManager = mock(PinotHelixResourceManager.class);
       ZkHelixPropertyStore<ZNRecord> helixPropertyStore = mock(ZkHelixPropertyStore.class);
-      when(helixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
+      when(helixResourceManager.getTableConfig(realtimeTableName)).thenReturn(tableConfig);
       when(helixResourceManager.getPropertyStore()).thenReturn(helixPropertyStore);
-      when(helixResourceManager.getDatabaseNames())
-          .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
-      when(helixResourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(allTableNames);
-      when(helixResourceManager.getTableIdealState(tableName)).thenReturn(idealState);
-      when(helixResourceManager.getTableExternalView(tableName)).thenReturn(externalView);
+      when(helixResourceManager.getAllTables()).thenReturn(List.of(realtimeTableName));
+      when(helixResourceManager.getTableIdealState(realtimeTableName)).thenReturn(idealState);
+      when(helixResourceManager.getTableExternalView(realtimeTableName)).thenReturn(externalView);
       ZNRecord znRecord = new ZNRecord("0");
       znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
       when(helixPropertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
@@ -121,61 +114,53 @@ public class RealtimeConsumerMonitorTest {
     // So, the consumer monitor should show: 1. partition-1 has 0 lag; partition-2 has some non-zero lag.
     // Segment 1 in replicas:
     TreeMap<String, List<ConsumingSegmentInfoReader.ConsumingSegmentInfo>> response = new TreeMap<>();
-    List<ConsumingSegmentInfoReader.ConsumingSegmentInfo> part1ServerConsumingSegmentInfo = new ArrayList<>(2);
-    part1ServerConsumingSegmentInfo.add(
-        getConsumingSegmentInfoForServer("pinot1", "1", "100", "100", "0"));
-    part1ServerConsumingSegmentInfo.add(
-        getConsumingSegmentInfoForServer("pinot2", "1", "100", "100", "0"));
-
+    List<ConsumingSegmentInfoReader.ConsumingSegmentInfo> part1ServerConsumingSegmentInfo =
+        List.of(getConsumingSegmentInfoForServer("pinot1", "1", "100", "100", "0"),
+            getConsumingSegmentInfoForServer("pinot2", "1", "100", "100", "0"));
     response.put(segmentPartition1Seq1.getSegmentName(), part1ServerConsumingSegmentInfo);
 
     // Segment 2 in replicas
-    List<ConsumingSegmentInfoReader.ConsumingSegmentInfo> part2ServerConsumingSegmentInfo = new ArrayList<>(2);
-    part2ServerConsumingSegmentInfo.add(
-        getConsumingSegmentInfoForServer("pinot1", "2", "120", "120", "0"));
-    part2ServerConsumingSegmentInfo.add(
-        getConsumingSegmentInfoForServer("pinot2", "2", "80", "120", "60000"));
-
+    List<ConsumingSegmentInfoReader.ConsumingSegmentInfo> part2ServerConsumingSegmentInfo =
+        List.of(getConsumingSegmentInfoForServer("pinot1", "2", "120", "120", "0"),
+            getConsumingSegmentInfoForServer("pinot2", "2", "80", "120", "60000"));
     response.put(segmentPartition2Seq0.getSegmentName(), part2ServerConsumingSegmentInfo);
 
     ConsumingSegmentInfoReader consumingSegmentReader = mock(ConsumingSegmentInfoReader.class);
-    when(consumingSegmentReader.getConsumingSegmentsInfo(tableName, 10000))
-        .thenReturn(new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response, 0, 0));
+    when(consumingSegmentReader.getConsumingSegmentsInfo(realtimeTableName, 10000)).thenReturn(
+        new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response, 0, 0));
     RealtimeConsumerMonitor realtimeConsumerMonitor =
-        new RealtimeConsumerMonitor(config, helixResourceManager, leadControllerManager,
-            controllerMetrics, consumingSegmentReader);
+        new RealtimeConsumerMonitor(config, helixResourceManager, leadControllerManager, controllerMetrics,
+            consumingSegmentReader);
     realtimeConsumerMonitor.start();
     realtimeConsumerMonitor.run();
-    Assert.assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, tableName, 1,
+
+    assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, realtimeTableName, 1,
         ControllerGauge.MAX_RECORDS_LAG), 0);
-    Assert.assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, tableName, 2,
+    assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, realtimeTableName, 2,
         ControllerGauge.MAX_RECORDS_LAG), 40);
-    Assert.assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, tableName, 1,
-            ControllerGauge.MAX_RECORD_AVAILABILITY_LAG_MS), 0);
-    Assert.assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, tableName, 2,
+    assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, realtimeTableName, 1,
+        ControllerGauge.MAX_RECORD_AVAILABILITY_LAG_MS), 0);
+    assertEquals(MetricValueUtils.getPartitionGaugeValue(controllerMetrics, realtimeTableName, 2,
         ControllerGauge.MAX_RECORD_AVAILABILITY_LAG_MS), 60000);
   }
 
   ConsumingSegmentInfoReader.ConsumingSegmentInfo getConsumingSegmentInfoForServer(String serverName,
       String partitionId, String currentOffset, String upstreamLatestOffset, String availabilityLagMs) {
-    Map<String, String> currentOffsetMap = Collections.singletonMap(partitionId, currentOffset);
-    Map<String, String> latestUpstreamOffsetMap = Collections.singletonMap(partitionId, upstreamLatestOffset);
-    Map<String, String> recordsLagMap = Collections.singletonMap(partitionId, String.valueOf(
-        Long.parseLong(upstreamLatestOffset) - Long.parseLong(currentOffset)));
-    Map<String, String> availabilityLagMsMap = Collections.singletonMap(partitionId, availabilityLagMs);
+    Map<String, String> currentOffsetMap = Map.of(partitionId, currentOffset);
+    Map<String, String> latestUpstreamOffsetMap = Map.of(partitionId, upstreamLatestOffset);
+    Map<String, String> recordsLagMap =
+        Map.of(partitionId, String.valueOf(Long.parseLong(upstreamLatestOffset) - Long.parseLong(currentOffset)));
+    Map<String, String> availabilityLagMsMap = Map.of(partitionId, availabilityLagMs);
 
     ConsumingSegmentInfoReader.PartitionOffsetInfo partitionOffsetInfo =
         new ConsumingSegmentInfoReader.PartitionOffsetInfo(currentOffsetMap, latestUpstreamOffsetMap, recordsLagMap,
             availabilityLagMsMap);
-    return new ConsumingSegmentInfoReader.ConsumingSegmentInfo(serverName, "CONSUMING", -1,
-        currentOffsetMap, partitionOffsetInfo);
+    return new ConsumingSegmentInfoReader.ConsumingSegmentInfo(serverName, "CONSUMING", -1, currentOffsetMap,
+        partitionOffsetInfo);
   }
 
   Map<String, String> getStreamConfigMap() {
-    return ImmutableMap.of(
-        "streamType", "kafka",
-        "stream.kafka.consumer.type", "simple",
-        "stream.kafka.topic.name", "test",
+    return Map.of("streamType", "kafka", "stream.kafka.consumer.type", "simple", "stream.kafka.topic.name", "test",
         "stream.kafka.decoder.class.name", "org.apache.pinot.plugin.stream.kafka.KafkaAvroMessageDecoder",
         "stream.kafka.consumer.factory.class.name",
         "org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTaskTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.helix.core.periodictask;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +34,6 @@ import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_DATABASE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,9 +87,7 @@ public class ControllerPeriodicTaskTest {
   public void beforeTest() {
     List<String> tables = new ArrayList<>(_numTables);
     IntStream.range(0, _numTables).forEach(i -> tables.add("table_" + i + " _OFFLINE"));
-    when(_resourceManager.getDatabaseNames())
-        .thenReturn(Collections.singletonList(DEFAULT_DATABASE));
-    when(_resourceManager.getAllTables(DEFAULT_DATABASE)).thenReturn(tables);
+    when(_resourceManager.getAllTables()).thenReturn(tables);
     when(_leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
   }
 
@@ -109,7 +105,6 @@ public class ControllerPeriodicTaskTest {
         _task.getInitialDelayInSeconds() >= ControllerConf.ControllerPeriodicTasksConf.MIN_INITIAL_DELAY_IN_SECONDS);
     assertTrue(
         _task.getInitialDelayInSeconds() < ControllerConf.ControllerPeriodicTasksConf.MAX_INITIAL_DELAY_IN_SECONDS);
-
     assertEquals(_task.getIntervalInSeconds(), RUN_FREQUENCY_IN_SECONDS);
   }
 
@@ -124,7 +119,7 @@ public class ControllerPeriodicTaskTest {
     assertFalse(_stopTaskCalled.get());
     assertTrue(_task.isStarted());
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
 
     // Run periodic task with leadership
     resetState();
@@ -133,8 +128,7 @@ public class ControllerPeriodicTaskTest {
     assertTrue(_processTablesCalled.get());
     assertEquals(_tablesProcessed.get(), _numTables);
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED),
-        _numTables);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), _numTables);
     assertFalse(_stopTaskCalled.get());
     assertTrue(_task.isStarted());
 
@@ -145,7 +139,7 @@ public class ControllerPeriodicTaskTest {
     assertFalse(_processTablesCalled.get());
     assertEquals(_tablesProcessed.get(), 0);
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
     assertTrue(_stopTaskCalled.get());
     assertFalse(_task.isStarted());
 
@@ -156,7 +150,7 @@ public class ControllerPeriodicTaskTest {
     assertFalse(_processTablesCalled.get());
     assertEquals(_tablesProcessed.get(), 0);
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
     assertFalse(_stopTaskCalled.get());
     assertFalse(_task.isStarted());
 
@@ -169,7 +163,7 @@ public class ControllerPeriodicTaskTest {
     assertFalse(_stopTaskCalled.get());
     assertTrue(_task.isStarted());
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), 0);
 
     // Run periodic task with leadership
     resetState();
@@ -178,7 +172,7 @@ public class ControllerPeriodicTaskTest {
     assertTrue(_processTablesCalled.get());
     assertEquals(_tablesProcessed.get(), _numTables);
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, TASK_NAME,
-            ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), _numTables);
+        ControllerGauge.PERIODIC_TASK_NUM_TABLES_PROCESSED), _numTables);
     assertFalse(_stopTaskCalled.get());
     assertTrue(_task.isStarted());
   }


### PR DESCRIPTION
From cluster management purpose, we need APIs to read table names from all databases. Keep the original APIs the same (without filtering on database), and for database aware purpose, use the new APIs.