### PR TITLE
Use constant value supplier to measure ingestion delay metrics

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -241,15 +241,17 @@ public class IngestionDelayTracker {
       // Only publish the metric if supported by the underlying stream. If not supported the stream
       // returns Long.MIN_VALUE
       if (ingestionTimeMs >= 0) {
+        long ingestionDelayMs = getPartitionIngestionDelayMs(partitionGroupId);
         _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionGroupId, ServerGauge.REALTIME_INGESTION_DELAY_MS,
-            () -> getPartitionIngestionDelayMs(partitionGroupId));
+            () -> ingestionDelayMs);
       }
       if (firstStreamIngestionTimeMs >= 0) {
+        long endToEndIngestionDelayMs = getPartitionEndToEndIngestionDelayMs(partitionGroupId);
         // Only publish this metric when creation time is supported by the underlying stream
         // When this timestamp is not supported it always returns the value Long.MIN_VALUE
         _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionGroupId,
             ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS,
-            () -> getPartitionEndToEndIngestionDelayMs(partitionGroupId));
+            () -> endToEndIngestionDelayMs);
       }
     }
     // If we are consuming we do not need to track this partition for removal.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Computes delay once and supplies constant to gauge lambdas for ingestion delay metrics\.

```mermaid
flowchart TD
  N0["updateIngestionDelay #40;F1#41;"]:::stModified
  N1["getPartitionIngestionDelayMs #40;F1#41;"]:::stUnchanged
  N2["setOrUpdatePartitionGauge #40;REALTIME#95;INGESTION#95;DELAY#95;MS#41; #40;F1#41;"]:::stModified
  N3["getPartitionEndToEndIngestionDelayMs #40;F1#41;"]:::stUnchanged
  N4["setOrUpdatePartitionGauge #40;END#95;TO#95;END#95;REALTIME#95;INGESTION#95;DELAY#95;MS#41; #40;F1#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"value supplied to lambda"| N2
  N0 -->|"calls"| N2
  N0 -->|"calls"| N3
  N3 -->|"value supplied to lambda"| N4
  N0 -->|"calls"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker\.java — [before](https://github.com/apache/pinot/blob/7dbc3459299a18772baa27c53c3c36f0a6edf60b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java) · [after](https://github.com/apache/pinot/blob/81a0382979c4e5f693bda71ba6336a2f13566788/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdkYmMzNDU5Mjk5YTE4NzcyYmFhMjdjNTNjM2MzNmYwYTZlZGY2MGIiLCJjb250ZXh0X2hhc2giOiI4NDQ1YWM5MzdmYmY1NzA5NTQ1ZDljNGFjNWIxY2U2YWRiYWJhNjQ0NTQ5MWJlZGQ4YmNmNDlmNmE1ZjE5YzZiIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzYwMzc2LCJoZWFkX3NoYSI6IjgxYTAzODI5NzljNGU1ZjY5M2JkYTcxYmE2MzM2YTJmMTM1NjY3ODgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyZjNkYjZlMDUzOWQ1ZDNkNTE0YjNjMGU2MDlmMmYxZGY3ODYxMTQ0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3becbee201593aefd36465f34e9e6524234ecf049c695f44eee9366cf08e990f -->
<!-- pinot-pr-flow:end -->

# Problem
In multiple Pinot deployments, we have seen the REALTIME_INGESTION_DELAY_MS and END_TO_END_REALTIME_INGESTION_DELAY_MS metrics monotonically grow even though there were no active Kafka consumers.

## How did I figure out that there are no active Kafka consumers?
consumingSegmentsInfo API returned the below response:
```
{
  "_segmentToConsumingInfoMap": {
    "telemetry__0__2399__20240415T1650Z": [],
    "telemetry__1__2435__20240415T1600Z": [],
    "telemetry__2__757__20240415T1632Z": [],
    "telemetry__3__2413__20240415T1642Z": []
  }
}
```

The above response shows that consumers are not connected. I also checked the thread dump, and there are no Kafka consumer threads.

## Image showing REALTIME_INGESTION_DELAY_MS grow monotonically
<img width="1245" alt="zoomed-out-ingestion-delay" src="https://github.com/apache/pinot/assets/127247229/32ca9545-bb55-408d-abbb-fc4680817e52">

## Zoomed out image showing REALTIME_INGESTION_DELAY_MS grow monotonically every minute
<img width="1279" alt="zoomed-in-ingestion-delay" src="https://github.com/apache/pinot/assets/127247229/dc6d5eb8-2b17-4e79-a028-72268526561d">

# Solution
Changed the supplier to provide constant value to publish REALTIME_INGESTION_DELAY_MS and END_TO_END_REALTIME_INGESTION_DELAY_MS metrics.

Ingestion delay metrics are published for every batch of messages fetched off Kafka [HERE](https://github.com/apache/pinot/blob/7f87cd3a9ffd7f73c14502d9457a037926aab75f/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java#L647), and this will continue to work when Kafka consumers are active.

`bugfix`