### PR TITLE
bugfix: fix TextMatchFilterOptimizer boolean grouping

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -162,7 +162,7 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
         mergedTextMatchFilter = String.join(SPACE + operator + SPACE, literals);
       }
       Expression mergedTextMatchExpression = RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name());
-      Expression mergedTextMatchFilterExpression = RequestUtils.getLiteralExpression(mergedTextMatchFilter);
+      Expression mergedTextMatchFilterExpression = RequestUtils.getLiteralExpression("(" + mergedTextMatchFilter + ")");
       mergedTextMatchExpression.getFunctionCall()
           .setOperands(Arrays.asList(entry.getKey(), mergedTextMatchFilterExpression));
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
@@ -178,7 +178,7 @@ public class QueryOptimizerTest {
     List<Expression> operands = filterFunction.getOperands();
     assertEquals(operands.size(), 2);
     assertEquals(operands.get(0), RequestUtils.getIdentifierExpression("string"));
-    assertEquals(operands.get(1), RequestUtils.getLiteralExpression("foo AND bar OR baz"));
+    assertEquals(operands.get(1), RequestUtils.getLiteralExpression("((foo AND bar) OR baz)"));
   }
 
   private static Expression getRangeFilterExpression(String column, String rangeString) {
@@ -268,32 +268,35 @@ public class QueryOptimizerTest {
 
     // TextMatchFilterOptimizer
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo') AND TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo AND bar')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(foo AND bar)')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, '\"foo bar\"') AND TEXT_MATCH(string, 'baz')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '\"foo bar\" AND baz')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(\"foo bar\" AND baz)')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, '\"foo bar\"') AND TEXT_MATCH(string, '/.*ooba.*/')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '\"foo bar\" AND /.*ooba.*/')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(\"foo bar\" AND /.*ooba.*/)')");
     testQuery("SELECT * FROM testTable WHERE int = 1 AND TEXT_MATCH(string, 'foo') AND TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE int = 1 AND TEXT_MATCH(string, 'foo AND bar')");
+        "SELECT * FROM testTable WHERE int = 1 AND TEXT_MATCH(string, '(foo AND bar)')");
     testQuery("SELECT * FROM testTable WHERE int = 1 OR TEXT_MATCH(string, 'foo') AND TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE int = 1 OR TEXT_MATCH(string, 'foo AND bar')");
+        "SELECT * FROM testTable WHERE int = 1 OR TEXT_MATCH(string, '(foo AND bar)')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo') AND NOT TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo AND NOT bar')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(foo AND NOT bar)')");
     testQuery("SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'foo') AND TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string, 'NOT foo AND bar')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(NOT foo AND bar)')");
     testQuery("SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'foo') AND NOT TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'foo OR bar')");
+        "SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, '(foo OR bar)')");
     testQuery("SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'foo') OR NOT TEXT_MATCH(string, 'bar')",
-        "SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'foo AND bar')");
+        "SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, '(foo AND bar)')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo') AND TEXT_MATCH(string, 'bar') OR "
-        + "TEXT_MATCH(string, 'baz')", "SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo AND bar OR baz')");
+        + "TEXT_MATCH(string, 'baz')", "SELECT * FROM testTable WHERE TEXT_MATCH(string, '((foo AND bar) OR baz)')");
+    testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo') AND (TEXT_MATCH(string, 'bar') OR "
+        + "TEXT_MATCH(string, 'baz'))", "SELECT * FROM testTable WHERE TEXT_MATCH(string, '(foo AND (bar OR baz))')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo1') AND TEXT_MATCH(string1, 'bar1') OR "
             + "TEXT_MATCH(string1, 'baz1') AND TEXT_MATCH(string2, 'foo')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo1 AND bar1') OR TEXT_MATCH(string1, 'baz1') AND "
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string1, '(foo1 AND bar1)') OR TEXT_MATCH(string1, 'baz1') AND "
             + "TEXT_MATCH(string2, 'foo')");
     testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo1') AND TEXT_MATCH(string1, 'bar1')"
             + "AND TEXT_MATCH(string2, 'foo2') AND TEXT_MATCH(string2, 'bar2')",
-        "SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo1 AND bar1') AND TEXT_MATCH(string2, 'foo2 AND bar2')");
+        "SELECT * FROM testTable WHERE TEXT_MATCH(string1, '(foo1 AND bar1)') AND TEXT_MATCH(string2, '(foo2 AND "
+            + "bar2)')");
     testCannotOptimizeQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo') OR TEXT_MATCH(string2, 'bar')");
     testCannotOptimizeQuery(
         "SELECT * FROM testTable WHERE int = 1 AND TEXT_MATCH(string, 'foo') OR TEXT_MATCH(string, 'bar')");


### PR DESCRIPTION
Previously the `text_match` filter optimizer didn't properly push down grouping. For example (tm = text_match):

`tm(a) AND (tm(b) OR tm(c))`and `(tm(a) AND tm(b)) OR tm(c)` both were optimized to `tm(a AND b OR c)`

This PR corrects the behavior to maintain the grouping, e.g. 
`tm(a) AND (tm(b) OR tm(c))` -> `tm(a AND (b OR c))`
`(tm(a) AND tm(b)) OR tm(c)` ->  `tm((a AND b) OR c)`

tag: `bugfix`