### PR TITLE
handle absent segments so that catchup checker doesn't get stuck on them

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -359,6 +359,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
         new ServiceStatus.MultipleCallbackServiceStatusCallback(serviceStatusCallbackListBuilder.build()));
   }
 
+  @Nullable
   private Set<String> getConsumingSegments(String realtimeTableName) {
     IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, realtimeTableName);
     if (idealState == null || !idealState.isEnabled()) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
@@ -20,6 +20,8 @@
 package org.apache.pinot.server.starter.helix;
 
 import java.util.Set;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -39,7 +41,12 @@ public class FreshnessBasedConsumptionStatusChecker extends IngestionBasedConsum
 
   public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
       long minFreshnessMs, long idleTimeoutMs) {
-    super(instanceDataManager, consumingSegments);
+    this(instanceDataManager, consumingSegments, null, minFreshnessMs, idleTimeoutMs);
+  }
+
+  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
+      @Nullable Supplier<Set<String>> consumingSegmentsSupplier, long minFreshnessMs, long idleTimeoutMs) {
+    super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
     _minFreshnessMs = minFreshnessMs;
     _idleTimeoutMs = idleTimeoutMs;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
@@ -22,7 +22,6 @@ package org.apache.pinot.server.starter.helix;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -41,12 +40,7 @@ public class FreshnessBasedConsumptionStatusChecker extends IngestionBasedConsum
   private final long _idleTimeoutMs;
 
   public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
-      Map<String, Set<String>> consumingSegments, long minFreshnessMs, long idleTimeoutMs) {
-    this(instanceDataManager, consumingSegments, null, minFreshnessMs, idleTimeoutMs);
-  }
-
-  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
-      Map<String, Set<String>> consumingSegments, @Nullable Function<String, Set<String>> consumingSegmentsSupplier,
+      Map<String, Set<String>> consumingSegments, Function<String, Set<String>> consumingSegmentsSupplier,
       long minFreshnessMs, long idleTimeoutMs) {
     super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
     _minFreshnessMs = minFreshnessMs;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusChecker.java
@@ -19,8 +19,9 @@
 
 package org.apache.pinot.server.starter.helix;
 
+import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
@@ -39,13 +40,14 @@ public class FreshnessBasedConsumptionStatusChecker extends IngestionBasedConsum
   private final long _minFreshnessMs;
   private final long _idleTimeoutMs;
 
-  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
-      long minFreshnessMs, long idleTimeoutMs) {
+  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Map<String, Set<String>> consumingSegments, long minFreshnessMs, long idleTimeoutMs) {
     this(instanceDataManager, consumingSegments, null, minFreshnessMs, idleTimeoutMs);
   }
 
-  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
-      @Nullable Supplier<Set<String>> consumingSegmentsSupplier, long minFreshnessMs, long idleTimeoutMs) {
+  public FreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Map<String, Set<String>> consumingSegments, @Nullable Function<String, Set<String>> consumingSegmentsSupplier,
+      long minFreshnessMs, long idleTimeoutMs) {
     super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
     _minFreshnessMs = minFreshnessMs;
     _idleTimeoutMs = idleTimeoutMs;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/IngestionBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/IngestionBasedConsumptionStatusChecker.java
@@ -20,17 +20,15 @@
 package org.apache.pinot.server.starter.helix;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +38,8 @@ public abstract class IngestionBasedConsumptionStatusChecker {
 
   // constructor parameters
   protected final InstanceDataManager _instanceDataManager;
-  protected volatile Set<String> _consumingSegments;
-  protected final Supplier<Set<String>> _consumingSegmentsSupplier;
+  protected final Map<String, Set<String>> _consumingSegments;
+  protected final Function<String, Set<String>> _consumingSegmentsSupplier;
 
   // helper variable, which is thread safe, as the method might be called from multiple threads when the health check
   // endpoint is called by many probes.
@@ -51,67 +49,70 @@ public abstract class IngestionBasedConsumptionStatusChecker {
    * Both consumingSegments and consumingSegmentsSupplier are provided as it can be costly to get consumingSegments
    * via the supplier, so only use it when any missing segment is detected.
    */
-  public IngestionBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
-      @Nullable Supplier<Set<String>> consumingSegmentsSupplier) {
+  public IngestionBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Map<String, Set<String>> consumingSegments, @Nullable Function<String, Set<String>> consumingSegmentsSupplier) {
     _instanceDataManager = instanceDataManager;
-    _consumingSegments = consumingSegments;
+    _consumingSegments = new ConcurrentHashMap<>(consumingSegments);
     _consumingSegmentsSupplier = consumingSegmentsSupplier;
   }
 
   public int getNumConsumingSegmentsNotReachedIngestionCriteria() {
-    Set<String> missingSegments = new HashSet<>();
-    for (String segName : _consumingSegments) {
-      if (_caughtUpSegments.contains(segName)) {
-        continue;
-      }
-      TableDataManager tableDataManager = getTableDataManager(segName);
+    Set<String> tablesWithMissingSegment = new HashSet<>();
+    for (Map.Entry<String, Set<String>> tableSegments : _consumingSegments.entrySet()) {
+      String tableNameWithType = tableSegments.getKey();
+      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableNameWithType);
       if (tableDataManager == null) {
-        _logger.info("TableDataManager is not yet setup for segment {}. Will check consumption status later", segName);
-        missingSegments.add(segName);
+        _logger.info("No tableDataManager for table: {}. Will check consumption status later", tableNameWithType);
+        tablesWithMissingSegment.add(tableNameWithType);
         continue;
       }
-      SegmentDataManager segmentDataManager = null;
-      try {
-        segmentDataManager = tableDataManager.acquireSegment(segName);
-        if (segmentDataManager == null) {
-          _logger.info("SegmentDataManager is not yet setup for segment {}. Will check consumption status later",
-              segName);
-          missingSegments.add(segName);
+      for (String segName : tableSegments.getValue()) {
+        if (_caughtUpSegments.contains(segName)) {
           continue;
         }
-        if (!(segmentDataManager instanceof RealtimeSegmentDataManager)) {
-          // There's a possibility that a consuming segment has converted to a committed segment. If that's the case,
-          // segment data manager will not be of type RealtimeSegmentDataManager.
-          _logger.info("Segment {} is already committed and is considered caught up.", segName);
-          _caughtUpSegments.add(segName);
-          continue;
-        }
-
-        RealtimeSegmentDataManager rtSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
-        if (isSegmentCaughtUp(segName, rtSegmentDataManager)) {
-          _caughtUpSegments.add(segName);
-        }
-      } finally {
-        if (segmentDataManager != null) {
-          tableDataManager.releaseSegment(segmentDataManager);
+        SegmentDataManager segmentDataManager = null;
+        try {
+          segmentDataManager = tableDataManager.acquireSegment(segName);
+          if (segmentDataManager == null) {
+            _logger.info("No SegmentDataManager for segment: {}. Will check consumption status later", segName);
+            tablesWithMissingSegment.add(tableNameWithType);
+            continue;
+          }
+          if (!(segmentDataManager instanceof RealtimeSegmentDataManager)) {
+            // There's a possibility that a consuming segment has converted to a committed segment. If that's the case,
+            // segment data manager will not be of type RealtimeSegmentDataManager.
+            _logger.info("Segment: {} is already committed and is considered caught up.", segName);
+            _caughtUpSegments.add(segName);
+            continue;
+          }
+          RealtimeSegmentDataManager rtSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
+          if (isSegmentCaughtUp(segName, rtSegmentDataManager)) {
+            _caughtUpSegments.add(segName);
+          }
+        } finally {
+          if (segmentDataManager != null) {
+            tableDataManager.releaseSegment(segmentDataManager);
+          }
         }
       }
     }
-    if (!missingSegments.isEmpty() && _consumingSegmentsSupplier != null) {
-      _consumingSegments = _consumingSegmentsSupplier.get();
-      _caughtUpSegments.retainAll(_consumingSegments);
-      _logger.warn("Found missing segments: {}. Refreshed consumingSegments: {} and caughtUpSegments: {}",
-          missingSegments, _consumingSegments, _caughtUpSegments);
+    if (!tablesWithMissingSegment.isEmpty() && _consumingSegmentsSupplier != null) {
+      for (String tableName : tablesWithMissingSegment) {
+        Set<String> consumingSegments = _consumingSegmentsSupplier.apply(tableName);
+        if (consumingSegments == null || consumingSegments.isEmpty()) {
+          _consumingSegments.remove(tableName);
+        } else {
+          _consumingSegments.put(tableName, consumingSegments);
+        }
+        _logger.info("Found missing segments in table: {}. Updated its consumingSegments: {}", tableName,
+            consumingSegments);
+      }
     }
-    return _consumingSegments.size() - _caughtUpSegments.size();
+    Set<String> currentConsumingSegments = new HashSet<>();
+    _consumingSegments.forEach((k, v) -> currentConsumingSegments.addAll(v));
+    _caughtUpSegments.retainAll(currentConsumingSegments);
+    return currentConsumingSegments.size() - _caughtUpSegments.size();
   }
 
   protected abstract boolean isSegmentCaughtUp(String segmentName, RealtimeSegmentDataManager rtSegmentDataManager);
-
-  private TableDataManager getTableDataManager(String segmentName) {
-    LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-    String tableName = llcSegmentName.getTableName();
-    String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
-    return _instanceDataManager.getTableDataManager(tableNameWithType);
-  }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -19,8 +19,9 @@
 
 package org.apache.pinot.server.starter.helix;
 
+import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
@@ -36,12 +37,13 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
  */
 public class OffsetBasedConsumptionStatusChecker extends IngestionBasedConsumptionStatusChecker {
 
-  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments) {
+  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Map<String, Set<String>> consumingSegments) {
     this(instanceDataManager, consumingSegments, null);
   }
 
-  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
-      @Nullable Supplier<Set<String>> consumingSegmentsSupplier) {
+  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Map<String, Set<String>> consumingSegments, @Nullable Function<String, Set<String>> consumingSegmentsSupplier) {
     super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -20,6 +20,8 @@
 package org.apache.pinot.server.starter.helix;
 
 import java.util.Set;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -35,7 +37,12 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 public class OffsetBasedConsumptionStatusChecker extends IngestionBasedConsumptionStatusChecker {
 
   public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments) {
-    super(instanceDataManager, consumingSegments);
+    this(instanceDataManager, consumingSegments, null);
+  }
+
+  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments,
+      @Nullable Supplier<Set<String>> consumingSegmentsSupplier) {
+    super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -22,7 +22,6 @@ package org.apache.pinot.server.starter.helix;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -38,12 +37,7 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 public class OffsetBasedConsumptionStatusChecker extends IngestionBasedConsumptionStatusChecker {
 
   public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
-      Map<String, Set<String>> consumingSegments) {
-    this(instanceDataManager, consumingSegments, null);
-  }
-
-  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
-      Map<String, Set<String>> consumingSegments, @Nullable Function<String, Set<String>> consumingSegmentsSupplier) {
+      Map<String, Set<String>> consumingSegments, Function<String, Set<String>> consumingSegmentsSupplier) {
     super(instanceDataManager, consumingSegments, consumingSegmentsSupplier);
   }
 

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ConsumptionStatusCheckerTestUtils.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ConsumptionStatusCheckerTestUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter.helix;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+
+class ConsumptionStatusCheckerTestUtils {
+  private ConsumptionStatusCheckerTestUtils() {
+  }
+
+  public static Function<String, Set<String>> getConsumingSegments(Map<String, Set<String>> consumingSegments) {
+    // Create a new Set instance to keep updates separated from the consumingSegments.
+    return (tableName) -> {
+      Set<String> updated = consumingSegments.get(tableName);
+      return updated == null ? null : new HashSet<>(updated);
+    };
+  }
+}

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
@@ -138,8 +138,13 @@ public class FreshnessBasedConsumptionStatusCheckerTest {
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     FreshnessBasedConsumptionStatusChecker statusChecker =
         new FreshnessBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
-            // Create a new Set instance to keep statusChecker._consumingSegments and this Set separate.
-            updatedConsumingSegments::get, 10L, 0L);
+            // Create a new Set instance to keep statusChecker._consumingSegments and updatedConsumingSegments
+            // separate, as we'll update updatedConsumingSegments. Otherwise, statusChecker._consumingSegments is
+            // updated directly, reducing the test coverage.
+            (tableName) -> {
+              Set<String> updated = updatedConsumingSegments.get(tableName);
+              return updated == null ? null : new HashSet<>(updated);
+            }, 10L, 0L);
 
     // TableDataManager is not set up yet
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 3);

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
@@ -46,7 +46,7 @@ public class FreshnessBasedConsumptionStatusCheckerTest {
 
     public FakeFreshnessBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
         Map<String, Set<String>> consumingSegments, long minFreshnessMs, long idleTimeoutMs, long now) {
-      super(instanceDataManager, consumingSegments, minFreshnessMs, idleTimeoutMs);
+      super(instanceDataManager, consumingSegments, consumingSegments::get, minFreshnessMs, idleTimeoutMs);
       _now = now;
     }
 
@@ -66,7 +66,8 @@ public class FreshnessBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     FreshnessBasedConsumptionStatusChecker statusChecker =
-        new FreshnessBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, 10000L, 0L);
+        new FreshnessBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get,
+            10000L, 0L);
 
     // TableDataManager is not set up yet
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 3);

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -48,7 +48,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -98,7 +98,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
 
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
 
     // TableDataManager is not set up yet
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 3);
@@ -160,7 +160,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -212,7 +212,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -48,7 +48,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
+            ConsumptionStatusCheckerTestUtils.getConsumingSegments(consumingSegments));
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -98,7 +99,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
 
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
+            ConsumptionStatusCheckerTestUtils.getConsumingSegments(consumingSegments));
 
     // TableDataManager is not set up yet
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 3);
@@ -160,7 +162,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
+            ConsumptionStatusCheckerTestUtils.getConsumingSegments(consumingSegments));
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -198,6 +201,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0        committed at 1200               1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 1);
+    consumingSegments.get("tableB_REALTIME").remove(segB0);
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 0);
   }
 
@@ -212,7 +217,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments, consumingSegments::get);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
+            ConsumptionStatusCheckerTestUtils.getConsumingSegments(consumingSegments));
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -20,6 +20,8 @@
 package org.apache.pinot.server.starter.helix;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
@@ -41,7 +43,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
+    Map<String, Set<String>> consumingSegments = new HashMap<>();
+    consumingSegments.put("tableA_REALTIME", ImmutableSet.of(segA0, segA1));
+    consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
         new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
@@ -88,7 +92,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
+    Map<String, Set<String>> consumingSegments = new HashMap<>();
+    consumingSegments.put("tableA_REALTIME", ImmutableSet.of(segA0, segA1));
+    consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
 
     OffsetBasedConsumptionStatusChecker statusChecker =
@@ -149,7 +155,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
+    Map<String, Set<String>> consumingSegments = new HashMap<>();
+    consumingSegments.put("tableA_REALTIME", ImmutableSet.of(segA0, segA1));
+    consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
         new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
@@ -199,7 +207,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
+    Map<String, Set<String>> consumingSegments = new HashMap<>();
+    consumingSegments.put("tableA_REALTIME", ImmutableSet.of(segA0, segA1));
+    consumingSegments.put("tableB_REALTIME", ImmutableSet.of(segB0));
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
         new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);


### PR DESCRIPTION
Handle absent segments so that catchup checker doesn't get stuck on them. When server is catching up, the tables or segments might get dropped, if those segments are not skipped, the checker will block server from starting up.