### PR TITLE
Use separate action for /tasks/scheduler/jobDetails API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -553,9 +553,9 @@ public class PinotTaskRestletResource {
 
   @GET
   @Path("/tasks/scheduler/jobDetails")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_SCHEDULER_INFO)
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Table.GET_SCHEDULER_JOB_DETAILS)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation("Fetch cron scheduler job keys")
+  @ApiOperation("Fetch job details for table tasks")
   public Map<String, Object> getCronSchedulerJobDetails(
       @ApiParam(value = "Table name (with type suffix)", required = true) @QueryParam("tableName") String tableName,
       @ApiParam(value = "Task type") @QueryParam("taskType") String taskType, @Context HttpHeaders headers)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -553,7 +553,7 @@ public class PinotTaskRestletResource {
 
   @GET
   @Path("/tasks/scheduler/jobDetails")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Table.GET_SCHEDULER_JOB_DETAILS)
+  @Authorize(targetType = TargetType.TABLE, action = Actions.Table.GET_SCHEDULER_JOB_DETAILS)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation("Fetch job details for table tasks")
   public Map<String, Object> getCronSchedulerJobDetails(

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -131,6 +131,7 @@ public class Actions {
     public static final String GET_TABLE_CONFIGS = "GetTableConfigs";
     public static final String GET_TABLE_LEADER = "GetTableLeader";
     public static final String GET_TIME_BOUNDARY = "GetTimeBoundary";
+    public static final String GET_SCHEDULER_JOB_DETAILS = "GetSchedulerJobDetails";
     public static final String PAUSE_CONSUMPTION = "PauseConsumption";
     public static final String QUERY = "Query";
     public static final String REBALANCE_TABLE = "RebalanceTable";


### PR DESCRIPTION
Created new Action `GET_SCHEDULER_JOB_DETAILS ` under the `Table` actions for the endpoint `/tasks/scheduler/jobDetails` as its fetching table level information and the existing action puts this endpoint under `Cluster` actions.


