### PR TITLE
Dependency test failures fix for Reflections from 0.9.11 to 0.10.2

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
@@ -53,7 +53,7 @@ public class PinotReflectionUtils {
     try {
       synchronized (REFLECTION_LOCK) {
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
-            .filterInputsBy(new FilterBuilder.Include(regexPattern))).getTypesAnnotatedWith(annotation);
+            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))).getTypesAnnotatedWith(annotation);
       }
     } catch (Throwable t) {
       // Log an error then re-throw it because this method is usually called in a static block, where exception might
@@ -73,7 +73,7 @@ public class PinotReflectionUtils {
           urls.addAll(ClasspathHelper.forPackage(packageName));
         }
         return new Reflections(new ConfigurationBuilder().setUrls(urls)
-            .filterInputsBy(new FilterBuilder.Include(regexPattern))).getTypesAnnotatedWith(annotation);
+            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))).getTypesAnnotatedWith(annotation);
       }
     } catch (Throwable t) {
       // Log an error then re-throw it because this method is usually called in a static block, where exception might
@@ -93,7 +93,7 @@ public class PinotReflectionUtils {
     try {
       synchronized (REFLECTION_LOCK) {
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
-            .filterInputsBy(new FilterBuilder.Include(regexPattern))
+            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))
             .setScanners(new MethodAnnotationsScanner())).getMethodsAnnotatedWith(annotation);
       }
     } catch (Throwable t) {

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <quartz.version>2.3.2</quartz.version>
     <calcite.version>1.36.0</calcite.version>
     <lucene.version>9.8.0</lucene.version>
-    <reflections.version>0.9.11</reflections.version>
+    <reflections.version>0.10.2</reflections.version>
     <!-- helix-core, spark-core use libraries from io.dropwizard.metrics -->
     <dropwizard-metrics.version>4.2.25</dropwizard-metrics.version>
     <snappy-java.version>1.1.10.5</snappy-java.version>


### PR DESCRIPTION
Fix for failures in https://github.com/apache/pinot/pull/9076

#12880

Include, Exclude are no longer supported. They are deprecated in 0.10.2. Used suggested method includePattern instead