### PR TITLE
Cleanup HTTP components dependencies and upgrade Thrift

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -41,5 +41,9 @@
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractor.java
@@ -97,7 +97,8 @@ public class ThriftRecordExtractor extends BaseRecordExtractor<TBase> {
   protected Object convertRecord(Object value) {
     TBase record = (TBase) value;
     Map<Object, Object> convertedRecord = new HashMap<>();
-    for (TFieldIdEnum tFieldIdEnum : FieldMetaData.getStructMetaDataMap(record.getClass()).keySet()) {
+    Set<TFieldIdEnum> tFieldIdEnums = FieldMetaData.getStructMetaDataMap(record.getClass()).keySet();
+    for (TFieldIdEnum tFieldIdEnum : tFieldIdEnums) {
       Object fieldValue = record.getFieldValue(tFieldIdEnum);
       if (fieldValue != null) {
         fieldValue = convert(fieldValue);

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
     <snappy-java.version>1.1.10.5</snappy-java.version>
     <zstd-jni.version>1.5.6-2</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
+    <libthrift.verion>0.20.0</libthrift.verion>
     <log4j.version>2.23.1</log4j.version>
     <slf4j.version>2.0.12</slf4j.version>
     <netty.version>4.1.108.Final</netty.version>
@@ -210,6 +211,12 @@
     <javax.jsr311-api.version>1.1.1</javax.jsr311-api.version>
     <javax.activation.version>1.1.1</javax.activation.version>
     <javax.jsp-api.version>2.2</javax.jsp-api.version>
+
+    <!-- HTTP Components Libraries -->
+    <httpclient.version>4.5.14</httpclient.version>
+    <httpcore.version>4.4.16</httpcore.version>
+    <httpclient5.version>5.3.1</httpclient5.version>
+    <httpcore5.version>5.2.4</httpcore5.version>
 
     <!-- Google Libraries -->
     <google.cloud.libraries.version>26.37.0</google.cloud.libraries.version>
@@ -462,27 +469,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpmime</artifactId>
-        <version>4.5.13</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.14</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>4.4.16</version>
-      </dependency>
 
       <!-- netty BOM -->
       <dependency>
@@ -556,7 +542,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.15.0</version>
+        <version>${libthrift.verion}</version>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
@@ -845,6 +831,39 @@
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>javax.servlet.jsp-api</artifactId>
         <version>${javax.jsp-api.version}</version>
+      </dependency>
+
+      <!-- HTTP Components Libraries -->
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpmime</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${httpcore.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${httpclient5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${httpcore5.version}</version>
       </dependency>
 
       <!-- Google Libraries -->


### PR DESCRIPTION
Another try of #12899 

- Upgrade `httpmime` to match `httpclient` (from `4.5.13` to `4.5.14`)
- Upgrade `libthrift` from `0.15.0` to `0.20.0`
- Introduce `httpclient5` (`5.3.1`) and `httpcore5` (`5.2.4`)