### PR TITLE
Enhancement: Sketch value aggregator performance

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountCPCSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountCPCSketchStarTreeV2Test.java
@@ -48,7 +48,11 @@ public class DistinctCountCPCSketchStarTreeV2Test extends BaseStarTreeV2Test<Obj
 
   @Override
   void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
-    assertEquals((long) toSketch(starTreeResult).getEstimate(), (long) toSketch(nonStarTreeResult).getEstimate());
+    // Use error at (lgK=12, stddev=2) from:
+    // https://datasketches.apache.org/docs/CPC/CpcPerformance.html
+    double delta = (1 << 12) * 0.01;
+    assertEquals((long) toSketch(starTreeResult).getEstimate(), (long) toSketch(nonStarTreeResult).getEstimate(),
+        delta);
   }
 
   private CpcSketch toSketch(Object value) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountIntegerSumTupleSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountIntegerSumTupleSketchStarTreeV2Test.java
@@ -52,7 +52,10 @@ public class DistinctCountIntegerSumTupleSketchStarTreeV2Test extends BaseStarTr
 
   @Override
   void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
-    assertEquals(toSketch(starTreeResult).getEstimate(), toSketch(nonStarTreeResult).getEstimate());
+    // Use error at (lgK=14, stddev=2) from:
+    // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
+    double delta = (1 << 14) * 0.01563;
+    assertEquals(toSketch(starTreeResult).getEstimate(), toSketch(nonStarTreeResult).getEstimate(), delta);
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.startree.v2;
 
 import java.util.Random;
 import org.apache.datasketches.theta.Sketch;
+import org.apache.datasketches.theta.Union;
 import org.apache.pinot.segment.local.aggregator.DistinctCountThetaSketchValueAggregator;
 import org.apache.pinot.segment.local.aggregator.ValueAggregator;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -27,10 +28,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<Object, Sketch> {
+public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<Object, Object> {
 
   @Override
-  ValueAggregator<Object, Sketch> getValueAggregator() {
+  ValueAggregator<Object, Object> getValueAggregator() {
     return new DistinctCountThetaSketchValueAggregator();
   }
 
@@ -45,7 +46,18 @@ public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<O
   }
 
   @Override
-  void assertAggregatedValue(Sketch starTreeResult, Sketch nonStarTreeResult) {
-    assertEquals(starTreeResult.getEstimate(), nonStarTreeResult.getEstimate());
+  void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
+    assertEquals(toSketch(starTreeResult).getEstimate(), toSketch(nonStarTreeResult).getEstimate());
+  }
+
+  private Sketch toSketch(Object value) {
+    if (value instanceof Union) {
+      return ((Union) value).getResult();
+    } else if (value instanceof Sketch) {
+      return (Sketch) value;
+    } else {
+      throw new IllegalStateException(
+          "Unsupported data type for Theta Sketch aggregation: " + value.getClass().getSimpleName());
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -47,7 +47,10 @@ public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<O
 
   @Override
   void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
-    assertEquals(toSketch(starTreeResult).getEstimate(), toSketch(nonStarTreeResult).getEstimate());
+    // Use error at (lgK=14, stddev=2) from:
+    // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
+    double delta = (1 << 14) * 0.01563;
+    assertEquals(toSketch(starTreeResult).getEstimate(), toSketch(nonStarTreeResult).getEstimate(), delta);
   }
 
   private Sketch toSketch(Object value) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregator.java
@@ -21,8 +21,6 @@ package org.apache.pinot.segment.local.aggregator;
 import java.util.List;
 import org.apache.datasketches.cpc.CpcSketch;
 import org.apache.datasketches.cpc.CpcUnion;
-import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Union;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -18,29 +18,26 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
-import java.util.Arrays;
-import java.util.stream.StreamSupport;
+import org.apache.datasketches.theta.SetOperationBuilder;
 import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
-import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
-public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Sketch> {
+public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Object> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
 
-  private final Union _union;
+  private final SetOperationBuilder _setOperationBuilder;
 
   // This changes a lot similar to the Bitmap aggregator
   private int _maxByteSize;
 
   public DistinctCountThetaSketchValueAggregator() {
-    // TODO: Handle configurable nominal entries for StarTreeBuilder
-    _union = Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
+    _setOperationBuilder =
+        Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES);
   }
 
   @Override
@@ -53,51 +50,49 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
     return AGGREGATED_VALUE_TYPE;
   }
 
-  // Utility method to create a theta sketch with one item in it
-  private Sketch singleItemSketch(Object rawValue) {
-    // TODO: Handle configurable nominal entries for StarTreeBuilder
-    UpdateSketch sketch =
-        Sketches.updateSketchBuilder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
-            .build();
+  private void singleItemUpdate(Union thetaUnion, Object rawValue) {
     if (rawValue instanceof String) {
-      sketch.update((String) rawValue);
+      thetaUnion.update((String) rawValue);
     } else if (rawValue instanceof Integer) {
-      sketch.update((Integer) rawValue);
+      thetaUnion.update((Integer) rawValue);
     } else if (rawValue instanceof Long) {
-      sketch.update((Long) rawValue);
+      thetaUnion.update((Long) rawValue);
     } else if (rawValue instanceof Double) {
-      sketch.update((Double) rawValue);
+      thetaUnion.update((Double) rawValue);
     } else if (rawValue instanceof Float) {
-      sketch.update((Float) rawValue);
+      thetaUnion.update((Float) rawValue);
     } else if (rawValue instanceof Object[]) {
-      addObjectsToSketch((Object[]) rawValue, sketch);
+      multiItemUpdate(thetaUnion, (Object[]) rawValue);
+    } else if (rawValue instanceof Sketch) {
+      thetaUnion.union((Sketch) rawValue);
+    } else if (rawValue instanceof Union) {
+      thetaUnion.union(((Union) rawValue).getResult());
     } else {
       throw new IllegalStateException(
           "Unsupported data type for Theta Sketch aggregation: " + rawValue.getClass().getSimpleName());
     }
-    return sketch.compact();
   }
 
-  private void addObjectsToSketch(Object[] rawValues, UpdateSketch updateSketch) {
+  private void multiItemUpdate(Union thetaUnion, Object[] rawValues) {
     if (rawValues instanceof String[]) {
       for (String s : (String[]) rawValues) {
-        updateSketch.update(s);
+        thetaUnion.update(s);
       }
     } else if (rawValues instanceof Integer[]) {
       for (Integer i : (Integer[]) rawValues) {
-        updateSketch.update(i);
+        thetaUnion.update(i);
       }
     } else if (rawValues instanceof Long[]) {
       for (Long l : (Long[]) rawValues) {
-        updateSketch.update(l);
+        thetaUnion.update(l);
       }
     } else if (rawValues instanceof Double[]) {
       for (Double d : (Double[]) rawValues) {
-        updateSketch.update(d);
+        thetaUnion.update(d);
       }
     } else if (rawValues instanceof Float[]) {
       for (Float f : (Float[]) rawValues) {
-        updateSketch.update(f);
+        thetaUnion.update(f);
       }
     } else {
       throw new IllegalStateException(
@@ -105,59 +100,64 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
     }
   }
 
-  // Utility method to merge two sketches
-  private Sketch union(Sketch left, Sketch right) {
-    return _union.union(left, right);
-  }
-
-  // Utility method to make an empty sketch
-  private Sketch empty() {
-    // TODO: Handle configurable nominal entries for StarTreeBuilder
-    return Sketches.updateSketchBuilder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
-        .build().compact();
-  }
-
   @Override
-  public Sketch getInitialAggregatedValue(Object rawValue) {
-    Sketch initialValue;
+  public Object getInitialAggregatedValue(Object rawValue) {
+    Union thetaUnion = _setOperationBuilder.buildUnion();
     if (rawValue instanceof byte[]) { // Serialized Sketch
       byte[] bytes = (byte[]) rawValue;
-      initialValue = deserializeAggregatedValue(bytes);
-      _maxByteSize = Math.max(_maxByteSize, bytes.length);
+      Sketch sketch = deserializeAggregatedValue(bytes);
+      thetaUnion.union(sketch);
     } else if (rawValue instanceof byte[][]) { // Multiple Serialized Sketches
       byte[][] serializedSketches = (byte[][]) rawValue;
-      initialValue = StreamSupport.stream(Arrays.stream(serializedSketches).spliterator(), false)
-          .map(this::deserializeAggregatedValue).reduce(this::union).orElseGet(this::empty);
-      _maxByteSize = Math.max(_maxByteSize, initialValue.getCurrentBytes());
+      for (byte[] sketchBytes : serializedSketches) {
+        thetaUnion.union(deserializeAggregatedValue(sketchBytes));
+      }
     } else {
-      initialValue = singleItemSketch(rawValue);
-      _maxByteSize = Math.max(_maxByteSize, initialValue.getCurrentBytes());
+      singleItemUpdate(thetaUnion, rawValue);
     }
-    return initialValue;
+    _maxByteSize = Math.max(_maxByteSize, thetaUnion.getCurrentBytes());
+    return thetaUnion;
+  }
+
+  private Union extractUnion(Object value) {
+    if (value == null) {
+      return _setOperationBuilder.buildUnion();
+    } else if (value instanceof Union) {
+      return (Union) value;
+    } else if (value instanceof Sketch) {
+      Sketch sketch = (Sketch) value;
+      Union thetaUnion = _setOperationBuilder.buildUnion();
+      thetaUnion.union(sketch);
+      return thetaUnion;
+    } else {
+      throw new IllegalStateException(
+          "Unsupported data type for Theta Sketch aggregation: " + value.getClass().getSimpleName());
+    }
   }
 
   @Override
-  public Sketch applyRawValue(Sketch value, Object rawValue) {
-    Sketch right;
+  public Object applyRawValue(Object aggregatedValue, Object rawValue) {
+    Union thetaUnion = extractUnion(aggregatedValue);
     if (rawValue instanceof byte[]) {
-      right = deserializeAggregatedValue((byte[]) rawValue);
+      Sketch sketch = deserializeAggregatedValue((byte[]) rawValue);
+      thetaUnion.union(sketch);
     } else {
-      right = singleItemSketch(rawValue);
+      singleItemUpdate(thetaUnion, rawValue);
     }
-    Sketch result = union(value, right).compact();
-    _maxByteSize = Math.max(_maxByteSize, result.getCurrentBytes());
-    return result;
+    _maxByteSize = Math.max(_maxByteSize, thetaUnion.getCurrentBytes());
+    return thetaUnion;
   }
 
   @Override
-  public Sketch applyAggregatedValue(Sketch value, Sketch aggregatedValue) {
-    Sketch result = union(value, aggregatedValue);
-    _maxByteSize = Math.max(_maxByteSize, result.getCurrentBytes());
-    return result;
+  public Object applyAggregatedValue(Object value, Object aggregatedValue) {
+    Union thetaUnion = extractUnion(aggregatedValue);
+    singleItemUpdate(thetaUnion, value);
+    _maxByteSize = Math.max(_maxByteSize, thetaUnion.getCurrentBytes());
+    return thetaUnion;
   }
 
   @Override
-  public Sketch cloneAggregatedValue(Sketch value) {
+  public Object cloneAggregatedValue(Object value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
   }
 
@@ -167,8 +167,15 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
   }
 
   @Override
-  public byte[] serializeAggregatedValue(Sketch value) {
-    return CustomSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(value);
+  public byte[] serializeAggregatedValue(Object value) {
+    if (value instanceof Union) {
+      return CustomSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(((Union) value).getResult());
+    } else if (value instanceof Sketch) {
+      return CustomSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(((Sketch) value));
+    } else {
+      throw new IllegalStateException(
+          "Unsupported data type for Theta Sketch aggregation: " + value.getClass().getSimpleName());
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregatorTest.java
@@ -43,7 +43,8 @@ public class DistinctCountCPCSketchValueAggregatorTest {
     IntStream.range(0, 100).forEach(input::update);
     DistinctCountCPCSketchValueAggregator agg = new DistinctCountCPCSketchValueAggregator(Collections.emptyList());
     byte[] bytes = agg.serializeAggregatedValue(input);
-    assertEquals(Math.round(toSketch(agg.getInitialAggregatedValue(bytes)).getEstimate()), Math.round(input.getEstimate()));
+    assertEquals(Math.round(toSketch(agg.getInitialAggregatedValue(bytes)).getEstimate()),
+        Math.round(input.getEstimate()));
     assertEquals(agg.getMaxAggregatedValueByteSize(), 2580);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -37,7 +37,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
   @Test
   public void initialShouldCreateSingleItemSketch() {
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
-    assertEquals(agg.getInitialAggregatedValue("hello world").getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue("hello world")).getEstimate(), 1.0);
   }
 
   @Test
@@ -47,7 +47,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     Sketch result = input.compact();
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
     byte[] bytes = agg.serializeAggregatedValue(result);
-    assertEquals(agg.getInitialAggregatedValue(bytes).getEstimate(), result.getEstimate());
+    assertEquals(toSketch(agg.getInitialAggregatedValue(bytes)).getEstimate(), result.getEstimate());
 
     // and should update the max size
     assertEquals(agg.getMaxAggregatedValueByteSize(), result.getCurrentBytes());
@@ -61,7 +61,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     input2.update("world");
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
     byte[][] bytes = {agg.serializeAggregatedValue(input1), agg.serializeAggregatedValue(input2)};
-    assertEquals(agg.getInitialAggregatedValue(bytes).getEstimate(), 2.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(bytes)).getEstimate(), 2.0);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     IntStream.range(0, 1000).forEach(input2::update);
     Sketch result2 = input2.compact();
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
-    Sketch result = agg.applyAggregatedValue(result1, result2);
+    Sketch result = toSketch(agg.applyAggregatedValue(result1, result2));
     Union union =
         Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
 
@@ -95,7 +95,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     Sketch result2 = input2.compact();
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
     byte[] result2bytes = agg.serializeAggregatedValue(result2);
-    Sketch result = agg.applyRawValue(result1, result2bytes);
+    Sketch result = toSketch(agg.applyRawValue(result1, result2bytes));
     Union union =
         Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
 
@@ -113,7 +113,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     input1.update("hello".hashCode());
     Sketch result1 = input1.compact();
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
-    Sketch result = agg.applyRawValue(result1, "world");
+    Sketch result = toSketch(agg.applyRawValue(result1, "world"));
 
     assertEquals(result.getEstimate(), 2.0);
 
@@ -129,7 +129,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     Sketch result1 = input1.compact();
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
     String[] strings = {"hello", "world", "this", "is", "some", "strings"};
-    Sketch result = agg.applyRawValue(result1, (Object) strings);
+    Sketch result = toSketch(agg.applyRawValue(result1, (Object) strings));
 
     assertEquals(result.getEstimate(), 6.0);
 
@@ -141,10 +141,10 @@ public class DistinctCountThetaSketchValueAggregatorTest {
   @Test
   public void getInitialValueShouldSupportDifferentTypes() {
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
-    assertEquals(agg.getInitialAggregatedValue(12345).getEstimate(), 1.0);
-    assertEquals(agg.getInitialAggregatedValue(12345L).getEstimate(), 1.0);
-    assertEquals(agg.getInitialAggregatedValue(12.345f).getEstimate(), 1.0);
-    assertEquals(agg.getInitialAggregatedValue(12.345d).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(12345)).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(12345L)).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(12.345f)).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(12.345d)).getEstimate(), 1.0);
     assertThrows(() -> agg.getInitialAggregatedValue(new Object()));
   }
 
@@ -152,17 +152,17 @@ public class DistinctCountThetaSketchValueAggregatorTest {
   public void getInitialValueShouldSupportMultiValueTypes() {
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
     Integer[] ints = {12345};
-    assertEquals(agg.getInitialAggregatedValue(ints).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(ints)).getEstimate(), 1.0);
     Long[] longs = {12345L};
-    assertEquals(agg.getInitialAggregatedValue(longs).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(longs)).getEstimate(), 1.0);
     Float[] floats = {12.345f};
-    assertEquals(agg.getInitialAggregatedValue(floats).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(floats)).getEstimate(), 1.0);
     Double[] doubles = {12.345d};
-    assertEquals(agg.getInitialAggregatedValue(doubles).getEstimate(), 1.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(doubles)).getEstimate(), 1.0);
     Object[] objects = {new Object()};
     assertThrows(() -> agg.getInitialAggregatedValue(objects));
     byte[][] zeroSketches = {};
-    assertEquals(agg.getInitialAggregatedValue(zeroSketches).getEstimate(), 0.0);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(zeroSketches)).getEstimate(), 0.0);
   }
 
   @Test
@@ -172,7 +172,18 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     Sketch unordered = input.compact(false, null);
     Sketch ordered = input.compact(true, null);
     DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
-    assertTrue(agg.cloneAggregatedValue(ordered).isOrdered());
-    assertFalse(agg.cloneAggregatedValue(unordered).isOrdered());
+    assertTrue(toSketch(agg.cloneAggregatedValue(ordered)).isOrdered());
+    assertFalse(toSketch(agg.cloneAggregatedValue(unordered)).isOrdered());
+  }
+
+  private Sketch toSketch(Object value) {
+    if (value instanceof Union) {
+      return ((Union) value).getResult();
+    } else if (value instanceof Sketch) {
+      return (Sketch) value;
+    } else {
+      throw new IllegalStateException(
+          "Unsupported data type for Theta Sketch aggregation: " + value.getClass().getSimpleName());
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
@@ -35,8 +35,6 @@ public class IntegerTupleSketchValueAggregatorTest {
     return is.compact().toByteArray();
   }
 
-  ;
-
   @Test
   public void initialShouldParseASketch() {
     IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
@@ -50,7 +50,7 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyAggregatedValue(s1, s2));
     assertEquals(merged.getEstimate(), 2.0);
-    assertEquals(agg.getMaxAggregatedValueByteSize(), 786456);
+    assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);
   }
 
   @Test
@@ -62,7 +62,7 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyRawValue(s1, agg.serializeAggregatedValue(s2)));
     assertEquals(merged.getEstimate(), 2.0);
-    assertEquals(agg.getMaxAggregatedValueByteSize(), 786456);
+    assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -107,7 +107,9 @@ public class CommonConstants {
     // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
     public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 16384;
 
-    public static final int DEFAULT_TUPLE_SKETCH_LGK = 16;
+    // 2 to the power of 14, for tradeoffs see datasketches library documentation:
+    // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
+    public static final int DEFAULT_TUPLE_SKETCH_LGK = 14;
 
     public static final int DEFAULT_CPC_SKETCH_LGK = 12;
     public static final int DEFAULT_ULTRALOGLOG_P = 12;


### PR DESCRIPTION
This addresses excessive resource consumption and performance problems with the following Apache Datasketches value aggregators:
- Theta
- CPC
- Tuple (Integer)

When merging sketches via union, it is often a costly operation that creates intermediate book-keeping structures.  In addition, the operation performs better when the cost is amortized over many sketch inputs instead of pairwise merges on two sketches at a time.

When tested in a production environment, I measured a median reduction of 10x in the time spent creating StarTrees.

Related to issue:
https://github.com/apache/pinot/issues/13019

`release-notes`
- Signature changes to Theta, Tuple and CPC value aggregators; now use Object as the aggregated value type
