### PR TITLE
bugfix: prevent background merges on the realtime lucene index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -130,6 +131,15 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
       indexWriterConfig.setRAMBufferSizeMB(config.getLuceneMaxBufferSizeMB());
       indexWriterConfig.setCommitOnClose(commit);
       indexWriterConfig.setUseCompoundFile(config.isLuceneUseCompoundFile());
+
+      // For the realtime segment, prevent background merging. The realtime segment will call .commit()
+      // on the IndexWriter when segment conversion occurs. By default, Lucene will sometimes choose to
+      // merge segments in the background, which is problematic because the lucene index directory's
+      // contents is copied to create the immutable segment. If a background merge occurs during this
+      // copy, a FileNotFoundException will be triggered and segment build will fail.
+      if (!_commitOnClose) {
+        indexWriterConfig.setMergeScheduler(NoMergeScheduler.INSTANCE);
+      }
 
       if (_reuseMutableIndex) {
         LOGGER.info("Reusing the realtime lucene index for segment {} and column {}", segmentIndexDir, column);


### PR DESCRIPTION
https://github.com/apache/pinot/pull/12744 changed the Lucene index build process to commit the realtime Lucene index, and reuse it in the immutable segment. 

`.commit()` is called at the beginning of segment conversion, and the Lucene index directory is copied to another location. Since `IndexWriter` can merge segments in the background even without insertions/updates to the index, these merges non-deterministically can trigger a `FileNotFoundException`:

```
java.lang.RuntimeException: Caught exception while instantiating the LuceneTextIndexCreator for column: __mergedTextIndex 
     at org.apache.pinot.segment.local.segment.creator.impl.text.LuceneTextIndexCreator.<init>(LuceneTextIndexCreator.java:149) 
<...>
Caused by: java.lang.RuntimeException: Failed to copy the mutable lucene index: java.io.FileNotFoundException: File system element for parameter 'source' does not exist: '/.../dataDir/table_REALTIME/consumers/table__0__3170__20240430T2313Z/col.lucene.v9.index/_3r.si' 
     at org.apache.pinot.segment.local.segment.creator.impl.text.LuceneTextIndexCreator.convertMutableSegment(LuceneTextIndexCreator.java:192) ...
```

By using `NoMergeScheduler`, the async merges will never occur. This patch was tested in our staging/prod env and the intermittent segment build failures disappeared. 

tag: `bugfix`