### PR TITLE
[Draft] track the use of partition upsert metadata mgr to reset preloading flag

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1333,6 +1333,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger.error("Could not stop consumer thread");
     }
     _realtimeSegment.destroy();
+    if (_partitionUpsertMetadataManager != null) {
+      _partitionUpsertMetadataManager.decreaseReferenceCount();
+    }
     closeStreamConsumers();
     cleanupMetrics();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -37,8 +37,15 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
 
   @Override
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
-        k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
+    return _partitionMetadataManagerMap.compute(partitionId, (k, mgr) -> {
+      if (mgr == null) {
+        mgr = new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, partitionId, _context);
+      } else {
+        mgr.tryResetIsPreloading();
+      }
+      mgr.increaseReferenceCount();
+      return mgr;
+    });
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -110,6 +110,10 @@ public interface PartitionUpsertMetadataManager extends Closeable {
    */
   void removeExpiredPrimaryKeys();
 
+  void increaseReferenceCount();
+
+  void decreaseReferenceCount();
+
   /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Reference counting around partition upsert metadata manager to reset preloading flag when unused\.

```mermaid
flowchart TD
  N0["RealtimeSegmentDataManager#46;doDestroy decreases reference count #40;F1#41;"]:::stModified
  N1["ConcurrentMapTableUpsertMetadataManager#46;getOrCreatePartitionManager increases e#44; #40;F4#41;"]:::stModified
  N2["PartitionUpsertMetadataManager reference count operations #40;increase#47;decrease#41; #40;F3#41;"]:::stModified
  N3["tryResetIsPreloading may set #95;isPreloading to true when referenceCount#61;#61;0 and #40;F3#41;"]:::stModified
  N4["RealtimeTableDataManager#46;addSegment calls preloadSegments with try#45;finally dec #40;F2#41;"]:::stModified
  N5["RealtimeTableDataManager#46;handleUpsert preloading branch calls preloadSegment #40;F2#41;"]:::stModified
  N6["RealtimeTableDataManager#46;handleUpsert finally block decreases reference count #40;F2#41;"]:::stModified
  N0 -->|"calls"| N2
  N1 -->|"calls"| N2
  N1 -->|"calls"| N3
  N4 -->|"calls"| N2
  N5 -->|"calls"| N2
  N6 -->|"calls"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/af8fd4089c33db3c11e09ab74df64746fa324f2f/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/19e7268e3731fec7c7055c6d2924d24187e8894b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager\.java — [before](https://github.com/apache/pinot/blob/af8fd4089c33db3c11e09ab74df64746fa324f2f/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java) · [after](https://github.com/apache/pinot/blob/19e7268e3731fec7c7055c6d2924d24187e8894b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/af8fd4089c33db3c11e09ab74df64746fa324f2f/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/19e7268e3731fec7c7055c6d2924d24187e8894b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/af8fd4089c33db3c11e09ab74df64746fa324f2f/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/19e7268e3731fec7c7055c6d2924d24187e8894b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImFmOGZkNDA4OWMzM2RiM2MxMWUwOWFiNzRkZjY0NzQ2ZmEzMjRmMmYiLCJjb250ZXh0X2hhc2giOiIwNDBjMzc4OWNlMmU0ZjdlYTFmOWRhMDdkNTc4NzRhMDkxNTcyZWRhMTlkZjAwNTU4YzcwNjdjMDY1ZmI0MWE1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODEzNDc2LCJoZWFkX3NoYSI6IjE5ZTcyNjhlMzczMWZlYzdjNzA1NWM2ZDI5MjRkMjQxODdlODg5NGIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlYzQ1MmE0OWYzYzg4NTMwODYxM2JjNDVkZmE0NGI0OGExNjA3NmJhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a4ace8264d7fc1155ebe2b3c2135b374cd57e73e13ae380475cc673d11cf0e40 -->
<!-- pinot-pr-flow:end -->

Try to use refCnt to track threads using partition upsert metadata mgr so that we can be sure when we can reset the isPreloading flag, so that the mgr can load segments via preloading again, e.g. when the table partition is rebalanced back to the old server. 