### PR TITLE
Refine SegmentFetcherFactory

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -693,27 +693,22 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  // not thread safe. Caller should invoke it with safe concurrency control.
   protected void downloadFromPeersWithoutStreaming(String segmentName, SegmentZKMetadata zkMetadata, File destTarFile)
       throws Exception {
-    Preconditions.checkState(_peerDownloadScheme != null, "Download peers require non null peer download scheme");
-    List<URI> peerSegmentURIs =
-        PeerServerSegmentFinder.getPeerServerURIs(_helixManager, _tableNameWithType, segmentName, _peerDownloadScheme);
-    if (peerSegmentURIs.isEmpty()) {
-      String msg = String.format("segment %s doesn't have any peers", segmentName);
-      LOGGER.warn(msg);
-      // HelixStateTransitionHandler would catch the runtime exception and mark the segment state as Error
-      throw new RuntimeException(msg);
-    }
+    Preconditions.checkState(_peerDownloadScheme != null, "Peer download is not enabled for table: %s",
+        _tableNameWithType);
     try {
-      // Next download the segment from a randomly chosen server using configured scheme.
-      SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(peerSegmentURIs, destTarFile, zkMetadata.getCrypterName());
-      LOGGER.info("Fetched segment {} from peers: {} to: {} of size: {}", segmentName, peerSegmentURIs, destTarFile,
+      SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(segmentName, _peerDownloadScheme, () -> {
+        List<URI> peerServerURIs =
+            PeerServerSegmentFinder.getPeerServerURIs(_helixManager, _tableNameWithType, segmentName,
+                _peerDownloadScheme);
+        Collections.shuffle(peerServerURIs);
+        return peerServerURIs;
+      }, destTarFile, zkMetadata.getCrypterName());
+      _logger.info("Downloaded tarred segment: {} from peers to: {}, file length: {}", segmentName, destTarFile,
           destTarFile.length());
-    } catch (AttemptsExceededException e) {
-      LOGGER.error("Attempts exceeded when downloading segment: {} for table: {} from peers {} to: {}", segmentName,
-          _tableNameWithType, peerSegmentURIs, destTarFile);
-      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_DOWNLOAD_FROM_PEERS_FAILURES, 1L);
+    } catch (Exception e) {
+      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_DOWNLOAD_FROM_PEERS_FAILURES, 1);
       throw e;
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -38,7 +38,6 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.BaseSegmentFetcher;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
-import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -645,26 +644,6 @@ public class BaseTableDataManagerTest {
       tmgr.downloadAndDecrypt("seg01", zkmd, tempRootDir);
     }
     verify(tmgr, times(1)).downloadFromPeersWithoutStreaming("seg01", zkmd, destFile);
-  }
-
-  // happy case: download from peers
-  @Test
-  public void testDownloadFromPeersWithoutStreaming()
-      throws Exception {
-    URI uri = mockRemoteCopy();
-    InstanceDataManagerConfig config = createDefaultInstanceDataManagerConfig();
-    when(config.getSegmentPeerDownloadScheme()).thenReturn("http");
-    HelixManager helixManager = mock(HelixManager.class);
-    BaseTableDataManager tmgr = createTableManager(config, helixManager);
-    File tempRootDir = tmgr.getTmpSegmentDataDir("test-download-peer-without-streaming");
-    File destFile = new File(tempRootDir, "seg01" + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
-    try (MockedStatic<PeerServerSegmentFinder> mockPeerSegFinder = mockStatic(PeerServerSegmentFinder.class)) {
-      mockPeerSegFinder.when(
-          () -> PeerServerSegmentFinder.getPeerServerURIs(helixManager, TABLE_NAME_WITH_TYPE, "seg01",
-              CommonConstants.HTTP_PROTOCOL)).thenReturn(List.of(uri));
-      tmgr.downloadFromPeersWithoutStreaming("seg01", mock(SegmentZKMetadata.class), destFile);
-    }
-    assertEquals(FileUtils.readFileToString(destFile), "this is from somewhere remote");
   }
 
   @Test


### PR DESCRIPTION
Separated from #12886 for easier review
- Make `SegmentFetcherFactory` a util class
- Integrate the new `API` with URI supplier from `SegmentFetcher` into `SegmentFetcherFactory`

Note: Removed `BaseTableDataManagerTest.testDownloadFromPeersWithoutStreaming()` because the test setup is incorrect (peer download scheme is `http` but provided uri scheme is `file`). Didn't add a new test because it is just testing the mocking behavior, and the real flow is tested with integration test