### PR TITLE
Enable complexType handling in SegmentProcessFramework

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -290,8 +290,7 @@ public class SegmentProcessorFramework {
           GenericRowFileRecordReader recordReaderForRange = recordReader.getRecordReaderForRange(startRowId, endRowId);
           SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
           driver.init(generatorConfig, new RecordReaderSegmentCreationDataSource(recordReaderForRange),
-              RecordEnricherPipeline.getPassThroughPipeline(),
-              TransformPipeline.getPassThroughPipeline());
+              RecordEnricherPipeline.getPassThroughPipeline(), TransformPipeline.getPassThroughPipeline());
           driver.build();
           outputSegmentDirs.add(driver.getOutputDirectory());
           _segmentNumRowProvider.updateSegmentInfo(driver.getSegmentStats().getTotalDocCount(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -290,7 +290,8 @@ public class SegmentProcessorFramework {
           GenericRowFileRecordReader recordReaderForRange = recordReader.getRecordReaderForRange(startRowId, endRowId);
           SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
           driver.init(generatorConfig, new RecordReaderSegmentCreationDataSource(recordReaderForRange),
-              RecordEnricherPipeline.getPassThroughPipeline(), TransformPipeline.getPassThroughPipeline());
+              RecordEnricherPipeline.getPassThroughPipeline(),
+              TransformPipeline.getPassThroughPipeline());
           driver.build();
           outputSegmentDirs.add(driver.getOutputDirectory());
           _segmentNumRowProvider.updateSegmentInfo(driver.getSegmentStats().getTotalDocCount(),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -83,10 +83,11 @@ public class CompositeTransformer implements RecordTransformer {
    */
   public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema) {
     return Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
-        new SchemaConformingTransformer(tableConfig, schema), new SchemaConformingTransformerV2(tableConfig, schema),
-        new DataTypeTransformer(tableConfig, schema), new TimeValidationTransformer(tableConfig, schema),
-        new SpecialValueTransformer(schema), new NullValueTransformer(tableConfig, schema),
-        new SanitizationTransformer(schema)).filter(t -> !t.isNoOp()).collect(Collectors.toList());
+            new SchemaConformingTransformer(tableConfig, schema),
+            new SchemaConformingTransformerV2(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
+            new TimeValidationTransformer(tableConfig, schema), new SpecialValueTransformer(schema),
+            new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
+        .collect(Collectors.toList());
   }
 
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -83,11 +83,10 @@ public class CompositeTransformer implements RecordTransformer {
    */
   public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema) {
     return Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
-            new SchemaConformingTransformer(tableConfig, schema),
-            new SchemaConformingTransformerV2(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
-            new TimeValidationTransformer(tableConfig, schema), new SpecialValueTransformer(schema),
-            new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
-        .collect(Collectors.toList());
+        new SchemaConformingTransformer(tableConfig, schema), new SchemaConformingTransformerV2(tableConfig, schema),
+        new DataTypeTransformer(tableConfig, schema), new TimeValidationTransformer(tableConfig, schema),
+        new SpecialValueTransformer(schema), new NullValueTransformer(tableConfig, schema),
+        new SanitizationTransformer(schema)).filter(t -> !t.isNoOp()).collect(Collectors.toList());
   }
 
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {
@@ -104,6 +103,10 @@ public class CompositeTransformer implements RecordTransformer {
   public static CompositeTransformer composeAllTransformers(List<RecordTransformer> customTransformers,
       TableConfig tableConfig, Schema schema) {
     List<RecordTransformer> allTransformers = new ArrayList<>(customTransformers);
+    ComplexTypeTransformer complexTypeTransformer = ComplexTypeTransformer.getComplexTypeTransformer(tableConfig);
+    if (complexTypeTransformer != null) {
+      allTransformers.add(complexTypeTransformer);
+    }
     allTransformers.addAll(getDefaultTransformers(tableConfig, schema));
     return new CompositeTransformer(allTransformers);
   }


### PR DESCRIPTION
**Whats in the PR**:
Enabling complexType (ingestion config) handling in SegmentProcessorFramework

**Why its needed**:
For batch/minion based ingestion SegmentProcessorFramework is the building block which currently does not support [complex type](https://docs.pinot.apache.org/v/release-0.9.0/basics/data-import/complex-type) transformation. With this change, all batch ingestion tasks that use SegmentProcessorFramework, will get the ability to transform complexType. 