### PR TITLE
Ensure all the lists used in PinotQuery are ArrayList

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -24,8 +24,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -301,6 +303,43 @@ public class RequestUtils {
     return RequestUtils.getLiteralExpression(object.toString());
   }
 
+  public static Function getFunction(String canonicalName, List<Expression> operands) {
+    Function function = new Function(canonicalName);
+    function.setOperands(operands);
+    return function;
+  }
+
+  public static Function getFunction(String canonicalName, Expression operand) {
+    // NOTE: Create an ArrayList because we might need to modify the list later
+    List<Expression> operands = new ArrayList<>(1);
+    operands.add(operand);
+    return getFunction(canonicalName, operands);
+  }
+
+  public static Function getFunction(String canonicalName, Expression... operands) {
+    // NOTE: Create an ArrayList because we might need to modify the list later
+    return getFunction(canonicalName, new ArrayList<>(Arrays.asList(operands)));
+  }
+
+  public static Expression getFunctionExpression(Function function) {
+    Expression expression = new Expression(ExpressionType.FUNCTION);
+    expression.setFunctionCall(function);
+    return expression;
+  }
+
+  public static Expression getFunctionExpression(String canonicalName, List<Expression> operands) {
+    return getFunctionExpression(getFunction(canonicalName, operands));
+  }
+
+  public static Expression getFunctionExpression(String canonicalName, Expression operand) {
+    return getFunctionExpression(getFunction(canonicalName, operand));
+  }
+
+  public static Expression getFunctionExpression(String canonicalName, Expression... operands) {
+    return getFunctionExpression(getFunction(canonicalName, operands));
+  }
+
+  @Deprecated
   public static Expression getFunctionExpression(String canonicalName) {
     assert canonicalName.equalsIgnoreCase(canonicalizeFunctionNamePreservingSpecialKey(canonicalName));
     Expression expression = new Expression(ExpressionType.FUNCTION);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -23,10 +23,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -379,8 +377,7 @@ public class CalciteSqlParser {
       Function function = expression.getFunctionCall();
       if (function != null) {
         if (excludeAs && function.getOperator().equals("as")) {
-          identifiers.addAll(
-              extractIdentifiers(new ArrayList<>(Collections.singletonList(function.getOperands().get(0))), true));
+          identifiers.addAll(extractIdentifiers(List.of(function.getOperands().get(0)), true));
         } else {
           identifiers.addAll(extractIdentifiers(function.getOperands(), excludeAs));
         }
@@ -589,25 +586,22 @@ public class CalciteSqlParser {
   }
 
   private static List<Expression> convertDistinctSelectList(SqlNodeList selectList) {
-    List<Expression> selectExpr = new ArrayList<>();
+    // NOTE: Create an ArrayList because we might need to modify the list later
+    List<Expression> selectExpr = new ArrayList<>(1);
     selectExpr.add(convertDistinctAndSelectListToFunctionExpression(selectList));
     return selectExpr;
   }
 
   private static List<Expression> convertSelectList(SqlNodeList selectList) {
-    List<Expression> selectExpr = new ArrayList<>();
-
-    final Iterator<SqlNode> iterator = selectList.iterator();
-    while (iterator.hasNext()) {
-      final SqlNode next = iterator.next();
-      selectExpr.add(toExpression(next));
+    List<Expression> selectExpr = new ArrayList<>(selectList.size());
+    for (SqlNode sqlNode : selectList) {
+      selectExpr.add(toExpression(sqlNode));
     }
-
     return selectExpr;
   }
 
   private static List<Expression> convertOrderByList(SqlNodeList orderList) {
-    List<Expression> orderByExpr = new ArrayList<>();
+    List<Expression> orderByExpr = new ArrayList<>(orderList.size());
     for (SqlNode sqlNode : orderList) {
       orderByExpr.add(convertOrderBy(sqlNode, true));
     }
@@ -621,19 +615,17 @@ public class CalciteSqlParser {
     Expression expression;
     if (node.getKind() == SqlKind.NULLS_LAST) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression(NULLS_LAST);
-      expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), true));
+      expression =
+          RequestUtils.getFunctionExpression(NULLS_LAST, convertOrderBy(basicCall.getOperandList().get(0), true));
     } else if (node.getKind() == SqlKind.NULLS_FIRST) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression(NULLS_FIRST);
-      expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), true));
+      expression =
+          RequestUtils.getFunctionExpression(NULLS_FIRST, convertOrderBy(basicCall.getOperandList().get(0), true));
     } else if (node.getKind() == SqlKind.DESCENDING) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression(DESC);
-      expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), false));
+      expression = RequestUtils.getFunctionExpression(DESC, convertOrderBy(basicCall.getOperandList().get(0), false));
     } else if (createAscExpression) {
-      expression = RequestUtils.getFunctionExpression(ASC);
-      expression.getFunctionCall().addToOperands(toExpression(node));
+      expression = RequestUtils.getFunctionExpression(ASC, toExpression(node));
     } else {
       return toExpression(node);
     }
@@ -648,7 +640,7 @@ public class CalciteSqlParser {
    * @return DISTINCT function expression
    */
   private static Expression convertDistinctAndSelectListToFunctionExpression(SqlNodeList selectList) {
-    Expression functionExpression = RequestUtils.getFunctionExpression("distinct");
+    List<Expression> operands = new ArrayList<>(selectList.size());
     for (SqlNode node : selectList) {
       Expression columnExpression = toExpression(node);
       if (columnExpression.getType() == ExpressionType.IDENTIFIER && columnExpression.getIdentifier().getName()
@@ -662,9 +654,9 @@ public class CalciteSqlParser {
               "Syntax error: Use of DISTINCT with aggregation functions is not supported");
         }
       }
-      functionExpression.getFunctionCall().addToOperands(columnExpression);
+      operands.add(columnExpression);
     }
-    return functionExpression;
+    return RequestUtils.getFunctionExpression("distinct", operands);
   }
 
   private static Expression toExpression(SqlNode node) {
@@ -705,10 +697,7 @@ public class CalciteSqlParser {
             return leftExpr;
           }
         }
-        Expression asFuncExpr = RequestUtils.getFunctionExpression("as");
-        asFuncExpr.getFunctionCall().addToOperands(leftExpr);
-        asFuncExpr.getFunctionCall().addToOperands(rightExpr);
-        return asFuncExpr;
+        return RequestUtils.getFunctionExpression("as", leftExpr, rightExpr);
       case CASE:
         // CASE WHEN Statement is model as a function with variable length parameters.
         // Assume N is number of WHEN Statements, total number of parameters is (2 * N + 1).
@@ -717,26 +706,22 @@ public class CalciteSqlParser {
         // - 1: Convert ELSE Statement into an Expression.
         SqlCase caseSqlNode = (SqlCase) node;
         SqlNodeList whenOperands = caseSqlNode.getWhenOperands();
+        int numWhenOperands = whenOperands.size();
         SqlNodeList thenOperands = caseSqlNode.getThenOperands();
+        Preconditions.checkState(numWhenOperands == thenOperands.size());
         SqlNode elseOperand = caseSqlNode.getElseOperand();
-        Expression caseFuncExpr = RequestUtils.getFunctionExpression("case");
-        Preconditions.checkState(whenOperands.size() == thenOperands.size());
-        for (int i = 0; i < whenOperands.size(); i++) {
-          SqlNode whenSqlNode = whenOperands.get(i);
-          Expression whenExpression = toExpression(whenSqlNode);
-          caseFuncExpr.getFunctionCall().addToOperands(whenExpression);
-
-          SqlNode thenSqlNode = thenOperands.get(i);
-          Expression thenExpression = toExpression(thenSqlNode);
-          caseFuncExpr.getFunctionCall().addToOperands(thenExpression);
+        List<Expression> caseOperands = new ArrayList<>(2 * numWhenOperands + 1);
+        for (int i = 0; i < numWhenOperands; i++) {
+          caseOperands.add(toExpression(whenOperands.get(i)));
+          caseOperands.add(toExpression(thenOperands.get(i)));
         }
         Expression elseExpression = toExpression(elseOperand);
         if (isAggregateExpression(elseExpression)) {
           throw new SqlCompilationException(
               "Aggregation functions inside ELSE Clause is not supported - " + elseExpression);
         }
-        caseFuncExpr.getFunctionCall().addToOperands(elseExpression);
-        return caseFuncExpr;
+        caseOperands.add(elseExpression);
+        return RequestUtils.getFunctionExpression("case", caseOperands);
       default:
         if (node instanceof SqlDataTypeSpec) {
           // This is to handle expression like: CAST(col AS INT)
@@ -808,15 +793,9 @@ public class CalciteSqlParser {
       }
     }
     ParserUtils.validateFunction(canonicalName, operands);
-    Expression functionExpression = RequestUtils.getFunctionExpression(canonicalName);
-    functionExpression.getFunctionCall().setOperands(operands);
+    Expression functionExpression = RequestUtils.getFunctionExpression(canonicalName, operands);
     if (negated) {
-      Expression negatedFunctionExpression = RequestUtils.getFunctionExpression(FilterKind.NOT.name());
-      // Do not use `Collections.singletonList()` because we might modify the operand later
-      List<Expression> negatedFunctionOperands = new ArrayList<>(1);
-      negatedFunctionOperands.add(functionExpression);
-      negatedFunctionExpression.getFunctionCall().setOperands(negatedFunctionOperands);
-      return negatedFunctionExpression;
+      return RequestUtils.getFunctionExpression(FilterKind.NOT.name(), functionExpression);
     } else {
       return functionExpression;
     }
@@ -886,9 +865,7 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
-    Expression andExpression = RequestUtils.getFunctionExpression(FilterKind.AND.name());
-    andExpression.getFunctionCall().setOperands(operands);
-    return andExpression;
+    return RequestUtils.getFunctionExpression(FilterKind.AND.name(), operands);
   }
 
   /**
@@ -904,9 +881,7 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
-    Expression andExpression = RequestUtils.getFunctionExpression(FilterKind.OR.name());
-    andExpression.getFunctionCall().setOperands(operands);
-    return andExpression;
+    return RequestUtils.getFunctionExpression(FilterKind.OR.name(), operands);
   }
 
   public static boolean isLiteralOnlyExpression(Expression e) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriter.java
@@ -101,14 +101,12 @@ public class ExprMinMaxRewriter implements QueryRewriter {
     for (Map.Entry<List<Expression>, Set<Expression>> entry : exprMinMaxFunctionMap.entrySet()) {
       List<Expression> measuringColumns = entry.getKey();
       Set<Expression> projectionColumns = entry.getValue();
-      Expression functionExpression = RequestUtils.getFunctionExpression(isMax ? EXPR_MAX_PARENT : EXPR_MIN_PARENT);
       List<Expression> operands = new ArrayList<>(2 + measuringColumns.size() + projectionColumns.size());
       operands.add(RequestUtils.getLiteralExpression((int) exprMinMaxFunctionIDMap.get(measuringColumns)));
       operands.add(RequestUtils.getLiteralExpression(measuringColumns.size()));
       operands.addAll(measuringColumns);
       operands.addAll(projectionColumns);
-      functionExpression.getFunctionCall().setOperands(operands);
-      selectList.add(functionExpression);
+      selectList.add(RequestUtils.getFunctionExpression(isMax ? EXPR_MAX_PARENT : EXPR_MIN_PARENT, operands));
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.sql.parsers.rewriter;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
@@ -76,9 +77,11 @@ public class NonAggregationGroupByToDistinctQueryRewriter implements QueryRewrit
     }
     Set<Expression> groupByExpressions = new HashSet<>(pinotQuery.getGroupByList());
     if (selectExpressions.equals(groupByExpressions)) {
-      Expression distinct = RequestUtils.getFunctionExpression("distinct");
-      distinct.getFunctionCall().setOperands(pinotQuery.getSelectList());
-      pinotQuery.setSelectList(Collections.singletonList(distinct));
+      Expression distinct = RequestUtils.getFunctionExpression("distinct", pinotQuery.getSelectList());
+      // NOTE: Create an ArrayList because we might need to modify the list later
+      List<Expression> newSelectList = new ArrayList<>(1);
+      newSelectList.add(distinct);
+      pinotQuery.setSelectList(newSelectList);
       pinotQuery.setGroupByList(null);
       return pinotQuery;
     } else {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.sql.parsers.rewriter;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
@@ -49,8 +49,10 @@ public class OrdinalsUpdater implements QueryRewriter {
         if (isNullsLast != null) {
           functionToSet = functionToSet.getOperands().get(0).getFunctionCall();
         }
-        functionToSet.setOperands(
-            Collections.singletonList(getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal)));
+        // NOTE: Create an ArrayList because we might need to modify the list later
+        List<Expression> newOperands = new ArrayList<>(1);
+        newOperands.add(getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal));
+        functionToSet.setOperands(newOperands);
       }
     }
     return pinotQuery;

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.sql.parsers;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.calcite.sql.SqlNumericLiteral;
@@ -48,21 +49,66 @@ import org.testng.annotations.Test;
 public class CalciteSqlCompilerTest {
   private static final long ONE_HOUR_IN_MS = TimeUnit.HOURS.toMillis(1);
 
+  /* Verify all lists in PinotQuery are ArrayLists because we might need to modify them during query optimization */
+
+  private Expression compileToExpression(String expressionStr) {
+    Expression expression = CalciteSqlParser.compileToExpression(expressionStr);
+    verifyListInExpression(expression);
+    return expression;
+  }
+
+  private void verifyListInExpression(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function != null) {
+      verifyListInExpressions(function.getOperands());
+    }
+  }
+
+  private void verifyListInExpressions(List<Expression> expressions) {
+    Assert.assertTrue(expressions instanceof ArrayList);
+    for (Expression expression : expressions) {
+      verifyListInExpression(expression);
+    }
+  }
+
+  private PinotQuery compileToPinotQuery(String sql) {
+    PinotQuery query = CalciteSqlParser.compileToPinotQuery(sql);
+    List<Expression> selectList = query.getSelectList();
+    verifyListInExpressions(selectList);
+    Expression filterExpression = query.getFilterExpression();
+    if (filterExpression != null) {
+      verifyListInExpression(filterExpression);
+    }
+    List<Expression> groupByList = query.getGroupByList();
+    if (groupByList != null) {
+      verifyListInExpressions(groupByList);
+    }
+    List<Expression> orderByList = query.getOrderByList();
+    if (orderByList != null) {
+      verifyListInExpressions(orderByList);
+    }
+    Expression havingExpression = query.getHavingExpression();
+    if (havingExpression != null) {
+      verifyListInExpression(havingExpression);
+    }
+    return query;
+  }
+
   @Test
   public void testCanonicalFunctionName() {
-    Expression expression = CalciteSqlParser.compileToExpression("dIsTiNcT_cOuNt(AbC)");
+    Expression expression = compileToExpression("dIsTiNcT_cOuNt(AbC)");
     Function function = expression.getFunctionCall();
     Assert.assertEquals(function.getOperator(), AggregationFunctionType.DISTINCTCOUNT.name().toLowerCase());
     Assert.assertEquals(function.getOperands().size(), 1);
     Assert.assertEquals(function.getOperands().get(0).getIdentifier().getName(), "AbC");
 
-    expression = CalciteSqlParser.compileToExpression("ReGeXpLiKe(AbC)");
+    expression = compileToExpression("ReGeXpLiKe(AbC)");
     function = expression.getFunctionCall();
     Assert.assertEquals(function.getOperator(), FilterKind.REGEXP_LIKE.name());
     Assert.assertEquals(function.getOperands().size(), 1);
     Assert.assertEquals(function.getOperands().get(0).getIdentifier().getName(), "AbC");
 
-    expression = CalciteSqlParser.compileToExpression("aBc > DeF");
+    expression = compileToExpression("aBc > DeF");
     function = expression.getFunctionCall();
     Assert.assertEquals(function.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(function.getOperands().size(), 2);
@@ -73,7 +119,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testCaseWhenStatements() {
     //@formatter:off
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = compileToPinotQuery(
         "SELECT OrderID, Quantity,\n"
             + "CASE\n"
             + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
@@ -102,7 +148,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getFieldValue(), "The quantity is under 30");
 
     //@formatter:off
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "SELECT Quantity,\n"
             + "SUM(CASE\n"
             + "    WHEN Quantity > 30 THEN 3\n"
@@ -141,7 +187,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testAggregationInCaseWhenStatementsWithGroupBy() {
     //@formatter:off
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = compileToPinotQuery(
         "SELECT OrderID, SUM(Quantity),\n"
             + "CASE\n"
             + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
@@ -168,7 +214,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testAggregationInCaseWhenStatements() {
     //@formatter:off
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = compileToPinotQuery(
         "SELECT sum(Quantity),\n"
             + "CASE\n"
             + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
@@ -193,24 +239,22 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testQuotedStrings() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = 'Martha''s Vineyard'");
+    PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where origin = 'Martha''s Vineyard'");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
         "Martha's Vineyard");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = 'Martha\"\"s Vineyard'");
+    pinotQuery = compileToPinotQuery("select * from vegetables where origin = 'Martha\"\"s Vineyard'");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
         "Martha\"\"s Vineyard");
 
-    pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = \"Martha\"\"s Vineyard\"");
+    pinotQuery = compileToPinotQuery("select * from vegetables where origin = \"Martha\"\"s Vineyard\"");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "Martha\"s Vineyard");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where origin = \"Martha''s Vineyard\"");
+    pinotQuery = compileToPinotQuery("select * from vegetables where origin = \"Martha''s Vineyard\"");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "Martha''s Vineyard");
@@ -220,28 +264,28 @@ public class CalciteSqlCompilerTest {
   public void testExtract() {
     {
       // Case 1 -- Year and date format ('2017-06-15')
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15')");
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15')");
       Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
       Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "YEAR");
       Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
     }
     {
       // Case 2 -- date format ('2017-06-15 09:34:21')
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15 09:34:21')");
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15 09:34:21')");
       Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
       Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "YEAR");
       Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15 09:34:21");
     }
     {
       // Case 3 -- Month
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT EXTRACT(MONTH FROM '2017-06-15')");
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(MONTH FROM '2017-06-15')");
       Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
       Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "MONTH");
       Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
     }
     {
       // Case 4 -- Day
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT EXTRACT(DAY FROM '2017-06-15')");
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(DAY FROM '2017-06-15')");
       Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
       Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "DAY");
       Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
@@ -251,7 +295,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testFilterClauses() {
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > 1.5");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where a > 1.5");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "a");
@@ -259,7 +303,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where b < 100");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
@@ -267,7 +311,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where c >= 10");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
@@ -275,7 +319,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where d <= 50");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where d <= 50");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
@@ -283,8 +327,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
@@ -293,8 +336,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetables where regexp_like(E, '^U.*')");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where regexp_like(E, '^U.*')");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), "REGEXP_LIKE");
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "E");
@@ -302,8 +344,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
@@ -314,7 +355,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where g");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetable where g");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
@@ -322,7 +363,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where g or f = true");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetable where g or f = true");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.OR.name());
       List<Expression> operands = func.getOperands();
@@ -337,8 +378,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetable where startsWith(g, 'str')");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetable where startsWith(g, 'str')");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
       Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "startswith");
@@ -346,8 +386,8 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-          "select * from vegetable where startsWith(g, 'str')=true and startsWith(f, 'str')");
+      PinotQuery pinotQuery =
+          compileToPinotQuery("select * from vegetable where startsWith(g, 'str')=true and startsWith(f, 'str')");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
       List<Expression> operands = func.getOperands();
@@ -365,7 +405,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+      PinotQuery pinotQuery = compileToPinotQuery(
           "select * from vegetable where (startsWith(g, 'str')=true and startsWith(f, 'str')) AND (e and d=true)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
@@ -394,8 +434,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetable where isSubnetOf('192.168.0.1/24', foo)");
+      PinotQuery pinotQuery = compileToPinotQuery("select * from vegetable where isSubnetOf('192.168.0.1/24', foo)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
       List<Expression> operands = func.getOperands();
@@ -405,7 +444,7 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+      PinotQuery pinotQuery = compileToPinotQuery(
           "select * from vegetable where isSubnetOf('192.168.0.1/24', foo)=true AND isSubnetOf('192.168.0.1/24', "
               + "foo)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
@@ -429,7 +468,7 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testFilterClausesWithRightExpression() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > b");
+    PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where a > b");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -438,7 +477,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "b");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 0 < a-b");
+    pinotQuery = compileToPinotQuery("select * from vegetables where 0 < a-b");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -448,7 +487,7 @@ public class CalciteSqlCompilerTest {
         "b");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100 + c");
+    pinotQuery = compileToPinotQuery("select * from vegetables where b < 100 + c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -463,7 +502,7 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b -(100+c)< 0");
+    pinotQuery = compileToPinotQuery("select * from vegetables where b -(100+c)< 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -479,8 +518,7 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
 
-    pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) <= foo2(bar2(c+d))");
+    pinotQuery = compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) <= foo2(bar2(c+d))");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -517,8 +555,7 @@ public class CalciteSqlCompilerTest {
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "d");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
-    pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) - foo2(bar2(c+d)) <= 0");
+    pinotQuery = compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) - foo2(bar2(c+d)) <= 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
@@ -556,12 +593,12 @@ public class CalciteSqlCompilerTest {
         "d");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
+    pinotQuery = compileToPinotQuery("select * from vegetables where c >= 10");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 10 <= c");
+    pinotQuery = compileToPinotQuery("select * from vegetables where 10 <= c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
@@ -584,7 +621,7 @@ public class CalciteSqlCompilerTest {
 
   private void testInvalidFilterClause(String filter) {
     try {
-      CalciteSqlParser.compileToPinotQuery("select * from vegetables where " + filter);
+      compileToPinotQuery("select * from vegetables where " + filter);
     } catch (SqlCompilationException e) {
       // Expected
       return;
@@ -614,8 +651,7 @@ public class CalciteSqlCompilerTest {
   public void testLimitOffsets() {
     PinotQuery pinotQuery;
     try {
-      pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 100 offset 200");
+      pinotQuery = compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 100 offset 200");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -626,8 +662,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(200, pinotQuery.getOffset());
 
     try {
-      pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 200,100");
+      pinotQuery = compileToPinotQuery("select a, b, c from meetupRsvp order by a, b, c limit 200,100");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -643,7 +678,7 @@ public class CalciteSqlCompilerTest {
 
     PinotQuery pinotQuery;
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+      pinotQuery = compileToPinotQuery(
           "select sum(rsvp_count), count(*), group_city from meetupRsvp group by group_city order by sum(rsvp_count) "
               + "limit 10");
     } catch (SqlCompilationException e) {
@@ -660,7 +695,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(10, pinotQuery.getLimit());
 
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+      pinotQuery = compileToPinotQuery(
           "select sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count) limit 10");
     } catch (SqlCompilationException e) {
       throw e;
@@ -676,7 +711,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(10, pinotQuery.getLimit());
 
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+      pinotQuery = compileToPinotQuery(
           "select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count),"
               + " count(*) limit 10");
     } catch (SqlCompilationException e) {
@@ -703,10 +738,9 @@ public class CalciteSqlCompilerTest {
 
     // nested functions in group by
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(
-          "select concat(upper(playerName), lower(teamID), '-') playerTeam, "
-              + "upper(league) leagueUpper, count(playerName) cnt from baseballStats group by playerTeam, lower"
-              + "(teamID), leagueUpper having cnt > 1 order by cnt desc limit 10");
+      pinotQuery = compileToPinotQuery("select concat(upper(playerName), lower(teamID), '-') playerTeam, "
+          + "upper(league) leagueUpper, count(playerName) cnt from baseballStats group by playerTeam, lower"
+          + "(teamID), leagueUpper having cnt > 1 order by cnt desc limit 10");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -723,7 +757,7 @@ public class CalciteSqlCompilerTest {
 
   private void assertCompilationFails(String query) {
     try {
-      CalciteSqlParser.compileToPinotQuery(query);
+      compileToPinotQuery(query);
     } catch (SqlCompilationException e) {
       // Expected
       return;
@@ -735,7 +769,7 @@ public class CalciteSqlCompilerTest {
   private void testTopZeroFor(String s, final int expectedTopN, boolean parseException) {
     PinotQuery pinotQuery;
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(s);
+      pinotQuery = compileToPinotQuery(s);
     } catch (SqlCompilationException e) {
       if (parseException) {
         return;
@@ -766,7 +800,7 @@ public class CalciteSqlCompilerTest {
     final String query = "select foo from bar where baz ? 2";
 
     try {
-      CalciteSqlParser.compileToPinotQuery(query);
+      compileToPinotQuery(query);
     } catch (SqlCompilationException e) {
       // Expected
       Assert.assertTrue(e.getCause().getMessage().contains("at line 1, column 31."),
@@ -780,11 +814,10 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testCStyleInequalityOperator() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
+    PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_EQUALS");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where name != 'Brussels sprouts'");
+    pinotQuery = compileToPinotQuery("select * from vegetables where name != 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_EQUALS");
   }
 
@@ -792,18 +825,17 @@ public class CalciteSqlCompilerTest {
   @Deprecated
   // TODO: to be removed once OPTIONS REGEX match is deprecated
   public void testQueryOptions() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
+    PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
     Assert.assertNull(pinotQuery.getQueryOptions());
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes)");
+    pinotQuery =
+        compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes)");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
     Assert.assertEquals(pinotQuery.getQueryOptions().get("delicious"), "yes");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes, foo=1234, bar='potato')");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
@@ -813,7 +845,7 @@ public class CalciteSqlCompilerTest {
 
     // Assert that wrongly inserted query option will not be parsed.
     try {
-      CalciteSqlParser.compileToPinotQuery(
+      compileToPinotQuery(
           "select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes) option(foo=1234) option"
               + "(bar='potato')");
     } catch (SqlCompilationException e) {
@@ -821,7 +853,7 @@ public class CalciteSqlCompilerTest {
       Assert.assertTrue(e.getCause().getMessage().contains("OPTION"));
     }
     try {
-      CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels OPTION (delicious=yes)");
+      compileToPinotQuery("select * from vegetables where name <> 'Brussels OPTION (delicious=yes)");
     } catch (SqlCompilationException e) {
       Assert.assertTrue(e.getCause() instanceof ParseException);
     }
@@ -829,18 +861,16 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testQuerySetOptions() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
+    PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
     Assert.assertNull(pinotQuery.getQueryOptions());
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SET delicious='yes'; select * from vegetables where name <> 'Brussels sprouts'");
+    pinotQuery = compileToPinotQuery("SET delicious='yes'; select * from vegetables where name <> 'Brussels sprouts'");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
     Assert.assertEquals(pinotQuery.getQueryOptions().get("delicious"), "yes");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET delicious='yes'; SET foo='1234'; SET bar='''potato''';"
+    pinotQuery = compileToPinotQuery("SET delicious='yes'; SET foo='1234'; SET bar='''potato''';"
         + "select * from vegetables where name <> 'Brussels sprouts' ");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
@@ -848,7 +878,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getQueryOptions().get("foo"), "1234");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("bar"), "'potato'");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET delicious='yes'; SET foo='1234'; "
+    pinotQuery = compileToPinotQuery("SET delicious='yes'; SET foo='1234'; "
         + "SET bar='''potato'''; select * from vegetables where name <> 'Brussels sprouts' ");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
@@ -856,7 +886,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getQueryOptions().get("foo"), "1234");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("bar"), "'potato'");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET delicious='yes'; SET foo='1234'; "
+    pinotQuery = compileToPinotQuery("SET delicious='yes'; SET foo='1234'; "
         + "select * from vegetables where name <> 'Brussels sprouts'; SET bar='''potato'''; ");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
@@ -866,23 +896,21 @@ public class CalciteSqlCompilerTest {
 
     // test invalid options
     try {
-      CalciteSqlParser.compileToPinotQuery(
-          "select * from vegetables SET delicious='yes', foo='1234' where name <> 'Brussels sprouts'");
+      compileToPinotQuery("select * from vegetables SET delicious='yes', foo='1234' where name <> 'Brussels sprouts'");
       Assert.fail("SQL should not be compiled");
     } catch (SqlCompilationException sce) {
       // expected.
     }
 
     try {
-      CalciteSqlParser.compileToPinotQuery(
-          "select * from vegetables where name <> 'Brussels sprouts'; SET (delicious='yes', foo=1234)");
+      compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'; SET (delicious='yes', foo=1234)");
       Assert.fail("SQL should not be compiled");
     } catch (SqlCompilationException sce) {
       // expected.
     }
 
     try {
-      CalciteSqlParser.compileToPinotQuery(
+      compileToPinotQuery(
           "select * from vegetables where name <> 'Brussels sprouts'; SET (delicious='yes', foo=1234); select * from "
               + "meat");
       Assert.fail("SQL should not be compiled");
@@ -934,15 +962,15 @@ public class CalciteSqlCompilerTest {
   }
 
   private void testRemoveComments(String sqlWithComments, String expectedSqlWithoutComments) {
-    PinotQuery commentedResult = CalciteSqlParser.compileToPinotQuery(sqlWithComments);
-    PinotQuery expectedResult = CalciteSqlParser.compileToPinotQuery(expectedSqlWithoutComments);
+    PinotQuery commentedResult = compileToPinotQuery(sqlWithComments);
+    PinotQuery expectedResult = compileToPinotQuery(expectedSqlWithoutComments);
     Assert.assertEquals(commentedResult, expectedResult);
   }
 
   @Test
   public void testIdentifierQuoteCharacter() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "select avg(attributes.age) as avg_age from person group by attributes.address_city");
+    PinotQuery pinotQuery =
+        compileToPinotQuery("select avg(attributes.age) as avg_age from person group by attributes.address_city");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "attributes.age");
@@ -955,8 +983,7 @@ public class CalciteSqlCompilerTest {
     assertCompilationFails("SELECT 'foo' FROM table");
 
     // Allow string literal column in aggregation and group-by query
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("SELECT SUM('foo'), MAX(bar) FROM myTable GROUP BY 'foo', bar");
+    PinotQuery pinotQuery = compileToPinotQuery("SELECT SUM('foo'), MAX(bar) FROM myTable GROUP BY 'foo', bar");
     List<Expression> selectFunctionList = pinotQuery.getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 2);
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getLiteral().getStringValue(),
@@ -969,8 +996,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(groupbyList.get(1).getIdentifier().getName(), "bar");
 
     // For UDF, string literal won't be treated as column but as LITERAL
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT SUM(ADD(foo, 'bar')) FROM myTable GROUP BY sub(foo, bar), SUB(BAR, FOO)");
+    pinotQuery = compileToPinotQuery("SELECT SUM(ADD(foo, 'bar')) FROM myTable GROUP BY sub(foo, bar), SUB(BAR, FOO)");
     selectFunctionList = pinotQuery.getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 1);
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "sum");
@@ -1000,8 +1026,7 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testFilterUdf() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("select count(*) from baseballStats where DIV(numberOfGames,10) = 100");
+    PinotQuery pinotQuery = compileToPinotQuery("select count(*) from baseballStats where DIV(numberOfGames,10) = 100");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "count");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
@@ -1017,7 +1042,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 100);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "SELECT count(*) FROM mytable WHERE timeConvert(DaysSinceEpoch,'DAYS','SECONDS') = 1394323200");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "count");
     Assert.assertEquals(
@@ -1042,8 +1067,8 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testSelectionTransformFunction() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
+    PinotQuery pinotQuery =
+        compileToPinotQuery("  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "mapkey");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "mapField");
@@ -1067,7 +1092,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testTimeTransformFunction() {
     PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
+        compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "hour");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
@@ -1083,7 +1108,7 @@ public class CalciteSqlCompilerTest {
   public void testSqlDistinctQueryCompilation() {
     // test single column DISTINCT
     String sql = "SELECT DISTINCT c1 FROM foo";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
     List<Expression> selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
     Assert.assertEquals(selectListExpressions.get(0).getType(), ExpressionType.FUNCTION);
@@ -1097,7 +1122,7 @@ public class CalciteSqlCompilerTest {
 
     // test multi column DISTINCT
     sql = "SELECT DISTINCT c1, c2 FROM foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
     Assert.assertEquals(selectListExpressions.get(0).getType(), ExpressionType.FUNCTION);
@@ -1113,7 +1138,7 @@ public class CalciteSqlCompilerTest {
 
     // test multi column DISTINCT with filter
     sql = "SELECT DISTINCT c1, c2, c3 FROM foo WHERE c3 > 100";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
 
     selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
@@ -1138,7 +1163,7 @@ public class CalciteSqlCompilerTest {
     // not supported by Calcite SQL (this is in compliance with SQL standard)
     try {
       sql = "SELECT sum(c1), DISTINCT c2 FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1147,7 +1172,7 @@ public class CalciteSqlCompilerTest {
     // not supported by Calcite SQL (this is in compliance with SQL standard)
     try {
       sql = "SELECT c1, DISTINCT c2 FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1156,7 +1181,7 @@ public class CalciteSqlCompilerTest {
     // not supported by Calcite SQL (this is in compliance with SQL standard)
     try {
       sql = "SELECT DIV(c1,c2), DISTINCT c3 FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1173,7 +1198,7 @@ public class CalciteSqlCompilerTest {
     // transform
     try {
       sql = "SELECT DISTINCT c1, sum(c2) FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1184,7 +1209,7 @@ public class CalciteSqlCompilerTest {
     // same reason as above
     try {
       sql = "SELECT DISTINCT sum(c1) FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1195,7 +1220,7 @@ public class CalciteSqlCompilerTest {
     // Pinot currently does not support DISTINCT * syntax
     try {
       sql = "SELECT DISTINCT * FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1207,7 +1232,7 @@ public class CalciteSqlCompilerTest {
     // Pinot currently does not support DISTINCT * syntax
     try {
       sql = "SELECT DISTINCT *, C1 FROM foo";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1219,7 +1244,7 @@ public class CalciteSqlCompilerTest {
     // Pinot currently does not support GROUP BY with DISTINCT
     try {
       sql = "SELECT DISTINCT C1, C2 FROM foo GROUP BY C1";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1231,7 +1256,7 @@ public class CalciteSqlCompilerTest {
 
     // test DISTINCT with single transform function
     sql = "SELECT DISTINCT add(col1,col2) FROM foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
     Assert.assertEquals(selectListExpressions.get(0).getType(), ExpressionType.FUNCTION);
@@ -1250,7 +1275,7 @@ public class CalciteSqlCompilerTest {
 
     // multi-column distinct with multiple transform functions
     sql = "SELECT DISTINCT add(div(col1, col2), mul(col3, col4)), sub(col3, col4) FROM foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
     Assert.assertEquals(selectListExpressions.get(0).getType(), ExpressionType.FUNCTION);
@@ -1293,7 +1318,7 @@ public class CalciteSqlCompilerTest {
 
     // multi-column distinct with multiple transform columns and additional identifiers
     sql = "SELECT DISTINCT add(div(col1, col2), mul(col3, col4)), sub(col3, col4), col5, col6 FROM foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     selectListExpressions = pinotQuery.getSelectList();
     Assert.assertEquals(selectListExpressions.size(), 1);
     Assert.assertEquals(selectListExpressions.get(0).getType(), ExpressionType.FUNCTION);
@@ -1349,7 +1374,7 @@ public class CalciteSqlCompilerTest {
     String sql =
         "select group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_city, group_country ORDER BY "
             + "sum(rsvp_count), count(*) limit 50";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
 
@@ -1357,7 +1382,7 @@ public class CalciteSqlCompilerTest {
     try {
       sql = "select group_city, group_country, sum(rsvp_count), count(*) from meetupRsvp group by group_country ORDER "
           + "BY sum(rsvp_count), count(*) limit 50";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1367,7 +1392,7 @@ public class CalciteSqlCompilerTest {
     // Valid groupBy non-aggregate function should pass.
     sql = "select dateConvert(secondsSinceEpoch), sum(rsvp_count), count(*) from meetupRsvp group by dateConvert"
         + "(secondsSinceEpoch) limit 50";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
 
@@ -1375,7 +1400,7 @@ public class CalciteSqlCompilerTest {
     try {
       sql = "select secondsSinceEpoch, dateConvert(secondsSinceEpoch), sum(rsvp_count), count(*) from meetupRsvp"
           + " group by dateConvert(secondsSinceEpoch) limit 50";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1386,7 +1411,7 @@ public class CalciteSqlCompilerTest {
     try {
       sql = "select  sum(rsvp_count), count(*) from meetupRsvp group by group_country, sum(rsvp_count), count(*) limit "
           + "50";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1401,7 +1426,7 @@ public class CalciteSqlCompilerTest {
     // Valid alias in query.
     sql = "select secondsSinceEpoch, sum(rsvp_count) as sum_rsvp_count, count(*) as cnt from meetupRsvp"
         + " group by secondsSinceEpoch order by cnt, sum_rsvp_count DESC limit 50";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
@@ -1423,7 +1448,7 @@ public class CalciteSqlCompilerTest {
     // Valid mixed alias expressions in query.
     sql = "select secondsSinceEpoch, sum(rsvp_count), count(*) as cnt from meetupRsvp group by secondsSinceEpoch"
         + " order by cnt, sum(rsvp_count) DESC limit 50";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
@@ -1445,7 +1470,7 @@ public class CalciteSqlCompilerTest {
     sql = "select secondsSinceEpoch/86400 AS daysSinceEpoch, sum(rsvp_count) as sum_rsvp_count, count(*) as cnt"
         + " from meetupRsvp where daysSinceEpoch = 18523 group by daysSinceEpoch order by cnt, sum_rsvp_count DESC"
         + " limit 50";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     // Alias should not be applied to filter
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
@@ -1466,7 +1491,7 @@ public class CalciteSqlCompilerTest {
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).
     try {
       sql = "select sum(rsvp_count), count(*) as cnt from meetupRsvp group by group_country, cnt limit 50";
-      CalciteSqlParser.compileToPinotQuery(sql);
+      compileToPinotQuery(sql);
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1478,7 +1503,7 @@ public class CalciteSqlCompilerTest {
   public void testAliasInSelection() {
     // Alias should not be applied
     String sql = "SELECT C1 AS ALIAS_C1, C2 AS ALIAS_C2, ALIAS_C1 + ALIAS_C2 FROM Foo";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
@@ -1504,7 +1529,7 @@ public class CalciteSqlCompilerTest {
     String sql;
     PinotQuery pinotQuery;
     sql = "SELECT C1 AS C1, C2 AS C2 FROM Foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "C2");
@@ -1514,7 +1539,7 @@ public class CalciteSqlCompilerTest {
   public void testAliasInFilter() {
     // Alias should not be applied
     String sql = "SELECT C1 AS ALIAS_CI FROM Foo WHERE ALIAS_CI > 10";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ALIAS_CI");
   }
@@ -1522,7 +1547,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testColumnOverride() {
     String sql = "SELECT C1 + 1 AS C1, COUNT(*) AS cnt FROM Foo GROUP BY 1";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
@@ -1532,7 +1557,7 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testArithmeticOperator() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select a,b+2,c*5,(d+5)*2 from myTable");
+    PinotQuery pinotQuery = compileToPinotQuery("select a,b+2,c*5,(d+5)*2 from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 4);
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
@@ -1557,7 +1582,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select a % 200 + b * 5  from myTable");
+    pinotQuery = compileToPinotQuery("select a % 200 + b * 5  from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
@@ -1588,7 +1613,7 @@ public class CalciteSqlCompilerTest {
   public void testReservedKeywords() {
 
     // min, max, avg, sum, value, count, groups
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = compileToPinotQuery(
         "select max(value) as max, min(value) as min, sum(value) as sum, count(*) as count, avg(value) as avg from "
             + "myTable where groups = 'foo'");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 5);
@@ -1644,7 +1669,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(), "foo");
 
     // language, module, return, position, system
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "select * from myTable where (language = 'en' or return > 100) and position < 10 order by module, system desc");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
@@ -1664,7 +1689,7 @@ public class CalciteSqlCompilerTest {
 
     // table - need to escape
     try {
-      CalciteSqlParser.compileToPinotQuery("select count(*) from myTable where table = 'foo'");
+      compileToPinotQuery("select count(*) from myTable where table = 'foo'");
       Assert.fail("Query should have failed to compile");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1672,7 +1697,7 @@ public class CalciteSqlCompilerTest {
     }
     // date - need to escape
     try {
-      CalciteSqlParser.compileToPinotQuery("select count(*) from myTable group by Date");
+      compileToPinotQuery("select count(*) from myTable group by Date");
       Assert.fail("Query should have failed to compile");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1680,7 +1705,7 @@ public class CalciteSqlCompilerTest {
 
     // timestamp - need to escape
     try {
-      CalciteSqlParser.compileToPinotQuery("select count(*) from myTable where timestamp < 1000");
+      compileToPinotQuery("select count(*) from myTable where timestamp < 1000");
       Assert.fail("Query should have failed to compile");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1688,7 +1713,7 @@ public class CalciteSqlCompilerTest {
 
     // time - need to escape
     try {
-      CalciteSqlParser.compileToPinotQuery("select count(*) from myTable where time > 100");
+      compileToPinotQuery("select count(*) from myTable where time > 100");
       Assert.fail("Query should have failed to compile");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
@@ -1696,14 +1721,14 @@ public class CalciteSqlCompilerTest {
 
     // group - need to escape
     try {
-      CalciteSqlParser.compileToPinotQuery("select group from myTable where bar = 'foo'");
+      compileToPinotQuery("select group from myTable where bar = 'foo'");
       Assert.fail("Query should have failed to compile");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
     }
 
     // escaping the above works
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "select sum(foo) from \"table\" where \"Date\" = 2019 and (\"timestamp\" < 100 or \"time\" > 200) group by "
             + "\"group\"");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -1722,23 +1747,23 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testCastTransformation() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select CAST(25.65 AS int) from myTable");
+    PinotQuery pinotQuery = compileToPinotQuery("select CAST(25.65 AS int) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 25);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST('20170825' AS LONG) from myTable");
+    pinotQuery = compileToPinotQuery("SELECT CAST('20170825' AS LONG) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 20170825);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(20170825.0 AS Float) from myTable");
+    pinotQuery = compileToPinotQuery("SELECT CAST(20170825.0 AS Float) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals((float) pinotQuery.getSelectList().get(0).getLiteral().getDoubleValue(), 20170825.0F);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(20170825.0 AS dOuble) from myTable");
+    pinotQuery = compileToPinotQuery("SELECT CAST(20170825.0 AS dOuble) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals((float) pinotQuery.getSelectList().get(0).getLiteral().getDoubleValue(), 20170825.0F);
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(column1 AS STRING) from myTable");
+    pinotQuery = compileToPinotQuery("SELECT CAST(column1 AS STRING) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
     Assert.assertEquals(
@@ -1747,7 +1772,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
         "STRING");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(column1 AS varchar) from myTable");
+    pinotQuery = compileToPinotQuery("SELECT CAST(column1 AS varchar) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
     Assert.assertEquals(
@@ -1756,7 +1781,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
         "VARCHAR");
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    pinotQuery = compileToPinotQuery(
         "SELECT SUM(CAST(CAST(ArrTime AS STRING) AS LONG)) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = "
             + "'DL'");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -1772,21 +1797,21 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testDistinctCountRewrite() {
     String query = "SELECT count(distinct bar) FROM foo";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar), distinctCount(bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
@@ -1797,14 +1822,14 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar), count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar) AS distinct_bar, count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
@@ -1821,21 +1846,21 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testDistinctSumRewrite() {
     String query = "SELECT sum(distinct bar) FROM foo";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctsum");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT sum(distinct bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctsum");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT sum(distinct bar), distinctSum(bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctsum");
     Assert.assertEquals(
@@ -1846,14 +1871,14 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT sum(distinct bar), count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctsum");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT sum(distinct bar) AS distinct_bar, count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
@@ -1868,7 +1893,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT sum(distinct bar) AS distinct_bar, count(*), sum(a),min(a),max(b) FROM foo GROUP BY city ORDER BY "
         + "distinct_bar";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Function selectFunctionCall = pinotQuery.getSelectList().get(0).getFunctionCall();
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
@@ -1889,21 +1914,21 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testDistinctAvgRewrite() {
     String query = "SELECT avg(distinct bar) FROM foo";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctavg");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT avg(distinct bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctavg");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT avg(distinct bar), distinctAvg(bar) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctavg");
     Assert.assertEquals(
@@ -1914,14 +1939,14 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT avg(distinct bar), count(*), avg(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctavg");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT avg(distinct bar) AS distinct_bar, count(*), avg(a),min(a),max(b) FROM foo GROUP BY city";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
@@ -1936,7 +1961,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT avg(distinct bar) AS distinct_bar, count(*), avg(a),min(a),max(b) FROM foo GROUP BY city ORDER BY"
         + " distinct_bar";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
@@ -1961,7 +1986,7 @@ public class CalciteSqlCompilerTest {
   public void testInvalidDistinctAggregationRewrite() {
     String query = "SELECT max(distinct bar) FROM foo";
     try {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertEquals(e.getMessage(), "Function 'max' on DISTINCT is not supported.");
@@ -1971,7 +1996,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testOrdinalsQueryRewrite() {
     String query = "SELECT foo, bar, count(*) FROM t GROUP BY 1, 2 ORDER BY 1, 2 DESC";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "foo");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "bar");
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getIdentifier().getName(), "foo");
@@ -1982,7 +2007,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT foo, bar, count(*) FROM t GROUP BY 2, 1 ORDER BY 2, 1 DESC";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "foo");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "bar");
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getIdentifier().getName(), "bar");
@@ -1993,7 +2018,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
 
     query = "SELECT foo as f, bar as b, count(*) FROM t GROUP BY 2, 1 ORDER BY 2, 1 DESC";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getIdentifier().getName(), "bar");
     Assert.assertEquals(pinotQuery.getGroupByList().get(1).getIdentifier().getName(), "foo");
     Assert.assertEquals(
@@ -2002,7 +2027,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
 
     query = "select a, b + 2, array_sum(c) as array_sum_c, count(*) from data group by a, 2, array_sum_c";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getIdentifier().getName(), "a");
     Assert.assertEquals(pinotQuery.getGroupByList().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
@@ -2014,9 +2039,9 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getGroupByList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
 
     Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT foo, bar, count(*) FROM t GROUP BY 0"));
+        () -> compileToPinotQuery("SELECT foo, bar, count(*) FROM t GROUP BY 0"));
     Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT foo, bar, count(*) FROM t GROUP BY 3"));
+        () -> compileToPinotQuery("SELECT foo, bar, count(*) FROM t GROUP BY 3"));
   }
 
   @Test
@@ -2024,7 +2049,7 @@ public class CalciteSqlCompilerTest {
     String query =
         "SELECT baseballStats.playerName AS playerName FROM baseballStats GROUP BY baseballStats.playerName ORDER BY "
             + "1 ASC";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "baseballStats.playerName");
@@ -2037,17 +2062,17 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testNoArgFunction() {
     String query = "SELECT noArgFunc() FROM foo ";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "noargfunc");
 
     query = "SELECT a FROM foo where time_col > noArgFunc()";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     Function minus = greaterThan.getOperands().get(0).getFunctionCall();
     Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "noargfunc");
 
     query = "SELECT sum(a), noArgFunc() FROM foo group by noArgFunc()";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "noargfunc");
   }
 
@@ -2055,7 +2080,7 @@ public class CalciteSqlCompilerTest {
   public void testCompilationInvokedFunction() {
     String query = "SELECT now() FROM foo";
     long lowerBound = System.currentTimeMillis();
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     long nowTs = pinotQuery.getSelectList().get(0).getLiteral().getLongValue();
     long upperBound = System.currentTimeMillis();
     Assert.assertTrue(nowTs >= lowerBound);
@@ -2063,7 +2088,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT a FROM foo where time_col > now()";
     lowerBound = System.currentTimeMillis();
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     nowTs = greaterThan.getOperands().get(1).getLiteral().getLongValue();
     upperBound = System.currentTimeMillis();
@@ -2071,14 +2096,14 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(nowTs <= upperBound);
 
     query = "SELECT a FROM foo where time_col > fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z')";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     nowTs = greaterThan.getOperands().get(1).getLiteral().getLongValue();
     Assert.assertEquals(nowTs, 1577836800000L);
 
     query = "SELECT ago('PT1H') FROM foo";
     lowerBound = System.currentTimeMillis() - ONE_HOUR_IN_MS;
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     nowTs = pinotQuery.getSelectList().get(0).getLiteral().getLongValue();
     upperBound = System.currentTimeMillis() - ONE_HOUR_IN_MS;
     Assert.assertTrue(nowTs >= lowerBound);
@@ -2086,7 +2111,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT a FROM foo where time_col > ago('PT1H')";
     lowerBound = System.currentTimeMillis() - ONE_HOUR_IN_MS;
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     nowTs = greaterThan.getOperands().get(1).getLiteral().getLongValue();
     upperBound = System.currentTimeMillis() - ONE_HOUR_IN_MS;
@@ -2095,7 +2120,7 @@ public class CalciteSqlCompilerTest {
 
     query = "select encodeUrl('key1=value 1&key2=value@!$2&key3=value%3'), "
         + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     String encoded = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     String decoded = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
     Assert.assertEquals(encoded, "key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
@@ -2105,7 +2130,7 @@ public class CalciteSqlCompilerTest {
         + "encodeUrl('key1=val1 key2=45% key3=#47 key4={''key'':[3,5]} + key5=1;2;3;4 key6=(a|b)&c key7= "
         + "key8=5*(6/4) key9=https://pinot@pinot.com key10=CFLAGS=\"-O2 -mcpu=pentiumpro\" key12=$JAVA_HOME'),'') "
         + "from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     encoded = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     Assert.assertEquals(encoded, "https://www.google.com/search?q=key1%3Dval1+key2%3D45%25+key3%3D%2347+"
         + "key4%3D%7B%27key%27%3A%5B3%2C5%5D%7D+%2B+key5%3D1%3B2%3B3%3B4+"
@@ -2116,7 +2141,7 @@ public class CalciteSqlCompilerTest {
         + "key4%3D%7B%27key%27%3A%5B3%2C5%5D%7D+%2B+key5%3D1%3B2%3B3%3B4+key6%3D%28a%7Cb%29%26c+"
         + "key7%3D+key8%3D5*%286%2F4%29+key9%3Dhttps%3A%2F%2Fpinot%40pinot.com+"
         + "key10%3DCFLAGS%3D%22-O2+-mcpu%3Dpentiumpro%22+key12%3D%24JAVA_HOME') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     decoded = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     Assert.assertEquals(decoded, "https://www.google.com/search?q=key1=val1 key2=45% key3=#47 "
         + "key4={'key':[3,5]} + key5=1;2;3;4 key6=(a|b)&c key7= "
@@ -2124,7 +2149,7 @@ public class CalciteSqlCompilerTest {
 
     query = "select a from mytable where foo=encodeUrl('key1=value 1&key2=value@!$2&key3=value%3') and"
         + " bar=decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Function and = pinotQuery.getFilterExpression().getFunctionCall();
     encoded = and.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
     decoded = and.getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
@@ -2132,14 +2157,14 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(decoded, "key1=value 1&key2=value@!$2&key3=value%3");
 
     query = "select toBase64(toUtf8('hello!')), fromUtf8(fromBase64('aGVsbG8h')) from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     String encodedBase64 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     String decodedBase64 = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
     Assert.assertEquals(encodedBase64, "aGVsbG8h");
     Assert.assertEquals(decodedBase64, "hello!");
 
     query = "select toBase64(fromBase64('aGVsbG8h')), fromUtf8(fromBase64(toBase64(toUtf8('hello!')))) from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     encodedBase64 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     decodedBase64 = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
     Assert.assertEquals(encodedBase64, "aGVsbG8h");
@@ -2147,7 +2172,7 @@ public class CalciteSqlCompilerTest {
 
     query = "select toBase64(toUtf8(upper('hello!'))), fromUtf8(fromBase64(toBase64(toUtf8(upper('hello!'))))) from "
         + "mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     encodedBase64 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     decodedBase64 = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
     Assert.assertEquals(encodedBase64, "SEVMTE8h");
@@ -2155,7 +2180,7 @@ public class CalciteSqlCompilerTest {
 
     query = "select reverse(fromUtf8(fromBase64(toBase64(toUtf8(upper('hello!')))))) from mytable where "
         + "fromUtf8(fromBase64(toBase64(toUtf8(upper('hello!'))))) = bar";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     String arg1 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     String leftOp =
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
@@ -2163,7 +2188,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(leftOp, "HELLO!");
 
     query = "select a from mytable where foo = toBase64(toUtf8('hello!')) and bar = fromUtf8(fromBase64('aGVsbG8h'))";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     and = pinotQuery.getFilterExpression().getFunctionCall();
     encoded = and.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
     decoded = and.getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
@@ -2173,7 +2198,7 @@ public class CalciteSqlCompilerTest {
     query = "select fromBase64('hello') from mytable";
     Exception expectedError = null;
     try {
-      CalciteSqlParser.compileToPinotQuery(query);
+      compileToPinotQuery(query);
     } catch (Exception e) {
       expectedError = e;
     }
@@ -2183,7 +2208,7 @@ public class CalciteSqlCompilerTest {
     query = "select toBase64('hello!') from mytable";
     expectedError = null;
     try {
-      CalciteSqlParser.compileToPinotQuery(query);
+      compileToPinotQuery(query);
     } catch (Exception e) {
       expectedError = e;
     }
@@ -2191,108 +2216,108 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(expectedError instanceof SqlCompilationException);
 
     query = "select isSubnetOf('192.168.0.1/24', '192.168.0.225') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     boolean result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('192.168.0.1/24', '192.168.0.1') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('130.191.23.32/27', '130.191.23.40') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('130.191.23.32/26', '130.192.23.33') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
     query = "select isSubnetOf('153.87.199.160/28', '153.87.199.166') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('2001:4800:7825:103::/64', '2001:4800:7825:103::2050') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('130.191.23.32/26', '130.191.23.33') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('2001:4801:7825:103:be76:4efe::/96', '2001:4801:7825:103:be76:4efe::e15') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('122.152.15.0/26', '122.152.15.28') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('96.141.228.254/26', '96.141.228.254') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('3.175.47.128/26', '3.175.48.178') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
     query = "select isSubnetOf('192.168.0.1/24', '192.168.0.0') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('10.3.128.1/22', '10.3.128.123') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('10.3.128.1/22', '10.3.131.255') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('10.3.128.1/22', '1.2.3.1') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
     query = "select isSubnetOf('1.2.3.128/1', '127.255.255.255') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('1.2.3.128/0', '192.168.5.1') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from "
         + "mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query = "select isSubnetOf('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
     query = "select isSubnetOf('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7336') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
     query = "select isSubnetOf('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7335') from mytable";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
   }
@@ -2300,7 +2325,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testCompilationInvokedNestedFunctions() {
     String query = "SELECT a FROM foo where time_col > toDateTime(now(), 'yyyy-MM-dd z')";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     String today = greaterThan.getOperands().get(1).getLiteral().getStringValue();
     String expectedTodayStr =
@@ -2312,7 +2337,7 @@ public class CalciteSqlCompilerTest {
   public void testCompileTimeExpression() {
     final CompileTimeFunctionsInvoker compileTimeFunctionsInvoker = new CompileTimeFunctionsInvoker();
     long lowerBound = System.currentTimeMillis();
-    Expression expression = CalciteSqlParser.compileToExpression("now()");
+    Expression expression = compileToExpression("now()");
     Assert.assertNotNull(expression.getFunctionCall());
     PinotQuery pinotQuery = new PinotQuery();
     pinotQuery.setFilterExpression(expression);
@@ -2324,7 +2349,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(result >= lowerBound && result <= upperBound);
 
     lowerBound = TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis()) + 1;
-    expression = CalciteSqlParser.compileToExpression("to_epoch_hours(now() + 3600000)");
+    expression = compileToExpression("to_epoch_hours(now() + 3600000)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2335,7 +2360,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(result >= lowerBound && result <= upperBound);
 
     lowerBound = System.currentTimeMillis() - ONE_HOUR_IN_MS;
-    expression = CalciteSqlParser.compileToExpression("ago('PT1H')");
+    expression = compileToExpression("ago('PT1H')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2346,7 +2371,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertTrue(result >= lowerBound && result <= upperBound);
 
     lowerBound = System.currentTimeMillis() + ONE_HOUR_IN_MS;
-    expression = CalciteSqlParser.compileToExpression("ago('PT-1H')");
+    expression = compileToExpression("ago('PT-1H')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2356,7 +2381,7 @@ public class CalciteSqlCompilerTest {
     result = expression.getLiteral().getLongValue();
     Assert.assertTrue(result >= lowerBound && result <= upperBound);
 
-    expression = CalciteSqlParser.compileToExpression("toDateTime(millisSinceEpoch)");
+    expression = compileToExpression("toDateTime(millisSinceEpoch)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2366,7 +2391,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "millisSinceEpoch");
 
-    expression = CalciteSqlParser.compileToExpression("encodeUrl('key1=value 1&key2=value@!$2&key3=value%3')");
+    expression = compileToExpression("encodeUrl('key1=value 1&key2=value@!$2&key3=value%3')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2375,8 +2400,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(expression.getLiteral().getFieldValue(),
         "key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
 
-    expression =
-        CalciteSqlParser.compileToExpression("decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')");
+    expression = compileToExpression("decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2384,7 +2408,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertEquals(expression.getLiteral().getFieldValue(), "key1=value 1&key2=value@!$2&key3=value%3");
 
-    expression = CalciteSqlParser.compileToExpression("reverse(playerName)");
+    expression = compileToExpression("reverse(playerName)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2393,7 +2417,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(expression.getFunctionCall().getOperator(), "reverse");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerName");
 
-    expression = CalciteSqlParser.compileToExpression("reverse('playerName')");
+    expression = compileToExpression("reverse('playerName')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2401,7 +2425,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertEquals(expression.getLiteral().getFieldValue(), "emaNreyalp");
 
-    expression = CalciteSqlParser.compileToExpression("reverse(123)");
+    expression = compileToExpression("reverse(123)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2409,7 +2433,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertEquals(expression.getLiteral().getFieldValue(), "321");
 
-    expression = CalciteSqlParser.compileToExpression("count(*)");
+    expression = compileToExpression("count(*)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2418,7 +2442,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(expression.getFunctionCall().getOperator(), "count");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
 
-    expression = CalciteSqlParser.compileToExpression("toBase64(toUtf8('hello!'))");
+    expression = compileToExpression("toBase64(toUtf8('hello!'))");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2426,7 +2450,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertEquals(expression.getLiteral().getFieldValue(), "aGVsbG8h");
 
-    expression = CalciteSqlParser.compileToExpression("fromUtf8(fromBase64('aGVsbG8h'))");
+    expression = compileToExpression("fromUtf8(fromBase64('aGVsbG8h'))");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2434,7 +2458,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expression.getLiteral());
     Assert.assertEquals(expression.getLiteral().getFieldValue(), "hello!");
 
-    expression = CalciteSqlParser.compileToExpression("fromBase64(foo)");
+    expression = compileToExpression("fromBase64(foo)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2443,7 +2467,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(expression.getFunctionCall().getOperator(), "frombase64");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
 
-    expression = CalciteSqlParser.compileToExpression("toBase64(foo)");
+    expression = compileToExpression("toBase64(foo)");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
@@ -2455,56 +2479,54 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testLiteralExpressionCheck() {
-    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("1123")));
-    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("'ab'")));
-    Assert.assertTrue(
-        CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS('ab', randomStr)")));
-    Assert.assertTrue(
-        CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("AS(123, randomTime)")));
-    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("sum(abc)")));
-    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("count(*)")));
-    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("a+B")));
-    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("c+1")));
+    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("1123")));
+    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("'ab'")));
+    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("AS('ab', randomStr)")));
+    Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("AS(123, randomTime)")));
+    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("sum(abc)")));
+    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("count(*)")));
+    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("a+B")));
+    Assert.assertFalse(CalciteSqlParser.isLiteralOnlyExpression(compileToExpression("c+1")));
   }
 
   @Test
   public void testCaseInsensitiveFilter() {
     String query = "SELECT count(*) FROM foo where text_match(col, 'expr')";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "TEXT_MATCH");
 
     query = "SELECT count(*) FROM foo where TEXT_MATCH(col, 'expr')";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "TEXT_MATCH");
 
     query = "SELECT count(*) FROM foo where regexp_like(col, 'expr')";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "REGEXP_LIKE");
 
     query = "SELECT count(*) FROM foo where REGEXP_LIKE(col, 'expr')";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "REGEXP_LIKE");
 
     query = "SELECT count(*) FROM foo where col is not null";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
 
     query = "SELECT count(*) FROM foo where col IS NOT NULL";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
 
     query = "SELECT count(*) FROM foo where col is null";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
 
     query = "SELECT count(*) FROM foo where col IS NULL";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
@@ -2513,14 +2535,14 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testNonAggregationGroupByQuery() {
     String query = "SELECT col1 FROM foo GROUP BY col1";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
 
     query = "SELECT col1, col2 FROM foo GROUP BY col1, col2";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
@@ -2529,7 +2551,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "col2");
 
     query = "SELECT col1+col2*5 FROM foo GROUP BY col1+col2*5";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
@@ -2549,7 +2571,7 @@ public class CalciteSqlCompilerTest {
             .getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
 
     query = "SELECT col1+col2*5 AS col3 FROM foo GROUP BY col3";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
@@ -2579,20 +2601,20 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testInvalidNonAggregationGroupBy() {
     Assert.assertThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1 FROM foo GROUP BY col1, col2"));
+        () -> compileToPinotQuery("SELECT col1 FROM foo GROUP BY col1, col2"));
     Assert.assertThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, col2 FROM foo GROUP BY col1"));
+        () -> compileToPinotQuery("SELECT col1, col2 FROM foo GROUP BY col1"));
     Assert.assertThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1 + col2 FROM foo GROUP BY col1"));
+        () -> compileToPinotQuery("SELECT col1 + col2 FROM foo GROUP BY col1"));
     Assert.assertThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1+col2 FROM foo GROUP BY col1,col2"));
+        () -> compileToPinotQuery("SELECT col1+col2 FROM foo GROUP BY col1,col2"));
   }
 
   @Test
   public void testFlattenAndOr() {
     {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 > 0 AND col3 > 0) AND col4 > 0";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2603,7 +2625,7 @@ public class CalciteSqlCompilerTest {
     }
     {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND startsWith(col4, 'myStr')";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2621,7 +2643,7 @@ public class CalciteSqlCompilerTest {
     }
     {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4 = true";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2639,7 +2661,7 @@ public class CalciteSqlCompilerTest {
     }
     {
       String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 <= 0 OR (col3 <= 0 OR col4 <= 0)";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.OR.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2650,7 +2672,7 @@ public class CalciteSqlCompilerTest {
     }
     {
       String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 OR (col3 <= 0 OR col4)";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.OR.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2666,7 +2688,7 @@ public class CalciteSqlCompilerTest {
     {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND ((col2 > 0 AND col3 > 0) AND (col1 <= 0 OR (col2 <= 0 OR "
           + "(col3 <= 0 OR col4 <= 0) OR (col3 > 0 AND col4 > 0))))";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2695,7 +2717,7 @@ public class CalciteSqlCompilerTest {
   public void testHavingClause() {
     {
       String query = "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 HAVING SUM(col1) > 10";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.GREATER_THAN.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2706,7 +2728,7 @@ public class CalciteSqlCompilerTest {
     {
       String query = "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 "
           + "HAVING SUM(col1) > 10 AND SUM(col3) > 5 AND SUM(col4) > 15";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2721,7 +2743,7 @@ public class CalciteSqlCompilerTest {
   public void testPostAggregation() {
     {
       String query = "SELECT SUM(col1) * SUM(col2) FROM foo";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       List<Expression> selectList = pinotQuery.getSelectList();
       Assert.assertEquals(selectList.size(), 1);
       Function functionCall = selectList.get(0).getFunctionCall();
@@ -2734,7 +2756,7 @@ public class CalciteSqlCompilerTest {
     }
     {
       String query = "SELECT SUM(col1), col2 FROM foo GROUP BY col2 ORDER BY MAX(col1) - MAX(col3)";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       List<Expression> orderByList = pinotQuery.getOrderByList();
       Assert.assertEquals(orderByList.size(), 1);
       Function functionCall = orderByList.get(0).getFunctionCall();
@@ -2752,7 +2774,7 @@ public class CalciteSqlCompilerTest {
     {
       // Having will be rewritten to (SUM(col1) + SUM(col3)) - MAX(col4) > 0
       String query = "SELECT SUM(col1), col2 FROM foo GROUP BY col2 HAVING SUM(col1) + SUM(col3) > MAX(col4)";
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.GREATER_THAN.name());
       List<Expression> operands = functionCall.getOperands();
@@ -2777,7 +2799,7 @@ public class CalciteSqlCompilerTest {
     String sql;
     PinotQuery pinotQuery;
     sql = "SELECT sum(array_sum(a)) FROM Foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "summv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
@@ -2785,7 +2807,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT MIN(ARRAYMIN(a)) FROM Foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "minmv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
@@ -2793,7 +2815,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT Max(ArrayMax(a)) FROM Foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "maxmv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
@@ -2801,7 +2823,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
 
     sql = "SELECT Max(ArrayMax(a)) + 1 FROM Foo";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 2);
@@ -2880,7 +2902,7 @@ public class CalciteSqlCompilerTest {
 
   private void testUnsupportedDistinctQuery(String query, String errorMessage) {
     try {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      PinotQuery pinotQuery = compileToPinotQuery(query);
       Assert.fail("Query should have failed");
     } catch (Exception e) {
       Assert.assertEquals(errorMessage, e.getMessage());
@@ -2888,7 +2910,7 @@ public class CalciteSqlCompilerTest {
   }
 
   private void testSupportedDistinctQuery(String query) {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     Assert.assertNotNull(pinotQuery);
   }
 
@@ -2897,27 +2919,27 @@ public class CalciteSqlCompilerTest {
     String sql;
     PinotQuery pinotQuery;
     sql = "SELECT col1, col2 FROM foo;";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "col2");
 
     // Query having extra white spaces before the semicolon
     sql = "SELECT col1, col2 FROM foo                 ;";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "col2");
 
     // Query having leading and trailing whitespaces
     sql = "         SELECT col1, col2 FROM foo;             ";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "col2");
 
     sql = "SELECT col1, count(*) FROM foo group by col1;";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
@@ -2927,14 +2949,14 @@ public class CalciteSqlCompilerTest {
     // Check for Option SQL Query
     // TODO: change to SET syntax
     sql = "SELECT col1, count(*) FROM foo group by col1 option(skipUpsert=true);";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("skipUpsert"));
 
     // Check for the query where the literal has semicolon
     // TODO: change to SET syntax
     sql = "select col1, count(*) from foo where col1 = 'x;y' GROUP BY col1 option(skipUpsert=true);";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    pinotQuery = compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("skipUpsert"));
   }
@@ -2943,41 +2965,40 @@ public class CalciteSqlCompilerTest {
   public void testCatalogNameResolvedToDefault() {
     // Pinot doesn't support catalog. However, for backward compatibility, if a catalog is provided, we will resolve
     // the table from our default catalog. this means `a.foo` will be equivalent to `foo`.
-    PinotQuery randomCatalogQuery = CalciteSqlParser.compileToPinotQuery("SELECT count(*) FROM rand_catalog.foo");
-    PinotQuery defaultCatalogQuery = CalciteSqlParser.compileToPinotQuery("SELECT count(*) FROM default.foo");
+    PinotQuery randomCatalogQuery = compileToPinotQuery("SELECT count(*) FROM rand_catalog.foo");
+    PinotQuery defaultCatalogQuery = compileToPinotQuery("SELECT count(*) FROM default.foo");
     Assert.assertEquals(randomCatalogQuery.getDataSource().getTableName(), "rand_catalog.foo");
     Assert.assertEquals(defaultCatalogQuery.getDataSource().getTableName(), "default.foo");
   }
 
   @Test
   public void testInvalidQueryWithSemicolon() {
-    Assert.expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(";"));
+    Assert.expectThrows(SqlCompilationException.class, () -> compileToPinotQuery(";"));
 
-    Assert.expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(";;;;"));
+    Assert.expectThrows(SqlCompilationException.class, () -> compileToPinotQuery(";;;;"));
 
     Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY ; col1"));
+        () -> compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY ; col1"));
 
     // Query having multiple SQL statements
-    Assert.expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(
+    Assert.expectThrows(SqlCompilationException.class, () -> compileToPinotQuery(
         "SELECT col1, count(*) FROM foo GROUP BY col1; SELECT col2, count(*) FROM foo GROUP BY col2"));
 
     // Query having multiple SQL statements with trailing and leading whitespaces
-    Assert.expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(
+    Assert.expectThrows(SqlCompilationException.class, () -> compileToPinotQuery(
         "        SELECT col1, count(*) FROM foo GROUP BY col1;   "
             + "SELECT col2, count(*) FROM foo GROUP BY col2             "));
   }
 
   @Test
   public void testInvalidQueryWithAggregateFunction() {
-    Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) from foo"));
+    Assert.expectThrows(SqlCompilationException.class, () -> compileToPinotQuery("SELECT col1, count(*) from foo"));
 
     Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT UPPER(col1), count(*) from foo"));
+        () -> compileToPinotQuery("SELECT UPPER(col1), count(*) from foo"));
 
     Assert.expectThrows(SqlCompilationException.class,
-        () -> CalciteSqlParser.compileToPinotQuery("SELECT UPPER(col1), avg(col2) from foo"));
+        () -> compileToPinotQuery("SELECT UPPER(col1), avg(col2) from foo"));
   }
 
   /**
@@ -2986,7 +3007,8 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testParserExtensionImpl() {
     String customSql = "INSERT INTO db.tbl FROM FILE 'file:///tmp/file1', FILE 'file:///tmp/file2'";
-    SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(customSql);;
+    SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(customSql);
+    ;
     Assert.assertTrue(sqlNodeAndOptions.getSqlNode() instanceof SqlInsertFromFile);
     Assert.assertEquals(sqlNodeAndOptions.getSqlType(), PinotSqlType.DML);
   }
@@ -2997,7 +3019,7 @@ public class CalciteSqlCompilerTest {
     String sql = "SELECT ts AT TIME ZONE 'pst' FROM myTable;";
 
     // When:
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
 
     // Then:
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -3014,7 +3036,7 @@ public class CalciteSqlCompilerTest {
     String sql = "SELECT ts + 123 AT TIME ZONE 'pst' FROM myTable;";
 
     // When:
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
 
     // Then:
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -3036,7 +3058,7 @@ public class CalciteSqlCompilerTest {
     String sql = "SELECT ts AT TIME ZONE 'pst' > 123 FROM myTable;";
 
     // When:
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    PinotQuery pinotQuery = compileToPinotQuery(sql);
 
     // Then:
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -3054,7 +3076,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testJoin() {
     String query = "SELECT T1.a, T2.b FROM T1 JOIN T2";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    PinotQuery pinotQuery = compileToPinotQuery(query);
     DataSource dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3066,7 +3088,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertNull(join.getCondition());
 
     query = "SELECT T1.a, T2.b FROM T1 INNER JOIN T2 ON T1.key = T2.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3075,10 +3097,10 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(join.getType(), JoinType.INNER);
     Assert.assertEquals(join.getLeft().getTableName(), "T1");
     Assert.assertEquals(join.getRight().getTableName(), "T2");
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.key = T2.key"));
 
     query = "SELECT T1.a, T2.b FROM T1 FULL JOIN T2 ON T1.key = T2.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3087,10 +3109,10 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(join.getType(), JoinType.FULL);
     Assert.assertEquals(join.getLeft().getTableName(), "T1");
     Assert.assertEquals(join.getRight().getTableName(), "T2");
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.key = T2.key"));
 
     query = "SELECT T1.a, T2.b FROM T1 LEFT JOIN T2 ON T1.a > T2.b";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3099,11 +3121,11 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(join.getType(), JoinType.LEFT);
     Assert.assertEquals(join.getLeft().getTableName(), "T1");
     Assert.assertEquals(join.getRight().getTableName(), "T2");
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.a > T2.b"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.a > T2.b"));
 
     query =
         "SELECT T1.a, T2.b FROM T1 RIGHT JOIN (SELECT a, COUNT(*) AS b FROM T3 GROUP BY a) AS T2 ON T1.key = T2.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3114,13 +3136,12 @@ public class CalciteSqlCompilerTest {
     DataSource right = join.getRight();
     Assert.assertEquals(right.getTableName(), "T2");
     PinotQuery rightSubquery = right.getSubquery();
-    Assert.assertEquals(rightSubquery,
-        CalciteSqlParser.compileToPinotQuery("SELECT a, COUNT(*) AS b FROM T3 GROUP BY a"));
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
+    Assert.assertEquals(rightSubquery, compileToPinotQuery("SELECT a, COUNT(*) AS b FROM T3 GROUP BY a"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.key = T2.key"));
 
     query = "SELECT T1.a, T2.b FROM T1 JOIN (SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key) AS T2 "
         + "ON T1.key = T2.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3131,13 +3152,12 @@ public class CalciteSqlCompilerTest {
     right = join.getRight();
     Assert.assertEquals(right.getTableName(), "T2");
     rightSubquery = right.getSubquery();
-    Assert.assertEquals(rightSubquery,
-        CalciteSqlParser.compileToPinotQuery("SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key"));
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
+    Assert.assertEquals(rightSubquery, compileToPinotQuery("SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.key = T2.key"));
 
     // test for self join queries.
     query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T1) as self ON T1.key=self.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    pinotQuery = compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();
     Assert.assertNull(dataSource.getTableName());
     Assert.assertNull(dataSource.getSubquery());
@@ -3148,72 +3168,72 @@ public class CalciteSqlCompilerTest {
     right = join.getRight();
     Assert.assertEquals(right.getTableName(), "self");
     rightSubquery = right.getSubquery();
-    Assert.assertEquals(rightSubquery, CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
+    Assert.assertEquals(rightSubquery, compileToPinotQuery("SELECT key FROM T1"));
+    Assert.assertEquals(join.getCondition(), compileToExpression("T1.key = self.key"));
   }
 
   @Test
   public void testInPredicateWithOutNullPasses() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2) AND column2 = 1");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2) AND column2 = 1");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in IN "
       + "filter is not supported")
   public void testSingleInPredicateWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2, NULL)");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2, NULL)");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in NOT_IN "
       + "filter is not supported")
   public void testSingleNotInPredicateWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 NOT IN (1, 2, NULL)");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 NOT IN (1, 2, NULL)");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in IN "
       + "filter is not supported")
   public void testAndFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2, NULL) AND column2 = 1");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 IN (1, 2, NULL) AND column2 = 1");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in NOT_IN "
       + "filter is not supported")
   public void testOrFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 NOT IN (1, 2, NULL) OR column2 = 1");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 NOT IN (1, 2, NULL) OR column2 = 1");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in IN "
       + "filter is not supported")
   public void testNotFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE NOT(column1 IN (NULL, 1, 2))");
+    compileToPinotQuery("SELECT * FROM testTable WHERE NOT(column1 IN (NULL, 1, 2))");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in "
       + "GREATER_THAN filter is not supported")
   public void testGreaterThanNullFilterFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 > null");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 > null");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in "
       + "LESS_THAN_OR_EQUAL filter is not supported")
   public void testLessThanOrEqualNullFilterFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 <= null");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 <= null");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in LIKE "
       + "filter is not supported")
   public void testLikeFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 LIKE null");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 LIKE null");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in EQUALS "
       + "filter is not supported")
   public void testEqualFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 = null");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 = null");
   }
 
   @Test(expectedExceptions = {IllegalStateException.class}, expectedExceptionsMessageRegExp = "Using NULL in "
       + "NOT_EQUALS filter is not supported")
   public void testInEqualFilterWithNullFails() {
-    CalciteSqlParser.compileToPinotQuery("SELECT * FROM testTable WHERE column1 != null");
+    compileToPinotQuery("SELECT * FROM testTable WHERE column1 != null");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeEqInFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeEqInFilterOptimizer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.optimizer.filter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -164,16 +163,12 @@ public class MergeEqInFilterOptimizer implements FilterOptimizer {
   private static Expression getFilterExpression(Expression lhs, Set<Expression> values) {
     int numValues = values.size();
     if (numValues == 1) {
-      Expression eqFilter = RequestUtils.getFunctionExpression(FilterKind.EQUALS.name());
-      eqFilter.getFunctionCall().setOperands(Arrays.asList(lhs, values.iterator().next()));
-      return eqFilter;
+      return RequestUtils.getFunctionExpression(FilterKind.EQUALS.name(), lhs, values.iterator().next());
     } else {
-      Expression inFilter = RequestUtils.getFunctionExpression(FilterKind.IN.name());
       List<Expression> operands = new ArrayList<>(numValues + 1);
       operands.add(lhs);
       operands.addAll(values);
-      inFilter.getFunctionCall().setOperands(operands);
-      return inFilter;
+      return RequestUtils.getFunctionExpression(FilterKind.IN.name(), operands);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.optimizer.filter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,9 +153,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
    * Helper method to construct a RANGE predicate filter Expression from the given column and range.
    */
   private static Expression getRangeFilterExpression(String column, Range range) {
-    Expression rangeFilter = RequestUtils.getFunctionExpression(FilterKind.RANGE.name());
-    rangeFilter.getFunctionCall().setOperands(Arrays.asList(RequestUtils.getIdentifierExpression(column),
-        RequestUtils.getLiteralExpression(range.getRangeString())));
-    return rangeFilter;
+    return RequestUtils.getFunctionExpression(FilterKind.RANGE.name(), RequestUtils.getIdentifierExpression(column),
+        RequestUtils.getLiteralExpression(range.getRangeString()));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.query.optimizer.filter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,26 +159,20 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
       } else {
         mergedTextMatchFilter = String.join(SPACE + operator + SPACE, literals);
       }
-      Expression mergedTextMatchExpression = RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name());
-      Expression mergedTextMatchFilterExpression = RequestUtils.getLiteralExpression("(" + mergedTextMatchFilter + ")");
-      mergedTextMatchExpression.getFunctionCall()
-          .setOperands(Arrays.asList(entry.getKey(), mergedTextMatchFilterExpression));
-
+      Expression mergedTextMatchExpression =
+          RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name(), entry.getKey(),
+              RequestUtils.getLiteralExpression("(" + mergedTextMatchFilter + ")"));
       if (allNot) {
-        Expression notExpression = RequestUtils.getFunctionExpression(FilterKind.NOT.name());
-        notExpression.getFunctionCall().setOperands(Collections.singletonList(mergedTextMatchExpression));
-        newChildren.add(notExpression);
-        continue;
+        newChildren.add(RequestUtils.getFunctionExpression(FilterKind.NOT.name(), mergedTextMatchExpression));
+      } else {
+        newChildren.add(mergedTextMatchExpression);
       }
-      newChildren.add(mergedTextMatchExpression);
     }
 
     if (newChildren.size() == 1) {
       return newChildren.get(0);
     }
     assert operator.equals(FilterKind.OR.name()) || operator.equals(FilterKind.AND.name());
-    Expression newExpression = RequestUtils.getFunctionExpression(operator);
-    newExpression.getFunctionCall().setOperands(newChildren);
-    return newExpression;
+    return RequestUtils.getFunctionExpression(operator, newChildren);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -223,9 +223,9 @@ public class QueryOverrideWithHintsTest {
   public void testRewriteExpressionsWithHints() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT datetrunc('MONTH', ts), count(*), sum(abc) from myTable group by datetrunc('MONTH', ts) ");
-    Expression dateTruncFunctionExpr = RequestUtils.getFunctionExpression("datetrunc");
-    dateTruncFunctionExpr.getFunctionCall().setOperands(new ArrayList<>(
-        ImmutableList.of(RequestUtils.getLiteralExpression("MONTH"), RequestUtils.getIdentifierExpression("ts"))));
+    Expression dateTruncFunctionExpr =
+        RequestUtils.getFunctionExpression("datetrunc", RequestUtils.getLiteralExpression("MONTH"),
+            RequestUtils.getIdentifierExpression("ts"));
     Expression timestampIndexColumn = RequestUtils.getIdentifierExpression("$ts$MONTH");
     pinotQuery.setExpressionOverrideHints(ImmutableMap.of(dateTruncFunctionExpr, timestampIndexColumn));
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
@@ -238,9 +238,9 @@ public class QueryOverrideWithHintsTest {
   public void testNotRewriteExpressionsWithHints() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT datetrunc('DAY', ts), count(*), sum(abc) from myTable group by datetrunc('DAY', ts)");
-    Expression dateTruncFunctionExpr = RequestUtils.getFunctionExpression("datetrunc");
-    dateTruncFunctionExpr.getFunctionCall().setOperands(new ArrayList<>(
-        ImmutableList.of(RequestUtils.getLiteralExpression("DAY"), RequestUtils.getIdentifierExpression("ts"))));
+    Expression dateTruncFunctionExpr =
+        RequestUtils.getFunctionExpression("datetrunc", RequestUtils.getLiteralExpression("DAY"),
+            RequestUtils.getIdentifierExpression("ts"));
     Expression timestampIndexColumn = RequestUtils.getIdentifierExpression("$ts$DAY");
     pinotQuery.setExpressionOverrideHints(ImmutableMap.of(dateTruncFunctionExpr, timestampIndexColumn));
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
@@ -79,10 +79,8 @@ public class QueryOptimizerTest {
   }
 
   private static Expression getEqFilterExpression(String column, Object value) {
-    Expression eqFilterExpression = RequestUtils.getFunctionExpression(FilterKind.EQUALS.name());
-    eqFilterExpression.getFunctionCall().setOperands(
-        Arrays.asList(RequestUtils.getIdentifierExpression(column), RequestUtils.getLiteralExpression(value)));
-    return eqFilterExpression;
+    return RequestUtils.getFunctionExpression(FilterKind.EQUALS.name(), RequestUtils.getIdentifierExpression(column),
+        RequestUtils.getLiteralExpression(value));
   }
 
   @Test
@@ -182,10 +180,8 @@ public class QueryOptimizerTest {
   }
 
   private static Expression getRangeFilterExpression(String column, String rangeString) {
-    Expression rangeFilterExpression = RequestUtils.getFunctionExpression(FilterKind.RANGE.name());
-    rangeFilterExpression.getFunctionCall().setOperands(
-        Arrays.asList(RequestUtils.getIdentifierExpression(column), RequestUtils.getLiteralExpression(rangeString)));
-    return rangeFilterExpression;
+    return RequestUtils.getFunctionExpression(FilterKind.RANGE.name(), RequestUtils.getIdentifierExpression(column),
+        RequestUtils.getLiteralExpression(rangeString));
   }
 
   @Test

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.plan.server;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -229,14 +228,13 @@ public class ServerPlanRequestUtils {
     String timeColumn = timeBoundaryInfo.getTimeColumn();
     String timeValue = timeBoundaryInfo.getTimeValue();
     Expression timeFilterExpression = RequestUtils.getFunctionExpression(
-        isOfflineRequest ? FilterKind.LESS_THAN_OR_EQUAL.name() : FilterKind.GREATER_THAN.name());
-    timeFilterExpression.getFunctionCall().setOperands(
-        Arrays.asList(RequestUtils.getIdentifierExpression(timeColumn), RequestUtils.getLiteralExpression(timeValue)));
+        isOfflineRequest ? FilterKind.LESS_THAN_OR_EQUAL.name() : FilterKind.GREATER_THAN.name(),
+        RequestUtils.getIdentifierExpression(timeColumn), RequestUtils.getLiteralExpression(timeValue));
 
     Expression filterExpression = pinotQuery.getFilterExpression();
     if (filterExpression != null) {
-      Expression andFilterExpression = RequestUtils.getFunctionExpression(FilterKind.AND.name());
-      andFilterExpression.getFunctionCall().setOperands(Arrays.asList(filterExpression, timeFilterExpression));
+      Expression andFilterExpression =
+          RequestUtils.getFunctionExpression(FilterKind.AND.name(), filterExpression, timeFilterExpression);
       pinotQuery.setFilterExpression(andFilterExpression);
     } else {
       pinotQuery.setFilterExpression(timeFilterExpression);
@@ -253,21 +251,26 @@ public class ServerPlanRequestUtils {
     List<Expression> expressions = new ArrayList<>();
     for (int i = 0; i < leftJoinKeys.size(); i++) {
       Expression leftExpr = pinotQuery.getSelectList().get(leftJoinKeys.get(i));
-      if (dataContainer.size() == 0) {
+      if (dataContainer.isEmpty()) {
         // put a constant false expression
-        Expression constantFalseExpr = RequestUtils.getLiteralExpression(false);
-        expressions.add(constantFalseExpr);
+        expressions.add(RequestUtils.getLiteralExpression(false));
       } else {
         int rightIdx = rightJoinKeys.get(i);
-        Expression inFilterExpr = RequestUtils.getFunctionExpression(FilterKind.IN.name());
         List<Expression> operands = new ArrayList<>(dataContainer.size() + 1);
         operands.add(leftExpr);
         operands.addAll(computeInOperands(dataContainer, dataSchema, rightIdx));
-        inFilterExpr.getFunctionCall().setOperands(operands);
-        expressions.add(inFilterExpr);
+        expressions.add(RequestUtils.getFunctionExpression(FilterKind.IN.name(), operands));
       }
     }
-    attachFilterExpression(pinotQuery, FilterKind.AND, expressions);
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      expressions.add(filterExpression);
+    }
+    if (expressions.size() > 1) {
+      pinotQuery.setFilterExpression(RequestUtils.getFunctionExpression(FilterKind.AND.name(), expressions));
+    } else {
+      pinotQuery.setFilterExpression(expressions.get(0));
+    }
   }
 
   private static List<Expression> computeInOperands(List<Object[]> dataContainer, DataSchema dataSchema, int colIdx) {
@@ -334,24 +337,5 @@ public class ServerPlanRequestUtils {
         throw new IllegalStateException("Illegal SV data type for ID_SET aggregation function: " + storedType);
     }
     return expressions;
-  }
-
-  /**
-   * Attach Filter Expression to existing PinotQuery.
-   */
-  private static void attachFilterExpression(PinotQuery pinotQuery, FilterKind attachKind, List<Expression> exprs) {
-    Preconditions.checkState(attachKind == FilterKind.AND || attachKind == FilterKind.OR);
-    Expression filterExpression = pinotQuery.getFilterExpression();
-    List<Expression> arrayList = new ArrayList<>(exprs);
-    if (filterExpression != null) {
-      arrayList.add(filterExpression);
-    }
-    if (arrayList.size() > 1) {
-      Expression attachFilterExpression = RequestUtils.getFunctionExpression(attachKind.name());
-      attachFilterExpression.getFunctionCall().setOperands(arrayList);
-      pinotQuery.setFilterExpression(attachFilterExpression);
-    } else {
-      pinotQuery.setFilterExpression(arrayList.get(0));
-    }
   }
 }


### PR DESCRIPTION
Refactor the code to ensure the lists used in `PinotQuery` (thrift object) are all `ArrayList`.
Thrift internally always use `ArrayList`, but we might set it with other list types, such as `Arrays.asList()`, `Collections.singletonList()` etc. The problem with this is that query optimizer assumes the lists are mutable, and might modify the list. Currently query optimizer only replaces elements, which is supported by `Arrays.asList()` but not `Collections.singletonList()`. This PR ensures all lists are `ArrayList` so that it is also future proof.

We detect this issue by using ordinal in ORDER BY along with expression override. Here is the exception:
```
Exception: java.lang.UnsupportedOperationException
        at java.base/java.util.Collections$SingletonList.replaceAll(Collections.java:5194)
        at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleExpressionOverride(BaseBrokerRequestHandler.java:1395)
        at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:562)
        at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:290)
```