### PR TITLE
dynamic chunk sizing for v4 raw forward index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.fwd;
+
+public class ForwardIndexUtils {
+  public static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
+
+  private ForwardIndexUtils() {
+  }
+
+  /**
+   * Get the dynamic target chunk size based on the maximum length of the values, target number of documents per chunk.
+   *
+   * If targetDocsPerChunk is Integer.MAX_VALUE, the target chunk size is the targetMaxChunkSizeBytes and chunk size
+   * shall not be dynamically chosen
+   * @param maxLength max length of the values
+   * @param targetDocsPerChunk target number of documents to store per chunk
+   * @param targetMaxChunkSizeBytes target max chunk size in bytes
+   */
+  public static int getDynamicTargetChunkSize(int maxLength, int targetDocsPerChunk, int targetMaxChunkSizeBytes) {
+    if (targetDocsPerChunk == Integer.MAX_VALUE) {
+      return targetMaxChunkSizeBytes;
+    }
+    return Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.segment.local.segment.creator.impl.fwd;
 
 public class ForwardIndexUtils {
-  public static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
+  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
   private ForwardIndexUtils() {
   }
@@ -27,14 +27,14 @@ public class ForwardIndexUtils {
   /**
    * Get the dynamic target chunk size based on the maximum length of the values, target number of documents per chunk.
    *
-   * If targetDocsPerChunk is Integer.MAX_VALUE, the target chunk size is the targetMaxChunkSizeBytes and chunk size
+   * If targetDocsPerChunk is negative, the target chunk size is the targetMaxChunkSizeBytes and chunk size
    * shall not be dynamically chosen
    * @param maxLength max length of the values
    * @param targetDocsPerChunk target number of documents to store per chunk
    * @param targetMaxChunkSizeBytes target max chunk size in bytes
    */
   public static int getDynamicTargetChunkSize(int maxLength, int targetDocsPerChunk, int targetMaxChunkSizeBytes) {
-    if (targetDocsPerChunk == Integer.MAX_VALUE) {
+    if (targetDocsPerChunk < 0) {
       return targetMaxChunkSizeBytes;
     }
     return Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
@@ -35,7 +35,7 @@ public class ForwardIndexUtils {
    */
   public static int getDynamicTargetChunkSize(int maxLength, int targetDocsPerChunk, int targetMaxChunkSizeBytes) {
     if (targetDocsPerChunk < 0 || (long) maxLength * targetDocsPerChunk > Integer.MAX_VALUE) {
-      return targetMaxChunkSizeBytes;
+      return Math.max(targetMaxChunkSizeBytes, TARGET_MIN_CHUNK_SIZE);
     }
     return Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
@@ -34,7 +34,7 @@ public class ForwardIndexUtils {
    * @param targetMaxChunkSizeBytes target max chunk size in bytes
    */
   public static int getDynamicTargetChunkSize(int maxLength, int targetDocsPerChunk, int targetMaxChunkSizeBytes) {
-    if (targetDocsPerChunk < 0) {
+    if (targetDocsPerChunk < 0 || (long) maxLength * targetDocsPerChunk > Integer.MAX_VALUE) {
       return targetMaxChunkSizeBytes;
     }
     return Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -66,7 +66,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
       DataType valueType, int maxNumberOfMultiValueElements, boolean deriveNumDocsPerChunk, int writerVersion)
       throws IOException {
     this(indexFile, compressionType, totalDocs, valueType, maxNumberOfMultiValueElements, deriveNumDocsPerChunk,
-        writerVersion, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        writerVersion, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES,
         ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * FLOAT, DOUBLE).
  */
 public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
-  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -86,7 +86,8 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
         TARGET_MAX_CHUNK_SIZE / (totalMaxLength + VarByteChunkForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE), 1)
         : DEFAULT_NUM_DOCS_PER_CHUNK;
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
-    int dynamicTargetChunkSize = Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+    int dynamicTargetChunkSize =
+        (int) Math.min((long) totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
     _indexWriter =
         writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(indexFile,
             compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -83,7 +83,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
         1) : targetDocsPerChunk;
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        Math.max(Math.min(totalMaxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+        ForwardIndexUtils.getDynamicTargetChunkSize(totalMaxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
     _indexWriter =
         writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(indexFile,
             compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  */
 public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
+  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
   private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
@@ -87,7 +88,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
         : DEFAULT_NUM_DOCS_PER_CHUNK;
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        (int) Math.min((long) totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+        Math.max(Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE), TARGET_MIN_CHUNK_SIZE);
     _indexWriter =
         writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(indexFile,
             compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -85,10 +85,12 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
     int numDocsPerChunk = deriveNumDocsPerChunk ? Math.max(
         TARGET_MAX_CHUNK_SIZE / (totalMaxLength + VarByteChunkForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE), 1)
         : DEFAULT_NUM_DOCS_PER_CHUNK;
+    // For columns with very small max value, target chunk size should also be capped to reduce memory during read
+    int dynamicTargetChunkSize = Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
     _indexWriter =
         writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(indexFile,
             compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
-            : new VarByteChunkForwardIndexWriterV4(indexFile, compressionType, TARGET_MAX_CHUNK_SIZE);
+            : new VarByteChunkForwardIndexWriterV4(indexFile, compressionType, dynamicTargetChunkSize);
     _valueType = valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * BYTES).
  */
 public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
-  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -55,7 +55,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
       int totalDocs, DataType valueType, int maxRowLengthInBytes, int maxNumberOfElements)
       throws IOException {
     this(baseIndexDir, compressionType, column, totalDocs, valueType, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
-        maxRowLengthInBytes, maxNumberOfElements, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        maxRowLengthInBytes, maxNumberOfElements, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES,
         ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -85,7 +85,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
         1);
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        Math.max(Math.min(totalMaxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+        ForwardIndexUtils.getDynamicTargetChunkSize(totalMaxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -38,7 +38,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
   private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
-  private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;
@@ -58,7 +57,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
       int totalDocs, DataType valueType, int maxRowLengthInBytes, int maxNumberOfElements)
       throws IOException {
     this(baseIndexDir, compressionType, column, totalDocs, valueType, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
-        maxRowLengthInBytes, maxNumberOfElements);
+        maxRowLengthInBytes, maxNumberOfElements, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE);
   }
 
   /**
@@ -74,18 +73,19 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
    * @param writerVersion writer format version
    */
   public MultiValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
-      int totalDocs, DataType valueType, int writerVersion, int maxRowLengthInBytes, int maxNumberOfElements)
+      int totalDocs, DataType valueType, int writerVersion, int maxRowLengthInBytes, int maxNumberOfElements,
+      int targetMaxChunkSizeBytes)
       throws IOException {
     //we will prepend the actual content with numElements and length array containing length of each element
     int totalMaxLength = getTotalRowStorageBytes(maxNumberOfElements, maxRowLengthInBytes);
 
     File file = new File(baseIndexDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
     int numDocsPerChunk = Math.max(
-        TARGET_MAX_CHUNK_SIZE / (totalMaxLength + VarByteChunkForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE),
+        targetMaxChunkSizeBytes / (totalMaxLength + VarByteChunkForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE),
         1);
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        Math.max(Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE), TARGET_MIN_CHUNK_SIZE);
+        Math.max(Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  */
 public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
+  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
   private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
@@ -84,7 +85,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
         1);
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        (int) Math.min((long) totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+        Math.max(Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE), TARGET_MIN_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -83,7 +83,8 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
         TARGET_MAX_CHUNK_SIZE / (totalMaxLength + VarByteChunkForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE),
         1);
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
-    int dynamicTargetChunkSize = Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+    int dynamicTargetChunkSize =
+        (int) Math.min((long) totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * BYTES).
  */
 public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
-  private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
   private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
@@ -57,7 +56,8 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
       int totalDocs, DataType valueType, int maxRowLengthInBytes, int maxNumberOfElements)
       throws IOException {
     this(baseIndexDir, compressionType, column, totalDocs, valueType, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
-        maxRowLengthInBytes, maxNumberOfElements, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE);
+        maxRowLengthInBytes, maxNumberOfElements, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
   }
 
   /**
@@ -74,7 +74,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
    */
   public MultiValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
       int totalDocs, DataType valueType, int writerVersion, int maxRowLengthInBytes, int maxNumberOfElements,
-      int targetMaxChunkSizeBytes)
+      int targetMaxChunkSizeBytes, int targetDocsPerChunk)
       throws IOException {
     //we will prepend the actual content with numElements and length array containing length of each element
     int totalMaxLength = getTotalRowStorageBytes(maxNumberOfElements, maxRowLengthInBytes);
@@ -85,7 +85,7 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
         1);
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        Math.max(Math.min(totalMaxLength * DEFAULT_NUM_DOCS_PER_CHUNK, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+        Math.max(Math.min(totalMaxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, totalMaxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueFixedByteRawIndexCreator.java
@@ -33,8 +33,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * FLOAT, DOUBLE).
  */
 public class SingleValueFixedByteRawIndexCreator implements ForwardIndexCreator {
-  private static final int NUM_DOCS_PER_CHUNK = 1000; // TODO: Auto-derive this based on metadata.
-
   private final FixedByteChunkForwardIndexWriter _indexWriter;
   private final DataType _valueType;
 
@@ -51,7 +49,8 @@ public class SingleValueFixedByteRawIndexCreator implements ForwardIndexCreator 
   public SingleValueFixedByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
       int totalDocs, DataType valueType)
       throws IOException {
-    this(baseIndexDir, compressionType, column, totalDocs, valueType, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION);
+    this(baseIndexDir, compressionType, column, totalDocs, valueType, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
+        ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
   }
 
   /**
@@ -66,11 +65,11 @@ public class SingleValueFixedByteRawIndexCreator implements ForwardIndexCreator 
    * @throws IOException
    */
   public SingleValueFixedByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
-      int totalDocs, DataType valueType, int writerVersion)
+      int totalDocs, DataType valueType, int writerVersion, int targetDocsPerChunk)
       throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     _indexWriter =
-        new FixedByteChunkForwardIndexWriter(file, compressionType, totalDocs, NUM_DOCS_PER_CHUNK, valueType.size(),
+        new FixedByteChunkForwardIndexWriter(file, compressionType, totalDocs, targetDocsPerChunk, valueType.size(),
             writerVersion);
     _valueType = valueType;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * STRING, BYTES).
  */
 public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
-  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -84,7 +84,7 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
 
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
     int dynamicTargetChunkSize =
-        Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+        ForwardIndexUtils.getDynamicTargetChunkSize(maxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, maxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -77,9 +77,12 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
       throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     int numDocsPerChunk = deriveNumDocsPerChunk ? getNumDocsPerChunk(maxLength) : DEFAULT_NUM_DOCS_PER_CHUNK;
+
+    // For columns with very small max value, target chunk size should also be capped to reduce memory during read
+    int dynamicTargetChunkSize = Math.min(maxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, maxLength, writerVersion)
-        : new VarByteChunkForwardIndexWriterV4(file, compressionType, TARGET_MAX_CHUNK_SIZE);
+        : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);
     _valueType = valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -79,7 +79,7 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
     int numDocsPerChunk = deriveNumDocsPerChunk ? getNumDocsPerChunk(maxLength) : DEFAULT_NUM_DOCS_PER_CHUNK;
 
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
-    int dynamicTargetChunkSize = Math.min(maxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+    int dynamicTargetChunkSize = (int) Math.min((long) maxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, maxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  */
 public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
+  private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
   private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
   private final VarByteChunkWriter _indexWriter;
@@ -79,7 +80,8 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
     int numDocsPerChunk = deriveNumDocsPerChunk ? getNumDocsPerChunk(maxLength) : DEFAULT_NUM_DOCS_PER_CHUNK;
 
     // For columns with very small max value, target chunk size should also be capped to reduce memory during read
-    int dynamicTargetChunkSize = (int) Math.min((long) maxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE);
+    int dynamicTargetChunkSize =
+        Math.max(Math.min(maxLength * DEFAULT_NUM_DOCS_PER_CHUNK, TARGET_MAX_CHUNK_SIZE), TARGET_MIN_CHUNK_SIZE);
     _indexWriter = writerVersion < VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexWriter(file,
         compressionType, totalDocs, numDocsPerChunk, maxLength, writerVersion)
         : new VarByteChunkForwardIndexWriterV4(file, compressionType, dynamicTargetChunkSize);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -54,7 +54,7 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
       int totalDocs, DataType valueType, int maxLength)
       throws IOException {
     this(baseIndexDir, compressionType, column, totalDocs, valueType, maxLength, false,
-        ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES,
         ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
@@ -80,13 +80,14 @@ public class ForwardIndexCreatorFactory {
       }
       boolean deriveNumDocsPerChunk = indexConfig.isDeriveNumDocsPerChunk();
       int writerVersion = indexConfig.getRawIndexWriterVersion();
+      int targetMaxChunkSize = indexConfig.getTargetMaxChunkSizeBytes();
       if (fieldSpec.isSingleValueField()) {
         return getRawIndexCreatorForSVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
-            context.getLengthOfLongestEntry(), deriveNumDocsPerChunk, writerVersion);
+            context.getLengthOfLongestEntry(), deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
       } else {
         return getRawIndexCreatorForMVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
             context.getMaxNumberOfMultiValueElements(), deriveNumDocsPerChunk, writerVersion,
-            context.getMaxRowLengthInBytes());
+            context.getMaxRowLengthInBytes(), targetMaxChunkSize);
       }
     }
   }
@@ -97,7 +98,7 @@ public class ForwardIndexCreatorFactory {
    */
   public static ForwardIndexCreator getRawIndexCreatorForSVColumn(File indexDir, ChunkCompressionType compressionType,
       String column, DataType storedType, int numTotalDocs, int lengthOfLongestEntry, boolean deriveNumDocsPerChunk,
-      int writerVersion)
+      int writerVersion, int targetMaxChunkSize)
       throws IOException {
     switch (storedType) {
       case INT:
@@ -110,7 +111,7 @@ public class ForwardIndexCreatorFactory {
       case STRING:
       case BYTES:
         return new SingleValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion);
+            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }
@@ -122,7 +123,7 @@ public class ForwardIndexCreatorFactory {
    */
   public static ForwardIndexCreator getRawIndexCreatorForMVColumn(File indexDir, ChunkCompressionType compressionType,
       String column, DataType storedType, int numTotalDocs, int maxNumberOfMultiValueElements,
-      boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes)
+      boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes, int targetMaxChunkSize)
       throws IOException {
     switch (storedType) {
       case INT:
@@ -130,11 +131,11 @@ public class ForwardIndexCreatorFactory {
       case FLOAT:
       case DOUBLE:
         return new MultiValueFixedByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion);
+            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
       case STRING:
       case BYTES:
         return new MultiValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements);
+            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements, targetMaxChunkSize);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
@@ -81,13 +81,15 @@ public class ForwardIndexCreatorFactory {
       boolean deriveNumDocsPerChunk = indexConfig.isDeriveNumDocsPerChunk();
       int writerVersion = indexConfig.getRawIndexWriterVersion();
       int targetMaxChunkSize = indexConfig.getTargetMaxChunkSizeBytes();
+      int targetDocsPerChunk = indexConfig.getTargetDocsPerChunk();
       if (fieldSpec.isSingleValueField()) {
         return getRawIndexCreatorForSVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
-            context.getLengthOfLongestEntry(), deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
+            context.getLengthOfLongestEntry(), deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize,
+            targetDocsPerChunk);
       } else {
         return getRawIndexCreatorForMVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
             context.getMaxNumberOfMultiValueElements(), deriveNumDocsPerChunk, writerVersion,
-            context.getMaxRowLengthInBytes(), targetMaxChunkSize);
+            context.getMaxRowLengthInBytes(), targetMaxChunkSize, targetDocsPerChunk);
       }
     }
   }
@@ -98,7 +100,7 @@ public class ForwardIndexCreatorFactory {
    */
   public static ForwardIndexCreator getRawIndexCreatorForSVColumn(File indexDir, ChunkCompressionType compressionType,
       String column, DataType storedType, int numTotalDocs, int lengthOfLongestEntry, boolean deriveNumDocsPerChunk,
-      int writerVersion, int targetMaxChunkSize)
+      int writerVersion, int targetMaxChunkSize, int targetDocsPerChunk)
       throws IOException {
     switch (storedType) {
       case INT:
@@ -106,12 +108,12 @@ public class ForwardIndexCreatorFactory {
       case FLOAT:
       case DOUBLE:
         return new SingleValueFixedByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            writerVersion);
+            writerVersion, targetDocsPerChunk);
       case BIG_DECIMAL:
       case STRING:
       case BYTES:
         return new SingleValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
+            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize, targetDocsPerChunk);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }
@@ -123,7 +125,8 @@ public class ForwardIndexCreatorFactory {
    */
   public static ForwardIndexCreator getRawIndexCreatorForMVColumn(File indexDir, ChunkCompressionType compressionType,
       String column, DataType storedType, int numTotalDocs, int maxNumberOfMultiValueElements,
-      boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes, int targetMaxChunkSize)
+      boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes, int targetMaxChunkSize,
+      int targetDocsPerChunk)
       throws IOException {
     switch (storedType) {
       case INT:
@@ -131,11 +134,12 @@ public class ForwardIndexCreatorFactory {
       case FLOAT:
       case DOUBLE:
         return new MultiValueFixedByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize);
+            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize,
+            targetDocsPerChunk);
       case STRING:
       case BYTES:
         return new MultiValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements, targetMaxChunkSize);
+            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements, targetMaxChunkSize, targetDocsPerChunk);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -157,7 +157,7 @@ public class MultiValueFixedByteRawIndexCreatorTest {
     file.delete();
     MultiValueFixedByteRawIndexCreator creator =
         new MultiValueFixedByteRawIndexCreator(new File(OUTPUT_DIR), compressionType, column, numDocs, dataType,
-            maxElements, false, writerVersion, 1024 * 1024);
+            maxElements, false, writerVersion, 1024 * 1024, 1000);
     inputs.forEach(input -> injector.inject(creator, input));
     creator.close();
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -157,7 +157,7 @@ public class MultiValueFixedByteRawIndexCreatorTest {
     file.delete();
     MultiValueFixedByteRawIndexCreator creator =
         new MultiValueFixedByteRawIndexCreator(new File(OUTPUT_DIR), compressionType, column, numDocs, dataType,
-            maxElements, false, writerVersion);
+            maxElements, false, writerVersion, 1024 * 1024);
     inputs.forEach(input -> injector.inject(creator, input));
     creator.close();
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
@@ -119,7 +119,7 @@ public class MultiValueVarByteRawIndexCreatorTest {
       inputs.add(values);
     }
     try (MultiValueVarByteRawIndexCreator creator = new MultiValueVarByteRawIndexCreator(OUTPUT_DIR, compressionType,
-        column, numDocs, DataType.STRING, maxTotalLength, maxElements, writerVersion, 1024 * 1024)) {
+        column, numDocs, DataType.STRING, maxTotalLength, maxElements, writerVersion, 1024 * 1024, 1000)) {
       for (String[] input : inputs) {
         creator.putStringMV(input);
       }
@@ -171,7 +171,7 @@ public class MultiValueVarByteRawIndexCreatorTest {
       inputs.add(values);
     }
     try (MultiValueVarByteRawIndexCreator creator = new MultiValueVarByteRawIndexCreator(OUTPUT_DIR, compressionType,
-        column, numDocs, DataType.BYTES, writerVersion, maxTotalLength, maxElements, 1024 * 1024)) {
+        column, numDocs, DataType.BYTES, writerVersion, maxTotalLength, maxElements, 1024 * 1024, 1000)) {
       for (byte[][] input : inputs) {
         creator.putBytesMV(input);
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
@@ -119,7 +119,7 @@ public class MultiValueVarByteRawIndexCreatorTest {
       inputs.add(values);
     }
     try (MultiValueVarByteRawIndexCreator creator = new MultiValueVarByteRawIndexCreator(OUTPUT_DIR, compressionType,
-        column, numDocs, DataType.STRING, maxTotalLength, maxElements, writerVersion)) {
+        column, numDocs, DataType.STRING, maxTotalLength, maxElements, writerVersion, 1024 * 1024)) {
       for (String[] input : inputs) {
         creator.putStringMV(input);
       }
@@ -171,7 +171,7 @@ public class MultiValueVarByteRawIndexCreatorTest {
       inputs.add(values);
     }
     try (MultiValueVarByteRawIndexCreator creator = new MultiValueVarByteRawIndexCreator(OUTPUT_DIR, compressionType,
-        column, numDocs, DataType.BYTES, writerVersion, maxTotalLength, maxElements)) {
+        column, numDocs, DataType.BYTES, writerVersion, maxTotalLength, maxElements, 1024 * 1024)) {
       for (byte[][] input : inputs) {
         creator.putBytesMV(input);
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -337,7 +337,8 @@ public class ForwardIndexTypeTest {
                   + "      \"forward\": {"
                   + "        \"chunkCompressionType\": " + valueJson + ",\n"
                   + "        \"deriveNumDocsPerChunk\": true,\n"
-                  + "        \"rawIndexWriterVersion\": 10\n"
+                  + "        \"rawIndexWriterVersion\": 10,\n"
+                  + "        \"targetMaxChunkSize\": \"512K\"\n"
                   + "      }"
                   + "    }\n"
                   + " }"
@@ -349,6 +350,7 @@ public class ForwardIndexTypeTest {
               .withDictIdCompressionType(expectedDictCompression)
               .withDeriveNumDocsPerChunk(true)
               .withRawIndexWriterVersion(10)
+              .withTargetMaxChunkSize(512 * 1024)
               .build()
       );
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -338,7 +338,8 @@ public class ForwardIndexTypeTest {
                   + "        \"chunkCompressionType\": " + valueJson + ",\n"
                   + "        \"deriveNumDocsPerChunk\": true,\n"
                   + "        \"rawIndexWriterVersion\": 10,\n"
-                  + "        \"targetMaxChunkSize\": \"512K\"\n"
+                  + "        \"targetMaxChunkSize\": \"512K\",\n"
+                  + "        \"targetDocsPerChunk\": \"2000\"\n"
                   + "      }"
                   + "    }\n"
                   + " }"
@@ -351,6 +352,7 @@ public class ForwardIndexTypeTest {
               .withDeriveNumDocsPerChunk(true)
               .withRawIndexWriterVersion(10)
               .withTargetMaxChunkSize(512 * 1024)
+              .withTargetDocsPerChunk(2000)
               .build()
       );
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
@@ -39,6 +39,7 @@ public class ForwardIndexUtilsTest {
     return new Integer[][]{
         {100, 1000, 1024 * 1024, 1000 * 100}, // small maxValue returns dynamic chunk
         {100, Integer.MAX_VALUE, 1024 * 1024, 1024 * 1024}, // overflow falls back to targetMaxChunkSizeBytes
+        {100, -1, 1024 * 1024, 1024 * 1024}, // negative targetDocsPerChunk falls back to targetMaxChunkSizeBytes
         {2000, 1000, 1024 * 1024, 1024 * 1024} // large maxValue limited by targetMaxChunkSizeBytes
     };
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.forward;
+
+import org.apache.pinot.segment.local.segment.creator.impl.fwd.ForwardIndexUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class ForwardIndexUtilsTest {
+
+  @Test(dataProvider = "dynamicTargetChunkSizeProvider")
+  public void testDynamicTargetChunkSize(Integer maxLength, Integer targetDocsPerChunk, Integer targetMaxChunkSizeBytes,
+      Integer expectedChunkSize) {
+    int chunkSize = ForwardIndexUtils.getDynamicTargetChunkSize(maxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
+    assertEquals(chunkSize, expectedChunkSize);
+  }
+
+  @DataProvider(name = "dynamicTargetChunkSizeProvider")
+  public Integer[][] dynamicTargetChunkSizeProvider() {
+    return new Integer[][]{
+        {100, 1000, 1024 * 1024, 1000 * 100}, // small maxValue returns dynamic chunk
+        {100, Integer.MAX_VALUE, 1024 * 1024, 1024 * 1024}, // overflow falls back to targetMaxChunkSizeBytes
+        {2000, 1000, 1024 * 1024, 1024 * 1024} // large maxValue limited by targetMaxChunkSizeBytes
+    };
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
@@ -40,7 +40,8 @@ public class ForwardIndexUtilsTest {
         {100, 1000, 1024 * 1024, 1000 * 100}, // small maxValue returns dynamic chunk
         {100, Integer.MAX_VALUE, 1024 * 1024, 1024 * 1024}, // overflow falls back to targetMaxChunkSizeBytes
         {100, -1, 1024 * 1024, 1024 * 1024}, // negative targetDocsPerChunk falls back to targetMaxChunkSizeBytes
-        {2000, 1000, 1024 * 1024, 1024 * 1024} // large maxValue limited by targetMaxChunkSizeBytes
+        {2000, 1000, 1024 * 1024, 1024 * 1024}, // large maxValue limited by targetMaxChunkSizeBytes
+        {100, -1, 1024, 4 * 1024} // tiny targetMaxChunkSizeBytes falls back to TARGET_MIN_CHUNK_SIZE
     };
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
@@ -237,7 +237,7 @@ public class VarByteChunkSVForwardIndexTest {
       maxStringLengthInBytes = Math.max(maxStringLengthInBytes, value.getBytes(UTF_8).length);
     }
 
-    int numDocsPerChunk = SingleValueVarByteRawIndexCreator.getNumDocsPerChunk(maxStringLengthInBytes);
+    int numDocsPerChunk = SingleValueVarByteRawIndexCreator.getNumDocsPerChunk(maxStringLengthInBytes, 1024 * 1024);
     try (VarByteChunkForwardIndexWriter writer = new VarByteChunkForwardIndexWriter(outFile, compressionType, numDocs,
         numDocsPerChunk, maxStringLengthInBytes, 3)) {
       // NOTE: No need to test BYTES explicitly because STRING is handled as UTF-8 encoded bytes

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -220,7 +220,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private boolean _deriveNumDocsPerChunk = false;
     private int _rawIndexWriterVersion = DEFAULT_RAW_WRITER_VERSION;
     private String _targetMaxChunkSize;
-    private int _targetDocsPerChunk;
+    private int _targetDocsPerChunk = DEFAULT_TARGET_DOCS_PER_CHUNK;
 
     public Builder() {
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -36,7 +36,9 @@ import org.apache.pinot.spi.utils.DataSizeUtils;
 
 public class ForwardIndexConfig extends IndexConfig {
   public static final int DEFAULT_RAW_WRITER_VERSION = 2;
-  public static final int DEFAULT_TARGET_MAX_CHUNK_SIZE = 1024 * 1024; // 1MB
+  public static final int DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES = 1024 * 1024; // 1MB
+  public static final String DEFAULT_TARGET_MAX_CHUNK_SIZE =
+      DataSizeUtils.fromBytes(DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES);
   public static final int DEFAULT_TARGET_DOCS_PER_CHUNK = 1000;
   public static final ForwardIndexConfig DISABLED =
       new ForwardIndexConfig(true, null, null, null, null, null, null, null);
@@ -47,6 +49,7 @@ public class ForwardIndexConfig extends IndexConfig {
   private final boolean _deriveNumDocsPerChunk;
   private final int _rawIndexWriterVersion;
   private final String _targetMaxChunkSize;
+  private final int _targetMaxChunkSizeBytes;
   private final int _targetDocsPerChunk;
 
   @Nullable
@@ -66,8 +69,10 @@ public class ForwardIndexConfig extends IndexConfig {
       throw new IllegalStateException(
           "targetMaxChunkSize should only be used when deriveNumDocsPerChunk is true or rawIndexWriterVersion is 4");
     }
+    _targetMaxChunkSizeBytes = targetMaxChunkSize == null ? DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES
+        : (int) DataSizeUtils.toBytes(targetMaxChunkSize);
     _targetMaxChunkSize =
-        targetMaxChunkSize == null ? DataSizeUtils.fromBytes(DEFAULT_TARGET_MAX_CHUNK_SIZE) : targetMaxChunkSize;
+        targetMaxChunkSize == null ? DEFAULT_TARGET_MAX_CHUNK_SIZE : targetMaxChunkSize;
     _targetDocsPerChunk = targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK : targetDocsPerChunk;
 
     if (compressionCodec != null) {
@@ -175,7 +180,7 @@ public class ForwardIndexConfig extends IndexConfig {
 
   @JsonIgnore
   public int getTargetMaxChunkSizeBytes() {
-    return (int) DataSizeUtils.toBytes(_targetMaxChunkSize);
+    return _targetMaxChunkSizeBytes;
   }
 
   @JsonIgnore

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -68,8 +68,7 @@ public class ForwardIndexConfig extends IndexConfig {
     }
     _targetMaxChunkSize =
         targetMaxChunkSize == null ? DataSizeUtils.fromBytes(DEFAULT_TARGET_MAX_CHUNK_SIZE) : targetMaxChunkSize;
-    _targetDocsPerChunk = targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK
-        : targetDocsPerChunk < 0 ? Integer.MAX_VALUE : targetDocsPerChunk;
+    _targetDocsPerChunk = targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK : targetDocsPerChunk;
 
     if (compressionCodec != null) {
       switch (compressionCodec) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -68,8 +68,8 @@ public class ForwardIndexConfig extends IndexConfig {
     }
     _targetMaxChunkSize =
         targetMaxChunkSize == null ? DataSizeUtils.fromBytes(DEFAULT_TARGET_MAX_CHUNK_SIZE) : targetMaxChunkSize;
-    _targetDocsPerChunk =
-        targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK : targetDocsPerChunk;
+    _targetDocsPerChunk = targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK
+        : targetDocsPerChunk < 0 ? Integer.MAX_VALUE : targetDocsPerChunk;
 
     if (compressionCodec != null) {
       switch (compressionCodec) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -37,7 +37,9 @@ import org.apache.pinot.spi.utils.DataSizeUtils;
 public class ForwardIndexConfig extends IndexConfig {
   public static final int DEFAULT_RAW_WRITER_VERSION = 2;
   public static final int DEFAULT_TARGET_MAX_CHUNK_SIZE = 1024 * 1024; // 1MB
-  public static final ForwardIndexConfig DISABLED = new ForwardIndexConfig(true, null, null, null, null, null, null);
+  public static final int DEFAULT_TARGET_DOCS_PER_CHUNK = 1000;
+  public static final ForwardIndexConfig DISABLED =
+      new ForwardIndexConfig(true, null, null, null, null, null, null, null);
   public static final ForwardIndexConfig DEFAULT = new Builder().build();
 
   @Nullable
@@ -45,6 +47,7 @@ public class ForwardIndexConfig extends IndexConfig {
   private final boolean _deriveNumDocsPerChunk;
   private final int _rawIndexWriterVersion;
   private final String _targetMaxChunkSize;
+  private final int _targetDocsPerChunk;
 
   @Nullable
   private final ChunkCompressionType _chunkCompressionType;
@@ -53,7 +56,7 @@ public class ForwardIndexConfig extends IndexConfig {
 
   public ForwardIndexConfig(@Nullable Boolean disabled, @Nullable CompressionCodec compressionCodec,
       @Nullable Boolean deriveNumDocsPerChunk, @Nullable Integer rawIndexWriterVersion,
-      @Nullable String targetMaxChunkSize) {
+      @Nullable String targetMaxChunkSize, @Nullable Integer targetDocsPerChunk) {
     super(disabled);
     _deriveNumDocsPerChunk = Boolean.TRUE.equals(deriveNumDocsPerChunk);
     _rawIndexWriterVersion = rawIndexWriterVersion == null ? DEFAULT_RAW_WRITER_VERSION : rawIndexWriterVersion;
@@ -65,6 +68,8 @@ public class ForwardIndexConfig extends IndexConfig {
     }
     _targetMaxChunkSize =
         targetMaxChunkSize == null ? DataSizeUtils.fromBytes(DEFAULT_TARGET_MAX_CHUNK_SIZE) : targetMaxChunkSize;
+    _targetDocsPerChunk =
+        targetDocsPerChunk == null ? DEFAULT_TARGET_DOCS_PER_CHUNK : targetDocsPerChunk;
 
     if (compressionCodec != null) {
       switch (compressionCodec) {
@@ -109,9 +114,10 @@ public class ForwardIndexConfig extends IndexConfig {
       @Deprecated @JsonProperty("dictIdCompressionType") @Nullable DictIdCompressionType dictIdCompressionType,
       @JsonProperty("deriveNumDocsPerChunk") @Nullable Boolean deriveNumDocsPerChunk,
       @JsonProperty("rawIndexWriterVersion") @Nullable Integer rawIndexWriterVersion,
-      @JsonProperty("targetMaxChunkSize") @Nullable String targetMaxChunkSizeBytes) {
+      @JsonProperty("targetMaxChunkSize") @Nullable String targetMaxChunkSizeBytes,
+      @JsonProperty("targetDocsPerChunk") @Nullable Integer targetDocsPerChunk) {
     this(disabled, getActualCompressionCodec(compressionCodec, chunkCompressionType, dictIdCompressionType),
-        deriveNumDocsPerChunk, rawIndexWriterVersion, targetMaxChunkSizeBytes);
+        deriveNumDocsPerChunk, rawIndexWriterVersion, targetMaxChunkSizeBytes, targetDocsPerChunk);
   }
 
   public static CompressionCodec getActualCompressionCodec(@Nullable CompressionCodec compressionCodec,
@@ -164,6 +170,10 @@ public class ForwardIndexConfig extends IndexConfig {
     return _targetMaxChunkSize;
   }
 
+  public int getTargetDocsPerChunk() {
+    return _targetDocsPerChunk;
+  }
+
   @JsonIgnore
   public int getTargetMaxChunkSizeBytes() {
     return (int) DataSizeUtils.toBytes(_targetMaxChunkSize);
@@ -194,12 +204,14 @@ public class ForwardIndexConfig extends IndexConfig {
     }
     ForwardIndexConfig that = (ForwardIndexConfig) o;
     return _compressionCodec == that._compressionCodec && _deriveNumDocsPerChunk == that._deriveNumDocsPerChunk
-        && _rawIndexWriterVersion == that._rawIndexWriterVersion;
+        && _rawIndexWriterVersion == that._rawIndexWriterVersion && Objects.equals(_targetMaxChunkSize,
+        that._targetMaxChunkSize) && _targetDocsPerChunk == that._targetDocsPerChunk;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), _compressionCodec, _deriveNumDocsPerChunk, _rawIndexWriterVersion);
+    return Objects.hash(super.hashCode(), _compressionCodec, _deriveNumDocsPerChunk, _rawIndexWriterVersion,
+        _targetMaxChunkSize, _targetDocsPerChunk);
   }
 
   public static class Builder {
@@ -208,6 +220,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private boolean _deriveNumDocsPerChunk = false;
     private int _rawIndexWriterVersion = DEFAULT_RAW_WRITER_VERSION;
     private String _targetMaxChunkSize;
+    private int _targetDocsPerChunk;
 
     public Builder() {
     }
@@ -217,6 +230,7 @@ public class ForwardIndexConfig extends IndexConfig {
       _deriveNumDocsPerChunk = other._deriveNumDocsPerChunk;
       _rawIndexWriterVersion = other._rawIndexWriterVersion;
       _targetMaxChunkSize = other._targetMaxChunkSize;
+      _targetDocsPerChunk = other._targetDocsPerChunk;
     }
 
     public Builder withCompressionCodec(CompressionCodec compressionCodec) {
@@ -236,6 +250,11 @@ public class ForwardIndexConfig extends IndexConfig {
 
     public Builder withTargetMaxChunkSize(int targetMaxChunkSize) {
       _targetMaxChunkSize = DataSizeUtils.fromBytes(targetMaxChunkSize);
+      return this;
+    }
+
+    public Builder withTargetDocsPerChunk(int targetDocsPerChunk) {
+      _targetDocsPerChunk = targetDocsPerChunk;
       return this;
     }
 
@@ -299,7 +318,7 @@ public class ForwardIndexConfig extends IndexConfig {
 
     public ForwardIndexConfig build() {
       return new ForwardIndexConfig(false, _compressionCodec, _deriveNumDocsPerChunk, _rawIndexWriterVersion,
-          _targetMaxChunkSize);
+          _targetMaxChunkSize, _targetDocsPerChunk);
     }
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -81,6 +81,15 @@ public class ForwardIndexConfigTest {
   }
 
   @Test
+  public void withNegativeTargetDocsPerChunk()
+      throws JsonProcessingException {
+    String confStr = "{\"targetDocsPerChunk\": \"-1\"}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertEquals(config.getTargetDocsPerChunk(), Integer.MAX_VALUE, "Unexpected defaultTargetDocsPerChunk");
+  }
+
+  @Test
   public void withSomeData()
       throws JsonProcessingException {
     String confStr = "{\n"

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -86,7 +86,7 @@ public class ForwardIndexConfigTest {
     String confStr = "{\"targetDocsPerChunk\": \"-1\"}";
     ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
 
-    assertEquals(config.getTargetDocsPerChunk(), Integer.MAX_VALUE, "Unexpected defaultTargetDocsPerChunk");
+    assertEquals(config.getTargetDocsPerChunk(), -1, "Unexpected defaultTargetDocsPerChunk");
   }
 
   @Test

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -87,7 +87,8 @@ public class ForwardIndexConfigTest {
         + "        \"chunkCompressionType\": \"SNAPPY\",\n"
         + "        \"deriveNumDocsPerChunk\": true,\n"
         + "        \"rawIndexWriterVersion\": 10,\n"
-        + "        \"targetMaxChunkSize\": \"512K\"\n"
+        + "        \"targetMaxChunkSize\": \"512K\",\n"
+        + "        \"targetDocsPerChunk\": \"2000\"\n"
         + "}";
     ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
 
@@ -96,5 +97,6 @@ public class ForwardIndexConfigTest {
     assertTrue(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
     assertEquals(config.getRawIndexWriterVersion(), 10, "Unexpected rawIndexWriterVersion");
     assertEquals(config.getTargetMaxChunkSizeBytes(), 512 * 1024, "Unexpected targetMaxChunkSizeBytes");
+    assertEquals(config.getTargetDocsPerChunk(), 2000, "Unexpected defaultTargetDocsPerChunk");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -86,7 +86,8 @@ public class ForwardIndexConfigTest {
     String confStr = "{\n"
         + "        \"chunkCompressionType\": \"SNAPPY\",\n"
         + "        \"deriveNumDocsPerChunk\": true,\n"
-        + "        \"rawIndexWriterVersion\": 10\n"
+        + "        \"rawIndexWriterVersion\": 10,\n"
+        + "        \"targetMaxChunkSize\": \"512K\"\n"
         + "}";
     ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
 
@@ -94,5 +95,6 @@ public class ForwardIndexConfigTest {
     assertEquals(config.getChunkCompressionType(), ChunkCompressionType.SNAPPY, "Unexpected chunkCompressionType");
     assertTrue(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
     assertEquals(config.getRawIndexWriterVersion(), 10, "Unexpected rawIndexWriterVersion");
+    assertEquals(config.getTargetMaxChunkSizeBytes(), 512 * 1024, "Unexpected targetMaxChunkSizeBytes");
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -48,7 +48,7 @@ public class QuickstartRunner {
   private static final int ZK_PORT = 2123;
   private static final String ZK_ADDRESS = "localhost:" + ZK_PORT;
 
-  private static final int DEFAULT_CONTROLLER_PORT = 9000;
+  private static final int DEFAULT_CONTROLLER_PORT = 9099;
   private static final int DEFAULT_BROKER_PORT = 8000;
   private static final int DEFAULT_SERVER_ADMIN_API_PORT = 7500;
   private static final int DEFAULT_SERVER_NETTY_PORT = 7050;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -48,7 +48,7 @@ public class QuickstartRunner {
   private static final int ZK_PORT = 2123;
   private static final String ZK_ADDRESS = "localhost:" + ZK_PORT;
 
-  private static final int DEFAULT_CONTROLLER_PORT = 9099;
+  private static final int DEFAULT_CONTROLLER_PORT = 9000;
   private static final int DEFAULT_BROKER_PORT = 8000;
   private static final int DEFAULT_SERVER_ADMIN_API_PORT = 7500;
   private static final int DEFAULT_SERVER_NETTY_PORT = 7050;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -318,7 +318,7 @@ public class DictionaryToRawIndexConverter {
 
     try (ForwardIndexCreator rawIndexCreator = ForwardIndexCreatorFactory.getRawIndexCreatorForSVColumn(newSegment,
         compressionType, column, storedType, numDocs, lengthOfLongestEntry, false,
-        ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES,
         ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext()) {
       switch (storedType) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -318,7 +318,7 @@ public class DictionaryToRawIndexConverter {
 
     try (ForwardIndexCreator rawIndexCreator = ForwardIndexCreatorFactory
         .getRawIndexCreatorForSVColumn(newSegment, compressionType, column, storedType, numDocs, lengthOfLongestEntry,
-            false, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION);
+            false, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext()) {
       switch (storedType) {
         case INT:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -316,9 +316,10 @@ public class DictionaryToRawIndexConverter {
     int numDocs = segment.getSegmentMetadata().getTotalDocs();
     int lengthOfLongestEntry = (storedType == DataType.STRING) ? getLengthOfLongestEntry(dictionary) : -1;
 
-    try (ForwardIndexCreator rawIndexCreator = ForwardIndexCreatorFactory
-        .getRawIndexCreatorForSVColumn(newSegment, compressionType, column, storedType, numDocs, lengthOfLongestEntry,
-            false, ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE);
+    try (ForwardIndexCreator rawIndexCreator = ForwardIndexCreatorFactory.getRawIndexCreatorForSVColumn(newSegment,
+        compressionType, column, storedType, numDocs, lengthOfLongestEntry, false,
+        ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION, ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE,
+        ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext()) {
       switch (storedType) {
         case INT:


### PR DESCRIPTION
**Background**
- V4 format was introduced to better handle variable length data chunk size by reducing the potential for large allocations https://github.com/apache/pinot/pull/7661 
- V3 format allocated direct memory based on `numDocPerChunk * lengthOfLongestEntry`, which was very efficient for near-constant length/short data. 
- For example, in each format a null column’s chunk size would be:
  - V3: 1000 docs * 4 bytes (‘null’) = `4KB`
  - V4: `1MB` hardcoded target

**Problem**
- Making V4 default (https://github.com/apache/pinot/pull/11120) will result in a large direct memory increase for the values we typically see. 
- For the static 1000 docs/chunk used in V2/3 (assuming `deriveNumDocsPerChunk` is not set) the breakeven point assumes the `lengthOfLongestEntry` of a column in a segment is ~1KB

We have seen this behavior first hand after making V4 default internally. We have many columns for which we do not know if they will contain variable length data or ‘short data’, and it's desirable to handle both cases with a single format.

**Change**
This PR introduces dynamic chunk sizing for V4 format. Target chunk size is calculated based on the heuristic:
```
max(min(maxLength * targetDocsPerChunk, targetMaxChunkSize), TARGET_MIN_CHUNK_SIZE)
```
where new configs are introduced:
```
"forward": {
  "targetMaxChunkSize": "1M",
  "targetDocsPerChunk": 1000
}
```
and `TARGET_MIN_CHUNK_SIZE = 4K`

In testing I’ve found doing this results in reduced direct memory spikes, especially against wide tables/high QPS. The below graph shows the improvement in direct memory spikes for a env with majority of tables using 3-7 day TTL and adhoc QPS. Some spikes are still present as not all segments with the old static chunk size have been expired (some 30 day TTL tables exist).

![image](https://github.com/apache/pinot/assets/27231838/b414a7a3-240a-4d76-8a01-987e552b1b1a)

I think dynamic chunk sizing should be the default implementation for V4 and have not put this behind a config. It bridges the gap between the variable length data behavior of V4 with the 'short data' behavior of V2/V3. 

There are no backward compatibility concerns with this PR. 

tags: `performance`