### PR TITLE
Handle backward compatibility for kafka common package references in KafkaStreamConfig

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConfigBackwardCompatibleUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConfigBackwardCompatibleUtils.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka20;
+
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.stream.StreamConfig;
+
+
+public class KafkaConfigBackwardCompatibleUtils {
+  private KafkaConfigBackwardCompatibleUtils() {
+  }
+
+  public static final String KAFKA_COMMON_PACKAGE_PREFIX = "org.apache.kafka.common";
+  public static final String PINOT_SHADED_PACKAGE_PREFIX = "org.apache.pinot.shaded.";
+
+  /**
+   * Handle the stream config to replace the Kafka common package with the shaded version if needed.
+   */
+  public static void handleStreamConfig(StreamConfig streamConfig) {
+    Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
+    for (Map.Entry<String, String> entry : streamConfigMap.entrySet()) {
+      String[] valueParts = StringUtils.split(entry.getValue(), ' ');
+      boolean updated = false;
+      for (int i = 0; i < valueParts.length; i++) {
+        if (valueParts[i].startsWith(KAFKA_COMMON_PACKAGE_PREFIX)) {
+          try {
+            Class.forName(valueParts[i]);
+          } catch (ClassNotFoundException e1) {
+            // If not, replace the class with the shaded version
+            try {
+              String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + valueParts[i];
+              Class.forName(shadedClassName);
+              valueParts[i] = shadedClassName;
+              updated = true;
+            } catch (ClassNotFoundException e2) {
+              // Do nothing, shaded class is not found as well, keep the original class
+            }
+          }
+        }
+      }
+      if (updated) {
+        entry.setValue(String.join(" ", valueParts));
+      }
+    }
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
@@ -39,6 +39,7 @@ public class KafkaConsumerFactory extends StreamConsumerFactory {
   @Override
   public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
+    KafkaConfigBackwardCompatibleUtils.handleStreamConfig(_streamConfig);
     return new KafkaPartitionLevelConsumer(clientId, _streamConfig,
         partitionGroupConsumptionStatus.getPartitionGroupId());
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelStreamConfigTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelStreamConfigTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.plugin.stream.kafka20;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -50,10 +51,17 @@ public class KafkaPartitionLevelStreamConfigTest {
   private KafkaPartitionLevelStreamConfig getStreamConfig(String topic, String bootstrapHosts, String buffer,
       String socketTimeout, String fetcherSize, String fetcherMinBytes, String isolationLevel,
       String populateRowMetadata) {
+    return new KafkaPartitionLevelStreamConfig(
+        getStreamConfig(topic, bootstrapHosts, buffer, socketTimeout, fetcherSize, fetcherMinBytes, isolationLevel,
+            populateRowMetadata, "tableName_REALTIME"));
+  }
+
+  private StreamConfig getStreamConfig(String topic, String bootstrapHosts, String buffer,
+      String socketTimeout, String fetcherSize, String fetcherMinBytes, String isolationLevel,
+      String populateRowMetadata, String tableNameWithType) {
     Map<String, String> streamConfigMap = new HashMap<>();
     String streamType = "kafka";
     String consumerFactoryClassName = KafkaConsumerFactory.class.getName();
-    String tableNameWithType = "tableName_REALTIME";
     streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
     streamConfigMap.put(
         StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
@@ -81,7 +89,7 @@ public class KafkaPartitionLevelStreamConfigTest {
     if (populateRowMetadata != null) {
       streamConfigMap.put("stream.kafka.metadata.populate", populateRowMetadata);
     }
-    return new KafkaPartitionLevelStreamConfig(new StreamConfig(tableNameWithType, streamConfigMap));
+    return new StreamConfig(tableNameWithType, streamConfigMap);
   }
 
   @Test
@@ -191,5 +199,20 @@ public class KafkaPartitionLevelStreamConfigTest {
 
     config = getStreamConfig("topic", "host1", null, null, null, null, null, "TrUe");
     Assert.assertTrue(config.isPopulateMetadata());
+  }
+
+  @Test
+  public void testBackwardCompatibility() {
+    StreamConfig streamConfig = getStreamConfig("topic", "host1", "100", "200", "300", "400", "read_committed", "true",
+        "myTable_REALTIME");
+    streamConfig.getStreamConfigsMap().put("sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required \n username=\"user\" \n password=\"pwd\";");
+    streamConfig.getStreamConfigsMap().put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.WrongStringDeserializer");
+    KafkaConfigBackwardCompatibleUtils.handleStreamConfig(streamConfig);
+    Assert.assertEquals(streamConfig.getStreamConfigsMap().get("sasl.jaas.config"),
+        "org.apache.kafka.common.security.plain.PlainLoginModule required \n username=\"user\" \n password=\"pwd\";");
+    Assert.assertEquals(streamConfig.getStreamConfigsMap().get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG),
+        "org.apache.kafka.common.serialization.WrongStringDeserializer");
   }
 }


### PR DESCRIPTION
Due to the recent shade plugin change, `org.apache.kafka` package is always relocated to `org.apache.pinot.shaded.org.apache.kafka.common`.

Try to amend any reference in `org.apache.kafka.common` package to `org.apache.pinot.shaded.org.apache.kafka.common` if the referenced class doesn't exist.

E.g. Kafka Stream config: 
`"sasl.jaas.config"`: `"org.apache.kafka.common.security.plain.PlainLoginModule required \n username=\"user\" \n password=\"pwd\";"`
will be replaced to 
`"sasl.jaas.config"`: `"org.apache.pinot.shaded.org.apache.kafka.common.security.plain.PlainLoginModule required \n username=\"user\" \n password=\"pwd\";"`