### PR TITLE
make reflection calls compatible with 0.9.11 

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
@@ -52,6 +52,7 @@ public class PinotReflectionUtils {
       Class<? extends Annotation> annotation) {
     try {
       synchronized (REFLECTION_LOCK) {
+        // we use deprecated method include here to avoid the compatibility issue with reflections 0.9.11 -> 0.10.2
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
             .filterInputsBy(new FilterBuilder().include(regexPattern))).getTypesAnnotatedWith(annotation);
       }
@@ -72,6 +73,7 @@ public class PinotReflectionUtils {
         for (String packageName : packages) {
           urls.addAll(ClasspathHelper.forPackage(packageName));
         }
+        // we use deprecated method include here to avoid the compatibility issue with reflections 0.9.11 -> 0.10.2
         return new Reflections(new ConfigurationBuilder().setUrls(urls)
             .filterInputsBy(new FilterBuilder().include(regexPattern))).getTypesAnnotatedWith(annotation);
       }
@@ -92,6 +94,7 @@ public class PinotReflectionUtils {
       Class<? extends Annotation> annotation) {
     try {
       synchronized (REFLECTION_LOCK) {
+        // we use deprecated method include here to avoid the compatibility issue with reflections 0.9.11 -> 0.10.2
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
             .filterInputsBy(new FilterBuilder().include(regexPattern))
             .setScanners(new MethodAnnotationsScanner())).getMethodsAnnotatedWith(annotation);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
@@ -53,7 +53,7 @@ public class PinotReflectionUtils {
     try {
       synchronized (REFLECTION_LOCK) {
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
-            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))).getTypesAnnotatedWith(annotation);
+            .filterInputsBy(new FilterBuilder().include(regexPattern))).getTypesAnnotatedWith(annotation);
       }
     } catch (Throwable t) {
       // Log an error then re-throw it because this method is usually called in a static block, where exception might
@@ -73,7 +73,7 @@ public class PinotReflectionUtils {
           urls.addAll(ClasspathHelper.forPackage(packageName));
         }
         return new Reflections(new ConfigurationBuilder().setUrls(urls)
-            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))).getTypesAnnotatedWith(annotation);
+            .filterInputsBy(new FilterBuilder().include(regexPattern))).getTypesAnnotatedWith(annotation);
       }
     } catch (Throwable t) {
       // Log an error then re-throw it because this method is usually called in a static block, where exception might
@@ -93,7 +93,7 @@ public class PinotReflectionUtils {
     try {
       synchronized (REFLECTION_LOCK) {
         return new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packageName))
-            .filterInputsBy(new FilterBuilder().includePattern(regexPattern))
+            .filterInputsBy(new FilterBuilder().include(regexPattern))
             .setScanners(new MethodAnnotationsScanner())).getMethodsAnnotatedWith(annotation);
       }
     } catch (Throwable t) {


### PR DESCRIPTION
The changes in https://github.com/apache/pinot/pull/12885 creates compatibility issue for our internal builds when older versions of guava is pull in from internal libraries. We are seeing:

```
java.lang.NoSuchMethodError: 'java.util.Set org.reflections.Reflections.getResources(com.google.common.base.Predicate)'
```

We are changing this method call to use `new FilterBuilder().include(regexPattern))` to make this compatible for both `0.9.11` and `0.10.2`. As org.reflection is not being actively developed, this method should not be completely deprecated in near future.