### PR TITLE
log the log rate limiter rate for dropped broker logs

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -98,7 +98,7 @@ public class QueryLogger {
       long numDroppedLogsSinceLastLog = _numDroppedLogs.getAndSet(0);
       if (numDroppedLogsSinceLastLog > 0) {
         _logger.warn("{} logs were dropped. (log max rate per second: {})", numDroppedLogsSinceLastLog,
-            _droppedLogRateLimiter.getRate());
+            _logRateLimiter.getRate());
       }
     }
   }


### PR DESCRIPTION
This is a `bugfix` for broker query dropped logs. The `_droppedLogRateLimiter` rate is hardcoded to 1 so that you only log dropped logs once per second. I imagine we wanted to log the `_logRateLimiter` rate to see what the max logs per second are that we're then dropping after.
