### PR TITLE
Enhance Kinesis consumer

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -431,31 +431,4 @@ public class StreamConfigTest {
       // expected
     }
   }
-
-  @Test
-  public void testKinesisFetchTimeout() {
-    String streamType = "fakeStream";
-    String topic = "fakeTopic";
-    String tableName = "fakeTable_REALTIME";
-    String consumerFactoryClass = "KinesisConsumerFactory";
-    String decoderClass = FakeStreamMessageDecoder.class.getName();
-
-    Map<String, String> streamConfigMap = new HashMap<>();
-    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
-    streamConfigMap.put(
-        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
-    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
-        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS), consumerFactoryClass);
-    streamConfigMap.put(
-        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
-        decoderClass);
-
-    String consumerType = "simple";
-    streamConfigMap.put(
-        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
-        consumerType);
-    StreamConfig streamConfig = new StreamConfig(tableName, streamConfigMap);
-
-    assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS);
-  }
 }

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -34,7 +34,6 @@
 
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <localstack-utils.version>0.2.23</localstack-utils.version>
     <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 
@@ -310,12 +309,6 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
       <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>cloud.localstack</groupId>
-      <artifactId>localstack-utils</artifactId>
-      <version>${localstack-utils.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -60,77 +60,25 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kinesis</artifactId>
     </dependency>
-
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>apache-client</artifactId>
-      <version>${aws.sdk.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.reactivestreams</groupId>
-      <artifactId>reactive-streams</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-buffer</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
+    <!-- TODO: Move LocalStack related class to integration test module -->
     <dependency>
       <groupId>cloud.localstack</groupId>
       <artifactId>localstack-utils</artifactId>
       <version>${localstack-utils.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
@@ -65,8 +65,7 @@ public class KinesisConfig {
   public static final String SESSION_DURATION_SECONDS = "sessionDurationSeconds";
   public static final String ASYNC_SESSION_UPDATED_ENABLED = "asyncSessionUpdateEnabled";
 
-  // TODO: this is a starting point, until a better default is figured out
-  public static final String DEFAULT_MAX_RECORDS = "20";
+  public static final String DEFAULT_MAX_RECORDS = "10000";
   public static final String DEFAULT_SHARD_ITERATOR_TYPE = ShardIteratorType.LATEST.toString();
   public static final String DEFAULT_IAM_ROLE_BASED_ACCESS_ENABLED = "false";
   public static final String DEFAULT_SESSION_DURATION_SECONDS = "900";

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
@@ -44,10 +45,10 @@ import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 public class KinesisConsumer extends KinesisConnectionHandler implements PartitionGroupConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(KinesisConsumer.class);
 
-  private int _currentSecond = 0;
-  private int _numRequestsInCurrentSecond = 0;
   private String _nextStartSequenceNumber = null;
   private String _nextShardIterator = null;
+  private int _currentSecond = 0;
+  private int _numRequestsInCurrentSecond = 0;
 
   public KinesisConsumer(KinesisConfig config) {
     super(config);
@@ -66,8 +67,53 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     String shardId = startOffset.getShardId();
     String startSequenceNumber = startOffset.getSequenceNumber();
 
-    // NOTE: Kinesis enforces a limit of 5 getRecords request per second on each shard from AWS end, beyond which we
-    //       start getting ProvisionedThroughputExceededException. Rate limit the requests to avoid this.
+    // Get the shard iterator
+    String shardIterator;
+    if (startSequenceNumber.equals(_nextStartSequenceNumber)) {
+      shardIterator = _nextShardIterator;
+    } else {
+      // TODO: Revisit the offset handling logic. Reading after the start sequence number can lose the first message
+      //       when consuming from a new partition because the initial start sequence number is inclusive.
+      GetShardIteratorRequest getShardIteratorRequest =
+          GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId)
+              .startingSequenceNumber(startSequenceNumber).shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+              .build();
+      shardIterator = _kinesisClient.getShardIterator(getShardIteratorRequest).shardIterator();
+    }
+    if (shardIterator == null) {
+      return new KinesisMessageBatch(List.of(), startOffset, true);
+    }
+
+    // Read records
+    rateLimitRequests();
+    GetRecordsRequest getRecordRequest =
+        GetRecordsRequest.builder().shardIterator(shardIterator).limit(_config.getNumMaxRecordsToFetch()).build();
+    GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordRequest);
+    List<Record> records = getRecordsResponse.records();
+    List<BytesStreamMessage> messages;
+    KinesisPartitionGroupOffset offsetOfNextBatch;
+    if (!records.isEmpty()) {
+      messages = records.stream().map(record -> extractStreamMessage(record, shardId)).collect(Collectors.toList());
+      StreamMessageMetadata lastMessageMetadata = messages.get(messages.size() - 1).getMetadata();
+      assert lastMessageMetadata != null;
+      offsetOfNextBatch = (KinesisPartitionGroupOffset) lastMessageMetadata.getNextOffset();
+    } else {
+      // TODO: Revisit whether Kinesis can return empty batch when there are available records. The consumer cna handle
+      //       empty message batch, but it will treat it as fully caught up.
+      messages = List.of();
+      offsetOfNextBatch = startOffset;
+    }
+    assert offsetOfNextBatch != null;
+    _nextStartSequenceNumber = offsetOfNextBatch.getSequenceNumber();
+    _nextShardIterator = getRecordsResponse.nextShardIterator();
+    return new KinesisMessageBatch(messages, offsetOfNextBatch, _nextShardIterator == null);
+  }
+
+  /**
+   * Kinesis enforces a limit of 5 getRecords request per second on each shard from AWS end, beyond which we start
+   * getting {@link ProvisionedThroughputExceededException}. Rate limit the requests to avoid this.
+   */
+  private void rateLimitRequests() {
     long currentTimeMs = System.currentTimeMillis();
     int currentTimeSeconds = (int) TimeUnit.MILLISECONDS.toSeconds(currentTimeMs);
     if (currentTimeSeconds == _currentSecond) {
@@ -86,42 +132,6 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       _currentSecond = currentTimeSeconds;
       _numRequestsInCurrentSecond = 1;
     }
-
-    // Get the shard iterator
-    String shardIterator;
-    if (startSequenceNumber.equals(_nextStartSequenceNumber)) {
-      shardIterator = _nextShardIterator;
-    } else {
-      // TODO: Revisit this logic to see if we always miss the first message when consuming from a new shard
-      GetShardIteratorRequest getShardIteratorRequest =
-          GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId)
-              .startingSequenceNumber(startSequenceNumber).shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
-              .build();
-      shardIterator = _kinesisClient.getShardIterator(getShardIteratorRequest).shardIterator();
-    }
-    if (shardIterator == null) {
-      return new KinesisMessageBatch(List.of(), startOffset, true);
-    }
-
-    // Read records
-    GetRecordsRequest getRecordRequest =
-        GetRecordsRequest.builder().shardIterator(shardIterator).limit(_config.getNumMaxRecordsToFetch()).build();
-    GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordRequest);
-    List<BytesStreamMessage> messages =
-        getRecordsResponse.records().stream().map(record -> extractStreamMessage(record, shardId))
-            .collect(Collectors.toList());
-    KinesisPartitionGroupOffset offsetOfNextBatch;
-    if (messages.isEmpty()) {
-      offsetOfNextBatch = startOffset;
-    } else {
-      StreamMessageMetadata lastMessageMetadata = messages.get(messages.size() - 1).getMetadata();
-      assert lastMessageMetadata != null;
-      offsetOfNextBatch = (KinesisPartitionGroupOffset) lastMessageMetadata.getNextOffset();
-    }
-    assert offsetOfNextBatch != null;
-    _nextStartSequenceNumber = offsetOfNextBatch.getSequenceNumber();
-    _nextShardIterator = getRecordsResponse.nextShardIterator();
-    return new KinesisMessageBatch(messages, offsetOfNextBatch, _nextShardIterator == null);
   }
 
   private BytesStreamMessage extractStreamMessage(Record record, String shardId) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -20,31 +20,21 @@ package org.apache.pinot.plugin.stream.kinesis;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import org.apache.pinot.spi.stream.BytesStreamMessage;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
-import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
-import software.amazon.awssdk.services.kinesis.model.InvalidArgumentException;
-import software.amazon.awssdk.services.kinesis.model.KinesisException;
-import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
 import software.amazon.awssdk.services.kinesis.model.Record;
-import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
 
@@ -53,10 +43,11 @@ import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
  */
 public class KinesisConsumer extends KinesisConnectionHandler implements PartitionGroupConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(KinesisConsumer.class);
-  private static final long SLEEP_TIME_BETWEEN_REQUESTS = 1000L;
 
-  // TODO: Revisit the logic of using a separate executor to manage the request timeout. Currently it is not thread safe
-  private final ExecutorService _executorService = Executors.newSingleThreadExecutor();
+  private String _nextStartSequenceNumber = null;
+  private String _nextShardIterator = null;
+  private int _currentSecond = 0;
+  private int _numRequestsInCurrentSecond = 0;
 
   public KinesisConsumer(KinesisConfig config) {
     super(config);
@@ -73,130 +64,69 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
    * Fetch records from the Kinesis stream between the start and end KinesisCheckpoint
    */
   @Override
-  public KinesisMessageBatch fetchMessages(StreamPartitionMsgOffset startMsgOffset, int timeoutMs) {
+  public synchronized KinesisMessageBatch fetchMessages(StreamPartitionMsgOffset startMsgOffset, int timeoutMs) {
     KinesisPartitionGroupOffset startOffset = (KinesisPartitionGroupOffset) startMsgOffset;
-    List<BytesStreamMessage> messages = new ArrayList<>();
-    Future<KinesisMessageBatch> kinesisFetchResultFuture =
-        _executorService.submit(() -> getResult(startOffset, messages));
-    try {
-      return kinesisFetchResultFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
-      kinesisFetchResultFuture.cancel(true);
-    } catch (Exception e) {
-      // Ignored
+    String shardId = startOffset.getShardId();
+    String startSequenceNumber = startOffset.getSequenceNumber();
+    long endTimeMs = System.currentTimeMillis() + timeoutMs;
+
+    // Get the shard iterator
+    String shardIterator;
+    if (startSequenceNumber.equals(_nextStartSequenceNumber)) {
+      shardIterator = _nextShardIterator;
+    } else {
+      // TODO: Revisit this logic to see if we always miss the first message when consuming from a new shard
+      GetShardIteratorRequest getShardIteratorRequest =
+          GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId)
+              .startingSequenceNumber(startSequenceNumber).shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
+              .build();
+      shardIterator = _kinesisClient.getShardIterator(getShardIteratorRequest).shardIterator();
     }
-    return buildKinesisMessageBatch(startOffset, messages, false);
-  }
 
-  private KinesisMessageBatch getResult(KinesisPartitionGroupOffset startOffset, List<BytesStreamMessage> messages) {
-    try {
-      String shardId = startOffset.getShardId();
-      String shardIterator = getShardIterator(shardId, startOffset.getSequenceNumber());
-      boolean endOfShard = false;
-      long currentWindow = System.currentTimeMillis() / SLEEP_TIME_BETWEEN_REQUESTS;
-      int currentWindowRequests = 0;
-      while (shardIterator != null) {
-        GetRecordsRequest getRecordsRequest = GetRecordsRequest.builder().shardIterator(shardIterator).build();
-        long requestSentTime = System.currentTimeMillis() / 1000;
-        GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordsRequest);
-        List<Record> records = getRecordsResponse.records();
-        if (!records.isEmpty()) {
-          for (Record record : records) {
-            messages.add(extractStreamMessage(record, shardId));
-          }
-          if (messages.size() >= _config.getNumMaxRecordsToFetch()) {
-            break;
-          }
-        }
-
-        if (getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty()) {
-          //This statement returns true only when end of current shard has reached.
-          // hasChildShards only checks if the childShard is null and is a valid instance.
-          endOfShard = true;
-          break;
-        }
-
-        shardIterator = getRecordsResponse.nextShardIterator();
-
-        if (Thread.interrupted()) {
-          break;
-        }
-
-        // Kinesis enforces a limit of 5 .getRecords request per second on each shard from AWS end
-        // Beyond this limit we start getting ProvisionedThroughputExceededException which affect the ingestion
-        if (requestSentTime == currentWindow) {
-          currentWindowRequests++;
-        } else if (requestSentTime > currentWindow) {
-          currentWindow = requestSentTime;
-          currentWindowRequests = 0;
-        }
-
-        if (currentWindowRequests >= _config.getNumMaxRecordsToFetch()) {
+    // Read records
+    // NOTE: When the next shard iterator from the response is null, it means we have reached the end of the shard.
+    long currentTimeMs;
+    while (shardIterator != null && (currentTimeMs = System.currentTimeMillis()) <= endTimeMs) {
+      // NOTE: Kinesis enforces a limit of 5 getRecords request per second on each shard from AWS end, beyond which we
+      //       start getting ProvisionedThroughputExceededException. Rate limit the requests to avoid this.
+      int currentTimeSeconds = (int) TimeUnit.MILLISECONDS.toSeconds(currentTimeMs);
+      if (currentTimeSeconds == _currentSecond) {
+        if (_numRequestsInCurrentSecond == _config.getRpsLimit()) {
           try {
-            Thread.sleep(SLEEP_TIME_BETWEEN_REQUESTS);
+            Thread.sleep(1000 - (currentTimeMs % 1000));
           } catch (InterruptedException e) {
-            LOGGER.debug("Sleep interrupted while rate limiting Kinesis requests", e);
-            break;
+            throw new RuntimeException(e);
           }
+          _currentSecond++;
+          _numRequestsInCurrentSecond = 1;
+        } else {
+          _numRequestsInCurrentSecond++;
         }
+      } else {
+        _currentSecond = currentTimeSeconds;
+        _numRequestsInCurrentSecond = 1;
       }
 
-      return buildKinesisMessageBatch(startOffset, messages, endOfShard);
-    } catch (IllegalStateException e) {
-      debugOrLogWarning("Illegal state exception, connection is broken", e);
-    } catch (ProvisionedThroughputExceededException e) {
-      debugOrLogWarning("The request rate for the stream is too high", e);
-    } catch (ExpiredIteratorException e) {
-      debugOrLogWarning("ShardIterator expired while trying to fetch records", e);
-    } catch (ResourceNotFoundException | InvalidArgumentException e) {
-      // aws errors
-      LOGGER.error("Encountered AWS error while attempting to fetch records", e);
-    } catch (KinesisException e) {
-      debugOrLogWarning("Encountered unknown unrecoverable AWS exception", e);
-      throw new RuntimeException(e);
-    } catch (AbortedException e) {
-      if (!(e.getCause() instanceof InterruptedException)) {
-        debugOrLogWarning("Task aborted due to exception", e);
+      GetRecordsRequest getRecordRequest =
+          GetRecordsRequest.builder().shardIterator(shardIterator).limit(_config.getNumMaxRecordsToFetch()).build();
+      GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordRequest);
+      List<Record> records = getRecordsResponse.records();
+      shardIterator = getRecordsResponse.nextShardIterator();
+      if (!records.isEmpty()) {
+        List<BytesStreamMessage> messages =
+            records.stream().map(record -> extractStreamMessage(record, shardId)).collect(Collectors.toList());
+        StreamMessageMetadata lastMessageMetadata = messages.get(messages.size() - 1).getMetadata();
+        assert lastMessageMetadata != null;
+        KinesisPartitionGroupOffset nextOffset = (KinesisPartitionGroupOffset) lastMessageMetadata.getNextOffset();
+        assert nextOffset != null;
+        _nextStartSequenceNumber = nextOffset.getSequenceNumber();
+        _nextShardIterator = shardIterator;
+        return new KinesisMessageBatch(messages, nextOffset, shardIterator == null);
       }
-    } catch (Throwable e) {
-      // non transient errors
-      LOGGER.error("Unknown fetchRecords exception", e);
-      throw new RuntimeException(e);
     }
-    return buildKinesisMessageBatch(startOffset, messages, false);
-  }
 
-  private void debugOrLogWarning(String message, Throwable throwable) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(message, throwable);
-    } else {
-      LOGGER.warn("{}: {}", message, throwable.getMessage());
-    }
-  }
-
-  private KinesisMessageBatch buildKinesisMessageBatch(KinesisPartitionGroupOffset startOffset,
-      List<BytesStreamMessage> messages, boolean endOfShard) {
-    KinesisPartitionGroupOffset offsetOfNextBatch;
-    if (messages.isEmpty()) {
-      offsetOfNextBatch = startOffset;
-    } else {
-      StreamMessageMetadata lastMessageMetadata = messages.get(messages.size() - 1).getMetadata();
-      assert lastMessageMetadata != null;
-      offsetOfNextBatch = (KinesisPartitionGroupOffset) lastMessageMetadata.getNextOffset();
-    }
-    return new KinesisMessageBatch(messages, offsetOfNextBatch, endOfShard);
-  }
-
-  private String getShardIterator(String shardId, String sequenceNumber) {
-    GetShardIteratorRequest.Builder requestBuilder =
-        GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId);
-    if (sequenceNumber != null) {
-      requestBuilder = requestBuilder.startingSequenceNumber(sequenceNumber)
-          .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER);
-    } else {
-      requestBuilder = requestBuilder.shardIteratorType(_config.getShardIteratorType());
-    }
-    return _kinesisClient.getShardIterator(requestBuilder.build()).shardIterator();
+    // If no records are fetched, return an empty batch
+    return new KinesisMessageBatch(List.of(), startOffset, shardIterator == null);
   }
 
   private BytesStreamMessage extractStreamMessage(Record record, String shardId) {
@@ -219,18 +149,5 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   @Override
   public void close() {
     super.close();
-    shutdownAndAwaitTermination();
-  }
-
-  void shutdownAndAwaitTermination() {
-    _executorService.shutdown();
-    try {
-      if (!_executorService.awaitTermination(60, TimeUnit.SECONDS)) {
-        _executorService.shutdownNow();
-      }
-    } catch (InterruptedException ie) {
-      _executorService.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -47,8 +47,8 @@ public interface PartitionGroupConsumer extends Closeable {
   /**
    * Fetches messages from the stream partition from the given start offset within the specified timeout.
    *
-   * This method should return immediately if there are messages available. Otherwise, it will await the passed timeout.
-   * If the timeout expires, an empty message batch should be returned.
+   * This method should return within the timeout. If there is no message available before time runs out, an empty
+   * message batch should be returned.
    *
    * @param startOffset The offset of the first message desired, inclusive
    * @param timeoutMs Timeout in milliseconds

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -45,10 +45,10 @@ public interface PartitionGroupConsumer extends Closeable {
   }
 
   /**
-   * Return messages from the stream partition group within the specified timeout
+   * Fetches messages from the stream partition from the given start offset within the specified timeout.
    *
-   * The message may be fetched by actively polling the source or by retrieving from a pre-fetched buffer. This depends
-   * on the implementation.
+   * This method should return immediately if there are messages available. Otherwise, it will await the passed timeout.
+   * If the timeout expires, an empty message batch should be returned.
    *
    * @param startOffset The offset of the first message desired, inclusive
    * @param timeoutMs Timeout in milliseconds

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -48,7 +48,6 @@ public class StreamConfig {
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
-  public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS = 600_000;
   public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 3 * 60 * 1000;
 
   private static final double CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED = -1;
@@ -144,11 +143,7 @@ public class StreamConfig {
     }
     _connectionTimeoutMillis = connectionTimeoutMillis;
 
-    // For Kinesis, we need to set a higher fetch timeout to avoid getting stuck in empty records loop
-    // TODO: Remove this once we have a better way to handle empty records in Kinesis
-    int fetchTimeoutMillis =
-        _consumerFactoryClassName.contains("KinesisConsumerFactory") ? DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS
-            : DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;
+    int fetchTimeoutMillis = DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;
     String fetchTimeoutKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS);
     String fetchTimeoutValue = streamConfigMap.get(fetchTimeoutKey);
@@ -157,7 +152,7 @@ public class StreamConfig {
         fetchTimeoutMillis = Integer.parseInt(fetchTimeoutValue);
       } catch (Exception e) {
         LOGGER.warn("Invalid config {}: {}, defaulting to: {}", fetchTimeoutKey, fetchTimeoutValue,
-            DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS);
+            DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
       }
     }
     _fetchTimeoutMillis = fetchTimeoutMillis;


### PR DESCRIPTION
- Do not use a separate thread to fetch Kinesis records (this can fix the potential race condition)
- Cache the shard iterator
- Return the message batch immediately without combining multiple of them (timeout is ignored)
- Change the default max records per fetch to 10,000 (Kinesis default)
- Remove some unused dependencies