### PR TITLE
Add back shade profile for shade removed in #12712

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -33,7 +33,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
   <build>
     <resources>
@@ -82,4 +81,18 @@
       <artifactId>jsr305</artifactId>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -33,7 +33,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <build>
@@ -413,6 +412,16 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -179,4 +179,15 @@
     </dependency>
     <!-- Lucene dependencies end -->
   </dependencies>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <s3mock.version>2.12.2</s3mock.version>
-    <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
   <dependencies>
@@ -65,4 +64,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -35,7 +35,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <shade.phase.prop>package</shade.phase.prop>
     <reactive.version>1.0.2</reactive.version>
     <localstack-utils.version>0.2.23</localstack-utils.version>
   </properties>
@@ -133,4 +132,19 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -179,4 +179,15 @@
       <artifactId>reflections</artifactId>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Per #12969, this PR add back the profiles removed in #12712 for backward compatibility for submodules:

Use profile default to control, can enable by adding flag `-Pbuild-shaded-jar`:
```
pinot-spi
pinot-common(default is enabled)
pinot-core
```

Use property to control profile enable, default enabled, allow disable by adding flag `-DskipShade=true`
```
pinot-jdbc-client
pinot-s3
pinot-kinesis
```

Usage:
1. Enable the profile `build-shaded-jar`, default is true or false
```
mvn clean install -Pbin-dist -DskipTests -T1C  -pl pinot-spi -Pbuild-shaded-jar
```

2. Skip shade for certain plugin submodules:
```
mvn clean install -Pbin-dist -DskipTests -T1C  -pl :pinot-jdbc-client -DskipShade=true
```