### PR TITLE
Refactor PinotTaskManager class

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -626,13 +626,14 @@ public class PinotTaskRestletResource {
       // Schedule task for the given task type
       List<String> taskNames = tableName != null
           ? _pinotTaskManager.scheduleTask(taskType,
-          DatabaseUtils.translateTableName(tableName, headers), minionInstanceTag)
+          Collections.singletonList(DatabaseUtils.translateTableName(tableName, headers)), minionInstanceTag)
           : _pinotTaskManager.scheduleTaskForDatabase(taskType, database, minionInstanceTag);
       return Collections.singletonMap(taskType, taskNames == null ? null : StringUtils.join(taskNames, ','));
     } else {
       // Schedule tasks for all task types
       Map<String, List<String>> allTaskNames = tableName != null
-          ? _pinotTaskManager.scheduleTasks(DatabaseUtils.translateTableName(tableName, headers), minionInstanceTag)
+          ? _pinotTaskManager.scheduleTasks(Collections.singletonList(
+              DatabaseUtils.translateTableName(tableName, headers)), false, minionInstanceTag)
           : _pinotTaskManager.scheduleTasksForDatabase(database, minionInstanceTag);
       return allTaskNames.entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.join(",", entry.getValue())));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -625,16 +625,16 @@ public class PinotTaskRestletResource {
     if (taskType != null) {
       // Schedule task for the given task type
       List<String> taskNames = tableName != null
-          ? _pinotTaskManager.scheduleTask(taskType,
-          Collections.singletonList(DatabaseUtils.translateTableName(tableName, headers)), minionInstanceTag)
+          ? _pinotTaskManager.scheduleTaskForTable(taskType, DatabaseUtils.translateTableName(tableName, headers),
+          minionInstanceTag)
           : _pinotTaskManager.scheduleTaskForDatabase(taskType, database, minionInstanceTag);
       return Collections.singletonMap(taskType, taskNames == null ? null : StringUtils.join(taskNames, ','));
     } else {
       // Schedule tasks for all task types
       Map<String, List<String>> allTaskNames = tableName != null
-          ? _pinotTaskManager.scheduleTasks(Collections.singletonList(
-              DatabaseUtils.translateTableName(tableName, headers)), false, minionInstanceTag)
-          : _pinotTaskManager.scheduleTasksForDatabase(database, minionInstanceTag);
+          ? _pinotTaskManager.scheduleAllTasksForTable(DatabaseUtils.translateTableName(tableName, headers),
+          minionInstanceTag)
+          : _pinotTaskManager.scheduleAllTasksForDatabase(database, minionInstanceTag);
       return allTaskNames.entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.join(",", entry.getValue())));
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -618,22 +618,19 @@ public class PinotTaskRestletResource {
   @ApiOperation("Schedule tasks and return a map from task type to task name scheduled")
   public Map<String, String> scheduleTasks(@ApiParam(value = "Task type") @QueryParam("taskType") String taskType,
       @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName,
-      @ApiParam(value = "Minion Instance tag to schedule the task explicitly on")
-      @QueryParam("minionInstanceTag") @Nullable String minionInstanceTag,
-      @Context HttpHeaders headers) {
+      @ApiParam(value = "Minion Instance tag to schedule the task explicitly on") @QueryParam("minionInstanceTag")
+      @Nullable String minionInstanceTag, @Context HttpHeaders headers) {
     String database = headers != null ? headers.getHeaderString(DATABASE) : DEFAULT_DATABASE;
     if (taskType != null) {
       // Schedule task for the given task type
-      List<String> taskNames = tableName != null
-          ? _pinotTaskManager.scheduleTaskForTable(taskType, DatabaseUtils.translateTableName(tableName, headers),
-          minionInstanceTag)
+      List<String> taskNames = tableName != null ? _pinotTaskManager.scheduleTaskForTable(taskType,
+          DatabaseUtils.translateTableName(tableName, headers), minionInstanceTag)
           : _pinotTaskManager.scheduleTaskForDatabase(taskType, database, minionInstanceTag);
       return Collections.singletonMap(taskType, taskNames == null ? null : StringUtils.join(taskNames, ','));
     } else {
       // Schedule tasks for all task types
-      Map<String, List<String>> allTaskNames = tableName != null
-          ? _pinotTaskManager.scheduleAllTasksForTable(DatabaseUtils.translateTableName(tableName, headers),
-          minionInstanceTag)
+      Map<String, List<String>> allTaskNames = tableName != null ? _pinotTaskManager.scheduleAllTasksForTable(
+          DatabaseUtils.translateTableName(tableName, headers), minionInstanceTag)
           : _pinotTaskManager.scheduleAllTasksForDatabase(database, minionInstanceTag);
       return allTaskNames.entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.join(",", entry.getValue())));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -66,7 +65,7 @@ public class CronJobScheduleJob implements Job {
         return;
       }
       long jobStartTime = System.currentTimeMillis();
-      pinotTaskManager.scheduleTask(taskType, Collections.singletonList(table), null);
+      pinotTaskManager.scheduleTaskForTable(taskType, table, null);
       LOGGER.info("Finished CronJob: table - {}, task - {}, next runtime is {}", table, taskType,
           jobExecutionContext.getNextFireTime());
       pinotTaskManager.getControllerMetrics().addTimedTableValue(PinotTaskManager.getCronJobName(table, taskType),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -65,7 +66,7 @@ public class CronJobScheduleJob implements Job {
         return;
       }
       long jobStartTime = System.currentTimeMillis();
-      pinotTaskManager.scheduleTask(taskType, table);
+      pinotTaskManager.scheduleTask(taskType, Collections.singletonList(table), null);
       LOGGER.info("Finished CronJob: table - {}, task - {}, next runtime is {}", table, taskType,
           jobExecutionContext.getNextFireTime());
       pinotTaskManager.getControllerMetrics().addTimedTableValue(PinotTaskManager.getCronJobName(table, taskType),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -480,7 +479,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   }
 
   /**
-   * Public API to schedule tasks (all task types) for all tables.
+   * Schedules tasks (all task types) for all tables.
    * It might be called from the non-leader controller.
    * Returns a map from the task type to the list of tasks scheduled.
    */
@@ -489,7 +488,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   }
 
   /**
-   * Public API to schedule tasks (all task types) for all tables in given database.
+   * Schedules tasks (all task types) for all tables in the given database.
    * It might be called from the non-leader controller.
    * Returns a map from the task type to the list of tasks scheduled.
    */
@@ -499,28 +498,29 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   }
 
   /**
-   * Public API to schedule tasks (all task types) for the given table.
+   * Schedules tasks (all task types) for the given table.
    * It might be called from the non-leader controller.
    * Returns a map from the task type to the list of tasks scheduled.
    */
   public synchronized Map<String, List<String>> scheduleAllTasksForTable(String tableNameWithType,
       @Nullable String minionInstanceTag) {
-    return scheduleTasks(Collections.singletonList(tableNameWithType), false, minionInstanceTag);
+    return scheduleTasks(List.of(tableNameWithType), false, minionInstanceTag);
   }
 
   /**
-   * Public API to schedule task for the given task type for all tables in cluster.
+   * Schedules task for the given task type for all tables.
    * It might be called from the non-leader controller.
-   * Returns the list of task name, or {@code null} if no task is scheduled.
+   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
    */
+  @Nullable
   public synchronized List<String> scheduleTaskForAllTables(String taskType, @Nullable String minionInstanceTag) {
     return scheduleTask(taskType, _pinotHelixResourceManager.getAllTables(), minionInstanceTag);
   }
 
   /**
-   * Public API to schedule task for the given task type for all tables in given database.
+   * Schedules task for the given task type for all tables in the given database.
    * It might be called from the non-leader controller.
-   * Returns the list of task name, or {@code null} if no task is scheduled.
+   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
    */
   @Nullable
   public synchronized List<String> scheduleTaskForDatabase(String taskType, @Nullable String database,
@@ -529,22 +529,22 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   }
 
   /**
-   * Public API to schedule task for the given task type for the give table.
+   * Schedules task for the given task type for the give table.
    * It might be called from the non-leader controller.
-   * Returns the list of task name, or {@code null} if no task is scheduled.
+   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
    */
   @Nullable
   public synchronized List<String> scheduleTaskForTable(String taskType, String tableNameWithType,
       @Nullable String minionInstanceTag) {
-    return scheduleTask(taskType, Collections.singletonList(tableNameWithType), minionInstanceTag);
+    return scheduleTask(taskType, List.of(tableNameWithType), minionInstanceTag);
   }
 
   /**
    * Helper method to schedule tasks (all task types) for the given tables that have the tasks enabled. Returns a map
    * from the task type to the list of the tasks scheduled.
    */
-  private synchronized Map<String, List<String>> scheduleTasks(List<String> tableNamesWithType,
-      boolean isLeader, @Nullable String minionInstanceTag) {
+  private synchronized Map<String, List<String>> scheduleTasks(List<String> tableNamesWithType, boolean isLeader,
+      @Nullable String minionInstanceTag) {
     _controllerMetrics.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
     // Scan all table configs to get the tables with tasks enabled
@@ -616,8 +616,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     for (TableConfig tableConfig : enabledTableConfigs) {
       String tableName = tableConfig.getTableName();
       try {
-        String minionInstanceTag = minionInstanceTagForTask != null
-            ? minionInstanceTagForTask : taskGenerator.getMinionInstanceTag(tableConfig);
+        String minionInstanceTag = minionInstanceTagForTask != null ? minionInstanceTagForTask
+            : taskGenerator.getMinionInstanceTag(tableConfig);
         List<PinotTaskConfig> presentTaskConfig =
             minionInstanceTagToTaskConfigs.computeIfAbsent(minionInstanceTag, k -> new ArrayList<>());
         taskGenerator.generateTasks(List.of(tableConfig), presentTaskConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -411,10 +411,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -423,7 +423,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -530,10 +530,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -542,7 +542,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -642,10 +642,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -654,7 +654,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -797,10 +797,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -809,7 +809,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -933,10 +933,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskList = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -946,7 +946,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
       // Will not schedule task if there's incomplete task
       assertNull(
-          taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+          taskManager.scheduleAllTasksForTable(realtimeTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -1042,10 +1042,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null; taskList =
-        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
@@ -1054,7 +1054,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
       // Will not schedule task if there's incomplete task
       assertNull(
-          taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+          taskManager.scheduleAllTasksForTable(realtimeTableName, null)
               .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -1087,10 +1087,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     waitForAllDocsLoaded(600_000L);
 
     for (String tasks =
-        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null; taskList =
-        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
             .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -139,14 +139,14 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     List<File> avroFiles = unpackAvroData(_tempDir);
 
     // Create and upload segments
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, singleLevelConcatTableConfig, schema, 0, _segmentDir1, _tarDir1);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, singleLevelConcatTableConfig, schema, 0, _segmentDir1,
+        _tarDir1);
     buildSegmentsFromAvroWithPostfix(avroFiles, singleLevelRollupTableConfig, schema, 0, _segmentDir2, _tarDir2, "1");
     buildSegmentsFromAvroWithPostfix(avroFiles, singleLevelRollupTableConfig, schema, 0, _segmentDir2, _tarDir2, "2");
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, multiLevelConcatTableConfig, schema, 0, _segmentDir3, _tarDir3);
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, singleLevelConcatMetadataTableConfig, schema, 0, _segmentDir4, _tarDir4);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, multiLevelConcatTableConfig, schema, 0, _segmentDir3,
+        _tarDir3);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, singleLevelConcatMetadataTableConfig, schema, 0,
+        _segmentDir4, _tarDir4);
     uploadSegments(SINGLE_LEVEL_CONCAT_TEST_TABLE, _tarDir1);
     uploadSegments(SINGLE_LEVEL_ROLLUP_TEST_TABLE, _tarDir2);
     uploadSegments(MULTI_LEVEL_CONCAT_TEST_TABLE, _tarDir3);
@@ -160,8 +160,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     schema.setSchemaName(MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE);
     addSchema(schema);
     TableConfig singleLevelConcatProcessAllRealtimeTableConfig =
-        createRealtimeTableConfigWithProcessAllMode(avroFiles.get(0),
-            MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE, PROCESS_ALL_MODE_KAFKA_TOPIC);
+        createRealtimeTableConfigWithProcessAllMode(avroFiles.get(0), MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE,
+            PROCESS_ALL_MODE_KAFKA_TOPIC);
     addTableConfig(singleLevelConcatProcessAllRealtimeTableConfig);
 
     // Push data into Kafka
@@ -172,9 +172,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     ClusterIntegrationTestUtils.pushAvroIntoKafka(avroFiles.subList(0, 3), "localhost:" + getKafkaPort(),
         PROCESS_ALL_MODE_KAFKA_TOPIC, getMaxNumKafkaMessagesPerBatch(), getKafkaMessageHeader(), getPartitionColumn(),
         injectTombstones());
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles.subList(3, 9), singleLevelConcatProcessAllRealtimeTableConfig, schema, 0,
-            _segmentDir5, _tarDir5);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles.subList(3, 9),
+        singleLevelConcatProcessAllRealtimeTableConfig, schema, 0, _segmentDir5, _tarDir5);
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
 
@@ -216,14 +215,14 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
   private TableConfig createOfflineTableConfig(String tableName, TableTaskConfig taskConfig,
       @Nullable SegmentPartitionConfig partitionConfig) {
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
-        .setTimeColumnName(getTimeColumnName()).setSortedColumn(getSortedColumn())
-        .setInvertedIndexColumns(getInvertedIndexColumns()).setNoDictionaryColumns(getNoDictionaryColumns())
-        .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
-        .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
-        .setLoadMode(getLoadMode()).setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig())
-        .setNullHandlingEnabled(getNullHandlingEnabled()).setSegmentPartitionConfig(partitionConfig).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).setTimeColumnName(getTimeColumnName())
+        .setSortedColumn(getSortedColumn()).setInvertedIndexColumns(getInvertedIndexColumns())
+        .setNoDictionaryColumns(getNoDictionaryColumns()).setRangeIndexColumns(getRangeIndexColumns())
+        .setBloomFilterColumns(getBloomFilterColumns()).setFieldConfigList(getFieldConfigs())
+        .setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion()).setLoadMode(getLoadMode())
+        .setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant()).setServerTenant(getServerTenant())
+        .setIngestionConfig(getIngestionConfig()).setNullHandlingEnabled(getNullHandlingEnabled())
+        .setSegmentPartitionConfig(partitionConfig).build();
   }
 
   protected TableConfig createRealtimeTableConfigWithProcessAllMode(File sampleAvroFile, String tableName,
@@ -246,12 +245,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     tableTaskConfigs.put("ActualElapsedTime.aggregationType", "min");
     tableTaskConfigs.put("WeatherDelay.aggregationType", "sum");
     tableTaskConfigs.put("mode", "processAll");
-    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName)
-        .setTimeColumnName(getTimeColumnName()).setSortedColumn(getSortedColumn())
-        .setInvertedIndexColumns(getInvertedIndexColumns()).setNoDictionaryColumns(getNoDictionaryColumns())
-        .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
-        .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
-        .setLoadMode(getLoadMode()).setTaskConfig(
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName).setTimeColumnName(getTimeColumnName())
+        .setSortedColumn(getSortedColumn()).setInvertedIndexColumns(getInvertedIndexColumns())
+        .setNoDictionaryColumns(getNoDictionaryColumns()).setRangeIndexColumns(getRangeIndexColumns())
+        .setBloomFilterColumns(getBloomFilterColumns()).setFieldConfigList(getFieldConfigs())
+        .setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion()).setLoadMode(getLoadMode())
+        .setTaskConfig(
             new TableTaskConfig(Collections.singletonMap(MinionConstants.MergeRollupTask.TASK_TYPE, tableTaskConfigs)))
         .setBrokerTenant(getBrokerTenant()).setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig())
         .setQueryConfig(getQueryConfig()).setStreamConfigs(streamConfigs)
@@ -411,20 +410,16 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null;
-        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      assertNull(
-          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -530,20 +525,16 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null;
-        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      assertNull(
-          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -642,20 +633,16 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null;
-        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), 1);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      assertNull(
-          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -797,20 +784,16 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null;
-        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      assertNull(
-          _taskManager.scheduleAllTasksForTable(offlineTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -871,8 +854,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
         return false;
       }
       // Check if the task metadata is cleaned up
-      if (MinionTaskMetadataUtils
-          .fetchTaskMetadata(_propertyStore, MinionConstants.MergeRollupTask.TASK_TYPE, tableNameWithType) != null) {
+      if (MinionTaskMetadataUtils.fetchTaskMetadata(_propertyStore, MinionConstants.MergeRollupTask.TASK_TYPE,
+          tableNameWithType) != null) {
         return false;
       }
       return true;
@@ -933,21 +916,17 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null;
-        taskList = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
 //      assertEquals(helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
 
       // Will not schedule task if there's incomplete task
-      assertNull(
-          taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -1042,20 +1021,16 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null; taskList =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertTrue(helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
 
       // Will not schedule task if there's incomplete task
-      assertNull(
-          taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      assertNull(taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+          .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check not using watermarks
@@ -1087,13 +1062,10 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     waitForAllDocsLoaded(600_000L);
 
     for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
-        tasks != null; taskList =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null)
-            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null,
-        numTasks++) {
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
+            .get(0); tasks != null; taskList =
+        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       waitForTaskToComplete();
       // Check metrics
       long numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -411,9 +411,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
@@ -421,7 +423,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -527,9 +530,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
@@ -537,7 +542,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -636,9 +642,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), 1);
@@ -646,7 +654,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -788,9 +797,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskList = _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
@@ -798,7 +809,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
       assertNull(
-          _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          _taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -921,9 +933,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null;
-        taskList = taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskList = taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
 //      assertEquals(helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
@@ -932,7 +946,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
       // Will not schedule task if there's incomplete task
       assertNull(
-          taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check watermark
@@ -1027,9 +1042,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     int numTasks = 0;
     List<String> taskList;
     for (String tasks =
-        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null; taskList =
-        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       assertTrue(helixTaskResourceManager.getTaskQueues()
@@ -1037,7 +1054,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
       // Will not schedule task if there's incomplete task
       assertNull(
-          taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+          taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+              .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
       // Check not using watermarks
@@ -1069,9 +1087,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     waitForAllDocsLoaded(600_000L);
 
     for (String tasks =
-        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
+        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).get(0);
         tasks != null; taskList =
-        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE),
+        taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE),
         tasks = taskList != null ? taskList.get(0) : null,
         numTasks++) {
       waitForTaskToComplete();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -195,12 +195,12 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_FIRST_RUN_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
@@ -211,7 +211,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
           metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX));
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
@@ -242,12 +242,12 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
@@ -260,7 +260,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
       assertTrue(System.currentTimeMillis() - Long.parseLong(purgeTime) < 86400000);
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
@@ -293,7 +293,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
 
     // No task should be schedule as the delay is not passed
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
       // Check purge time
@@ -345,11 +345,11 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
 
     // schedule purge tasks
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
-    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
         .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,7 +62,6 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   private static final String PURGE_DELTA_NOT_PASSED_TABLE = "myTable3";
   private static final String PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE = "myTable4";
 
-
   protected PinotHelixTaskResourceManager _helixTaskResourceManager;
   protected PinotTaskManager _taskManager;
   protected PinotHelixResourceManager _pinotHelixResourceManager;
@@ -83,12 +81,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     startBrokers(1);
     startServers(1);
 
-    List<String> allTables = ImmutableList.of(
-        PURGE_FIRST_RUN_TABLE,
-        PURGE_DELTA_PASSED_TABLE,
-        PURGE_DELTA_NOT_PASSED_TABLE,
-        PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE
-    );
+    List<String> allTables = List.of(PURGE_FIRST_RUN_TABLE, PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE,
+        PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
     Schema schema = null;
     TableConfig tableConfig = null;
     for (String tableName : allTables) {
@@ -152,12 +146,9 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   private void setRecordPurger() {
     MinionContext minionContext = MinionContext.getInstance();
     minionContext.setRecordPurgerFactory(rawTableName -> {
-      List<String> tableNames = Arrays.asList(
-          PURGE_FIRST_RUN_TABLE,
-          PURGE_DELTA_PASSED_TABLE,
-          PURGE_DELTA_NOT_PASSED_TABLE,
-          PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE
-      );
+      List<String> tableNames =
+          Arrays.asList(PURGE_FIRST_RUN_TABLE, PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE,
+              PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
       if (tableNames.contains(rawTableName)) {
         return row -> row.getValue("ArrTime").equals(1);
       } else {
@@ -195,13 +186,12 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_FIRST_RUN_TABLE);
-    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values
@@ -211,8 +201,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
           metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX));
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
     // 115545 totals rows
@@ -242,13 +231,12 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
-    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values
@@ -260,8 +248,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
       assertTrue(System.currentTimeMillis() - Long.parseLong(purgeTime) < 86400000);
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
     // 115545 totals rows
@@ -293,8 +280,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
 
     // No task should be schedule as the delay is not passed
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
       // Check purge time
       String purgeTime =
@@ -345,12 +331,11 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
 
     // schedule purge tasks
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
-    assertNotNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(
+        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
-    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null)
-        .get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -195,11 +195,13 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_FIRST_RUN_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values
@@ -209,7 +211,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
           metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX));
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
     // 115545 totals rows
@@ -239,11 +242,13 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values
@@ -255,7 +260,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
       assertTrue(System.currentTimeMillis() - Long.parseLong(purgeTime) < 86400000);
     }
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
 
     // 52 rows with ArrTime = 1
     // 115545 totals rows
@@ -287,7 +293,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
 
     // No task should be schedule as the delay is not passed
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
       // Check purge time
       String purgeTime =
@@ -338,10 +345,12 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
 
     // schedule purge tasks
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
-    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
-    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(Collections.singletonList(offlineTableName), false, null)
+        .get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
     // Check that metadata contains expected values

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -134,14 +134,14 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
 
     Map<String, String> taskConfigsWithMetadata = new HashMap<>();
     taskConfigsWithMetadata.put(BatchConfigProperties.OVERWRITE_OUTPUT, "true");
-    taskConfigsWithMetadata.put(
-        BatchConfigProperties.PUSH_MODE, BatchConfigProperties.SegmentPushType.METADATA.toString());
+    taskConfigsWithMetadata.put(BatchConfigProperties.PUSH_MODE,
+        BatchConfigProperties.SegmentPushType.METADATA.toString());
     String tableWithMetadataPush = "myTable2";
     schema.setSchemaName(tableWithMetadataPush);
     addSchema(schema);
     TableConfig realtimeMetadataTableConfig = createRealtimeTableConfig(avroFiles.get(0), tableWithMetadataPush,
-        new TableTaskConfig(Collections.singletonMap(
-            MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, taskConfigsWithMetadata)));
+        new TableTaskConfig(Collections.singletonMap(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE,
+            taskConfigsWithMetadata)));
     realtimeMetadataTableConfig.setIngestionConfig(ingestionConfig);
     realtimeMetadataTableConfig.setFieldConfigList(Collections.singletonList(tsFieldConfig));
     addTableConfig(realtimeMetadataTableConfig);
@@ -150,7 +150,6 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
         createOfflineTableConfig(tableWithMetadataPush, null, getSegmentPartitionConfig());
     offlineMetadataTableConfig.setFieldConfigList(Collections.singletonList(tsFieldConfig));
     addTableConfig(offlineMetadataTableConfig);
-
 
     // Push data into Kafka
     pushAvroIntoKafka(avroFiles);
@@ -162,7 +161,6 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     waitForAllDocsLoaded(600_000L);
 
     waitForDocsLoaded(600_000L, true, tableWithMetadataPush);
-
 
     _taskResourceManager = _controllerStarter.getHelixTaskResourceManager();
     _taskManager = _controllerStarter.getTaskManager();
@@ -181,8 +179,8 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     }
     _dataSmallestTimeMs = minSegmentTimeMs;
 
-   segmentsZKMetadata = _helixResourceManager.getSegmentsZKMetadata(_realtimeMetadataTableName);
-   minSegmentTimeMs = Long.MAX_VALUE;
+    segmentsZKMetadata = _helixResourceManager.getSegmentsZKMetadata(_realtimeMetadataTableName);
+    minSegmentTimeMs = Long.MAX_VALUE;
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.DONE) {
         minSegmentTimeMs = Math.min(minSegmentTimeMs, segmentZKMetadata.getStartTimeMs());
@@ -193,28 +191,27 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
 
   private TableConfig createOfflineTableConfig(String tableName, @Nullable TableTaskConfig taskConfig,
       @Nullable SegmentPartitionConfig partitionConfig) {
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
-        .setTimeColumnName(getTimeColumnName()).setSortedColumn(getSortedColumn())
-        .setInvertedIndexColumns(getInvertedIndexColumns()).setNoDictionaryColumns(getNoDictionaryColumns())
-        .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
-        .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
-        .setLoadMode(getLoadMode()).setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig())
-        .setNullHandlingEnabled(getNullHandlingEnabled()).setSegmentPartitionConfig(partitionConfig).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).setTimeColumnName(getTimeColumnName())
+        .setSortedColumn(getSortedColumn()).setInvertedIndexColumns(getInvertedIndexColumns())
+        .setNoDictionaryColumns(getNoDictionaryColumns()).setRangeIndexColumns(getRangeIndexColumns())
+        .setBloomFilterColumns(getBloomFilterColumns()).setFieldConfigList(getFieldConfigs())
+        .setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion()).setLoadMode(getLoadMode())
+        .setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant()).setServerTenant(getServerTenant())
+        .setIngestionConfig(getIngestionConfig()).setNullHandlingEnabled(getNullHandlingEnabled())
+        .setSegmentPartitionConfig(partitionConfig).build();
   }
 
   protected TableConfig createRealtimeTableConfig(File sampleAvroFile, String tableName, TableTaskConfig taskConfig) {
     AvroFileSchemaKafkaAvroMessageDecoder._avroFile = sampleAvroFile;
-    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName)
-        .setTimeColumnName(getTimeColumnName()).setSortedColumn(getSortedColumn())
-        .setInvertedIndexColumns(getInvertedIndexColumns()).setNoDictionaryColumns(getNoDictionaryColumns())
-        .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
-        .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
-        .setLoadMode(getLoadMode()).setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setQueryConfig(getQueryConfig())
-        .setStreamConfigs(getStreamConfigs()).setNullHandlingEnabled(getNullHandlingEnabled()).build();
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName).setTimeColumnName(getTimeColumnName())
+        .setSortedColumn(getSortedColumn()).setInvertedIndexColumns(getInvertedIndexColumns())
+        .setNoDictionaryColumns(getNoDictionaryColumns()).setRangeIndexColumns(getRangeIndexColumns())
+        .setBloomFilterColumns(getBloomFilterColumns()).setFieldConfigList(getFieldConfigs())
+        .setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion()).setLoadMode(getLoadMode())
+        .setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant()).setServerTenant(getServerTenant())
+        .setIngestionConfig(getIngestionConfig()).setQueryConfig(getQueryConfig()).setStreamConfigs(getStreamConfigs())
+        .setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
-
 
   @Test
   public void testRealtimeToOfflineSegmentsTask()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -234,12 +234,12 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     long expectedWatermark = _dataSmallestTimeMs + 86400000;
     for (int i = 0; i < 3; i++) {
       // Schedule task
-      assertNotNull(_taskManager.scheduleTasks(_realtimeTableName)
+      assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeTableName), false, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       assertTrue(_taskResourceManager.getTaskQueues().contains(
           PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE)));
       // Should not generate more tasks
-      assertNull(_taskManager.scheduleTasks(_realtimeTableName)
+      assertNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeTableName), false, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
 
       // Wait at most 600 seconds for all tasks COMPLETED
@@ -286,12 +286,12 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     _taskManager.cleanUpTask();
     for (int i = 0; i < 3; i++) {
       // Schedule task
-      assertNotNull(_taskManager.scheduleTasks(_realtimeMetadataTableName)
+      assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeMetadataTableName), false, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       assertTrue(_taskResourceManager.getTaskQueues().contains(
           PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE)));
       // Should not generate more tasks
-      assertNull(_taskManager.scheduleTasks(_realtimeMetadataTableName)
+      assertNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeMetadataTableName), false, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
 
       // Wait at most 600 seconds for all tasks COMPLETED

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -234,12 +234,12 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     long expectedWatermark = _dataSmallestTimeMs + 86400000;
     for (int i = 0; i < 3; i++) {
       // Schedule task
-      assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeTableName), false, null)
+      assertNotNull(_taskManager.scheduleAllTasksForTable(_realtimeTableName, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       assertTrue(_taskResourceManager.getTaskQueues().contains(
           PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE)));
       // Should not generate more tasks
-      assertNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeTableName), false, null)
+      assertNull(_taskManager.scheduleAllTasksForTable(_realtimeTableName, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
 
       // Wait at most 600 seconds for all tasks COMPLETED
@@ -286,12 +286,12 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     _taskManager.cleanUpTask();
     for (int i = 0; i < 3; i++) {
       // Schedule task
-      assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeMetadataTableName), false, null)
+      assertNotNull(_taskManager.scheduleAllTasksForTable(_realtimeMetadataTableName, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       assertTrue(_taskResourceManager.getTaskQueues().contains(
           PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE)));
       // Should not generate more tasks
-      assertNull(_taskManager.scheduleTasks(Collections.singletonList(_realtimeMetadataTableName), false, null)
+      assertNull(_taskManager.scheduleAllTasksForTable(_realtimeMetadataTableName, null)
           .get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
 
       // Wait at most 600 seconds for all tasks COMPLETED

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -136,7 +136,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     assertEquals(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).size(), 0);
 
     // Should create the task queues and generate a task in the same minion instance
-    List<String> task1 = _taskManager.scheduleTasks().get(TASK_TYPE);
+    List<String> task1 = _taskManager.scheduleTasks(null, false, null).get(TASK_TYPE);
     assertNotNull(task1);
     assertEquals(task1.size(), 1);
     assertTrue(_helixTaskResourceManager.getTaskQueues()
@@ -150,7 +150,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     verifyTaskCount(task1.get(0), 0, 1, 1, 2);
     // Should generate one more task, with two sub-tasks. Both of these sub-tasks will wait
     // since we have one minion instance that is still running one of the sub-tasks.
-    List<String> task2 = _taskManager.scheduleTask(TASK_TYPE, null);
+    List<String> task2 = _taskManager.scheduleTask(TASK_TYPE, null, null);
     assertNotNull(task2);
     assertEquals(task2.size(), 1);
     assertTrue(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).contains(task2.get(0)));
@@ -159,8 +159,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Should not generate more tasks since SimpleMinionClusterIntegrationTests.NUM_TASKS is 2.
     // Our test task generator does not generate if there are already this many sub-tasks in the
     // running+waiting count already.
-    assertNull(_taskManager.scheduleTasks().get(TASK_TYPE));
-    assertNull(_taskManager.scheduleTask(TASK_TYPE, null));
+    assertNull(_taskManager.scheduleTasks(null, false, null).get(TASK_TYPE));
+    assertNull(_taskManager.scheduleTask(TASK_TYPE, null, null));
 
     // Wait at most 60 seconds for all tasks IN_PROGRESS
     TestUtils.waitForCondition(input -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -136,7 +136,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     assertEquals(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).size(), 0);
 
     // Should create the task queues and generate a task in the same minion instance
-    List<String> task1 = _taskManager.scheduleTasks(null, false, null).get(TASK_TYPE);
+    List<String> task1 = _taskManager.scheduleAllTasksForAllTables(null).get(TASK_TYPE);
     assertNotNull(task1);
     assertEquals(task1.size(), 1);
     assertTrue(_helixTaskResourceManager.getTaskQueues()
@@ -150,7 +150,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     verifyTaskCount(task1.get(0), 0, 1, 1, 2);
     // Should generate one more task, with two sub-tasks. Both of these sub-tasks will wait
     // since we have one minion instance that is still running one of the sub-tasks.
-    List<String> task2 = _taskManager.scheduleTask(TASK_TYPE, null, null);
+    List<String> task2 = _taskManager.scheduleTaskForAllTables(TASK_TYPE, null);
     assertNotNull(task2);
     assertEquals(task2.size(), 1);
     assertTrue(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).contains(task2.get(0)));
@@ -159,8 +159,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Should not generate more tasks since SimpleMinionClusterIntegrationTests.NUM_TASKS is 2.
     // Our test task generator does not generate if there are already this many sub-tasks in the
     // running+waiting count already.
-    assertNull(_taskManager.scheduleTasks(null, false, null).get(TASK_TYPE));
-    assertNull(_taskManager.scheduleTask(TASK_TYPE, null, null));
+    assertNull(_taskManager.scheduleAllTasksForAllTables(null).get(TASK_TYPE));
+    assertNull(_taskManager.scheduleTaskForAllTables(TASK_TYPE, null));
 
     // Wait at most 60 seconds for all tasks IN_PROGRESS
     TestUtils.waitForCondition(input -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -87,8 +87,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     properties.put(TASK_TYPE + MinionConstants.MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX, "2");
 
     helixResourceManager.getHelixAdmin().setConfig(
-        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
-            .forCluster(helixResourceManager.getHelixClusterName()).build(), properties);
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
+            helixResourceManager.getHelixClusterName()).build(), properties);
 
     // Add 3 offline tables, where 2 of them have TestTask enabled
     addDummySchema(TABLE_NAME_1);
@@ -183,13 +183,12 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     String inProgressGauge = TASK_TYPE + "." + TaskState.IN_PROGRESS;
     String stoppedGauge = TASK_TYPE + "." + TaskState.STOPPED;
     String completedGauge = TASK_TYPE + "." + TaskState.COMPLETED;
-    TestUtils.waitForCondition(
-        input -> MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS)
+    TestUtils.waitForCondition(input ->
+        MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS)
             == NUM_TASKS
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, stoppedGauge, ControllerGauge.TASK_STATUS) == 0
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, completedGauge, ControllerGauge.TASK_STATUS)
-            == 0,
-        ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
+            == 0, ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
 
     // Stop the task queue
     _helixTaskResourceManager.stopTaskQueue(TASK_TYPE);
@@ -211,14 +210,12 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     }, STATE_TRANSITION_TIMEOUT_MS, "Failed to get all tasks STOPPED");
 
     // Wait at most 30 seconds for ZK callback to update the controller gauges
-    TestUtils.waitForCondition(
-        input -> MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS)
-            == 0
+    TestUtils.waitForCondition(input ->
+        MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS) == 0
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, stoppedGauge, ControllerGauge.TASK_STATUS)
             == NUM_TASKS
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, completedGauge, ControllerGauge.TASK_STATUS)
-            == 0,
-        ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
+            == 0, ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
 
     // Task deletion requires the task queue to be stopped,
     // so deleting task1 here before resuming the task queue.
@@ -247,13 +244,11 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     }, STATE_TRANSITION_TIMEOUT_MS, "Failed to get all tasks COMPLETED");
 
     // Wait at most 30 seconds for ZK callback to update the controller gauges
-    TestUtils.waitForCondition(
-        input -> MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS)
-            == 0
+    TestUtils.waitForCondition(input ->
+        MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS) == 0
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, stoppedGauge, ControllerGauge.TASK_STATUS) == 0
-            && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, completedGauge, ControllerGauge.TASK_STATUS)
-            == (NUM_TASKS - 1),
-        ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
+            && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, completedGauge, ControllerGauge.TASK_STATUS) == (
+            NUM_TASKS - 1), ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
 
     // Delete the task queue
     _helixTaskResourceManager.deleteTaskQueue(TASK_TYPE, false);
@@ -263,13 +258,11 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
         STATE_TRANSITION_TIMEOUT_MS, "Failed to delete the task queue");
 
     // Wait at most 30 seconds for ZK callback to update the controller gauges
-    TestUtils.waitForCondition(
-        input -> MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS)
-            == 0
+    TestUtils.waitForCondition(input ->
+        MetricValueUtils.getGlobalGaugeValue(controllerMetrics, inProgressGauge, ControllerGauge.TASK_STATUS) == 0
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, stoppedGauge, ControllerGauge.TASK_STATUS) == 0
             && MetricValueUtils.getGlobalGaugeValue(controllerMetrics, completedGauge, ControllerGauge.TASK_STATUS)
-            == 0,
-        ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
+            == 0, ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -489,7 +489,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertTrue(resultBeforeOffline.getResultSet(0).getLong(0) > 0);
 
     // schedule offline segment generation
-    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks());
+    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks(null, false, null));
 
     // wait for offline segments
     JsonNode offlineSegments = TestUtils.waitForResult(() -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -489,7 +489,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertTrue(resultBeforeOffline.getResultSet(0).getLong(0) > 0);
 
     // schedule offline segment generation
-    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks(null, false, null));
+    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleAllTasksForAllTables(null));
 
     // wait for offline segments
     JsonNode offlineSegments = TestUtils.waitForResult(() -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -471,8 +471,8 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     waitForAllDocsLoaded(tableName, 600_000L, 1000);
     assertEquals(getScore(tableName), 3692);
     waitForNumQueriedSegmentsToConverge(tableName, 10_000L, 3);
-
-    assertNotNull(_taskManager.scheduleTasks(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName))
+    String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -501,8 +501,8 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     waitForAllDocsLoaded(tableName, 600_000L, 2000);
     assertEquals(getScore(tableName), 3692);
     waitForNumQueriedSegmentsToConverge(tableName, 10_000L, 5);
-
-    assertNotNull(_taskManager.scheduleTasks(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName))
+    String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -546,7 +546,8 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Run segment compaction. This time, we expect that the deleting rows are still there because they are
     // as part of the consuming segment
-    assertNotNull(_taskManager.scheduleTasks(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName))
+    String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -563,7 +564,8 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     assertEquals(getNumDeletedRows(tableName), 2);
 
     // Run segment compaction. This time, we expect that the deleting rows are cleaned up
-    assertNotNull(_taskManager.scheduleTasks(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName))
+    realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -472,7 +472,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     assertEquals(getScore(tableName), 3692);
     waitForNumQueriedSegmentsToConverge(tableName, 10_000L, 3);
     String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(realtimeTableName, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -502,7 +502,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     assertEquals(getScore(tableName), 3692);
     waitForNumQueriedSegmentsToConverge(tableName, 10_000L, 5);
     String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(realtimeTableName, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -547,7 +547,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     // Run segment compaction. This time, we expect that the deleting rows are still there because they are
     // as part of the consuming segment
     String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(realtimeTableName, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);
@@ -565,7 +565,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Run segment compaction. This time, we expect that the deleting rows are cleaned up
     realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
-    assertNotNull(_taskManager.scheduleTasks(Collections.singletonList(realtimeTableName), false, null)
+    assertNotNull(_taskManager.scheduleAllTasksForTable(realtimeTableName, null)
         .get(MinionConstants.UpsertCompactionTask.TASK_TYPE));
     waitForTaskToComplete();
     waitForAllDocsLoaded(tableName, 600_000L, 3);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
@@ -203,7 +203,7 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertTrue(resultBeforeOffline.getResultSet(0).getLong(0) > 0);
 
     // schedule offline segment generation
-    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks());
+    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks(null, false, null));
 
     // wait for offline segments
     JsonNode offlineSegments = TestUtils.waitForResult(() -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
@@ -203,7 +203,7 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertTrue(resultBeforeOffline.getResultSet(0).getLong(0) > 0);
 
     // schedule offline segment generation
-    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks(null, false, null));
+    Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleAllTasksForAllTables(null));
 
     // wait for offline segments
     JsonNode offlineSegments = TestUtils.waitForResult(() -> {


### PR DESCRIPTION
label:
`refactor`

The PinotTaskManager had a lot of `scheduleTask` methods which was making it unreadable and hard to make changes as adding a new param needs to properly vetted throughout the code.

This change leaves 6 public methods in the class:
- Map<String, List<String>> scheduleAllTasksForAllTables(String minionInstanceTag)
- Map<String, List<String>> scheduleAllTasksForDatabase(String database, String minionInstanceTag)
- Map<String, List<String>> scheduleAllTasksForTable(String tableNameWithType, String minionInstanceTag)
- List<String> scheduleTaskForAllTables(String taskType, String minionInstanceTag)
- List<String> scheduleTaskForDatabase(String taskType, String database, String minionInstanceTag)
- List<String> scheduleTaskForTable(String taskType, String tableNameWithType, String minionInstanceTag)

The first 3 methods schedules all the tasks for given table / database / cluster. The next 3 methods, schedules the task type specified for database / tables / cluster.

This makes the code more readable and easy to use. 