### PR TITLE
Create a class for MailboxId

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
@@ -71,7 +71,6 @@ public class MailboxId {
 
   @Override
   public String toString() {
-    // CHECKSTYLE:OFF
     // @formatter:off
     return "{\"requestId\":" + _requestId
         + ",\"senderStageId\":" + _senderStageId
@@ -80,7 +79,6 @@ public class MailboxId {
         + ",\"receiverWorkerId\":" + _receiverWorkerId
         + "}";
     // @formatter:on
-    // CHECKSTYLE:ON
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical;
+
+import java.util.Objects;
+
+
+public class MailboxId {
+  public static final char SEPARATOR = '|';
+
+  private final long _requestId;
+  private final int _senderStageId;
+  private final int _senderWorkerId;
+  private final int _receiverStageId;
+  private final int _receiverWorkerId;
+
+  public MailboxId(long requestId, int senderStageId, int senderWorkerId, int receiverStageId, int receiverWorkerId) {
+    _requestId = requestId;
+    _senderStageId = senderStageId;
+    _senderWorkerId = senderWorkerId;
+    _receiverStageId = receiverStageId;
+    _receiverWorkerId = receiverWorkerId;
+  }
+
+  public long getRequestId() {
+    return _requestId;
+  }
+
+  public int getSenderStageId() {
+    return _senderStageId;
+  }
+
+  public int getSenderWorkerId() {
+    return _senderWorkerId;
+  }
+
+  public int getReceiverStageId() {
+    return _receiverStageId;
+  }
+
+  public int getReceiverWorkerId() {
+    return _receiverWorkerId;
+  }
+
+  public static MailboxId fromPipeString(String mailboxIdStr) {
+    String[] parts = mailboxIdStr.split("\\" + SEPARATOR);
+    return new MailboxId(Long.parseLong(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]),
+        Integer.parseInt(parts[3]), Integer.parseInt(parts[4]));
+  }
+
+  public String toPipeString() {
+    return Long.toString(_requestId) + SEPARATOR + _senderStageId + SEPARATOR + _senderWorkerId + SEPARATOR
+        + _receiverStageId + SEPARATOR + _receiverWorkerId;
+  }
+
+  @Override
+  public String toString() {
+    // CHECKSTYLE:OFF
+    // @formatter:off
+    return "{\"requestId\":" + _requestId
+        + ",\"senderStageId\":" + _senderStageId
+        + ",\"senderWorkerId\":" + _senderWorkerId
+        + ",\"receiverStageId\":" + _receiverStageId
+        + ",\"receiverWorkerId\":" + _receiverWorkerId
+        + "}";
+    // @formatter:on
+    // CHECKSTYLE:ON
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MailboxId)) {
+      return false;
+    }
+    MailboxId mailboxId = (MailboxId) o;
+    return _requestId == mailboxId._requestId && _senderStageId == mailboxId._senderStageId
+        && _senderWorkerId == mailboxId._senderWorkerId && _receiverStageId == mailboxId._receiverStageId
+        && _receiverWorkerId == mailboxId._receiverWorkerId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_requestId, _senderStageId, _senderWorkerId, _receiverStageId, _receiverWorkerId);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxId.java
@@ -59,9 +59,31 @@ public class MailboxId {
   }
 
   public static MailboxId fromPipeString(String mailboxIdStr) {
-    String[] parts = mailboxIdStr.split("\\" + SEPARATOR);
-    return new MailboxId(Long.parseLong(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]),
-        Integer.parseInt(parts[3]), Integer.parseInt(parts[4]));
+    int requestEnd = mailboxIdStr.indexOf(SEPARATOR);
+    if (requestEnd == -1) {
+      throw new IllegalArgumentException("Invalid mailboxId string: " + mailboxIdStr + ". No " + SEPARATOR + " found");
+    }
+    int senderStageEnd = mailboxIdStr.indexOf(SEPARATOR, requestEnd + 1);
+    if (senderStageEnd == -1) {
+      throw new IllegalArgumentException("Invalid mailboxId string: " + mailboxIdStr + ". No sender stage found");
+    }
+    int senderWorkerEnd = mailboxIdStr.indexOf(SEPARATOR, senderStageEnd + 1);
+    if (senderWorkerEnd == -1) {
+      throw new IllegalArgumentException("Invalid mailboxId string: " + mailboxIdStr + ". No sender worker found");
+    }
+    int receiverStageEnd = mailboxIdStr.indexOf(SEPARATOR, senderWorkerEnd + 1);
+    if (receiverStageEnd == -1) {
+      throw new IllegalArgumentException("Invalid mailboxId string: " + mailboxIdStr + ". No receiver stage found");
+    }
+    if (receiverStageEnd == mailboxIdStr.length() - 1) {
+      throw new IllegalArgumentException("Invalid mailboxId string: " + mailboxIdStr + ". No receiver worker found");
+    }
+    return new MailboxId(
+        Long.parseLong(mailboxIdStr.substring(0, requestEnd)),
+        Integer.parseInt(mailboxIdStr.substring(requestEnd + 1, senderStageEnd)),
+        Integer.parseInt(mailboxIdStr.substring(senderStageEnd + 1, senderWorkerEnd)),
+        Integer.parseInt(mailboxIdStr.substring(senderWorkerEnd + 1, receiverStageEnd)),
+        Integer.parseInt(mailboxIdStr.substring(receiverStageEnd + 1)));
   }
 
   public String toPipeString() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxIdUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxIdUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.planner.physical;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.query.routing.MailboxInfo;
@@ -31,13 +30,6 @@ public class MailboxIdUtils {
 
   public static final char SEPARATOR = '|';
 
-  @VisibleForTesting
-  public static String toMailboxId(long requestId, int senderStageId, int senderWorkerId, int receiverStageId,
-      int receiverWorkerId) {
-    return Long.toString(requestId) + SEPARATOR + senderStageId + SEPARATOR + senderWorkerId + SEPARATOR
-        + receiverStageId + SEPARATOR + receiverWorkerId;
-  }
-
   public static List<RoutingInfo> toRoutingInfos(long requestId, int senderStageId, int senderWorkerId,
       int receiverStageId, List<MailboxInfo> receiverMailboxInfos) {
     List<RoutingInfo> routingInfos = new ArrayList<>();
@@ -46,18 +38,18 @@ public class MailboxIdUtils {
       int port = mailboxInfo.getPort();
       for (int receiverWorkerId : mailboxInfo.getWorkerIds()) {
         routingInfos.add(new RoutingInfo(hostname, port,
-            toMailboxId(requestId, senderStageId, senderWorkerId, receiverStageId, receiverWorkerId)));
+            new MailboxId(requestId, senderStageId, senderWorkerId, receiverStageId, receiverWorkerId)));
       }
     }
     return routingInfos;
   }
 
-  public static List<String> toMailboxIds(long requestId, int senderStageId, List<MailboxInfo> senderMailboxInfos,
+  public static List<MailboxId> toMailboxIds(long requestId, int senderStageId, List<MailboxInfo> senderMailboxInfos,
       int receiverStageId, int receiverWorkerId) {
-    List<String> mailboxIds = new ArrayList<>();
+    List<MailboxId> mailboxIds = new ArrayList<>();
     for (MailboxInfo mailboxInfo : senderMailboxInfos) {
       for (int senderWorkerId : mailboxInfo.getWorkerIds()) {
-        mailboxIds.add(toMailboxId(requestId, senderStageId, senderWorkerId, receiverStageId, receiverWorkerId));
+        mailboxIds.add(new MailboxId(requestId, senderStageId, senderWorkerId, receiverStageId, receiverWorkerId));
       }
     }
     return mailboxIds;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/RoutingInfo.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/RoutingInfo.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.query.routing;
 
+import org.apache.pinot.query.planner.physical.MailboxId;
+
+
 public class RoutingInfo {
   private final String _hostname;
   private final int _port;
-  private final String _mailboxId;
+  private final MailboxId _mailboxId;
 
-  public RoutingInfo(String hostname, int port, String mailboxId) {
+  public RoutingInfo(String hostname, int port, MailboxId mailboxId) {
     _hostname = hostname;
     _port = port;
     _mailboxId = mailboxId;
@@ -37,7 +40,7 @@ public class RoutingInfo {
     return _port;
   }
 
-  public String getMailboxId() {
+  public MailboxId getMailboxId() {
     return _mailboxId;
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/MailboxIdTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/MailboxIdTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class MailboxIdTest {
+
+  @Test
+  public void testJson() {
+    MailboxId mailboxId = new MailboxId(1036791369000154169L, 2, 4, 1, 4);
+
+    assertEquals(mailboxId.toString(),
+        "{\"requestId\":1036791369000154169,\"senderStageId\":2,\"senderWorkerId\":4,"
+            + "\"receiverStageId\":1,\"receiverWorkerId\":4}",
+        "MailboxId.toString() should return a JSON string representation of the mailboxId object");
+  }
+
+  @Test
+  public void testPipeString() {
+    MailboxId mailboxId = new MailboxId(1036791369000154169L, 2, 4, 1, 4);
+
+    assertEquals(mailboxId.toPipeString(), "1036791369000154169|2|4|1|4",
+        "MailboxId.toPipeString() should return a pipe-separated string representation of the mailboxId object");
+  }
+
+  @Test
+  public void testFromPipeString() {
+    MailboxId mailboxId = MailboxId.fromPipeString("1036791369000154169|2|4|1|4");
+
+    assertEquals(mailboxId.getRequestId(), 1036791369000154169L,
+        "MailboxId.getRequestId() should return the request ID of the mailboxId object");
+    assertEquals(mailboxId.getSenderStageId(), 2,
+        "MailboxId.getSenderStageId() should return the sender stage ID of the mailboxId object");
+    assertEquals(mailboxId.getSenderWorkerId(), 4,
+        "MailboxId.getSenderWorkerId() should return the sender worker ID of the mailboxId object");
+    assertEquals(mailboxId.getReceiverStageId(), 1,
+        "MailboxId.getReceiverStageId() should return the receiver stage ID of the mailboxId object");
+    assertEquals(mailboxId.getReceiverWorkerId(), 4,
+        "MailboxId.getReceiverWorkerId() should return the receiver worker ID of the mailboxId object");
+  }
+
+  @Test
+  public void testEncodeDecodePipe() {
+    MailboxId mailboxId = new MailboxId(1036791369000154169L, 2, 4, 1, 4);
+    String pipeString = mailboxId.toPipeString();
+    MailboxId decodedMailboxId = MailboxId.fromPipeString(pipeString);
+    assertEquals(mailboxId, decodedMailboxId);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.proto.Mailbox.MailboxContent;
 import org.apache.pinot.common.proto.PinotMailboxGrpc;
 import org.apache.pinot.query.mailbox.channel.ChannelManager;
 import org.apache.pinot.query.mailbox.channel.MailboxStatusObserver;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.slf4j.Logger;
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class GrpcSendingMailbox implements SendingMailbox {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcSendingMailbox.class);
 
-  private final String _id;
+  private final MailboxId _id;
   private final ChannelManager _channelManager;
   private final String _hostname;
   private final int _port;
@@ -49,7 +50,7 @@ public class GrpcSendingMailbox implements SendingMailbox {
 
   private StreamObserver<MailboxContent> _contentObserver;
 
-  public GrpcSendingMailbox(String id, ChannelManager channelManager, String hostname, int port, long deadlineMs) {
+  public GrpcSendingMailbox(MailboxId id, ChannelManager channelManager, String hostname, int port, long deadlineMs) {
     _id = id;
     _channelManager = channelManager;
     _hostname = hostname;
@@ -121,6 +122,6 @@ public class GrpcSendingMailbox implements SendingMailbox {
     DataBlock dataBlock = block.getDataBlock();
     byte[] bytes = dataBlock.toBytes();
     ByteString byteString = UnsafeByteOperations.unsafeWrap(bytes);
-    return MailboxContent.newBuilder().setMailboxId(_id).setPayload(byteString).build();
+    return MailboxContent.newBuilder().setMailboxId(_id.toPipeString()).setPayload(byteString).build();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.mailbox;
 
 import java.util.concurrent.TimeoutException;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.spi.exception.QueryCancelledException;
@@ -29,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class InMemorySendingMailbox implements SendingMailbox {
   private static final Logger LOGGER = LoggerFactory.getLogger(InMemorySendingMailbox.class);
 
-  private final String _id;
+  private final MailboxId _id;
   private final MailboxService _mailboxService;
   private final long _deadlineMs;
 
@@ -37,7 +38,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
   private volatile boolean _isTerminated;
   private volatile boolean _isEarlyTerminated;
 
-  public InMemorySendingMailbox(String id, MailboxService mailboxService, long deadlineMs) {
+  public InMemorySendingMailbox(MailboxId id, MailboxService mailboxService, long deadlineMs) {
     _id = id;
     _mailboxService = mailboxService;
     _deadlineMs = deadlineMs;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public class ReceivingMailbox {
   private static final TransferableBlock CANCELLED_ERROR_BLOCK =
       TransferableBlockUtils.getErrorTransferableBlock(new RuntimeException("Cancelled by receiver"));
 
-  private final String _id;
+  private final MailboxId _id;
   // TODO: Make the queue size configurable
   // TODO: Revisit if this is the correct way to apply back pressure
   private final BlockingQueue<TransferableBlock> _blocks = new ArrayBlockingQueue<>(DEFAULT_MAX_PENDING_BLOCKS);
@@ -54,7 +55,7 @@ public class ReceivingMailbox {
   @Nullable
   private volatile Reader _reader;
 
-  public ReceivingMailbox(String id) {
+  public ReceivingMailbox(MailboxId id) {
     _id = id;
   }
 
@@ -68,7 +69,7 @@ public class ReceivingMailbox {
     _reader = reader;
   }
 
-  public String getId() {
+  public MailboxId getId() {
     return _id;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.planner.physical.MailboxIdUtils;
 import org.apache.pinot.query.routing.MailboxInfos;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -46,7 +47,7 @@ import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
   protected final MailboxService _mailboxService;
   protected final RelDistribution.Type _exchangeType;
-  protected final List<String> _mailboxIds;
+  protected final List<MailboxId> _mailboxIds;
   protected final BlockingMultiStreamConsumer.OfTransferableBlock _multiConsumer;
 
   public BaseMailboxReceiveOperator(OpChainExecutionContext context, RelDistribution.Type exchangeType,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MailboxServiceTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.query.planner.physical.MailboxIdUtils;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.OperatorTestUtil;
@@ -70,7 +70,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalHappyPathSendFirst()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
 
     // Sends are non-blocking as long as channel capacity is not breached
     SendingMailbox sendingMailbox =
@@ -103,7 +103,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalHappyPathReceiveFirst()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
 
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
     AtomicInteger numCallbacks = new AtomicInteger();
@@ -141,7 +141,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalCancelledBySender()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -168,7 +168,7 @@ public class MailboxServiceTest {
 
   @Test
   public void testLocalCancelledBySenderBeforeSend() {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -195,7 +195,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalCancelledByReceiver()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -223,7 +223,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalTimeOut()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     long deadlineMs = System.currentTimeMillis() + 1000;
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, deadlineMs);
@@ -258,7 +258,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalBufferFull()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId,
             System.currentTimeMillis() + 1000);
@@ -296,7 +296,7 @@ public class MailboxServiceTest {
   @Test
   public void testLocalEarlyTerminated()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService1.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -322,7 +322,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteHappyPathSendFirst()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
 
     // Sends are non-blocking as long as channel capacity is not breached
     SendingMailbox sendingMailbox =
@@ -360,7 +360,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteHappyPathReceiveFirst()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
 
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
     AtomicInteger numCallbacks = new AtomicInteger();
@@ -404,7 +404,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteCancelledBySender()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService2.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -439,7 +439,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteCancelledBySenderBeforeSend()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService2.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -473,7 +473,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteCancelledByReceiver()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService2.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, Long.MAX_VALUE);
     ReceivingMailbox receivingMailbox = _mailboxService1.getReceivingMailbox(mailboxId);
@@ -506,7 +506,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteTimeOut()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     long deadlineMs = System.currentTimeMillis() + 1000;
     SendingMailbox sendingMailbox =
         _mailboxService2.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId, deadlineMs);
@@ -549,7 +549,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteBufferFull()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
     SendingMailbox sendingMailbox =
         _mailboxService2.getSendingMailbox("localhost", _mailboxService1.getPort(), mailboxId,
             System.currentTimeMillis() + 1000);
@@ -587,7 +587,7 @@ public class MailboxServiceTest {
   @Test
   public void testRemoteEarlyTerminated()
       throws Exception {
-    String mailboxId = MailboxIdUtils.toMailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
+    MailboxId mailboxId = createMailboxId();
 
     // Sends are non-blocking as long as channel capacity is not breached
     SendingMailbox sendingMailbox =
@@ -613,5 +613,9 @@ public class MailboxServiceTest {
 
     // sending side should early terminate
     TestUtils.waitForCondition(aVoid -> sendingMailbox.isEarlyTerminated(), 1000L, "Failed to early-terminate sender");
+  }
+
+  private MailboxId createMailboxId() {
+    return new MailboxId(_requestId++, SENDER_STAGE_ID, 0, RECEIVER_STAGE_ID, 0);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -28,7 +28,7 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
-import org.apache.pinot.query.planner.physical.MailboxIdUtils;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.routing.MailboxInfo;
 import org.apache.pinot.query.routing.MailboxInfos;
 import org.apache.pinot.query.routing.SharedMailboxInfos;
@@ -55,8 +55,8 @@ import static org.testng.Assert.assertTrue;
 public class MailboxReceiveOperatorTest {
   private static final DataSchema DATA_SCHEMA =
       new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-  private static final String MAILBOX_ID_1 = MailboxIdUtils.toMailboxId(0, 1, 0, 0, 0);
-  private static final String MAILBOX_ID_2 = MailboxIdUtils.toMailboxId(0, 1, 1, 0, 0);
+  private static final MailboxId MAILBOX_ID_1 = new MailboxId(0, 1, 0, 0, 0);
+  private static final MailboxId MAILBOX_ID_2 = new MailboxId(0, 1, 1, 0, 0);
 
   private StageMetadata _stageMetadataBoth;
   private StageMetadata _stageMetadata1;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -33,7 +33,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.physical.MailboxIdUtils;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.routing.MailboxInfo;
 import org.apache.pinot.query.routing.MailboxInfos;
 import org.apache.pinot.query.routing.SharedMailboxInfos;
@@ -63,8 +63,8 @@ public class SortedMailboxReceiveOperatorTest {
   private static final List<RexExpression> COLLATION_KEYS = Collections.singletonList(new RexExpression.InputRef(0));
   private static final List<Direction> COLLATION_DIRECTIONS = Collections.singletonList(Direction.ASCENDING);
   private static final List<NullDirection> COLLATION_NULL_DIRECTIONS = Collections.singletonList(NullDirection.LAST);
-  private static final String MAILBOX_ID_1 = MailboxIdUtils.toMailboxId(0, 1, 0, 0, 0);
-  private static final String MAILBOX_ID_2 = MailboxIdUtils.toMailboxId(0, 1, 1, 0, 0);
+  private static final MailboxId MAILBOX_ID_1 = new MailboxId(0, 1, 0, 0, 0);
+  private static final MailboxId MAILBOX_ID_2 = new MailboxId(0, 1, 1, 0, 0);
 
   private StageMetadata _stageMetadataBoth;
   private StageMetadata _stageMetadata1;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
@@ -31,7 +31,7 @@ import org.apache.calcite.rel.logical.PinotRelExchangeType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
-import org.apache.pinot.query.planner.physical.MailboxIdUtils;
+import org.apache.pinot.query.planner.physical.MailboxId;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
 import org.apache.pinot.query.routing.MailboxInfo;
@@ -61,8 +61,8 @@ import static org.mockito.Mockito.when;
 public class PipelineBreakerExecutorTest {
   private static final DataSchema DATA_SCHEMA =
       new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-  private static final String MAILBOX_ID_1 = MailboxIdUtils.toMailboxId(0, 1, 0, 0, 0);
-  private static final String MAILBOX_ID_2 = MailboxIdUtils.toMailboxId(0, 2, 0, 0, 0);
+  private static final MailboxId MAILBOX_ID_1 = new MailboxId(0, 1, 0, 0, 0);
+  private static final MailboxId MAILBOX_ID_2 = new MailboxId(0, 2, 0, 0, 0);
 
   private final VirtualServerAddress _server = new VirtualServerAddress("localhost", 123, 0);
   private final ExecutorService _executor = Executors.newCachedThreadPool();
@@ -88,8 +88,8 @@ public class PipelineBreakerExecutorTest {
     when(_mailboxService.getHostname()).thenReturn("localhost");
     when(_mailboxService.getPort()).thenReturn(123);
 
-    when(_mailbox1.getId()).thenReturn("mailbox1");
-    when(_mailbox2.getId()).thenReturn("mailbox2");
+    when(_mailbox1.getId()).thenReturn(new MailboxId(0, 1, 0, 0, 0));
+    when(_mailbox2.getId()).thenReturn(new MailboxId(0, 2, 0, 0, 0));
   }
 
   @AfterMethod


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Replaces string mailbox ID with MailboxId object internally, converting to/from pipe string at GRPC boundary\.

```mermaid
flowchart TD
  N0["Internal MailboxId #40;sender#41; #40;F4#41;"]:::stModified
  N1["GRPC send#58; toPipeString#40;#41; #40;F4#41;"]:::stModified
  N2["GRPC receive#58; fromPipeString#40;#41; #40;F8#41;"]:::stModified
  N3["Internal MailboxId #40;receiver#41; #40;F6#44; F7#41;"]:::stModified
  N0 -->|"uses"| N1
  N2 -->|"constructs"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F4: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox\.java — [before](https://github.com/apache/pinot/blob/7dbc3459299a18772baa27c53c3c36f0a6edf60b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java) · [after](https://github.com/apache/pinot/blob/ee38ebb34960d60f678d2a0bac1039b91cac1738/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java)
- F6: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService\.java — [before](https://github.com/apache/pinot/blob/7dbc3459299a18772baa27c53c3c36f0a6edf60b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java) · [after](https://github.com/apache/pinot/blob/ee38ebb34960d60f678d2a0bac1039b91cac1738/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java)
- F7: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox\.java — [before](https://github.com/apache/pinot/blob/7dbc3459299a18772baa27c53c3c36f0a6edf60b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java) · [after](https://github.com/apache/pinot/blob/ee38ebb34960d60f678d2a0bac1039b91cac1738/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java)
- F8: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver\.java — [before](https://github.com/apache/pinot/blob/7dbc3459299a18772baa27c53c3c36f0a6edf60b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java) · [after](https://github.com/apache/pinot/blob/ee38ebb34960d60f678d2a0bac1039b91cac1738/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdkYmMzNDU5Mjk5YTE4NzcyYmFhMjdjNTNjM2MzNmYwYTZlZGY2MGIiLCJjb250ZXh0X2hhc2giOiI2NjA4Y2MzNDEzMDYyZGNhYzA0NmRkZDZhOTIyY2YwODQ1MjkxZjk3MjE2MDlhMDdkMjc5M2FmM2MyNjQ3ZjU1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODk5OTQ5LCJoZWFkX3NoYSI6ImVlMzhlYmIzNDk2MGQ2MGY2NzhkMmEwYmFjMTAzOWI5MWNhYzE3MzgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3ZGJjMzQ1OTI5OWExODc3MmJhYTI3YzUzYzNjMzZmMGE2ZWRmNjBiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3384dde464f8d84efaeb611f879bd56c2e4584c1cecf2e303b5449f52310d27c -->
<!-- pinot-pr-flow:end -->

This PR changes several files, but the change is very simple. We had the concept of _mailboxId_ but it was represented as a string. This PR adds a class for that concept and change the usage in all the places it was used.

The only place where _mailboxId_ is being used as a string is GRPC message `MailboxContent`. We need to do that to keep GPRC protocol simple and backward compatible.

I think this will make the code easier to read but also improve error messages. For example, in case of timeout, before this PR the message show was:

```
Received error query execution result block: {1000=Timed out while offering data to mailbox: 1036791369000154169|2|4|1|4
```

And now it will be
```
Received error query execution result block: {1000=Timed out while offering data to mailbox: {"requestId": 1036791369000154169, "senderStageId": 2, "senderWorkerId": 4, "receiverStageId": 1, "receiverWorkerId": 4}
```

This message is still far from being great, but at least it doesn't look like magic numbers like the ones used in the TV show _Lost_.