### PR TITLE
Re-enable the Spotless plugin for Java 21

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -67,18 +67,10 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
           <java>
-            <includes>
-              <include>src/main/java/**/*.java</include>
-              <include>src/test/java/**/*.java</include>
-            </includes>
             <excludes>
               <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
               <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
             </excludes>
-            <importOrder>
-              <order>,\#</order>
-            </importOrder>
-            <removeUnusedImports/>
           </java>
         </configuration>
       </plugin>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -62,6 +62,27 @@
         <artifactId>protobuf-maven-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+              <include>src/test/java/**/*.java</include>
+            </includes>
+            <excludes>
+              <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
+              <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
+            </excludes>
+            <importOrder>
+              <order>,\#</order>
+            </importOrder>
+            <removeUnusedImports/>
+          </java>
+        </configuration>
+      </plugin>
+
       <!-- Following plugins and their configurations are used to generate the custom Calcite's SQL parser -->
       <!-- Copy the templates present in the codegen directory to ${project.build.directory}/codegen -->
       <plugin>
@@ -129,31 +150,6 @@
         </executions>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <configuration>
-            <java>
-              <includes>
-                <include>src/main/java/**/*.java</include>
-                <include>src/test/java/**/*.java</include>
-              </includes>
-              <excludes>
-                <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
-                <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
-              </excludes>
-              <importOrder>
-                <order>,\#</order>
-              </importOrder>
-              <removeUnusedImports/>
-            </java>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
   <dependencies>
     <dependency>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -62,6 +62,27 @@
         <artifactId>protobuf-maven-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+              <include>src/test/java/**/*.java</include>
+            </includes>
+            <excludes>
+              <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
+              <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
+            </excludes>
+            <importOrder>
+              <order>,\#</order>
+            </importOrder>
+            <removeUnusedImports/>
+          </java>
+        </configuration>
+      </plugin>
+
       <!-- Following plugins and their configurations are used to generate the custom Calcite's SQL parser -->
       <!-- Copy the templates present in the codegen directory to ${project.build.directory}/codegen -->
       <plugin>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -62,27 +62,6 @@
         <artifactId>protobuf-maven-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <java>
-            <includes>
-              <include>src/main/java/**/*.java</include>
-              <include>src/test/java/**/*.java</include>
-            </includes>
-            <excludes>
-              <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
-              <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
-            </excludes>
-            <importOrder>
-              <order>,\#</order>
-            </importOrder>
-            <removeUnusedImports/>
-          </java>
-        </configuration>
-      </plugin>
-
       <!-- Following plugins and their configurations are used to generate the custom Calcite's SQL parser -->
       <!-- Copy the templates present in the codegen directory to ${project.build.directory}/codegen -->
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -256,20 +256,6 @@
 
   <profiles>
     <profile>
-      <id>not-java-21</id>
-      <activation>
-        <jdk>!21</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>github-actions</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -2079,6 +2065,10 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
         <version>2.7.1</version>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.mycila</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1611,6 +1611,7 @@
           <version>2.43.0</version>
           <executions>
             <execution>
+              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
@@ -1622,10 +1623,6 @@
                 <include>src/main/java/**/*.java</include>
                 <include>src/test/java/**/*.java</include>
               </includes>
-              <excludes>
-                <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
-                <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
-              </excludes>
               <importOrder>
                 <order>,\#</order>
               </importOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -1611,7 +1611,6 @@
           <version>2.43.0</version>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1611,7 +1611,6 @@
           <version>2.43.0</version>
           <executions>
             <execution>
-              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>
@@ -1623,6 +1622,10 @@
                 <include>src/main/java/**/*.java</include>
                 <include>src/test/java/**/*.java</include>
               </includes>
+              <excludes>
+                <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
+                <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
+              </excludes>
               <importOrder>
                 <order>,\#</order>
               </importOrder>


### PR DESCRIPTION
- The Spotless plugin was disabled for Java 21 in https://github.com/apache/pinot/pull/11670 because Spotless didn't support Java 21 at the time.
- However, https://github.com/diffplug/spotless/pull/1920 fixed the incompatibility and was released in version `2.41.1` of the `spotless-maven-plugin`.
- https://github.com/apache/pinot/pull/12827 bumped up the Spotless plugin version from `2.28.0` to `2.43.0` and it can now be re-enabled for Java 21.
- This has been verified locally by running `mvn spotless:check` and `mvn spotless:apply` while using Java 21.