### PR TITLE
ban easymock library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1769,6 +1769,8 @@
                       <exclude>commons-logging:commons-logging</exclude>
                       <!-- Use org.glassfish.hk2.external:jakarta.inject -->
                       <exclude>javax.inject:javax.inject</exclude>
+                      <!-- Use mockito library instead of EasyMock -->
+                      <exclude>org.easymock:easymock</exclude>
                     </excludes>
                   </bannedDependencies>
                 </rules>


### PR DESCRIPTION
This project uses Mockito for mock objects. Therefore, we will ban EasyMock

https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html

https://mvnrepository.com/artifact/org.easymock/easymock

