### PR TITLE
skip retry very old rebalance jobs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -634,7 +634,8 @@ public class PinotTableRestletResource {
       @ApiParam(value = "How long to wait for next status update (i.e. heartbeat) before the job is considered failed")
       @DefaultValue("3600000") @QueryParam("heartbeatTimeoutInMs") long heartbeatTimeoutInMs,
       @ApiParam(value = "Max number of attempts to rebalance") @DefaultValue("3") @QueryParam("maxAttempts")
-      int maxAttempts,
+      int maxAttempts, @ApiParam(value = "Timeout to help skip retrying old rebalance jobs") @DefaultValue("3600000")
+      @QueryParam("skipRetryTimeoutInMs") long skipRetryTimeoutInMs,
       @ApiParam(value = "Initial delay to exponentially backoff retry") @DefaultValue("300000")
       @QueryParam("retryInitialDelayInMs") long retryInitialDelayInMs,
       @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
@@ -660,6 +661,7 @@ public class PinotTableRestletResource {
     heartbeatTimeoutInMs = Math.max(heartbeatTimeoutInMs, 3 * heartbeatIntervalInMs);
     rebalanceConfig.setHeartbeatTimeoutInMs(heartbeatTimeoutInMs);
     rebalanceConfig.setMaxAttempts(maxAttempts);
+    rebalanceConfig.setSkipRetryTimeoutInMs(skipRetryTimeoutInMs);
     rebalanceConfig.setRetryInitialDelayInMs(retryInitialDelayInMs);
     rebalanceConfig.setUpdateTargetTier(updateTargetTier);
     String rebalanceJobId = TableRebalancer.createUniqueRebalanceJobIdentifier();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -102,10 +102,18 @@ public class RebalanceConfig {
   @ApiModelProperty(example = "3600000")
   private long _heartbeatTimeoutInMs = 3600000L;
 
+  // Max number of attempts to rebalance, including the original rebalance job run.
   @JsonProperty("maxAttempts")
   @ApiModelProperty(example = "3")
   private int _maxAttempts = 3;
 
+  // Ignore rebalance jobs older than this timeout. The cleanup of job status is based on a max number (100 by
+  // default). In case there were very old job status left in ZK, this config avoids unexpected retries due to them.
+  @JsonProperty("skipRetryTimeoutInMs")
+  @ApiModelProperty(example = "86400000")
+  private long _skipRetryTimeoutInMs = 86400000;
+
+  // Initial delay to exponentially backoff retry.
   @JsonProperty("retryInitialDelayInMs")
   @ApiModelProperty(example = "300000")
   private long _retryInitialDelayInMs = 300000L;
@@ -222,6 +230,14 @@ public class RebalanceConfig {
     _maxAttempts = maxAttempts;
   }
 
+  public long getSkipRetryTimeoutInMs() {
+    return _skipRetryTimeoutInMs;
+  }
+
+  public void setSkipRetryTimeoutInMs(long skipRetryTimeoutInMs) {
+    _skipRetryTimeoutInMs = skipRetryTimeoutInMs;
+  }
+
   public long getRetryInitialDelayInMs() {
     return _retryInitialDelayInMs;
   }
@@ -234,12 +250,12 @@ public class RebalanceConfig {
   public String toString() {
     return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", _reassignInstances=" + _reassignInstances
         + ", _includeConsuming=" + _includeConsuming + ", _bootstrap=" + _bootstrap + ", _downtime=" + _downtime
-        + ", _minAvailableReplicas=" + _minAvailableReplicas + ", _bestEfforts=" + _bestEfforts
-        + ", _externalViewCheckIntervalInMs=" + _externalViewCheckIntervalInMs
+        + ", _minAvailableReplicas=" + _minAvailableReplicas + ", _lowDiskMode=" + _lowDiskMode + ", _bestEfforts="
+        + _bestEfforts + ", _externalViewCheckIntervalInMs=" + _externalViewCheckIntervalInMs
         + ", _externalViewStabilizationTimeoutInMs=" + _externalViewStabilizationTimeoutInMs + ", _updateTargetTier="
         + _updateTargetTier + ", _heartbeatIntervalInMs=" + _heartbeatIntervalInMs + ", _heartbeatTimeoutInMs="
-        + _heartbeatTimeoutInMs + ", _maxAttempts=" + _maxAttempts + ", _retryInitialDelayInMs="
-        + _retryInitialDelayInMs + '}';
+        + _heartbeatTimeoutInMs + ", _maxAttempts=" + _maxAttempts + ", _skipRetryTimeoutInMs=" + _skipRetryTimeoutInMs
+        + ", _retryInitialDelayInMs=" + _retryInitialDelayInMs + '}';
   }
 
   public static RebalanceConfig copy(RebalanceConfig cfg) {
@@ -257,6 +273,7 @@ public class RebalanceConfig {
     rc._heartbeatIntervalInMs = cfg._heartbeatIntervalInMs;
     rc._heartbeatTimeoutInMs = cfg._heartbeatTimeoutInMs;
     rc._maxAttempts = cfg._maxAttempts;
+    rc._skipRetryTimeoutInMs = cfg._skipRetryTimeoutInMs;
     rc._retryInitialDelayInMs = cfg._retryInitialDelayInMs;
     return rc;
   }

--- a/pinot-controller/src/test/resources/log4j2.xml
+++ b/pinot-controller/src/test/resources/log4j2.xml
@@ -26,7 +26,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="org.apache.pinot" level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="debug" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
     <Root level="error">

--- a/pinot-controller/src/test/resources/log4j2.xml
+++ b/pinot-controller/src/test/resources/log4j2.xml
@@ -26,7 +26,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="org.apache.pinot" level="debug" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
     <Root level="error">


### PR DESCRIPTION
This PR tries to enhance the RebalanceChecker a bit to skip failed rebalance jobs that's very old.

There could be edge cases that rebalance job failed and left a failure job status in ZK, but the table got rebalanced with server restarts or other cluster operations, leaving this failure job status in ZK for a long time until it's cleaned up (by a cleanup mechanism that's size based not time based). So when table got imbalanced like during planned maintenance, the checker might kick off rebalance unexpectedly. 

So adding a new config `skipRetryTimeoutInMs` for rebalance job to skip retrying old jobs. The config is 86400000 (i.e. 1day) by default.