### PR TITLE
Fix JavaEE related dependencies

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -177,6 +177,8 @@
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-babel</artifactId>
     </dependency>
+
+    <!-- Jersey Libraries -->
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
@@ -206,10 +208,14 @@
       <artifactId>swagger-jersey2-jaxrs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -263,15 +269,6 @@
       <artifactId>jopt-simple</artifactId>
     </dependency>
     <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>swagger-ui</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
@@ -286,11 +283,6 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -340,6 +332,23 @@
     <dependency>
       <groupId>io.github.hakky54</groupId>
       <artifactId>sslcontext-kickstart-for-netty</artifactId>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <profiles>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -95,10 +95,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>swagger-ui</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -90,32 +90,6 @@
       <artifactId>commons-math</artifactId>
     </dependency>
 
-    <!-- Jakarta Libraries -->
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.ws.rs</groupId>
-      <artifactId>jakarta.ws.rs-api</artifactId>
-    </dependency>
-    <!-- Legacy Javax Libraries -->
-    <!-- TODO: Move all usage to jakarta.servlet-api -->
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <!-- TODO: Move all usage to jakarta.ws.rs-api -->
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-    </dependency>
-    <!-- Required by jersey-common -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <snappy-java.version>1.1.10.5</snappy-java.version>
     <zstd-jni.version>1.5.6-3</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
-    <libthrift.verion>0.20.0</libthrift.verion>
+    <libthrift.verion>0.18.1</libthrift.verion>
     <log4j.version>2.23.1</log4j.version>
     <slf4j.version>2.0.13</slf4j.version>
     <netty.version>4.1.109.Final</netty.version>
@@ -201,25 +201,20 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-math.version>2.2</commons-math.version>
 
-    <!-- Jakarta Libraries -->
-    <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
-    <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
-    <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-    <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
-    <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
-    <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-    <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
-    <jakarta.servlet.jsp-api.version>3.1.1</jakarta.servlet.jsp-api.version>
-    <!-- Legacy Javax Libraries -->
+    <!-- Java EE Libraries -->
+    <!-- Include both newer jakarta ones and older javax ones, but not migrate to Jakarta EE yet -->
+    <!-- DO NOT upgrade these versions unless we are migrating to Jakarta EE -->
+    <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-    <javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
+    <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+    <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
+    <javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
+    <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
     <javax.jaxb-api.version>2.3.1</javax.jaxb-api.version>
-    <javax.stax-api.version>1.0-2</javax.stax-api.version>
+    <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
-    <javax.jsr311-api.version>1.1.1</javax.jsr311-api.version>
-    <javax.activation.version>1.1.1</javax.activation.version>
-    <javax.jsp-api.version>2.3.3</javax.jsp-api.version>
+    <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
 
     <!-- HTTP Components Libraries -->
     <httpclient.version>4.5.14</httpclient.version>
@@ -746,21 +741,16 @@
         <version>${commons-math.version}</version>
       </dependency>
 
-      <!-- Jakarta Libraries -->
+      <!-- Java EE Libraries -->
       <dependency>
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
         <version>${jakarta.servlet-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.inject</groupId>
-        <artifactId>jakarta.inject-api</artifactId>
-        <version>${jakarta.inject-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.validation</groupId>
-        <artifactId>jakarta.validation-api</artifactId>
-        <version>${jakarta.validation-api.version}</version>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${javax.servlet-api.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.annotation</groupId>
@@ -768,30 +758,14 @@
         <version>${jakarta.annotation-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.bind</groupId>
-        <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>${jakarta.xml.bind-api.version}</version>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotation-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.ws.rs</groupId>
-        <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>${jakarta.ws.rs-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
-        <version>${jakarta.activation-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.servlet.jsp</groupId>
-        <artifactId>jakarta.servlet.jsp-api</artifactId>
-        <version>${jakarta.servlet.jsp-api.version}</version>
-      </dependency>
-      <!-- Legacy Javax Libraries -->
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${javax.servlet-api.version}</version>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${jakarta.validation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -799,9 +773,9 @@
         <version>${javax.validation-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${javax.annotation-api.version}</version>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>${jakarta.xml.bind-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -809,9 +783,9 @@
         <version>${javax.jaxb-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>stax-api</artifactId>
-        <version>${javax.stax-api.version}</version>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -819,19 +793,9 @@
         <version>${javax.ws.rs-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>jsr311-api</artifactId>
-        <version>${javax.jsr311-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>${javax.activation.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.servlet.jsp</groupId>
-        <artifactId>javax.servlet.jsp-api</artifactId>
-        <version>${javax.jsp-api.version}</version>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>${jakarta.activation-api.version}</version>
       </dependency>
 
       <!-- HTTP Components Libraries -->
@@ -1781,8 +1745,6 @@
                     <excludes>
                       <!-- Use org.slf4j:jcl-over-slf4j -->
                       <exclude>commons-logging:commons-logging</exclude>
-                      <!-- Use org.glassfish.hk2.external:jakarta.inject -->
-                      <exclude>javax.inject:javax.inject</exclude>
                     </excludes>
                   </bannedDependencies>
                 </rules>


### PR DESCRIPTION
#12760 Upgraded jakarta libraries to the latest Jakarta EE (read more [here](https://en.wikipedia.org/wiki/Jakarta_EE)), but all the libraries in Pinot are still following Java EE.

This PR downgraded the library versions to be Java EE compatible:
```
    <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
    <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
    <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
    <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
    <javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
    <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
    <javax.jaxb-api.version>2.3.1</javax.jaxb-api.version>
    <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
    <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
    <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
```

Also downgrade `libthrift` from `0.20.0` to `0.18.1` which is the last version using Java EE