### PR TITLE
Upgrade jna to version 5.14.0 for Mac M1/M2 local execution support

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -371,8 +371,8 @@ jakarta.validation:jakarta.validation-api:2.0.2
 javax.inject:javax.inject:1
 javax.validation:validation-api:2.0.1.Final
 joda-time:joda-time:2.12.5
-net.java.dev.jna:jna-platform:5.6.0
-net.java.dev.jna:jna:5.5.0
+net.java.dev.jna:jna-platform:5.14.0
+net.java.dev.jna:jna:5.14.0
 net.minidev:accessors-smart:2.5.0
 net.minidev:json-smart:2.5.0
 net.openhft:chronicle-analytics:2.24ea0

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -67,12 +67,12 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna-platform</artifactId>
-        <version>5.14.0</version>
+        <version>${jna.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.6.0</version>
+        <version>${jna.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -45,12 +45,6 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.12.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.java.dev.jna</groupId>
-          <artifactId>jna-platform</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -45,6 +45,12 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.12.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna-platform</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>
@@ -63,16 +69,6 @@
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>3.6.5</version>
-      </dependency>
-      <dependency>
-        <groupId>net.java.dev.jna</groupId>
-        <artifactId>jna-platform</artifactId>
-        <version>${jna.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.java.dev.jna</groupId>
-        <artifactId>jna</artifactId>
-        <version>${jna.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1459,6 +1459,10 @@
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
     <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
     <bouncycastle.version>1.78</bouncycastle.version>
     <aircompressor.version>0.26</aircompressor.version>
+    <jna.version>5.14.0</jna.version>
   </properties>
 
   <profiles>
@@ -1459,7 +1460,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.7.0</version>
+        <version>${jna.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1459,7 +1459,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.5.0</version>
+        <version>5.7.0</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1460,6 +1460,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna-platform</artifactId>
+        <version>${jna.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
I'm raising this PR to understand the [conversation on Slack](https://apache-pinot.slack.com/archives/C013WKLT5T7/p1714096793342539) regarding the JNA upgrade.

Some tests fail on Mac M1/M2-based chips because of the `jna` loading issue. As per the StackOverflow solutions, `jna 5.7.0` has fixes for the loading issue. I updated the `jna` and got the test cases running locally. 