### PR TITLE
Upgrade ORC version to 1.9.3

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>orc-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-storage-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>${hadoop.dependencies.scope}</scope>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -39,14 +39,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.apache.orc</groupId>
-      <artifactId>orc-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-storage-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>${hadoop.dependencies.scope}</scope>
@@ -73,6 +65,14 @@
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-storage-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,8 @@
 
     <avro.version>1.11.3</avro.version>
     <parquet.version>1.13.1</parquet.version>
-    <orc.version>1.5.9</orc.version>
+    <orc.version>1.9.3</orc.version>
+    <hive.version>2.8.1</hive.version>
     <helix.version>1.3.1</helix.version>
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.12.7.20221012</jackson.version>
@@ -524,6 +525,11 @@
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-mapreduce</artifactId>
         <version>${orc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hive</groupId>
+        <artifactId>hive-storage-api</artifactId>
+        <version>${hive.version}</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
This is the PR for [issue](https://github.com/apache/pinot/issues/12858),

As mentioned in the issue, ORC 2.0.0 dropped the support for JDK8/11, and hence, we were seeing the following below issue in the [PR](https://github.com/apache/pinot/pull/12841) raised by dependabot for upgrade 
```bash
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project pinot-orc: Compilation failure: Compilation failure: 
Error:  /home/runner/work/pinot/pinot/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java:[43,21] error: cannot access OrcFile
Error:    bad class file: /home/runner/.m2/repository/org/apache/orc/orc-core/2.0.0/orc-core-2.0.0.jar(/org/apache/orc/OrcFile.class)
Error:      class file has wrong version 61.0, should be 55.0
Error:      Please remove or make sure it appears in the correct subdirectory of the classpath.
```

This is the follow-up to upgrade `ORC 1.9.3`, which still supports Java 11. Also, ORC removed the hive-related classes from the package, and hence, we need to explicitly add a `hive-storage-api` dependency. 