### PR TITLE
Support NOT in StarTree Index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/SortedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/SortedIndexBasedFilterOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.filter;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdSet;
@@ -90,10 +89,7 @@ public class SortedIndexBasedFilterOperator extends BaseColumnFilterOperator {
           return new SortedDocIdSet(Collections.singletonList(docIdRange));
         }
       } else {
-        // Sort the dictIds in ascending order so that their respective docIdRanges are adjacent if they are adjacent
-        Arrays.sort(dictIds);
-
-        // Merge adjacent docIdRanges
+        // Merge adjacent docIdRanges (dictIds are already sorted)
         List<IntPair> docIdRanges = new ArrayList<>();
         IntPair lastDocIdRange = _sortedIndexReader.getDocIds(dictIds[0]);
         for (int i = 1; i < numDictIds; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BasePredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BasePredicateEvaluator.java
@@ -42,14 +42,4 @@ public abstract class BasePredicateEvaluator implements PredicateEvaluator {
   public final boolean isExclusive() {
     return getPredicateType().isExclusive();
   }
-
-  @Override
-  public int getNumMatchingDictIds() {
-    return getMatchingDictIds().length;
-  }
-
-  @Override
-  public int getNumNonMatchingDictIds() {
-    return getNonMatchingDictIds().length;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -62,8 +62,7 @@ public class EqualsPredicateEvaluatorFactory {
    * @param dataType Data type for the column
    * @return Raw value based EQ predicate evaluator
    */
-  public static EqRawPredicateEvaluator newRawValueBasedEvaluator(EqPredicate eqPredicate,
-      DataType dataType) {
+  public static EqRawPredicateEvaluator newRawValueBasedEvaluator(EqPredicate eqPredicate, DataType dataType) {
     String value = eqPredicate.getValue();
     switch (dataType) {
       case INT:
@@ -92,10 +91,9 @@ public class EqualsPredicateEvaluatorFactory {
   private static final class DictionaryBasedEqPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator
       implements IntValue {
     final int _matchingDictId;
-    final int[] _matchingDictIds;
 
     DictionaryBasedEqPredicateEvaluator(EqPredicate eqPredicate, Dictionary dictionary, DataType dataType) {
-      super(eqPredicate);
+      super(eqPredicate, dictionary);
       String predicateValue = PredicateUtils.getStoredValue(eqPredicate.getValue(), dataType);
       _matchingDictId = dictionary.indexOf(predicateValue);
       if (_matchingDictId >= 0) {
@@ -107,6 +105,11 @@ public class EqualsPredicateEvaluatorFactory {
         _matchingDictIds = new int[0];
         _alwaysFalse = true;
       }
+    }
+
+    @Override
+    protected int[] calculateNonMatchingDictIds() {
+      return PredicateUtils.getDictIds(_dictionary.length(), _matchingDictId);
     }
 
     @Override
@@ -130,11 +133,6 @@ public class EqualsPredicateEvaluatorFactory {
         }
       }
       return matches;
-    }
-
-    @Override
-    public int[] getMatchingDictIds() {
-      return _matchingDictIds;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -71,8 +71,7 @@ public class InPredicateEvaluatorFactory {
    * @param dataType Data type for the column
    * @return Raw value based IN predicate evaluator
    */
-  public static InRawPredicateEvaluator newRawValueBasedEvaluator(InPredicate inPredicate,
-      DataType dataType) {
+  public static InRawPredicateEvaluator newRawValueBasedEvaluator(InPredicate inPredicate, DataType dataType) {
     switch (dataType) {
       case INT: {
         int[] intValues = inPredicate.getIntValues();
@@ -157,42 +156,34 @@ public class InPredicateEvaluatorFactory {
 
   private static final class DictionaryBasedInPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
     final IntSet _matchingDictIdSet;
-    final int _numMatchingDictIds;
-    int[] _matchingDictIds;
 
     DictionaryBasedInPredicateEvaluator(InPredicate inPredicate, Dictionary dictionary, DataType dataType,
         @Nullable QueryContext queryContext) {
-      super(inPredicate);
+      super(inPredicate, dictionary);
       _matchingDictIdSet = PredicateUtils.getDictIdSet(inPredicate, dictionary, dataType, queryContext);
-      _numMatchingDictIds = _matchingDictIdSet.size();
-      if (_numMatchingDictIds == 0) {
+      int numMatchingDictIds = _matchingDictIdSet.size();
+      if (numMatchingDictIds == 0) {
         _alwaysFalse = true;
-      } else if (dictionary.length() == _numMatchingDictIds) {
+      } else if (dictionary.length() == numMatchingDictIds) {
         _alwaysTrue = true;
       }
     }
 
     @Override
-    public boolean applySV(int dictId) {
-      return _matchingDictIdSet.contains(dictId);
-    }
-
-    @Override
-    public int getNumMatchingDictIds() {
-      return _numMatchingDictIds;
+    protected int[] calculateMatchingDictIds() {
+      int[] matchingDictIds = _matchingDictIdSet.toIntArray();
+      Arrays.sort(matchingDictIds);
+      return matchingDictIds;
     }
 
     @Override
     public int getNumMatchingItems() {
-      return getNumMatchingDictIds();
+      return _matchingDictIdSet.size();
     }
 
     @Override
-    public int[] getMatchingDictIds() {
-      if (_matchingDictIds == null) {
-        _matchingDictIds = _matchingDictIdSet.toIntArray();
-      }
-      return _matchingDictIds;
+    public boolean applySV(int dictId) {
+      return _matchingDictIdSet.contains(dictId);
     }
 
     @Override
@@ -477,9 +468,7 @@ public class InPredicateEvaluatorFactory {
 
     @Override
     public <R> R accept(MultiValueVisitor<R> visitor) {
-      byte[][] bytes = _matchingValues.stream()
-          .map(ByteArray::getBytes)
-          .toArray(byte[][]::new);
+      byte[][] bytes = _matchingValues.stream().map(ByteArray::getBytes).toArray(byte[][]::new);
       return visitor.visitBytes(bytes);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -58,8 +58,7 @@ public class NotEqualsPredicateEvaluatorFactory {
    * @param dataType Data type for the column
    * @return Raw value based NOT_EQ predicate evaluator
    */
-  public static NeqRawPredicateEvaluator newRawValueBasedEvaluator(NotEqPredicate notEqPredicate,
-      DataType dataType) {
+  public static NeqRawPredicateEvaluator newRawValueBasedEvaluator(NotEqPredicate notEqPredicate, DataType dataType) {
     String value = notEqPredicate.getValue();
     switch (dataType) {
       case INT:
@@ -87,12 +86,9 @@ public class NotEqualsPredicateEvaluatorFactory {
 
   private static final class DictionaryBasedNeqPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
     final int _nonMatchingDictId;
-    final int[] _nonMatchingDictIds;
-    final Dictionary _dictionary;
-    int[] _matchingDictIds;
 
     DictionaryBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, Dictionary dictionary, DataType dataType) {
-      super(notEqPredicate);
+      super(notEqPredicate, dictionary);
       String predicateValue = PredicateUtils.getStoredValue(notEqPredicate.getValue(), dataType);
       _nonMatchingDictId = dictionary.indexOf(predicateValue);
       if (_nonMatchingDictId >= 0) {
@@ -104,7 +100,11 @@ public class NotEqualsPredicateEvaluatorFactory {
         _nonMatchingDictIds = new int[0];
         _alwaysTrue = true;
       }
-      _dictionary = dictionary;
+    }
+
+    @Override
+    protected int[] calculateMatchingDictIds() {
+      return PredicateUtils.getDictIds(_dictionary.length(), _nonMatchingDictId);
     }
 
     @Override
@@ -128,33 +128,6 @@ public class NotEqualsPredicateEvaluatorFactory {
         }
       }
       return matches;
-    }
-
-    @Override
-    public int[] getMatchingDictIds() {
-      if (_matchingDictIds == null) {
-        int dictionarySize = _dictionary.length();
-        if (_nonMatchingDictId >= 0) {
-          _matchingDictIds = new int[dictionarySize - 1];
-          int index = 0;
-          for (int dictId = 0; dictId < dictionarySize; dictId++) {
-            if (dictId != _nonMatchingDictId) {
-              _matchingDictIds[index++] = dictId;
-            }
-          }
-        } else {
-          _matchingDictIds = new int[dictionarySize];
-          for (int dictId = 0; dictId < dictionarySize; dictId++) {
-            _matchingDictIds[dictId] = dictId;
-          }
-        }
-      }
-      return _matchingDictIds;
-    }
-
-    @Override
-    public int[] getNonMatchingDictIds() {
-      return _nonMatchingDictIds;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -71,8 +71,7 @@ public class NotInPredicateEvaluatorFactory {
    * @param dataType Data type for the column
    * @return Raw value based NOT_IN predicate evaluator
    */
-  public static NotInRawPredicateEvaluator newRawValueBasedEvaluator(NotInPredicate notInPredicate,
-      DataType dataType) {
+  public static NotInRawPredicateEvaluator newRawValueBasedEvaluator(NotInPredicate notInPredicate, DataType dataType) {
     switch (dataType) {
       case INT: {
         int[] intValues = notInPredicate.getIntValues();
@@ -157,27 +156,34 @@ public class NotInPredicateEvaluatorFactory {
 
   public static final class DictionaryBasedNotInPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
     final IntSet _nonMatchingDictIdSet;
-    final int _numNonMatchingDictIds;
-    final Dictionary _dictionary;
-    int[] _matchingDictIds;
-    int[] _nonMatchingDictIds;
 
     DictionaryBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Dictionary dictionary, DataType dataType,
         @Nullable QueryContext queryContext) {
-      super(notInPredicate);
+      super(notInPredicate, dictionary);
       _nonMatchingDictIdSet = PredicateUtils.getDictIdSet(notInPredicate, dictionary, dataType, queryContext);
-      _numNonMatchingDictIds = _nonMatchingDictIdSet.size();
-      if (_numNonMatchingDictIds == 0) {
+      int numNonMatchingDictIds = _nonMatchingDictIdSet.size();
+      if (numNonMatchingDictIds == 0) {
         _alwaysTrue = true;
-      } else if (dictionary.length() == _numNonMatchingDictIds) {
+      } else if (dictionary.length() == numNonMatchingDictIds) {
         _alwaysFalse = true;
       }
-      _dictionary = dictionary;
+    }
+
+    @Override
+    protected int[] calculateMatchingDictIds() {
+      return PredicateUtils.flipDictIds(getNonMatchingDictIds(), _dictionary.length());
+    }
+
+    @Override
+    protected int[] calculateNonMatchingDictIds() {
+      int[] nonMatchingDictIds = _nonMatchingDictIdSet.toIntArray();
+      Arrays.sort(nonMatchingDictIds);
+      return nonMatchingDictIds;
     }
 
     @Override
     public int getNumMatchingItems() {
-      return -_numNonMatchingDictIds;
+      return -_nonMatchingDictIdSet.size();
     }
 
     @Override
@@ -196,34 +202,6 @@ public class NotInPredicateEvaluatorFactory {
         }
       }
       return matches;
-    }
-
-    @Override
-    public int[] getMatchingDictIds() {
-      if (_matchingDictIds == null) {
-        int dictionarySize = _dictionary.length();
-        _matchingDictIds = new int[dictionarySize - _numNonMatchingDictIds];
-        int index = 0;
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          if (!_nonMatchingDictIdSet.contains(dictId)) {
-            _matchingDictIds[index++] = dictId;
-          }
-        }
-      }
-      return _matchingDictIds;
-    }
-
-    @Override
-    public int getNumNonMatchingDictIds() {
-      return _numNonMatchingDictIds;
-    }
-
-    @Override
-    public int[] getNonMatchingDictIds() {
-      if (_nonMatchingDictIds == null) {
-        _nonMatchingDictIds = _nonMatchingDictIdSet.toIntArray();
-      }
-      return _nonMatchingDictIds;
     }
   }
 
@@ -491,9 +469,7 @@ public class NotInPredicateEvaluatorFactory {
 
     @Override
     public <R> R accept(MultiValueVisitor<R> visitor) {
-      byte[][] bytes = _nonMatchingValues.stream()
-          .map(ByteArray::getBytes)
-          .toArray(byte[][]::new);
+      byte[][] bytes = _nonMatchingValues.stream().map(ByteArray::getBytes).toArray(byte[][]::new);
       return visitor.visitBytes(bytes);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
@@ -102,35 +102,24 @@ public interface PredicateEvaluator {
   boolean applyMV(int[] values, int length);
 
   /**
+   * Get the number of matching items. Negative number indicates exclusive (e.g. NOT_EQ, NOT_IN) match. Returns
+   * {@code Integer.MIN_VALUE} if not applicable.
+   */
+  default int getNumMatchingItems() {
+    return Integer.MIN_VALUE;
+  }
+
+  /**
    * APIs for dictionary based predicate evaluator
    */
 
   /**
-   * return the number of matching items specified by predicate
-   * negative number indicates exclusive (not eq, not in) match
-   * return {@code Integer.MIN_VALUE} for not applicable
-   */
-  default int getNumMatchingItems() {
-    return Integer.MIN_VALUE;
-  };
-
-  /**
-   * Get the number of matching dictionary ids.
-   */
-  int getNumMatchingDictIds();
-
-  /**
-   * Get the matching dictionary ids.
+   * Get the matching dictionary ids. The returned ids should be sorted.
    */
   int[] getMatchingDictIds();
 
   /**
-   * Get the number of non-matching dictionary ids.
-   */
-  int getNumNonMatchingDictIds();
-
-  /**
-   * Get the non-matching dictionary ids.
+   * Get the non-matching dictionary ids. The returned ids should be sorted.
    */
   int[] getNonMatchingDictIds();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -190,4 +190,38 @@ public class PredicateUtils {
     }
     return dictIdSet;
   }
+
+  public static int[] flipDictIds(int[] dictIds, int length) {
+    int numDictIds = dictIds.length;
+    int[] flippedDictIds = new int[length - numDictIds];
+    int flippedDictIdsIndex = 0;
+    int dictIdsIndex = 0;
+    for (int dictId = 0; dictId < length; dictId++) {
+      if (dictIdsIndex < numDictIds && dictId == dictIds[dictIdsIndex]) {
+        dictIdsIndex++;
+      } else {
+        flippedDictIds[flippedDictIdsIndex++] = dictId;
+      }
+    }
+    return flippedDictIds;
+  }
+
+  public static int[] getDictIds(int length, int excludeId) {
+    int[] dictIds;
+    if (excludeId >= 0) {
+      dictIds = new int[length - 1];
+      int index = 0;
+      for (int dictId = 0; dictId < length; dictId++) {
+        if (dictId != excludeId) {
+          dictIds[index++] = dictId;
+        }
+      }
+    } else {
+      dictIds = new int[length];
+      for (int dictId = 0; dictId < length; dictId++) {
+        dictIds[dictId] = dictId;
+      }
+    }
+    return dictIds;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.operator.filter.predicate;
 
 import com.google.common.base.Preconditions;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.regex.Matcher;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -66,12 +64,9 @@ public class RegexpLikePredicateEvaluatorFactory {
     // Reuse matcher to avoid excessive allocation. This is safe to do because the evaluator is always used
     // within the scope of a single thread.
     final Matcher _matcher;
-    final Dictionary _dictionary;
-    int[] _matchingDictIds;
 
     public DictionaryBasedRegexpLikePredicateEvaluator(RegexpLikePredicate regexpLikePredicate, Dictionary dictionary) {
-      super(regexpLikePredicate);
-      _dictionary = dictionary;
+      super(regexpLikePredicate, dictionary);
       _matcher = regexpLikePredicate.getPattern().matcher("");
     }
 
@@ -91,21 +86,6 @@ public class RegexpLikePredicateEvaluatorFactory {
         }
       }
       return matches;
-    }
-
-    @Override
-    public int[] getMatchingDictIds() {
-      if (_matchingDictIds == null) {
-        IntList matchingDictIds = new IntArrayList();
-        int dictionarySize = _dictionary.length();
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          if (applySV(dictId)) {
-            matchingDictIds.add(dictId);
-          }
-        }
-        _matchingDictIds = matchingDictIds.toIntArray();
-      }
-      return _matchingDictIds;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/CompositePredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/CompositePredicateEvaluator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree;
 
+import it.unimi.dsi.fastutil.objects.ObjectBooleanPair;
 import java.util.List;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 
@@ -26,19 +27,19 @@ import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
  * Represents a composite predicate.
  *
  * A composite predicate evaluator represents a single predicate evaluator or multiple predicate evaluators conjoined
- * with OR.
- * Consider the given predicate: (d1 > 10 OR d1 < 50). A composite predicate will represent two predicates -- (d1 > 10)
- * and (d1 < 50) and represent that they are related by the operator OR.
+ * with OR. Each predicate evaluator is associated with a boolean value indicating whether the predicate is negated.
+ * Consider the given predicate: (d1 > 10 OR NOT d1 > 50). A composite predicate will represent two predicates:
+ * (d1 > 10) and NOT(d1 > 50) and represent that they are related by the operator OR.
  */
 public class CompositePredicateEvaluator {
-  private final List<PredicateEvaluator> _predicateEvaluators;
+  private final List<ObjectBooleanPair<PredicateEvaluator>> _predicateEvaluators;
 
-  public CompositePredicateEvaluator(List<PredicateEvaluator> predicateEvaluators) {
+  public CompositePredicateEvaluator(List<ObjectBooleanPair<PredicateEvaluator>> predicateEvaluators) {
     assert !predicateEvaluators.isEmpty();
     _predicateEvaluators = predicateEvaluators;
   }
 
-  public List<PredicateEvaluator> getPredicateEvaluators() {
+  public List<ObjectBooleanPair<PredicateEvaluator>> getPredicateEvaluators() {
     return _predicateEvaluators;
   }
 
@@ -47,8 +48,8 @@ public class CompositePredicateEvaluator {
    * predicate evaluator, {@code false} otherwise.
    */
   public boolean apply(int dictId) {
-    for (PredicateEvaluator predicateEvaluator : _predicateEvaluators) {
-      if (predicateEvaluator.applySV(dictId)) {
+    for (ObjectBooleanPair<PredicateEvaluator> predicateEvaluator : _predicateEvaluators) {
+      if (predicateEvaluator.left().applySV(dictId) != predicateEvaluator.rightBoolean()) {
         return true;
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -103,20 +103,25 @@ abstract class BaseStarTreeV2Test<R, A> {
   private static final String QUERY_FILTER_AND = " WHERE d1__COLUMN_NAME = 0 AND __d2 < 10";
   // StarTree supports OR predicates only on a single dimension
   private static final String QUERY_FILTER_OR = " WHERE d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50";
+  private static final String QUERY_FILTER_NOT = " WHERE NOT d1__COLUMN_NAME > 10";
+  private static final String QUERY_FILTER_AND_NOT = " WHERE d1__COLUMN_NAME > 10 AND NOT __d2 < 10";
+  private static final String QUERY_FILTER_OR_NOT = " WHERE d1__COLUMN_NAME > 50 OR NOT d1__COLUMN_NAME > 10";
+  private static final String QUERY_NOT_NOT = " WHERE NOT NOT d1__COLUMN_NAME > 10";
   private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS =
-      " WHERE __d2 < 95 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
+      " WHERE __d2 < 95 AND (NOT d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME > 50)";
   private static final String QUERY_FILTER_COMPLEX_AND_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
-      " WHERE __d2 < 95 AND __d2 > 25 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
+      " WHERE __d2 < 95 AND NOT __d2 < 25 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
   private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
       " WHERE (__d2 > 95 OR __d2 < 25) AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
   private static final String QUERY_FILTER_COMPLEX_OR_SINGLE_DIMENSION =
-      " WHERE d1__COLUMN_NAME = 95 AND (d1__COLUMN_NAME > 90 OR d1__COLUMN_NAME < 100)";
+      " WHERE NOT d1__COLUMN_NAME = 95 AND (d1__COLUMN_NAME > 90 OR d1__COLUMN_NAME < 100)";
 
   // Unsupported filters
   private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS = " WHERE d1__COLUMN_NAME > 10 OR __d2 < 50";
   private static final String QUERY_FILTER_OR_ON_AND =
       " WHERE (d1__COLUMN_NAME > 10 AND d1__COLUMN_NAME < 50) OR d1__COLUMN_NAME < 50";
-  private static final String QUERY_FILTER_OR_ON_NOT = " WHERE (NOT d1__COLUMN_NAME > 10) OR d1__COLUMN_NAME < 50";
+  private static final String QUERY_FILTER_NOT_ON_AND = " WHERE NOT (d1__COLUMN_NAME > 10 AND d1__COLUMN_NAME < 50)";
+  private static final String QUERY_FILTER_NOT_ON_OR = " WHERE NOT (d1__COLUMN_NAME < 10 OR d1__COLUMN_NAME > 50)";
   // Always false filters
   private static final String QUERY_FILTER_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100";
   private static final String QUERY_FILTER_OR_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100 OR d1__COLUMN_NAME < 0";
@@ -199,7 +204,8 @@ abstract class BaseStarTreeV2Test<R, A> {
     String query = String.format("SELECT %s FROM %s", _aggregation, TABLE_NAME);
     testUnsupportedFilter(query + QUERY_FILTER_OR_MULTIPLE_DIMENSIONS);
     testUnsupportedFilter(query + QUERY_FILTER_OR_ON_AND);
-    testUnsupportedFilter(query + QUERY_FILTER_OR_ON_NOT);
+    testUnsupportedFilter(query + QUERY_FILTER_NOT_ON_AND);
+    testUnsupportedFilter(query + QUERY_FILTER_NOT_ON_OR);
     testUnsupportedFilter(query + QUERY_FILTER_ALWAYS_FALSE);
     testUnsupportedFilter(query + QUERY_FILTER_OR_ALWAYS_FALSE);
   }
@@ -213,6 +219,10 @@ abstract class BaseStarTreeV2Test<R, A> {
       testQuery(query);
       testQuery(query + QUERY_FILTER_AND);
       testQuery(query + QUERY_FILTER_OR);
+      testQuery(query + QUERY_FILTER_NOT);
+      testQuery(query + QUERY_FILTER_AND_NOT);
+      testQuery(query + QUERY_FILTER_OR_NOT);
+      testQuery(query + QUERY_NOT_NOT);
       testQuery(query + QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS);
       testQuery(query + QUERY_FILTER_COMPLEX_AND_MULTIPLE_DIMENSIONS_THREE_PREDICATES);
       testQuery(query + QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS_THREE_PREDICATES);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
@@ -180,18 +180,8 @@ public class BenchmarkScanDocIdIterators {
     }
 
     @Override
-    public int getNumMatchingDictIds() {
-      return 0;
-    }
-
-    @Override
     public int[] getMatchingDictIds() {
       return new int[0];
-    }
-
-    @Override
-    public int getNumNonMatchingDictIds() {
-      return 0;
     }
 
     @Override


### PR DESCRIPTION
Support NOT in StarTree Index when it is followed by predicate or NOT (not with nested AND/OR)
E.g.
- ` WHERE NOT d1 > 10`
- ` WHERE d1 > 10 AND NOT d2 < 10`
- ` WHERE d1__COLUMN_NAME > 50 OR NOT d1__COLUMN_NAME > 10`
- ` WHERE NOT NOT d1 > 10`
- ` WHERE d2 < 95 AND (NOT d1 > 10 OR d1 > 50)`
- ` WHERE d2 < 95 AND NOT d2 < 25 AND (d1 > 10 OR d1 < 50)`
- ` WHERE NOT d1 = 95 AND (d1 > 90 OR d1 < 100)`

In order to support NOT, dictionary based `BasePredicateEvaluator` are modified to support `getNonMatchingDictIds()`. Some refactor is done to avoid duplicate code.

Bugfix:
- Fix the unsorted dict ids returned from IN/NOT_IN predicate evaluator