### PR TITLE
Multi stage metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -121,12 +121,43 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   STREAM_DATA_LOSS("streamDataLoss", false),
 
   // Multi-stage
+  /**
+   * Number of times the max number of rows in the hash table has been reached.
+   * It is increased at most one by one each time per stage.
+   * That means that if a stage has 10 workers and all of them reach the limit, this will be increased by 1.
+   * But if a single query has 2 different join operators and each one reaches the limit, this will be increased by 2.
+   */
   HASH_JOIN_TIMES_MAX_ROWS_REACHED("times", true),
+  /**
+   * Number of times the max number of groups has been reached.
+   * It is increased at most one by one each time per stage.
+   * That means that if a stage has 10 workers and all of them reach the limit, this will be increased by 1.
+   * But if a single query has 2 different aggregate operators and each one reaches the limit, this will be increased
+   * by 2.
+   */
   AGGREGATE_TIMES_NUM_GROUPS_LIMIT_REACHED("times", true),
+  /**
+   * The number of blocks that have been sent to the next stage without being serialized.
+   * This is the sum of all blocks sent by all workers in the stage.
+   */
   MULTI_STAGE_IN_MEMORY_MESSAGES("messages", true),
+  /**
+   * The number of blocks that have been sent to the next stage in serialized format.
+   * This is the sum of all blocks sent by all workers in the stage.
+   */
   MULTI_STAGE_RAW_MESSAGES("messages", true),
+  /**
+   * The number of bytes that have been sent to the next stage in serialized format.
+   * This is the sum of all bytes sent by all workers in the stage.
+   */
   MULTI_STAGE_RAW_BYTES("bytes", true),
-  MAX_ROWS_IN_WINDOW_REACHED("times", true),;
+  /**
+   * Number of times the max number of rows in window has been reached.
+   * It is increased at most one by one each time per stage.
+   * That means that if a stage has 10 workers and all of them reach the limit, this will be increased by 1.
+   * But if a single query has 2 different window operators and each one reaches the limit, this will be increased by 2.
+   */
+  WINDOW_TIMES_MAX_ROWS_REACHED("times", true);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -118,7 +118,15 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
   LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
-  STREAM_DATA_LOSS("streamDataLoss", false);
+  STREAM_DATA_LOSS("streamDataLoss", false),
+
+  // Multi-stage
+  HASH_JOIN_TIMES_MAX_ROWS_REACHED("times", true),
+  AGGREGATE_TIMES_NUM_GROUPS_LIMIT_REACHED("times", true),
+  MULTI_STAGE_IN_MEMORY_MESSAGES("messages", true),
+  MULTI_STAGE_RAW_MESSAGES("messages", true),
+  MULTI_STAGE_RAW_BYTES("bytes", true),
+  MAX_ROWS_IN_WINDOW_REACHED("times", true),;
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -54,7 +54,14 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   UPSERT_REMOVE_EXPIRED_PRIMARY_KEYS_TIME_MS("milliseconds", false,
       "Total time taken to delete expired primary keys based on metadataTTL or deletedKeysTTL"),
   GRPC_QUERY_EXECUTION_MS("milliseconds", false, "Total execution time of a successful query over gRPC"),
-  UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot");
+  UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot"),
+
+  // Multi-stage
+  HASH_JOIN_CPU_TIME_BUILDING_HASH_TABLE_MS("millis", true),
+  MULTI_STAGE_SERIALIZATION_CPU_TIME_MS("millis", true),
+  MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS("millis", true),
+  RECEIVE_DOWNSTREAM_CPU_TIME_MS("millis", true),
+  RECEIVE_UPSTREAM_CPU_WAIT_MS("millis", true),;
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -57,11 +57,33 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot"),
 
   // Multi-stage
-  HASH_JOIN_CPU_TIME_BUILDING_HASH_TABLE_MS("millis", true),
+  /**
+   * Time spent building the hash table for the join.
+   * This is the sum of all time spent by all workers in the stage.
+   */
+  HASH_JOIN_BUILD_TABLE_CPU_TIME_MS("millis", true),
+  /**
+   * Time spent serializing blocks into bytes to be sent to the next stage.
+   * This is the sum of all time spent by all workers in the stage.
+   */
   MULTI_STAGE_SERIALIZATION_CPU_TIME_MS("millis", true),
+  /**
+   * Time spent deserializing bytes into blocks to be processed by the stage.
+   * This is the sum of all time spent by all workers in the stage.
+   */
   MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS("millis", true),
-  RECEIVE_DOWNSTREAM_CPU_TIME_MS("millis", true),
-  RECEIVE_UPSTREAM_CPU_WAIT_MS("millis", true),;
+  /**
+   * Time waiting on the receive mailbox for its parent operator to consume the data.
+   * Remember that each stage may have several workers and each one will have a receive mailbox for each worker it is
+   * reading from. This is the sum of all time waiting.
+   */
+  RECEIVE_DOWNSTREAM_WAIT_CPU_TIME_MS("millis", true),
+  /**
+   * Time waiting on the receive mailbox waiting for the child operator to produce the data.
+   * Remember that each stage may have several workers and each one will have a receive mailbox for each worker it is
+   * reading from. This is the sum of all time waiting.
+   */
+  RECEIVE_UPSTREAM_WAIT_CPU_TIME_MS("millis", true);
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -24,6 +24,9 @@ import com.google.common.base.Stopwatch;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -174,6 +177,17 @@ public abstract class MultiStageOperator
         response.mergeNumGroupsLimitReached(stats.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED));
         response.mergeMaxRowsInOperator(stats.getLong(AggregateOperator.StatKey.EMITTED_ROWS));
       }
+
+      @Override
+      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+        super.updateServerMetrics(map, serverMetrics);
+        @SuppressWarnings("unchecked")
+        StatMap<AggregateOperator.StatKey> stats = (StatMap<AggregateOperator.StatKey>) map;
+        boolean limitReached = stats.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED);
+        if (limitReached) {
+          serverMetrics.addMeteredGlobalValue(ServerMeter.AGGREGATE_TIMES_NUM_GROUPS_LIMIT_REACHED, 1);
+        }
+      }
     },
     FILTER(FilterOperator.StatKey.class) {
       @Override
@@ -190,6 +204,19 @@ public abstract class MultiStageOperator
         StatMap<HashJoinOperator.StatKey> stats = (StatMap<HashJoinOperator.StatKey>) map;
         response.mergeMaxRowsInOperator(stats.getLong(HashJoinOperator.StatKey.EMITTED_ROWS));
         response.mergeMaxRowsInJoinReached(stats.getBoolean(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN_REACHED));
+      }
+
+      @Override
+      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+        super.updateServerMetrics(map, serverMetrics);
+        @SuppressWarnings("unchecked")
+        StatMap<HashJoinOperator.StatKey> stats = (StatMap<HashJoinOperator.StatKey>) map;
+        boolean maxRowsInJoinReached = stats.getBoolean(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN_REACHED);
+        if (maxRowsInJoinReached) {
+          serverMetrics.addMeteredGlobalValue(ServerMeter.HASH_JOIN_TIMES_MAX_ROWS_REACHED, 1);
+        }
+        serverMetrics.addTimedValue(ServerTimer.HASH_JOIN_CPU_TIME_BUILDING_HASH_TABLE_MS,
+            stats.getLong(HashJoinOperator.StatKey.TIME_BUILDING_HASH_TABLE_MS), TimeUnit.MILLISECONDS);
       }
     },
     INTERSECT(SetOperator.StatKey.class) {
@@ -228,6 +255,27 @@ public abstract class MultiStageOperator
         StatMap<BaseMailboxReceiveOperator.StatKey> stats = (StatMap<BaseMailboxReceiveOperator.StatKey>) map;
         response.mergeMaxRowsInOperator(stats.getLong(BaseMailboxReceiveOperator.StatKey.EMITTED_ROWS));
       }
+
+      @Override
+      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+        super.updateServerMetrics(map, serverMetrics);
+        @SuppressWarnings("unchecked")
+        StatMap<BaseMailboxReceiveOperator.StatKey> stats = (StatMap<BaseMailboxReceiveOperator.StatKey>) map;
+
+        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_IN_MEMORY_MESSAGES,
+            stats.getInt(BaseMailboxReceiveOperator.StatKey.IN_MEMORY_MESSAGES));
+        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_MESSAGES,
+            stats.getInt(BaseMailboxReceiveOperator.StatKey.RAW_MESSAGES));
+        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_BYTES,
+            stats.getLong(BaseMailboxReceiveOperator.StatKey.DESERIALIZED_BYTES));
+
+        serverMetrics.addTimedValue(ServerTimer.MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS,
+            stats.getLong(BaseMailboxReceiveOperator.StatKey.DESERIALIZATION_TIME_MS), TimeUnit.MILLISECONDS);
+        serverMetrics.addTimedValue(ServerTimer.RECEIVE_DOWNSTREAM_CPU_TIME_MS,
+            stats.getLong(BaseMailboxReceiveOperator.StatKey.DOWNSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
+        serverMetrics.addTimedValue(ServerTimer.RECEIVE_UPSTREAM_CPU_WAIT_MS,
+            stats.getLong(BaseMailboxReceiveOperator.StatKey.UPSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
+      }
     },
     MAILBOX_SEND(MailboxSendOperator.StatKey.class) {
       @Override
@@ -235,6 +283,14 @@ public abstract class MultiStageOperator
         @SuppressWarnings("unchecked")
         StatMap<MailboxSendOperator.StatKey> stats = (StatMap<MailboxSendOperator.StatKey>) map;
         response.mergeMaxRowsInOperator(stats.getLong(MailboxSendOperator.StatKey.EMITTED_ROWS));
+      }
+
+      @Override
+      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+        @SuppressWarnings("unchecked")
+        StatMap<MailboxSendOperator.StatKey> stats = (StatMap<MailboxSendOperator.StatKey>) map;
+        serverMetrics.addTimedValue(ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS,
+            stats.getLong(MailboxSendOperator.StatKey.SERIALIZATION_TIME_MS), TimeUnit.MILLISECONDS);
       }
     },
     MINUS(SetOperator.StatKey.class) {
@@ -286,6 +342,15 @@ public abstract class MultiStageOperator
         response.mergeMaxRowsInWindowReached(
             stats.getBoolean(WindowAggregateOperator.StatKey.MAX_ROWS_IN_WINDOW_REACHED));
       }
+
+      @Override
+      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+        @SuppressWarnings("unchecked")
+        StatMap<WindowAggregateOperator.StatKey> stats = (StatMap<WindowAggregateOperator.StatKey>) map;
+        if (stats.getBoolean(WindowAggregateOperator.StatKey.MAX_ROWS_IN_WINDOW_REACHED)) {
+          serverMetrics.addMeteredGlobalValue(ServerMeter.MAX_ROWS_IN_WINDOW_REACHED, 1);
+        }
+      }
     },;
 
     private final Class _statKeyClass;
@@ -311,5 +376,9 @@ public abstract class MultiStageOperator
      * (compatible with {@link #getStatKeyClass()}). This is a way to avoid casting in the caller.
      */
     public abstract void mergeInto(BrokerResponseNativeV2 response, StatMap<?> map);
+
+    public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+      // Do nothing by default
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -215,7 +215,7 @@ public abstract class MultiStageOperator
         if (maxRowsInJoinReached) {
           serverMetrics.addMeteredGlobalValue(ServerMeter.HASH_JOIN_TIMES_MAX_ROWS_REACHED, 1);
         }
-        serverMetrics.addTimedValue(ServerTimer.HASH_JOIN_CPU_TIME_BUILDING_HASH_TABLE_MS,
+        serverMetrics.addTimedValue(ServerTimer.HASH_JOIN_BUILD_TABLE_CPU_TIME_MS,
             stats.getLong(HashJoinOperator.StatKey.TIME_BUILDING_HASH_TABLE_MS), TimeUnit.MILLISECONDS);
       }
     },
@@ -271,9 +271,9 @@ public abstract class MultiStageOperator
 
         serverMetrics.addTimedValue(ServerTimer.MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.DESERIALIZATION_TIME_MS), TimeUnit.MILLISECONDS);
-        serverMetrics.addTimedValue(ServerTimer.RECEIVE_DOWNSTREAM_CPU_TIME_MS,
+        serverMetrics.addTimedValue(ServerTimer.RECEIVE_DOWNSTREAM_WAIT_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.DOWNSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
-        serverMetrics.addTimedValue(ServerTimer.RECEIVE_UPSTREAM_CPU_WAIT_MS,
+        serverMetrics.addTimedValue(ServerTimer.RECEIVE_UPSTREAM_WAIT_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.UPSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
       }
     },
@@ -348,7 +348,7 @@ public abstract class MultiStageOperator
         @SuppressWarnings("unchecked")
         StatMap<WindowAggregateOperator.StatKey> stats = (StatMap<WindowAggregateOperator.StatKey>) map;
         if (stats.getBoolean(WindowAggregateOperator.StatKey.MAX_ROWS_IN_WINDOW_REACHED)) {
-          serverMetrics.addMeteredGlobalValue(ServerMeter.MAX_ROWS_IN_WINDOW_REACHED, 1);
+          serverMetrics.addMeteredGlobalValue(ServerMeter.WINDOW_TIMES_MAX_ROWS_REACHED, 1);
         }
       }
     },;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
@@ -256,7 +256,7 @@ public class MultiStageQueryStats {
           myStats.merge(otherStatsForStage);
         }
       } catch (IllegalArgumentException | IllegalStateException ex) {
-        LOGGER.warn("Error merging stats on stage " + i + ". Ignoring the new stats", ex);
+        LOGGER.warn("Error merging stats on stage {}. Ignoring the new stats", i, ex);
       }
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
@@ -256,7 +256,7 @@ public class MultiStageQueryStats {
           myStats.merge(otherStatsForStage);
         }
       } catch (IllegalArgumentException | IllegalStateException ex) {
-        LOGGER.warn("Error merging stats on stage {}. Ignoring the new stats", i, ex);
+        LOGGER.warn("Error merging stats on stage " + i + ". Ignoring the new stats", ex);
       }
     }
   }
@@ -284,12 +284,16 @@ public class MultiStageQueryStats {
             myStats.merge(dis);
           }
         } catch (IOException ex) {
-          LOGGER.warn("Error deserializing stats on stage {}. Considering the new stats empty", i, ex);
+          LOGGER.warn("Error deserializing stats on stage " + i + ". Considering the new stats empty", ex);
         } catch (IllegalArgumentException | IllegalStateException ex) {
-          LOGGER.warn("Error merging stats on stage {}. Ignoring the new stats", i, ex);
+          LOGGER.warn("Error merging stats on stage " + i + ". Ignoring the new stats", ex);
         }
       }
     }
+  }
+
+  public List<StageStats.Closed> getClosedStats() {
+    return Collections.unmodifiableList(_closedStats);
   }
 
   public JsonNode asJson() {
@@ -418,6 +422,14 @@ public class MultiStageQueryStats {
       return _operatorStats.size() - 1;
     }
 
+    public void forEach(BiConsumer<MultiStageOperator.Type, StatMap<?>> consumer) {
+      Iterator<MultiStageOperator.Type> typeIterator = _operatorTypes.iterator();
+      Iterator<StatMap<?>> statIterator = _operatorStats.iterator();
+      while (typeIterator.hasNext()) {
+        consumer.accept(typeIterator.next(), statIterator.next());
+      }
+    }
+
     public JsonNode asJson() {
       ArrayNode json = JsonUtils.newArrayNode();
 
@@ -538,14 +550,6 @@ public class MultiStageQueryStats {
       public static Closed deserialize(DataInput input)
           throws IOException {
         return deserialize(input, input.readInt());
-      }
-
-      public void forEach(BiConsumer<MultiStageOperator.Type, StatMap<?>> consumer) {
-        Iterator<MultiStageOperator.Type> typeIterator = _operatorTypes.iterator();
-        Iterator<StatMap<?>> statIterator = _operatorStats.iterator();
-        while (typeIterator.hasNext()) {
-          consumer.accept(typeIterator.next(), statIterator.next());
-        }
       }
     }
 


### PR DESCRIPTION
This PR adds some multi-stage metrics. The whole PR is built on top of https://github.com/apache/pinot/pull/12704 so it should only be merged once (and if) that other PR is merged.

All new metrics are server based. Specifically, they are:
* Meters:
  * HASH_JOIN_TIMES_MAX_ROWS_REACHED (global): How many times the max number of rows per join has been reached. If this happens multiple times in a single query, the meter will be increased as many times as this limit is reached.
  * AGGREGATE_TIMES_NUM_GROUPS_LIMIT_REACHED (global): How many times the max number of groups has been reached. If this happens multiple times in a single query, the meter will be increased as many times as this limit is reached.
  * MAX_ROWS_IN_WINDOW_REACHED (global): How many times the max number of elements in window has been reached. If this happens multiple times in a single query, the meter will be increased as many times as the limit is reached.
  * MULTI_STAGE_IN_MEMORY_MESSAGES (global): How many messages have been sent from one stage to the other without being serialized.  Optimizations like collocated joins can increase this number.
  * MULTI_STAGE_RAW_MESSAGES (global): How many times messages have been sent from one stage to the other in serialized way. Optimizations like collocated joins can reduce this number.
  * MULTI_STAGE_RAW_BYTES (global): How many bytes have been sent from one stage to the other. The smaller this number, the better.

* Timers
  * HASH_JOIN_CPU_TIME_BUILDING_HASH_TABLE_MS (global): The CPU time (in ms) spent building the hash table on each hash join.
  * MULTI_STAGE_SERIALIZATION_CPU_TIME_MS (global): The CPU time (in ms) spent when messages are being serialized from one stage to the other.
  * MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS (global): The CPU time (in ms) spent when messages are being deserialized after being received by other stage.
  * RECEIVE_DOWNSTREAM_CPU_TIME_MS (global): The CPU time (in ms) spent by sender mailboxes waiting the receiver (upstream) to read the messages.
  * RECEIVE_UPSTREAM_CPU_WAIT_MS (global): The CPU time (in ms) spent by receiver mailboxes waiting for new data from the sender (upstream).
