### PR TITLE
TLS Port for Minion

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -117,7 +117,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
       _instanceId = CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE + _hostname + "_" + _port;
     }
     _listenerConfigs = ListenerConfigUtil.buildMinionConfigs(_config);
-    _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, 0);
+    _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, -1);
     _helixManager = new ZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkAddress);
     MinionTaskZkMetadataManager minionTaskZkMetadataManager = new MinionTaskZkMetadataManager(_helixManager);
     _taskExecutorFactoryRegistry = new TaskExecutorFactoryRegistry(minionTaskZkMetadataManager, _config);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -134,7 +134,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
       updated |= HelixHelper.updateTlsPort(instanceConfig, _tlsPort);
     }
     updated |= HelixHelper.addDefaultTags(instanceConfig,
-        () -> Collections.singletonList(CommonConstants.Helix.CONTROLLER_INSTANCE));
+        () -> Collections.singletonList(CommonConstants.Helix.UNTAGGED_MINION_INSTANCE));
     updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
     if (updated) {
       HelixHelper.updateInstanceConfig(_helixManager, instanceConfig);


### PR DESCRIPTION
This PR adds a TLS port to minion, just like other components. With this, we can communicate with minion using `https`. In addition to this, we should add this config to minions:

```
pinot.minion.adminapi.access.protocols=internal
pinot.minion.adminapi.access.protocols.internal.protocol=https
pinot.minion.adminapi.access.protocols.internal.port=9500
```

And export port 9500 in the headless svc. 