### PR TITLE
Add threadLocal reusable byte array for VarByteChunkReaderV4

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -207,29 +207,29 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getStringMV(int docId, String[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    byte[] bytes = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     int numValues = byteBuffer.getInt();
-    byteBuffer.position((numValues + 1) * Integer.BYTES);
+    int offset = (numValues + 1) * Integer.BYTES;
     for (int i = 0; i < numValues; i++) {
       int length = byteBuffer.getInt((i + 1) * Integer.BYTES);
-      byte[] bytes = new byte[length];
-      byteBuffer.get(bytes);
-      valueBuffer[i] = new String(bytes, StandardCharsets.UTF_8);
+      valueBuffer[i] = new String(bytes, offset, length, StandardCharsets.UTF_8);
+      offset += length;
     }
     return numValues;
   }
 
   @Override
   public String[] getStringMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    byte[] bytes = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     int numValues = byteBuffer.getInt();
-    byteBuffer.position((numValues + 1) * Integer.BYTES);
+    int offset = (numValues + 1) * Integer.BYTES;
     String[] valueBuffer = new String[numValues];
     for (int i = 0; i < numValues; i++) {
       int length = byteBuffer.getInt((i + 1) * Integer.BYTES);
-      byte[] bytes = new byte[length];
-      byteBuffer.get(bytes);
-      valueBuffer[i] = new String(bytes, StandardCharsets.UTF_8);
+      valueBuffer[i] = new String(bytes, offset, length, StandardCharsets.UTF_8);
+      offset += length;
     }
     return valueBuffer;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -60,6 +60,14 @@ public class VarByteChunkForwardIndexReaderV4
   private final boolean _isSingleValue;
   private final long _chunksStartOffset;
 
+  // TODO: persist _longestLengthOfEntry in Table V5 header.
+  // If _longestLengthOfEntry > _maxReusableByteSize, we won't expand the _reusableBytes array.
+  // Make the value of _maxReusableByteSize as a tableConfig's fieldConfig.
+  // The default value is 0, meaning no reuse.
+  // make it static and set to 1024*1024 for temporary benchmarking.
+  public static int _maxReusableByteSize = 1024 * 1024;
+  public static ThreadLocal<byte[]> _reusableBytes = ThreadLocal.withInitial(() -> new byte[0]);
+
   public VarByteChunkForwardIndexReaderV4(PinotDataBuffer dataBuffer, FieldSpec.DataType storedType,
       boolean isSingleValue) {
     int version = dataBuffer.getInt(0);
@@ -108,22 +116,32 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public BigDecimal getBigDecimal(int docId, ReaderContext context) {
-    return BigDecimalUtils.deserialize(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
+    return BigDecimalUtils.deserialize(byteBuffer);
   }
 
   @Override
   public String getString(int docId, ReaderContext context) {
-    return new String(context.getValue(docId), StandardCharsets.UTF_8);
+    ReadResult res = context.getValue(docId);
+    return new String(res.getBytes(), 0, res.getLength(), StandardCharsets.UTF_8);
   }
 
   @Override
   public byte[] getBytes(int docId, ReaderContext context) {
-    return context.getValue(docId);
+    ReadResult res = context.getValue(docId);
+    if (!res.isReusable()) {
+      return res.getBytes();
+    }
+    byte[] bytes = new byte[res.getLength()];
+    System.arraycopy(res.getBytes(), 0, bytes, 0, res.getLength());
+    return bytes;
   }
 
   @Override
   public int getIntMV(int docId, int[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     for (int i = 0; i < numValues; i++) {
       valueBuffer[i] = byteBuffer.getInt();
@@ -133,7 +151,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int[] getIntMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     int[] valueBuffer = new int[numValues];
     for (int i = 0; i < numValues; i++) {
@@ -144,7 +163,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getLongMV(int docId, long[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     for (int i = 0; i < numValues; i++) {
       valueBuffer[i] = byteBuffer.getLong();
@@ -154,7 +174,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public long[] getLongMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     long[] valueBuffer = new long[numValues];
     for (int i = 0; i < numValues; i++) {
@@ -165,7 +186,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getFloatMV(int docId, float[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     for (int i = 0; i < numValues; i++) {
       valueBuffer[i] = byteBuffer.getFloat();
@@ -175,7 +197,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public float[] getFloatMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     float[] valueBuffer = new float[numValues];
     for (int i = 0; i < numValues; i++) {
@@ -186,7 +209,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getDoubleMV(int docId, double[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     for (int i = 0; i < numValues; i++) {
       valueBuffer[i] = byteBuffer.getDouble();
@@ -196,7 +220,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public double[] getDoubleMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     double[] valueBuffer = new double[numValues];
     for (int i = 0; i < numValues; i++) {
@@ -207,8 +232,9 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getStringMV(int docId, String[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    byte[] bytes = context.getValue(docId);
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    ReadResult res = context.getValue(docId);
+    byte[] bytes = res.getBytes();
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     int offset = (numValues + 1) * Integer.BYTES;
     for (int i = 0; i < numValues; i++) {
@@ -221,8 +247,9 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public String[] getStringMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    byte[] bytes = context.getValue(docId);
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    ReadResult res = context.getValue(docId);
+    byte[] bytes = res.getBytes();
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes, 0, res.getLength());
     int numValues = byteBuffer.getInt();
     int offset = (numValues + 1) * Integer.BYTES;
     String[] valueBuffer = new String[numValues];
@@ -236,7 +263,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public int getBytesMV(int docId, byte[][] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     byteBuffer.position((numValues + 1) * Integer.BYTES);
     for (int i = 0; i < numValues; i++) {
@@ -250,7 +278,8 @@ public class VarByteChunkForwardIndexReaderV4
 
   @Override
   public byte[][] getBytesMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(context.getValue(docId));
+    ReadResult res = context.getValue(docId);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(res.getBytes(), 0, res.getLength());
     int numValues = byteBuffer.getInt();
     byteBuffer.position((numValues + 1) * Integer.BYTES);
     byte[][] valueBuffer = new byte[numValues][];
@@ -294,6 +323,30 @@ public class VarByteChunkForwardIndexReaderV4
     throw new UnsupportedOperationException("Forward index is not fixed length type");
   }
 
+  static class ReadResult {
+    private boolean _isReusable;
+    private int _length;
+    private byte[] _bytes;
+
+    ReadResult(boolean isReusable, int length, byte[] bytes) {
+      _isReusable = isReusable;
+      _length = length;
+      _bytes = bytes;
+    }
+
+    boolean isReusable() {
+      return _isReusable;
+    }
+
+    int getLength() {
+      return _length;
+    }
+
+    byte[] getBytes() {
+      return _bytes;
+    }
+  }
+
   public static abstract class ReaderContext implements ForwardIndexReaderContext {
 
     protected final PinotDataBuffer _chunks;
@@ -319,7 +372,7 @@ public class VarByteChunkForwardIndexReaderV4
       }
     }
 
-    public byte[] getValue(int docId) {
+    public ReadResult getValue(int docId) {
       if (docId >= _docIdOffset && docId < _nextDocIdOffset) {
         return readSmallUncompressedValue(docId);
       } else {
@@ -350,12 +403,25 @@ public class VarByteChunkForwardIndexReaderV4
       return (low - 1) * METADATA_ENTRY_SIZE;
     }
 
-    protected abstract byte[] processChunkAndReadFirstValue(int docId, long offset, long limit)
+    protected ReadResult getOrExpandOrAllocateBytes(int length) {
+      // as time goes by, the _reusableBytes.length will be dynamically adjusted to
+      // the longest length of entry byte size smaller than or equal to _maxReusableByteSize
+      if (length > _maxReusableByteSize) {
+        return new ReadResult(false, length, new byte[length]);
+      }
+      // TODO: replace _maxAllocatedByteArraySizeForStrings with _longestLengthOfStringsEntry
+      if (_reusableBytes.get().length < _maxReusableByteSize) {
+        _reusableBytes.set(new byte[_maxReusableByteSize]);
+      }
+      return new ReadResult(true, length, _reusableBytes.get());
+    }
+
+    protected abstract ReadResult processChunkAndReadFirstValue(int docId, long offset, long limit)
         throws IOException;
 
-    protected abstract byte[] readSmallUncompressedValue(int docId);
+    protected abstract ReadResult readSmallUncompressedValue(int docId);
 
-    private byte[] decompressAndRead(int docId)
+    private ReadResult decompressAndRead(int docId)
         throws IOException {
       long metadataEntry = chunkIndexFor(docId);
       int info = _metadata.getInt(metadataEntry);
@@ -405,7 +471,7 @@ public class VarByteChunkForwardIndexReaderV4
     }
 
     @Override
-    protected byte[] processChunkAndReadFirstValue(int docId, long offset, long limit) {
+    protected ReadResult processChunkAndReadFirstValue(int docId, long offset, long limit) {
       _chunk = _chunks.toDirectByteBuffer(offset, (int) (limit - offset));
       if (!_regularChunk) {
         return readHugeValue();
@@ -414,23 +480,25 @@ public class VarByteChunkForwardIndexReaderV4
       return readSmallUncompressedValue(docId);
     }
 
-    private byte[] readHugeValue() {
-      byte[] value = new byte[_chunk.capacity()];
-      _chunk.get(value);
-      return value;
+    private ReadResult readHugeValue() {
+      int length = _chunk.capacity();
+      ReadResult res = getOrExpandOrAllocateBytes(length);
+      _chunk.get(res.getBytes(), 0, length);
+      return res;
     }
 
     @Override
-    protected byte[] readSmallUncompressedValue(int docId) {
+    protected ReadResult readSmallUncompressedValue(int docId) {
       int index = docId - _docIdOffset;
       int offset = _chunk.getInt((index + 1) * Integer.BYTES);
       int nextOffset =
           index == _numDocsInCurrentChunk - 1 ? _chunk.limit() : _chunk.getInt((index + 2) * Integer.BYTES);
-      byte[] bytes = new byte[nextOffset - offset];
+      int length = nextOffset - offset;
+      ReadResult res = getOrExpandOrAllocateBytes(length);
       _chunk.position(offset);
-      _chunk.get(bytes);
+      _chunk.get(res.getBytes(), 0, length);
       _chunk.position(0);
-      return bytes;
+      return res;
     }
 
     @Override
@@ -453,7 +521,7 @@ public class VarByteChunkForwardIndexReaderV4
     }
 
     @Override
-    protected byte[] processChunkAndReadFirstValue(int docId, long offset, long limit)
+    protected ReadResult processChunkAndReadFirstValue(int docId, long offset, long limit)
         throws IOException {
       _decompressedBuffer.clear();
       ByteBuffer compressed = _chunks.toDirectByteBuffer(offset, (int) (limit - offset));
@@ -467,38 +535,40 @@ public class VarByteChunkForwardIndexReaderV4
     }
 
     @Override
-    protected byte[] readSmallUncompressedValue(int docId) {
+    protected ReadResult readSmallUncompressedValue(int docId) {
       int index = docId - _docIdOffset;
       int offset = _decompressedBuffer.getInt((index + 1) * Integer.BYTES);
       int nextOffset = index == _numDocsInCurrentChunk - 1 ? _decompressedBuffer.limit()
           : _decompressedBuffer.getInt((index + 2) * Integer.BYTES);
-      byte[] bytes = new byte[nextOffset - offset];
+      int length = nextOffset - offset;
+      ReadResult res = getOrExpandOrAllocateBytes(length);
       _decompressedBuffer.position(offset);
-      _decompressedBuffer.get(bytes);
+      _decompressedBuffer.get(res.getBytes(), 0, length);
       _decompressedBuffer.position(0);
-      return bytes;
+      return res;
     }
 
-    private byte[] readHugeCompressedValue(ByteBuffer compressed, int decompressedLength)
+    private ReadResult readHugeCompressedValue(ByteBuffer compressed, int decompressedLength)
         throws IOException {
       // huge values don't have length prefixes; they occupy the entire chunk so are unambiguous
-      byte[] value = new byte[decompressedLength];
+      ReadResult res = getOrExpandOrAllocateBytes(decompressedLength);
       if (_chunkCompressionType == ChunkCompressionType.SNAPPY
           || _chunkCompressionType == ChunkCompressionType.ZSTANDARD) {
         // snappy and zstandard don't work without direct buffers
-        decompressViaDirectBuffer(compressed, value);
+        decompressViaDirectBuffer(compressed, res.getBytes(), decompressedLength);
       } else {
-        _chunkDecompressor.decompress(compressed, ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN));
+        _chunkDecompressor.decompress(compressed,
+                ByteBuffer.wrap(res.getBytes(), 0, decompressedLength).order(ByteOrder.LITTLE_ENDIAN));
       }
-      return value;
+      return res;
     }
 
-    private void decompressViaDirectBuffer(ByteBuffer compressed, byte[] target)
+    private void decompressViaDirectBuffer(ByteBuffer compressed, byte[] target, int length)
         throws IOException {
-      ByteBuffer buffer = ByteBuffer.allocateDirect(target.length).order(ByteOrder.LITTLE_ENDIAN);
+      ByteBuffer buffer = ByteBuffer.allocateDirect(length).order(ByteOrder.LITTLE_ENDIAN);
       try {
         _chunkDecompressor.decompress(compressed, buffer);
-        buffer.get(target);
+        buffer.get(target, 0, length);
       } finally {
         if (CleanerUtil.UNMAP_SUPPORTED) {
           CleanerUtil.getCleaner().freeBuffer(buffer);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds thread‑local reusable byte array via ReadResult to eliminate per‑record byte\[\] allocations in VarByteChunkForwardIndexReaderV4\.

```mermaid
flowchart TD
  N0["ReaderContext#46;getValue #40;F1#41;"]:::stModified
  N1["readSmallUncompressedValue #47; processChunkAndReadFirstValue #40;F1#41;"]:::stModified
  N2["getOrExpandOrAllocateBytes #40;F1#41;"]:::stAdded
  N3["fill byte array from chunk #40;#95;chunk#46;get #47; #95;decompressedBuffer#46;get#41; #40;F1#41;"]:::stModified
  N4["return ReadResult #40;F1#41;"]:::stModified
  N5["consumer method #40;getString#44; getBytes#44; getIntMV#8230;#41; using ReadResult #40;F1#41;"]:::stModified
  N0 -->|"calls read method based on docId range #40;evidence#58; getValue #8594;"| N1
  N1 -->|"calls getOrExpandOrAllocateBytes #40;evidence#58; ReadResult res #61;"| N2
  N1 -->|"fills array via #95;chunk#46;get #47; #95;decompressedBuffer#46;get #40;evid"| N3
  N1 -->|"returns the ReadResult #40;evidence#58; return res"| N4
  N4 -->|"consumer gets ReadResult from context#46;getValue #40;evi"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4\.java — [before](https://github.com/apache/pinot/blob/da6823600b5bf13a2b9fdbfb60f5e29525496bbc/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java) · [after](https://github.com/apache/pinot/blob/a811cfcbe5010d2c4a435b7ff0c0acde2d7e781a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRhNjgyMzYwMGI1YmYxM2EyYjlmZGJmYjYwZjVlMjk1MjU0OTZiYmMiLCJjb250ZXh0X2hhc2giOiJjNzVhYjI1YzkwMWVlYmUyMzdlNmU5Y2I5Mzg4YThkNGQ1ZDU2MWFmNTA5NjdjNzZiOTk1YzkwZmVlNGQ2OTUxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTAwMDI0LCJoZWFkX3NoYSI6ImE4MTFjZmNiZTUwMTBkMmM0YTQzNWI3ZmYwYzBhY2RlMmQ3ZTc4MWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlMWIwZTUzNTdlYmZjZWNmZmNjNmNjZTM5OTdhM2VkY2RhYzFhYTJjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 21979a767f87aaf0e58e325208889bf65143c56c6745f8e740ff26ff909dd782 -->
<!-- pinot-pr-flow:end -->

Intuition: Reduce repeated intermediate byte array allocation on jvm heap when QPS is high. Without this change, there will be an additional allocation of intermediate byte array in ReaderContext per record read. When qps is relatively, the YoungGC are likely to be triggered frequently. With this change, no allocation of intermediate byte array if the entry size is than the configurable _maxReusableByteSize.

Is it thread safe? Yes, since the ReaderContext is created per ProjectionOperator per segment per query. A non combine operator per segment would only be executed by a query worker.

Additional Permanent Memory cost: number of query workers *  _maxReusableByteSize (should be set as a fieldConfig per table). In the future, it will be number of query workers *  min(_longestLengthOfEntry, _maxReusableByteSize) if we can add _longestLengthOfEntry in the V5 segment header.

Potential proof demonstrating the benefits of reusable byte array on V2 / V3: https://github.com/apache/pinot/pull/12242#issuecomment-1932695513

This PR is rebased on top of https://github.com/apache/pinot/pull/12978