### PR TITLE
Update ORC and Hive dependency versions in the license binary file

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -420,7 +420,7 @@ org.apache.helix:helix-core:1.3.1
 org.apache.helix:metadata-store-directory-common:1.3.1
 org.apache.helix:metrics-common:1.3.1
 org.apache.helix:zookeeper-api:1.3.1
-org.apache.hive:hive-storage-api:2.7.1
+org.apache.hive:hive-storage-api:2.8.1
 org.apache.httpcomponents:httpclient:4.5.14
 org.apache.httpcomponents:httpcore:4.4.13
 org.apache.httpcomponents:httpmime:4.5.13
@@ -438,8 +438,8 @@ org.apache.lucene:lucene-core:9.8.0
 org.apache.lucene:lucene-queries:9.8.0
 org.apache.lucene:lucene-queryparser:9.8.0
 org.apache.lucene:lucene-sandbox:9.8.0
-org.apache.orc:orc-core:1.5.9
-org.apache.orc:orc-shims:1.5.9
+org.apache.orc:orc-core:1.9.3
+org.apache.orc:orc-shims:1.9.3
 org.apache.parquet:parquet-avro:1.13.1
 org.apache.parquet:parquet-column:1.13.1
 org.apache.parquet:parquet-common:1.13.1


### PR DESCRIPTION
- The ORC and Hive dependency versions were upgraded in https://github.com/apache/pinot/pull/12956. This patch updates the license binary file with the new versions.