### PR TITLE
Use try-with-resources to close file walk stream in LocalPinotFS

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -32,6 +32,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -112,8 +113,9 @@ public class LocalPinotFS extends BasePinotFS {
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
     } else {
-      return Files.walk(Paths.get(fileUri)).
-          filter(s -> !s.equals(file.toPath())).map(Path::toString).toArray(String[]::new);
+      try (Stream<Path> pathStream = Files.walk(Paths.get(fileUri))) {
+        return pathStream.filter(s -> !s.equals(file.toPath())).map(Path::toString).toArray(String[]::new);
+      }
     }
   }
 
@@ -124,8 +126,10 @@ public class LocalPinotFS extends BasePinotFS {
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> getFileMetadata(new File(file, s))).collect(Collectors.toList());
     } else {
-      return Files.walk(Paths.get(fileUri)).filter(s -> !s.equals(file.toPath())).map(p -> getFileMetadata(p.toFile()))
-          .collect(Collectors.toList());
+      try (Stream<Path> pathStream = Files.walk(Paths.get(fileUri))) {
+        return pathStream.filter(s -> !s.equals(file.toPath())).map(p -> getFileMetadata(p.toFile()))
+            .collect(Collectors.toList());
+      }
     }
   }
 


### PR DESCRIPTION
From the `File::walk` Javadoc:

<img width="918" alt="Screenshot 2024-04-30 at 8 35 13 AM" src="https://github.com/apache/pinot/assets/23502577/676b2873-7c74-4bdd-9e8e-c168a1cfacee">
