### PR TITLE
Add locking logic to get consistent table view for upsert tables

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -139,6 +139,11 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UPSERT));
   }
 
+  public static long getUpsertViewFreshnessMs(Map<String, String> queryOptions) {
+    String freshnessMsString = queryOptions.get(QueryOptionKey.UPSERT_VIEW_FRESHNESS_MS);
+    return freshnessMsString != null ? Long.parseLong(freshnessMsString) : -1;
+  }
+
   public static boolean isScanStarTreeNodes(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SCAN_STAR_TREE_NODES));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -302,7 +302,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     List<SegmentContext> segmentContexts = new ArrayList<>(selectedSegments.size());
     selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
     if (isUpsertEnabled() && !QueryOptionsUtils.isSkipUpsert(queryOptions)) {
-      _tableUpsertMetadataManager.setSegmentContexts(segmentContexts);
+      _tableUpsertMetadataManager.setSegmentContexts(segmentContexts, queryOptions);
     }
     return segmentContexts;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -125,7 +125,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   private volatile boolean _isPreloading;
 
   // There are two consistency modes:
-  // If using LOCK mode, the upsert threads take the WLock when the upsert involves two segments' bitmaps; and
+  // If using SYNC mode, the upsert threads take the WLock when the upsert involves two segments' bitmaps; and
   // the query threads take the RLock when getting bitmaps for all its selected segments.
   // If using SNAPSHOT mode, the query threads don't need to take lock when getting bitmaps for all its selected
   // segments, as the query threads access a copy of bitmaps that are kept updated by upsert thread periodically. But
@@ -1045,7 +1045,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, IndexSegment oldSegment, int oldDocId, int newDocId,
       RecordInfo recordInfo) {
     // For SNAPSHOT consistency mode, we can use RLock here. But for simplicity and considering there is only one
-    // thread doing upsert most of the time, we just use WLock, as required by LOCK mode.
+    // thread doing upsert most of the time, we just use WLock, as required by SYNC mode.
     if (_consistencyMode != UpsertConfig.ConsistencyMode.NONE) {
       _upsertViewLock.writeLock().lock();
     }
@@ -1154,7 +1154,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       setSegmentContexts(segmentContexts);
       return;
     }
-    if (_consistencyMode == UpsertConfig.ConsistencyMode.LOCK) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
       _upsertViewLock.readLock().lock();
       try {
         setSegmentContexts(segmentContexts);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -1175,7 +1175,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // When refreshing the copy of map, we need to take the WLock so only one thread is refreshing view.
     long upsertViewFreshnessMs =
         Math.min(QueryOptionsUtils.getUpsertViewFreshnessMs(queryOptions), _upsertViewRefreshIntervalMs);
-    if (upsertViewFreshnessMs == -1) {
+    if (upsertViewFreshnessMs < 0) {
       upsertViewFreshnessMs = _upsertViewRefreshIntervalMs;
     }
     doBatchRefreshUpsertView(upsertViewFreshnessMs);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -68,26 +68,23 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     boolean enablePreload = upsertConfig.isEnablePreload();
     double metadataTTL = upsertConfig.getMetadataTTL();
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
-    boolean enableUpsertView = upsertConfig.isEnableUpsertView();
-    boolean enableUpsertViewBatchRefresh = upsertConfig.isEnableUpsertViewBatchRefresh();
+    UpsertConfig.ConsistencyMode consistencyMode = upsertConfig.getConsistencyMode();
     long upsertViewRefreshIntervalMs = upsertConfig.getUpsertViewRefreshIntervalMs();
     File tableIndexDir = tableDataManager.getTableDataDir();
     _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
         .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
         .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot).setEnablePreload(enablePreload)
-        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setEnableUpsertView(enableUpsertView)
-        .setEnableUpsertViewBatchRefresh(enableUpsertViewBatchRefresh)
+        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setConsistencyMode(consistencyMode)
         .setUpsertViewRefreshIntervalMs(upsertViewRefreshIntervalMs).setTableIndexDir(tableIndexDir)
         .setTableDataManager(tableDataManager).build();
     LOGGER.info(
         "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
             + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-            + " deleted Keys TTL: {}, enable upsertView: {}, enable upsertView batchRefresh: {},"
-            + " upsertView refresh interval: {} ms, table index dir: {}", getClass().getSimpleName(),
-        _tableNameWithType, primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction,
-        upsertConfig.getMode(), enableSnapshot, enablePreload, metadataTTL, deletedKeysTTL, enableUpsertView,
-        enableUpsertViewBatchRefresh, upsertViewRefreshIntervalMs, tableIndexDir);
+            + " deleted Keys TTL: {}, consistency mode: {}, upsert view refresh interval: {}ms, table index dir: {}",
+        getClass().getSimpleName(), _tableNameWithType, primaryKeyColumns, comparisonColumns, deleteRecordColumn,
+        hashFunction, upsertConfig.getMode(), enableSnapshot, enablePreload, metadataTTL, deletedKeysTTL,
+        consistencyMode, upsertViewRefreshIntervalMs, tableIndexDir);
 
     initCustomVariables();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -68,19 +68,26 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     boolean enablePreload = upsertConfig.isEnablePreload();
     double metadataTTL = upsertConfig.getMetadataTTL();
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
+    boolean enableUpsertView = upsertConfig.isEnableUpsertView();
+    boolean enableUpsertViewBatchRefresh = upsertConfig.isEnableUpsertViewBatchRefresh();
+    long upsertViewRefreshIntervalMs = upsertConfig.getUpsertViewRefreshIntervalMs();
     File tableIndexDir = tableDataManager.getTableDataDir();
     _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
         .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
         .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot).setEnablePreload(enablePreload)
-        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setTableIndexDir(tableIndexDir)
+        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setEnableUpsertView(enableUpsertView)
+        .setEnableUpsertViewBatchRefresh(enableUpsertViewBatchRefresh)
+        .setUpsertViewRefreshIntervalMs(upsertViewRefreshIntervalMs).setTableIndexDir(tableIndexDir)
         .setTableDataManager(tableDataManager).build();
     LOGGER.info(
         "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
             + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-            + " deleted Keys TTL: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
+            + " deleted Keys TTL: {}, enable upsertView: {}, enable upsertView batchRefresh: {}, "
+            + "upsertView refresh interval: {} ms, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
         primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(), enableSnapshot,
-        enablePreload, metadataTTL, deletedKeysTTL, tableIndexDir);
+        enablePreload, metadataTTL, deletedKeysTTL, enableUpsertView, enableUpsertViewBatchRefresh,
+        upsertViewRefreshIntervalMs, tableIndexDir);
 
     initCustomVariables();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -83,11 +83,11 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     LOGGER.info(
         "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
             + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-            + " deleted Keys TTL: {}, enable upsertView: {}, enable upsertView batchRefresh: {}, "
-            + "upsertView refresh interval: {} ms, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
-        primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(), enableSnapshot,
-        enablePreload, metadataTTL, deletedKeysTTL, enableUpsertView, enableUpsertViewBatchRefresh,
-        upsertViewRefreshIntervalMs, tableIndexDir);
+            + " deleted Keys TTL: {}, enable upsertView: {}, enable upsertView batchRefresh: {},"
+            + " upsertView refresh interval: {} ms, table index dir: {}", getClass().getSimpleName(),
+        _tableNameWithType, primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction,
+        upsertConfig.getMode(), enableSnapshot, enablePreload, metadataTTL, deletedKeysTTL, enableUpsertView,
+        enableUpsertViewBatchRefresh, upsertViewRefreshIntervalMs, tableIndexDir);
 
     initCustomVariables();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -93,7 +93,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               // iterator will return records with incremental doc ids.
               if (currentSegment == segment) {
                 if (comparisonResult >= 0) {
-                  replaceDocId(validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
+                  replaceDocId(segment, validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
                   return new RecordLocation(segment, newDocId, newComparisonValue);
                 } else {
                   return currentRecordLocation;
@@ -108,7 +108,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               // snapshot for the old segment, which can be updated and used to track the docs not replaced yet.
               if (currentSegment == oldSegment) {
                 if (comparisonResult >= 0) {
-                  addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+                  addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
                   if (validDocIdsForOldSegment != null) {
                     validDocIdsForOldSegment.remove(currentDocId);
                   }
@@ -124,7 +124,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               if (currentSegmentName.equals(segmentName)) {
                 numKeysInWrongSegment.getAndIncrement();
                 if (comparisonResult >= 0) {
-                  addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+                  addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
                   return new RecordLocation(segment, newDocId, newComparisonValue);
                 } else {
                   return currentRecordLocation;
@@ -139,14 +139,14 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
                   && LLCSegmentName.isLLCSegment(currentSegmentName)
                   && LLCSegmentName.getSequenceNumber(segmentName) > LLCSegmentName.getSequenceNumber(
                   currentSegmentName))) {
-                replaceDocId(validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
+                replaceDocId(segment, validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
                 return new RecordLocation(segment, newDocId, newComparisonValue);
               } else {
                 return currentRecordLocation;
               }
             } else {
               // New primary key
-              addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+              addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
               return new RecordLocation(segment, newDocId, newComparisonValue);
             }
           });
@@ -166,7 +166,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
       RecordInfo recordInfo = recordInfoIterator.next();
       int newDocId = recordInfo.getDocId();
       Comparable newComparisonValue = recordInfo.getComparisonValue();
-      addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+      addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
       _primaryKeyToRecordLocationMap.put(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
           new RecordLocation(segment, newDocId, newComparisonValue));
     }
@@ -275,9 +275,9 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               IndexSegment currentSegment = currentRecordLocation.getSegment();
               int currentDocId = currentRecordLocation.getDocId();
               if (segment == currentSegment) {
-                replaceDocId(validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
+                replaceDocId(segment, validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
               } else {
-                replaceDocId(validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
+                replaceDocId(segment, validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
               }
               return new RecordLocation(segment, newDocId, newComparisonValue);
             } else {
@@ -288,7 +288,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
             }
           } else {
             // New primary key
-            addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+            addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
             return new RecordLocation(segment, newDocId, newComparisonValue);
           }
         });

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -58,9 +58,10 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
-  public void setSegmentContexts(List<SegmentContext> segmentContexts) {
+  public void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
     _partitionMetadataManagerMap.forEach(
-        (partitionID, upsertMetadataManager) -> upsertMetadataManager.setSegmentContexts(segmentContexts));
+        (partitionID, upsertMetadataManager) -> upsertMetadataManager.setSegmentContexts(segmentContexts,
+            queryOptions));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -53,6 +53,6 @@ public interface TableUpsertMetadataManager extends Closeable {
    */
   Map<Integer, Long> getPartitionToPrimaryKeyCount();
 
-  default void setSegmentContexts(List<SegmentContext> segmentContexts) {
+  default void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -26,6 +26,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -41,8 +42,7 @@ public class UpsertContext {
   private final boolean _enablePreload;
   private final double _metadataTTL;
   private final double _deletedKeysTTL;
-  private final boolean _enableUpsertView;
-  private final boolean _enableUpsertViewBatchRefresh;
+  private final UpsertConfig.ConsistencyMode _consistencyMode;
   private final long _upsertViewRefreshIntervalMs;
   private final File _tableIndexDir;
   private final TableDataManager _tableDataManager;
@@ -50,7 +50,7 @@ public class UpsertContext {
   private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
       List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
       @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
-      double metadataTTL, double deletedKeysTTL, boolean enableUpsertView, boolean enableUpsertViewBatchRefresh,
+      double metadataTTL, double deletedKeysTTL, UpsertConfig.ConsistencyMode consistencyMode,
       long upsertViewRefreshIntervalMs, File tableIndexDir, @Nullable TableDataManager tableDataManager) {
     _tableConfig = tableConfig;
     _schema = schema;
@@ -63,8 +63,7 @@ public class UpsertContext {
     _enablePreload = enablePreload;
     _metadataTTL = metadataTTL;
     _deletedKeysTTL = deletedKeysTTL;
-    _enableUpsertView = enableUpsertView;
-    _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+    _consistencyMode = consistencyMode;
     _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
     _tableIndexDir = tableIndexDir;
     _tableDataManager = tableDataManager;
@@ -114,12 +113,8 @@ public class UpsertContext {
     return _deletedKeysTTL;
   }
 
-  public boolean isUpsertViewEnabled() {
-    return _enableUpsertView;
-  }
-
-  public boolean isUpsertViewBatchRefreshEnabled() {
-    return _enableUpsertViewBatchRefresh;
+  public UpsertConfig.ConsistencyMode getConsistencyMode() {
+    return _consistencyMode;
   }
 
   public long getUpsertViewRefreshIntervalMs() {
@@ -146,8 +141,7 @@ public class UpsertContext {
     private boolean _enablePreload;
     private double _metadataTTL;
     private double _deletedKeysTTL;
-    private boolean _enableUpsertView;
-    private boolean _enableUpsertViewBatchRefresh;
+    private UpsertConfig.ConsistencyMode _consistencyMode;
     private long _upsertViewRefreshIntervalMs;
     private File _tableIndexDir;
     private TableDataManager _tableDataManager;
@@ -207,13 +201,8 @@ public class UpsertContext {
       return this;
     }
 
-    public Builder setEnableUpsertView(boolean enableUpsertView) {
-      _enableUpsertView = enableUpsertView;
-      return this;
-    }
-
-    public Builder setEnableUpsertViewBatchRefresh(boolean enableUpsertViewBatchRefresh) {
-      _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+    public Builder setConsistencyMode(UpsertConfig.ConsistencyMode consistencyMode) {
+      _consistencyMode = consistencyMode;
       return this;
     }
 
@@ -241,8 +230,7 @@ public class UpsertContext {
       Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
       return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
           _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
-          _enableUpsertView, _enableUpsertViewBatchRefresh, _upsertViewRefreshIntervalMs, _tableIndexDir,
-          _tableDataManager);
+          _consistencyMode, _upsertViewRefreshIntervalMs, _tableIndexDir, _tableDataManager);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -41,13 +41,17 @@ public class UpsertContext {
   private final boolean _enablePreload;
   private final double _metadataTTL;
   private final double _deletedKeysTTL;
+  private final boolean _enableUpsertView;
+  private final boolean _enableUpsertViewBatchRefresh;
+  private final long _upsertViewRefreshIntervalMs;
   private final File _tableIndexDir;
   private final TableDataManager _tableDataManager;
 
   private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
       List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
       @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
-      double metadataTTL, double deletedKeysTTL, File tableIndexDir, @Nullable TableDataManager tableDataManager) {
+      double metadataTTL, double deletedKeysTTL, boolean enableUpsertView, boolean enableUpsertViewBatchRefresh,
+      long upsertViewRefreshIntervalMs, File tableIndexDir, @Nullable TableDataManager tableDataManager) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
@@ -59,6 +63,9 @@ public class UpsertContext {
     _enablePreload = enablePreload;
     _metadataTTL = metadataTTL;
     _deletedKeysTTL = deletedKeysTTL;
+    _enableUpsertView = enableUpsertView;
+    _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+    _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
     _tableIndexDir = tableIndexDir;
     _tableDataManager = tableDataManager;
   }
@@ -107,6 +114,18 @@ public class UpsertContext {
     return _deletedKeysTTL;
   }
 
+  public boolean isUpsertViewEnabled() {
+    return _enableUpsertView;
+  }
+
+  public boolean isUpsertViewBatchRefreshEnabled() {
+    return _enableUpsertViewBatchRefresh;
+  }
+
+  public long getUpsertViewRefreshIntervalMs() {
+    return _upsertViewRefreshIntervalMs;
+  }
+
   public File getTableIndexDir() {
     return _tableIndexDir;
   }
@@ -127,6 +146,9 @@ public class UpsertContext {
     private boolean _enablePreload;
     private double _metadataTTL;
     private double _deletedKeysTTL;
+    private boolean _enableUpsertView;
+    private boolean _enableUpsertViewBatchRefresh;
+    private long _upsertViewRefreshIntervalMs;
     private File _tableIndexDir;
     private TableDataManager _tableDataManager;
 
@@ -185,6 +207,21 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setEnableUpsertView(boolean enableUpsertView) {
+      _enableUpsertView = enableUpsertView;
+      return this;
+    }
+
+    public Builder setEnableUpsertViewBatchRefresh(boolean enableUpsertViewBatchRefresh) {
+      _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+      return this;
+    }
+
+    public Builder setUpsertViewRefreshIntervalMs(long upsertViewRefreshIntervalMs) {
+      _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
+      return this;
+    }
+
     public Builder setTableIndexDir(File tableIndexDir) {
       _tableIndexDir = tableIndexDir;
       return this;
@@ -204,7 +241,8 @@ public class UpsertContext {
       Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
       return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
           _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
-          _tableIndexDir, _tableDataManager);
+          _enableUpsertView, _enableUpsertViewBatchRefresh, _upsertViewRefreshIntervalMs, _tableIndexDir,
+          _tableDataManager);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -244,10 +244,10 @@ public class BasePartitionUpsertMetadataManagerTest {
   }
 
   @Test
-  public void testConsistencyModeLock()
+  public void testConsistencyModeSync()
       throws Exception {
     UpsertContext upsertContext = mock(UpsertContext.class);
-    when(upsertContext.getConsistencyMode()).thenReturn(UpsertConfig.ConsistencyMode.LOCK);
+    when(upsertContext.getConsistencyMode()).thenReturn(UpsertConfig.ConsistencyMode.SYNC);
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -244,10 +244,10 @@ public class BasePartitionUpsertMetadataManagerTest {
   }
 
   @Test
-  public void testEnableUpsertView()
+  public void testConsistencyModeLock()
       throws Exception {
     UpsertContext upsertContext = mock(UpsertContext.class);
-    when(upsertContext.isUpsertViewEnabled()).thenReturn(true);
+    when(upsertContext.getConsistencyMode()).thenReturn(UpsertConfig.ConsistencyMode.LOCK);
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 
@@ -323,11 +323,10 @@ public class BasePartitionUpsertMetadataManagerTest {
   }
 
   @Test
-  public void testEnableUpsertViewBatchRefresh()
+  public void testConsistencyModeSnapshot()
       throws Exception {
     UpsertContext upsertContext = mock(UpsertContext.class);
-    when(upsertContext.isUpsertViewEnabled()).thenReturn(true);
-    when(upsertContext.isUpsertViewBatchRefreshEnabled()).thenReturn(true);
+    when(upsertContext.getConsistencyMode()).thenReturn(UpsertConfig.ConsistencyMode.SNAPSHOT);
     when(upsertContext.getUpsertViewRefreshIntervalMs()).thenReturn(3000L);
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -82,7 +82,7 @@ public class UpsertConfig extends BaseJsonConfig {
   private boolean _enableUpsertViewBatchRefresh;
 
   @JsonPropertyDescription("Refresh interval if using batch refresh mode to keep consistent view for upsert table")
-  private long _upsertViewRefreshIntervalMs;
+  private long _upsertViewRefreshIntervalMs = 3000;
 
   @JsonPropertyDescription("Custom class for upsert metadata manager")
   private String _metadataManagerClass;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -39,6 +39,10 @@ public class UpsertConfig extends BaseJsonConfig {
     APPEND, IGNORE, INCREMENT, MAX, MIN, OVERWRITE, UNION
   }
 
+  public enum ConsistencyMode {
+    LOCK, SNAPSHOT, NONE
+  }
+
   @JsonPropertyDescription("Upsert mode.")
   private Mode _mode;
 
@@ -75,13 +79,10 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to preload segments for fast upsert metadata recovery")
   private boolean _enablePreload;
 
-  @JsonPropertyDescription("Whether to enable consistent view for upsert table")
-  private boolean _enableUpsertView;
+  @JsonPropertyDescription("Configure the way to provide consistent view for upsert table")
+  private ConsistencyMode _consistencyMode = ConsistencyMode.NONE;
 
-  @JsonPropertyDescription("Whether to enable batch refresh mode to keep consistent view for upsert table")
-  private boolean _enableUpsertViewBatchRefresh;
-
-  @JsonPropertyDescription("Refresh interval if using batch refresh mode to keep consistent view for upsert table")
+  @JsonPropertyDescription("Refresh interval when using the snapshot consistency mode")
   private long _upsertViewRefreshIntervalMs = 3000;
 
   @JsonPropertyDescription("Custom class for upsert metadata manager")
@@ -156,12 +157,8 @@ public class UpsertConfig extends BaseJsonConfig {
     return _enablePreload;
   }
 
-  public boolean isEnableUpsertView() {
-    return _enableUpsertView;
-  }
-
-  public boolean isEnableUpsertViewBatchRefresh() {
-    return _enableUpsertViewBatchRefresh;
+  public ConsistencyMode getConsistencyMode() {
+    return _consistencyMode;
   }
 
   public long getUpsertViewRefreshIntervalMs() {
@@ -258,12 +255,8 @@ public class UpsertConfig extends BaseJsonConfig {
     _enablePreload = enablePreload;
   }
 
-  public void setEnableUpsertView(boolean enableUpsertView) {
-    _enableUpsertView = enableUpsertView;
-  }
-
-  public void setEnableUpsertViewBatchRefresh(boolean enableUpsertViewBatchRefresh) {
-    _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+  public void setConsistencyMode(ConsistencyMode consistencyMode) {
+    _consistencyMode = consistencyMode;
   }
 
   public void setUpsertViewRefreshIntervalMs(long upsertViewRefreshIntervalMs) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -40,7 +40,7 @@ public class UpsertConfig extends BaseJsonConfig {
   }
 
   public enum ConsistencyMode {
-    LOCK, SNAPSHOT, NONE
+    NONE, SYNC, SNAPSHOT
   }
 
   @JsonPropertyDescription("Upsert mode.")

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -75,6 +75,15 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to preload segments for fast upsert metadata recovery")
   private boolean _enablePreload;
 
+  @JsonPropertyDescription("Whether to enable consistent view for upsert table")
+  private boolean _enableUpsertView;
+
+  @JsonPropertyDescription("Whether to enable batch refresh mode to keep consistent view for upsert table")
+  private boolean _enableUpsertViewBatchRefresh;
+
+  @JsonPropertyDescription("Refresh interval if using batch refresh mode to keep consistent view for upsert table")
+  private long _upsertViewRefreshIntervalMs;
+
   @JsonPropertyDescription("Custom class for upsert metadata manager")
   private String _metadataManagerClass;
 
@@ -145,6 +154,18 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public boolean isEnablePreload() {
     return _enablePreload;
+  }
+
+  public boolean isEnableUpsertView() {
+    return _enableUpsertView;
+  }
+
+  public boolean isEnableUpsertViewBatchRefresh() {
+    return _enableUpsertViewBatchRefresh;
+  }
+
+  public long getUpsertViewRefreshIntervalMs() {
+    return _upsertViewRefreshIntervalMs;
   }
 
   public boolean isDropOutOfOrderRecord() {
@@ -235,6 +256,18 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public void setEnablePreload(boolean enablePreload) {
     _enablePreload = enablePreload;
+  }
+
+  public void setEnableUpsertView(boolean enableUpsertView) {
+    _enableUpsertView = enableUpsertView;
+  }
+
+  public void setEnableUpsertViewBatchRefresh(boolean enableUpsertViewBatchRefresh) {
+    _enableUpsertViewBatchRefresh = enableUpsertViewBatchRefresh;
+  }
+
+  public void setUpsertViewRefreshIntervalMs(long upsertViewRefreshIntervalMs) {
+    _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
   }
 
   public void setDropOutOfOrderRecord(boolean dropOutOfOrderRecord) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -352,6 +352,7 @@ public class CommonConstants {
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
+        public static final String UPSERT_VIEW_FRESHNESS_MS = "upsertViewFreshnessMs";
         public static final String USE_STAR_TREE = "useStarTree";
         public static final String SCAN_STAR_TREE_NODES = "scanStarTreeNodes";
         public static final String ROUTING_OPTIONS = "routingOptions";


### PR DESCRIPTION
This PR tries to support consistent table view for querying upsert tables. The consistency is at table partition level, which can contain many segments. Today, updates that involve two segments' bitmaps are not atomic, thus causing queries to see inconsistent table view, e.g. to return less than expected PKs.

The high level idea is either to synchronize the query threads and upsert threads (including consuming thread or HelixTaskExecutor threads) with locks for queries to get a consistent set of segments' validDocIds bitmaps; or let upsert threads keep a consistent set (i.e. upsert view) of bitmaps and refresh the view regularly. Both modes are added in this PR, as they can be wired up using one R/W lock.

Added a new upsert config consistencyMode, which can be NONE, SYNC or SNAPSHOT
1. by default, the feature is disabled, i.e. NONE
2. for SYNC mode, the upsert threads take the WLock when the upsert involves two segments' bitmaps; and the query threads take the RLock when getting bitmaps for all its selected segments. This is mode is best for data freshness, but queries may block data ingestion. Mainly for low qps or low ingestion cases.
3. for SNAPSHOT mode, the query threads don't need to take lock when getting bitmaps. The query threads access a copy of bitmaps that are kept updated by upsert thread periodically. In this mode, if data freshness is concerned, the query can specify a query option as called upsertViewFreshnessMs (e.g. 3s) to set its tolerance on data freshness, and the query thread can fresh the bitmap copies immediately if they are not fresh enough. Mainly high qps and high ingestion cases.
