### PR TITLE
Reduce logging for SpecialValueTransformer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -111,7 +111,7 @@ public class SpecialValueTransformer implements RecordTransformer {
       }
     }
     if (_negativeZeroConversionCount > 0 || _nanConversionCount > 0) {
-      LOGGER.info("Converted {} -0.0s to 0.0 and {} NaNs to null", _negativeZeroConversionCount, _nanConversionCount);
+      LOGGER.debug("Converted {} -0.0s to 0.0 and {} NaNs to null", _negativeZeroConversionCount, _nanConversionCount);
     }
     return record;
   }


### PR DESCRIPTION
# Issue
Logging the number of conversions per record is too much and ends up polluting the logs.

# Solution
This PR changes the log level to debug. The other solution is to log the conversion numbers in batches, but that will not be much helpful to debug issues since we are just logging numbers. 