### PR TITLE
Unify the usage of broker empty results

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -827,7 +827,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // Send empty response since we don't need to evaluate either offline or realtime request.
-    BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
+    BrokerResponseNative brokerResponse = BrokerResponseNative.EMPTY_RESULT;
     // Extract source info from incoming request
     _queryLogger.log(
         new QueryLogger.QueryLogParams(requestId, query, requestContext, tableName, 0, null, brokerResponse,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -320,7 +320,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   }
 
   private BrokerResponseNative constructMultistageExplainPlan(String sql, String plan) {
-    BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
+    BrokerResponseNative brokerResponse = BrokerResponseNative.EMPTY_RESULT;
     List<Object[]> rows = new ArrayList<>();
     rows.add(new Object[]{sql, plan});
     DataSchema multistageExplainResultSchema = new DataSchema(new String[]{"SQL", "PLAN"},

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -117,7 +117,7 @@ public class BrokerResponseNative implements BrokerResponse {
 
   /** Generate EXPLAIN PLAN output when queries are evaluated by Broker without going to the Server. */
   private static BrokerResponseNative getBrokerResponseExplainPlanOutput() {
-    BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
+    BrokerResponseNative brokerResponse = BrokerResponseNative.EMPTY_RESULT;
     List<Object[]> rows = new ArrayList<>();
     rows.add(new Object[]{"BROKER_EVALUATE", 0, -1});
     brokerResponse.setResultTable(new ResultTable(DataSchema.EXPLAIN_RESULT_SCHEMA, rows));
@@ -127,7 +127,7 @@ public class BrokerResponseNative implements BrokerResponse {
   /**
    * Get a new empty {@link BrokerResponseNative}.
    */
-  public static BrokerResponseNative empty() {
+  private static BrokerResponseNative empty() {
     return new BrokerResponseNative();
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/request/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/request/BrokerResponseNativeTest.java
@@ -36,7 +36,9 @@ public class BrokerResponseNativeTest {
     BrokerResponseNative actual = BrokerResponseNative.fromJsonString(brokerString);
     Assert.assertEquals(actual.getNumDocsScanned(), expected.getNumDocsScanned());
     Assert.assertEquals(actual.getTimeUsedMs(), expected.getTimeUsedMs());
-    Assert.assertEquals(actual.getResultTable(), expected.getResultTable());
+    Assert.assertNotNull(actual.getResultTable());
+    Assert.assertEquals(actual.getResultTable().getDataSchema(), expected.getResultTable().getDataSchema());
+    Assert.assertEquals(actual.getResultTable().getRows().size(), expected.getResultTable().getRows().size());
     Assert.assertEquals(actual.getSegmentStatistics().size(), expected.getSegmentStatistics().size());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -63,7 +63,7 @@ public class BrokerReduceService extends BaseReduceService {
       Map<ServerRoutingInstance, DataTable> dataTableMap, long reduceTimeOutMs, @Nullable BrokerMetrics brokerMetrics) {
     if (dataTableMap.isEmpty()) {
       // Empty response.
-      return BrokerResponseNative.empty();
+      return BrokerResponseNative.EMPTY_RESULT;
     }
 
     Map<String, String> queryOptions = brokerRequest.getPinotQuery().getQueryOptions();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionOnlyStreamingReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionOnlyStreamingReducer.java
@@ -90,7 +90,7 @@ public class SelectionOnlyStreamingReducer implements StreamingReducer {
   @Override
   public BrokerResponseNative seal() {
     if (_dataSchema == null) {
-      return BrokerResponseNative.empty();
+      return BrokerResponseNative.EMPTY_RESULT;
     }
     Pair<DataSchema, int[]> pair =
         SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(_queryContext, _dataSchema);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -63,7 +63,7 @@ public class StreamingReduceService extends BaseReduceService {
       throws IOException {
     if (serverResponseMap.isEmpty()) {
       // Empty response.
-      return BrokerResponseNative.empty();
+      return BrokerResponseNative.EMPTY_RESULT;
     }
 
     // prepare contextual info for reduce.


### PR DESCRIPTION
This PR tries to unify the usage of broker empty results in the code, so that empty result only refers to the same object with the same memory address. 
This could be useful for validations like `if (response == BrokerResponseNative.EMPTY_RESULT) {...}`.