### PR TITLE
Update and unify maven-shade-plugin version

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -95,7 +95,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>package</phase>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -214,7 +214,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <!-- Run shade goal on package phase -->
           <execution>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -152,7 +152,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -146,7 +146,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -95,7 +95,6 @@
         <plugins>
           <plugin>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
             <executions>
               <execution>
                 <phase>${phase.prop}</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -2269,7 +2269,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.1</version>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <transformers>


### PR DESCRIPTION
Versions below 3.5.1 may have issues with classes compiled in Java 20 and 21, which we may find in multi-release jar dependencies
