### PR TITLE
Add metrics to count joins and window functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -121,7 +121,33 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
 
   PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true),
-  DIRECT_MEMORY_OOM("directMemoryOOMCount", true);
+  DIRECT_MEMORY_OOM("directMemoryOOMCount", true),
+
+  /**
+   * How many queries with joins have been executed.
+   * <p>
+   * For each query with at least one join, this meter is increased exactly once.
+   */
+  QUERIES_WITH_JOINS("queries", true),
+  /**
+   * How many joins have been executed.
+   * <p>
+   * For each query with at least one join, this meter is increased as many times as joins in the query.
+   */
+  JOIN_COUNT("queries", true),
+  /**
+   * How many queries with window functions have been executed.
+   * <p>
+   * For each query with at least one window function, this meter is increased exactly once.
+   */
+  QUERIES_WITH_WINDOW("queries", true),
+  /**
+   * How many window functions have been executed.
+   * <p>
+   * For each query with at least one window function, this meter is increased as many times as window functions in the
+   * query.
+   */
+  WINDOW_COUNT("queries", true),;
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.metrics;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.metrics.NoopPinotMetricsRegistry;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS;
@@ -33,22 +34,21 @@ import static org.apache.pinot.spi.utils.CommonConstants.Broker.DEFAULT_METRICS_
  */
 public class BrokerMetrics extends AbstractMetrics<BrokerQueryPhase, BrokerMeter, BrokerGauge, BrokerTimer> {
 
-  private static final AtomicReference<BrokerMetrics> BROKER_METRICS_INSTANCE = new AtomicReference<>();
+  private static final BrokerMetrics NOOP = new BrokerMetrics(new NoopPinotMetricsRegistry());
+  private static final AtomicReference<BrokerMetrics> BROKER_METRICS_INSTANCE = new AtomicReference<>(NOOP);
 
   /**
    * register the brokerMetrics onto this class, so that we don't need to pass it down as a parameter
    */
   public static boolean register(BrokerMetrics brokerMetrics) {
-    return BROKER_METRICS_INSTANCE.compareAndSet(null, brokerMetrics);
+    return BROKER_METRICS_INSTANCE.compareAndSet(NOOP, brokerMetrics);
   }
 
   /**
    * should always call after registration
    */
   public static BrokerMetrics get() {
-    BrokerMetrics ret = BROKER_METRICS_INSTANCE.get();
-    assert ret != null;
-    return ret;
+    return BROKER_METRICS_INSTANCE.get();
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMetrics.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.metrics;
 
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.metrics.NoopPinotMetricsRegistry;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.DEFAULT_METRICS_PREFIX;
@@ -29,10 +30,11 @@ import static org.apache.pinot.spi.utils.CommonConstants.Controller.DEFAULT_METR
  */
 public class ControllerMetrics
     extends AbstractMetrics<AbstractMetrics.QueryPhase, ControllerMeter, ControllerGauge, ControllerTimer> {
-  private static final AtomicReference<ControllerMetrics> CONTROLLER_METRICS_INSTANCE = new AtomicReference<>();
+  private static final ControllerMetrics NOOP = new ControllerMetrics(new NoopPinotMetricsRegistry());
+  private static final AtomicReference<ControllerMetrics> CONTROLLER_METRICS_INSTANCE = new AtomicReference<>(NOOP);
 
   public static boolean register(ControllerMetrics controllerMetrics) {
-    return CONTROLLER_METRICS_INSTANCE.compareAndSet(null, controllerMetrics);
+    return CONTROLLER_METRICS_INSTANCE.compareAndSet(NOOP, controllerMetrics);
   }
 
   public static ControllerMetrics get() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMetrics.java
@@ -19,15 +19,17 @@
 package org.apache.pinot.common.metrics;
 
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.metrics.NoopPinotMetricsRegistry;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
 public class MinionMetrics extends AbstractMetrics<MinionQueryPhase, MinionMeter, MinionGauge, MinionTimer> {
-  private static final AtomicReference<MinionMetrics> MINION_METRICS_INSTANCE = new AtomicReference<>();
+  private static final MinionMetrics NOOP = new MinionMetrics(new NoopPinotMetricsRegistry());
+  private static final AtomicReference<MinionMetrics> MINION_METRICS_INSTANCE = new AtomicReference<>(NOOP);
 
   public static boolean register(MinionMetrics minionMetrics) {
-    return MINION_METRICS_INSTANCE.compareAndSet(null, minionMetrics);
+    return MINION_METRICS_INSTANCE.compareAndSet(NOOP, minionMetrics);
   }
 
   public static MinionMetrics get() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.metrics.NoopPinotMetricsRegistry;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Server.DEFAULT_ENABLE_TABLE_LEVEL_METRICS;
@@ -34,18 +35,20 @@ import static org.apache.pinot.spi.utils.CommonConstants.Server.DEFAULT_METRICS_
  */
 public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter, ServerGauge, ServerTimer> {
 
-  private static final AtomicReference<ServerMetrics> SERVER_METRICS_INSTANCE = new AtomicReference<>();
+  private static final ServerMetrics NOOP = new ServerMetrics(new NoopPinotMetricsRegistry());
+
+  private static final AtomicReference<ServerMetrics> SERVER_METRICS_INSTANCE = new AtomicReference<>(NOOP);
 
   /**
    * register the serverMetrics onto this class, so that we don't need to pass it down as a parameter
    */
   public static boolean register(ServerMetrics serverMetrics) {
-    return SERVER_METRICS_INSTANCE.compareAndSet(null, serverMetrics);
+    return SERVER_METRICS_INSTANCE.compareAndSet(NOOP, serverMetrics);
   }
 
   @VisibleForTesting
   public static void deregister() {
-    SERVER_METRICS_INSTANCE.set(null);
+    SERVER_METRICS_INSTANCE.set(NOOP);
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -291,7 +291,8 @@ public class QueryEnvironment {
   }
 
   private DispatchableSubPlan toDispatchableSubPlan(RelRoot relRoot, PlannerContext plannerContext, long requestId) {
-    SubPlan plan = PinotLogicalQueryPlanner.makePlan(relRoot);
+    PinotLogicalQueryPlanner logicalQueryPlanner = new PinotLogicalQueryPlanner();
+    SubPlan plan = logicalQueryPlanner.makePlan(relRoot);
     PinotDispatchPlanner pinotDispatchPlanner =
         new PinotDispatchPlanner(plannerContext, _workerManager, requestId, _tableCache);
     return pinotDispatchPlanner.createDispatchableSubPlan(plan);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
@@ -84,7 +84,7 @@ public class PinotLogicalQueryPlanner {
 //    return subPlanMap.get(0);
   }
 
-  private static PlanNode relNodeToPlanNode(RelNode node) {
+  private PlanNode relNodeToPlanNode(RelNode node) {
     PlanNode planNode = RelToPlanNodeConverter.toPlanNode(node, -1);
 
     if (planNode instanceof JoinNode) {
@@ -111,7 +111,7 @@ public class PinotLogicalQueryPlanner {
     return planNode;
   }
 
-  private static PlanFragment planNodeToPlanFragment(PlanNode node) {
+  private PlanFragment planNodeToPlanFragment(PlanNode node) {
     PlanFragmenter fragmenter = new PlanFragmenter();
     PlanFragmenter.Context fragmenterContext = fragmenter.createContext();
     node = node.visit(fragmenter, fragmenterContext);

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -33,8 +33,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.pinot.common.config.provider.TableCache;
-import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TablePartitionInfo.PartitionInfo;
@@ -48,8 +46,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
-
-import static org.mockito.Mockito.mock;
 
 
 public class QueryEnvironmentTestBase {
@@ -109,8 +105,6 @@ public class QueryEnvironmentTestBase {
     // the port doesn't matter as we are not actually making a server call.
     _queryEnvironment =
         getQueryEnvironment(3, 1, 2, TABLE_SCHEMAS, SERVER1_SEGMENTS, SERVER2_SEGMENTS, PARTITIONED_SEGMENTS_MAP);
-    BrokerMetrics.register(mock(BrokerMetrics.class));
-    ServerMetrics.register(mock(ServerMetrics.class));
   }
 
   @DataProvider(name = "testQueryDataProvider")

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -33,6 +33,8 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TablePartitionInfo.PartitionInfo;
@@ -46,6 +48,8 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
+
+import static org.mockito.Mockito.mock;
 
 
 public class QueryEnvironmentTestBase {
@@ -105,6 +109,8 @@ public class QueryEnvironmentTestBase {
     // the port doesn't matter as we are not actually making a server call.
     _queryEnvironment =
         getQueryEnvironment(3, 1, 2, TABLE_SCHEMAS, SERVER1_SEGMENTS, SERVER2_SEGMENTS, PARTITIONED_SEGMENTS_MAP);
+    BrokerMetrics.register(mock(BrokerMetrics.class));
+    ServerMetrics.register(mock(ServerMetrics.class));
   }
 
   @DataProvider(name = "testQueryDataProvider")

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.annotations.metrics;
 
 import java.util.function.Function;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.NoopPinotMetricsRegistry;
 import org.apache.pinot.spi.metrics.PinotGauge;
 import org.apache.pinot.spi.metrics.PinotJmxReporter;
 import org.apache.pinot.spi.metrics.PinotMetricName;
@@ -60,4 +61,37 @@ public interface PinotMetricsFactory {
    * Returns the name of metrics factory.
    */
   String getMetricsFactoryName();
+
+  class Noop implements PinotMetricsFactory {
+    private final NoopPinotMetricsRegistry _registry = new NoopPinotMetricsRegistry();
+    @Override
+    public void init(PinotConfiguration metricsConfiguration) {
+    }
+
+    @Override
+    public PinotMetricsRegistry getPinotMetricsRegistry() {
+      return _registry;
+    }
+
+    @Override
+    public PinotMetricName makePinotMetricName(Class<?> klass, String name) {
+      return () -> "noopMetricName";
+    }
+
+    @Override
+    public <T> PinotGauge<T> makePinotGauge(Function<Void, T> condition) {
+      return _registry.newGauge();
+    }
+
+    @Override
+    public PinotJmxReporter makePinotJmxReporter(PinotMetricsRegistry metricsRegistry) {
+      return () -> {
+      };
+    }
+
+    @Override
+    public String getMetricsFactoryName() {
+      return "noop";
+    }
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/NoopPinotMetricsRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/NoopPinotMetricsRegistry.java
@@ -1,0 +1,228 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.metrics;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+
+public class NoopPinotMetricsRegistry implements PinotMetricsRegistry {
+  @Override
+  public void removeMetric(PinotMetricName name) {
+  }
+
+  public <T> PinotGauge<T> newGauge() {
+    return new PinotGauge<T>() {
+      @Override
+      public T value() {
+        return null;
+      }
+
+      @Override
+      public Object getGauge() {
+        return null;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+
+      @Override
+      public void setValue(T value) {
+      }
+
+      @Override
+      public void setValueSupplier(Supplier<T> valueSupplier) {
+      }
+    };
+  }
+
+  @Override
+  public <T> PinotGauge<T> newGauge(PinotMetricName name, PinotGauge<T> gauge) {
+    return newGauge();
+  }
+
+  @Override
+  public PinotMeter newMeter(PinotMetricName name, String eventType, TimeUnit unit) {
+    return new PinotMeter() {
+      @Override
+      public void mark() {
+      }
+
+      @Override
+      public void mark(long unitCount) {
+      }
+
+      @Override
+      public long count() {
+        return 0;
+      }
+
+      @Override
+      public Object getMetered() {
+        return null;
+      }
+
+      @Override
+      public TimeUnit rateUnit() {
+        return null;
+      }
+
+      @Override
+      public String eventType() {
+        return "";
+      }
+
+      @Override
+      public double fifteenMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public double fiveMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public double meanRate() {
+        return 0;
+      }
+
+      @Override
+      public double oneMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public PinotCounter newCounter(PinotMetricName name) {
+    return new PinotCounter() {
+      @Override
+      public Object getCounter() {
+        return null;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public PinotTimer newTimer(PinotMetricName name, TimeUnit durationUnit, TimeUnit rateUnit) {
+    return new PinotTimer() {
+      @Override
+      public void update(long duration, TimeUnit unit) {
+      }
+
+      @Override
+      public Object getTimer() {
+        return null;
+      }
+
+      @Override
+      public Object getMetered() {
+        return null;
+      }
+
+      @Override
+      public TimeUnit rateUnit() {
+        return null;
+      }
+
+      @Override
+      public String eventType() {
+        return "";
+      }
+
+      @Override
+      public long count() {
+        return 0;
+      }
+
+      @Override
+      public double fifteenMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public double fiveMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public double meanRate() {
+        return 0;
+      }
+
+      @Override
+      public double oneMinuteRate() {
+        return 0;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public PinotHistogram newHistogram(PinotMetricName name, boolean biased) {
+    return new PinotHistogram() {
+      @Override
+      public Object getHistogram() {
+        return null;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public Map<PinotMetricName, PinotMetric> allMetrics() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public void addListener(PinotMetricsRegistryListener listener) {
+  }
+
+  @Override
+  public Object getMetricsRegistry() {
+    return new Object();
+  }
+
+  @Override
+  public void shutdown() {
+  }
+}


### PR DESCRIPTION
This PR adds 4 new metrics:

1. queriesWithJoins (global): How many queries with joins have been executed. For each query with at least one join, this meter is increased exactly once.
2. joinCount (global): How many joins have been executed. For each query with at least one join, this meter is increased as many times as joins in the query.
3. queriesWithWindow (global): How many queries with window functions have been executed. For each query with at least one window function, this meter is increased exactly once.
4. windowCount (global): How many window functions have been executed. For each query with at least one window function, this meter is increased as many times as window functions in the query.