### PR TITLE
Add back pinot spi shading

### DIFF
--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <build>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -33,8 +33,32 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
Add back pinot spi shading which is removed in https://github.com/apache/pinot/pull/12712
Tested building on local branch.
