### PR TITLE
SQL compliance: allow INT and FLOAT literal

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -267,7 +267,7 @@ jobs:
       matrix:
         test_suite: [ "compatibility-verifier/sample-test-suite" ]
         old_commit: [
-          "release-0.12.1", "release-1.0.0", "release-1.1.0", "master"
+          "release-1.0.0", "release-1.1.0", "master"
         ]
     name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1486,20 +1486,15 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   private void computeResultsForLiteral(Literal literal, List<String> columnNames,
       List<DataSchema.ColumnDataType> columnTypes, List<Object> row) {
-    Object fieldValue = literal.getFieldValue();
-    columnNames.add(fieldValue.toString());
+    columnNames.add(RequestUtils.prettyPrint(literal));
     switch (literal.getSetField()) {
+      case NULL_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.UNKNOWN);
+        row.add(null);
+        break;
       case BOOL_VALUE:
         columnTypes.add(DataSchema.ColumnDataType.BOOLEAN);
         row.add(literal.getBoolValue());
-        break;
-      case BYTE_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.INT);
-        row.add((int) literal.getByteValue());
-        break;
-      case SHORT_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.INT);
-        row.add((int) literal.getShortValue());
         break;
       case INT_VALUE:
         columnTypes.add(DataSchema.ColumnDataType.INT);
@@ -1529,10 +1524,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         columnTypes.add(DataSchema.ColumnDataType.BYTES);
         row.add(BytesUtils.toHexString(literal.getBinaryValue()));
         break;
-      case NULL_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.UNKNOWN);
-        row.add(null);
-        break;
+      // TODO: Revisit the array handling. Currently we are setting List into the row.
       case INT_ARRAY_VALUE:
         columnTypes.add(DataSchema.ColumnDataType.INT_ARRAY);
         row.add(literal.getIntArrayValue());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -253,7 +253,7 @@ public class TimeSegmentPruner implements SegmentPruner {
         return null;
       case RANGE:
         if (isTimeColumn(operands.get(0))) {
-          return parseInterval(operands.get(1).getLiteral().getFieldValue().toString());
+          return parseInterval(operands.get(1).getLiteral().getStringValue());
         }
         return null;
       default:
@@ -375,7 +375,22 @@ public class TimeSegmentPruner implements SegmentPruner {
   private long toMillisSinceEpoch(Expression expression) {
     Literal literal = expression.getLiteral();
     Preconditions.checkArgument(literal != null, "Literal is required for time column filter, got: %s", expression);
-    return _timeFormatSpec.fromFormatToMillis(literal.getFieldValue().toString());
+    String value;
+    Literal._Fields type = literal.getSetField();
+    switch (type) {
+      case INT_VALUE:
+        value = Integer.toString(literal.getIntValue());
+        break;
+      case LONG_VALUE:
+        value = Long.toString(literal.getLongValue());
+        break;
+      case STRING_VALUE:
+        value = literal.getStringValue();
+        break;
+      default:
+        throw new IllegalStateException("Unsupported literal type: " + type + " as time column filter");
+    }
+    return _timeFormatSpec.fromFormatToMillis(value);
   }
 
   /**

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -197,7 +197,8 @@ public class LiteralOnlyBrokerRequestTest {
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), String.format("%d", randNum));
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
         DataSchema.ColumnDataType.LONG);
-    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(1), ranStr);
+    Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(1),
+        String.format("'%s'", ranStr));
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(1),
         DataSchema.ColumnDataType.STRING);
     Assert.assertEquals(brokerResponse.getResultTable().getRows().size(), 1);

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -69,18 +69,8 @@ public class LiteralContext {
         _value = literal.getIntValue();
         break;
       case LONG_VALUE:
-        // TODO: Remove this special handling after broker uses INT type for integer literals.
-        //       https://github.com/apache/pinot/pull/11751
-//        _type = DataType.LONG;
-//        _value = literal.getLongValue();
-        long longValue = literal.getLongValue();
-        if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
-          _type = DataType.INT;
-          _value = (int) longValue;
-        } else {
-          _type = DataType.LONG;
-          _value = longValue;
-        }
+        _type = DataType.LONG;
+        _value = literal.getLongValue();
         break;
       case FLOAT_VALUE:
         _type = DataType.FLOAT;
@@ -102,6 +92,7 @@ public class LiteralContext {
         _type = DataType.BYTES;
         _value = literal.getBinaryValue();
         break;
+      // TODO: Revisit the type handling and whether we should convert value to primitive array for ARRAY types
       case INT_ARRAY_VALUE:
         _type = DataType.INT;
         _value = literal.getIntArrayValue();
@@ -110,6 +101,7 @@ public class LiteralContext {
         _type = DataType.LONG;
         _value = literal.getLongArrayValue();
         break;
+      // TODO: Revisit the FLOAT_ARRAY handling. Currently the values are stored as int bits.
       case FLOAT_ARRAY_VALUE:
         _type = DataType.FLOAT;
         _value = literal.getFloatArrayValue();
@@ -132,6 +124,7 @@ public class LiteralContext {
     _pinotDataType = getPinotDataType(_type);
   }
 
+  @Nullable
   private static PinotDataType getPinotDataType(DataType type) {
     switch (type) {
       case BOOLEAN:

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.request.context;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,8 +43,6 @@ import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
-import org.apache.pinot.spi.utils.BigDecimalUtils;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
@@ -249,7 +248,7 @@ public class RequestContextUtils {
         float[] vectorValue = getVectorValue(operands.get(1));
         int topK = VectorSimilarityPredicate.DEFAULT_TOP_K;
         if (operands.size() == 3) {
-          topK = (int) operands.get(2).getLiteral().getLongValue();
+          topK = operands.get(2).getLiteral().getIntValue();
         }
         return FilterContext.forPredicate(new VectorSimilarityPredicate(lhs, vectorValue, topK));
       case IS_NULL:
@@ -267,32 +266,7 @@ public class RequestContextUtils {
       throw new BadQueryRequestException(
           "Pinot does not support column or function on the right-hand side of the predicate");
     }
-    switch (literal.getSetField()) {
-      case BOOL_VALUE:
-        return Boolean.toString(literal.getBoolValue());
-      case BYTE_VALUE:
-        return Byte.toString(literal.getByteValue());
-      case SHORT_VALUE:
-        return Short.toString(literal.getShortValue());
-      case INT_VALUE:
-        return Integer.toString(literal.getIntValue());
-      case LONG_VALUE:
-        return Long.toString(literal.getLongValue());
-      case FLOAT_VALUE:
-        return Float.toString(literal.getFloatValue());
-      case DOUBLE_VALUE:
-        return Double.toString(literal.getDoubleValue());
-      case BIG_DECIMAL_VALUE:
-        return BigDecimalUtils.deserialize(literal.getBigDecimalValue()).toPlainString();
-      case STRING_VALUE:
-        return literal.getStringValue();
-      case BINARY_VALUE:
-        return BytesUtils.toHexString(literal.getBinaryValue());
-      case NULL_VALUE:
-        return "null";
-      default:
-        throw new IllegalStateException("Unsupported literal type: " + literal.getSetField());
-    }
+    return RequestUtils.getLiteralString(literal);
   }
 
   /**
@@ -472,46 +446,77 @@ public class RequestContextUtils {
   }
 
   private static float[] getVectorValue(Expression thriftExpression) {
-    if (thriftExpression.getType() == ExpressionType.LITERAL) {
-      Literal literalExpression = thriftExpression.getLiteral();
-      if (literalExpression.isSetIntArrayValue()) {
-        float[] vector = new float[literalExpression.getIntArrayValue().size()];
-        for (int i = 0; i < literalExpression.getIntArrayValue().size(); i++) {
-          vector[i] = literalExpression.getIntArrayValue().get(i).floatValue();
+    Literal literal = thriftExpression.getLiteral();
+    if (literal != null) {
+      Literal._Fields type = literal.getSetField();
+      switch (type) {
+        case INT_ARRAY_VALUE: {
+          List<Integer> values = literal.getIntArrayValue();
+          int numValues = values.size();
+          float[] vector = new float[numValues];
+          for (int i = 0; i < numValues; i++) {
+            vector[i] = values.get(i);
+          }
+          return vector;
         }
-        return vector;
-      }
-      if (literalExpression.isSetLongArrayValue()) {
-        float[] vector = new float[literalExpression.getLongArrayValue().size()];
-        for (int i = 0; i < literalExpression.getLongArrayValue().size(); i++) {
-          vector[i] = literalExpression.getLongArrayValue().get(i).floatValue();
+        case LONG_ARRAY_VALUE: {
+          List<Long> values = literal.getLongArrayValue();
+          int numValues = values.size();
+          float[] vector = new float[numValues];
+          for (int i = 0; i < numValues; i++) {
+            vector[i] = values.get(i);
+          }
+          return vector;
         }
-        return vector;
-      }
-      if (literalExpression.isSetFloatArrayValue()) {
-        float[] vector = new float[literalExpression.getFloatArrayValue().size()];
-        for (int i = 0; i < literalExpression.getFloatArrayValue().size(); i++) {
-          vector[i] = literalExpression.getFloatArrayValue().get(i);
+        case FLOAT_ARRAY_VALUE: {
+          List<Integer> values = literal.getFloatArrayValue();
+          int numValues = values.size();
+          float[] vector = new float[numValues];
+          for (int i = 0; i < numValues; i++) {
+            vector[i] = Float.intBitsToFloat(values.get(i));
+          }
+          return vector;
         }
-        return vector;
-      }
-      if (literalExpression.isSetDoubleArrayValue()) {
-        float[] vector = new float[literalExpression.getDoubleArrayValue().size()];
-        for (int i = 0; i < literalExpression.getDoubleArrayValue().size(); i++) {
-          vector[i] = literalExpression.getDoubleArrayValue().get(i).floatValue();
+        case DOUBLE_ARRAY_VALUE: {
+          List<Double> values = literal.getDoubleArrayValue();
+          int numValues = values.size();
+          float[] vector = new float[numValues];
+          for (int i = 0; i < numValues; i++) {
+            vector[i] = values.get(i).floatValue();
+          }
+          return vector;
         }
-        return vector;
+        default:
+          throw new IllegalStateException("Unsupported literal type: " + type);
       }
     }
-    if (thriftExpression.getType() != ExpressionType.FUNCTION) {
-      throw new BadQueryRequestException(
-          "Pinot does not support column or function on the right-hand side of the predicate");
-    }
-    float[] vector = new float[thriftExpression.getFunctionCall().getOperandsSize()];
-    for (int i = 0; i < thriftExpression.getFunctionCall().getOperandsSize(); i++) {
-      vector[i] = Float.parseFloat(
-          Double.toString(thriftExpression.getFunctionCall().getOperands().get(i).getLiteral().getDoubleValue()));
+    Function function = thriftExpression.getFunctionCall();
+    Preconditions.checkState(function != null,
+        "Unsupported right-hand side expression for vector similarity predicate: %s", thriftExpression);
+    List<Expression> operands = function.getOperands();
+    int numOperands = operands.size();
+    float[] vector = new float[numOperands];
+    for (int i = 0; i < numOperands; i++) {
+      vector[i] = getFloatValue(operands.get(i));
     }
     return vector;
+  }
+
+  private static float getFloatValue(Expression thriftExpression) {
+    Literal literal = thriftExpression.getLiteral();
+    Preconditions.checkState(literal != null, "Expecting literal expression, got: %s", thriftExpression);
+    Literal._Fields type = literal.getSetField();
+    switch (type) {
+      case INT_VALUE:
+        return literal.getIntValue();
+      case LONG_VALUE:
+        return (float) literal.getLongValue();
+      case FLOAT_VALUE:
+        return Float.intBitsToFloat(literal.getFloatValue());
+      case DOUBLE_VALUE:
+        return (float) literal.getDoubleValue();
+      default:
+        throw new IllegalStateException("Unsupported literal type: " + type);
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ClpRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ClpRewriter.java
@@ -426,8 +426,14 @@ public class ClpRewriter implements QueryRewriter {
     // Add any encoded variables
     int numEncodedVars = 0;
     for (long encodedVar : subquery.getEncodedVars()) {
+      Expression literal;
+      if (encodedVar <= Integer.MAX_VALUE && encodedVar >= Integer.MIN_VALUE) {
+        literal = RequestUtils.getLiteralExpression((int) encodedVar);
+      } else {
+        literal = RequestUtils.getLiteralExpression(encodedVar);
+      }
       subqueryFunctionOperands.add(RequestUtils.getFunctionExpression(SqlKind.EQUALS.name(),
-          RequestUtils.getIdentifierExpression(encodedVarsColumnName), RequestUtils.getLiteralExpression(encodedVar)));
+          RequestUtils.getIdentifierExpression(encodedVarsColumnName), literal));
       numEncodedVars++;
     }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
-import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -75,12 +74,7 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
       if (functionInfo != null) {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {
-          Literal literal = function.getOperands().get(i).getLiteral();
-          if (literal.isSetNullValue()) {
-            arguments[i] = null;
-          } else {
-            arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
-          }
+          arguments[i] = RequestUtils.getLiteralValue(function.getOperands().get(i).getLiteral());
         }
         try {
           FunctionInvoker invoker = new FunctionInvoker(functionInfo);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -32,21 +33,22 @@ public class OrdinalsUpdater implements QueryRewriter {
   public PinotQuery rewrite(PinotQuery pinotQuery) {
     // handle GROUP BY clause
     for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
-      final Expression groupByExpr = pinotQuery.getGroupByList().get(i);
-      if (groupByExpr.isSetLiteral() && groupByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) groupByExpr.getLiteral().getLongValue();
+      Expression groupByExpr = pinotQuery.getGroupByList().get(i);
+      Literal literal = groupByExpr.getLiteral();
+      if (literal != null && literal.isSetIntValue()) {
+        int ordinal = literal.getIntValue();
         pinotQuery.getGroupByList().set(i, getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal));
       }
     }
 
     // handle ORDER BY clause
     for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
-      Expression orderByExpr = CalciteSqlParser.removeOrderByFunctions(pinotQuery.getOrderByList().get(i));
-      Boolean isNullsLast = CalciteSqlParser.isNullsLast(pinotQuery.getOrderByList().get(i));
-      if (orderByExpr.isSetLiteral() && orderByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) orderByExpr.getLiteral().getLongValue();
-        Function functionToSet = pinotQuery.getOrderByList().get(i).getFunctionCall();
-        if (isNullsLast != null) {
+      Expression orderByExpr = pinotQuery.getOrderByList().get(i);
+      Literal literal = CalciteSqlParser.removeOrderByFunctions(orderByExpr).getLiteral();
+      if (literal != null && literal.isSetIntValue()) {
+        int ordinal = literal.getIntValue();
+        Function functionToSet = orderByExpr.getFunctionCall();
+        if (CalciteSqlParser.isNullsLast(orderByExpr) != null) {
           functionToSet = functionToSet.getOperands().get(0).getFunctionCall();
         }
         // NOTE: Create an ArrayList because we might need to modify the list later

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -28,7 +28,6 @@ import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -42,18 +41,10 @@ public class RequestUtilsTest {
     assertTrue(nullExpr.getLiteral().getNullValue());
   }
 
-  // please check comments inside RequestUtils.getLiteralExpression() for why we need this test
-  @Test
-  public void testGetLiteralExpressionForObject() {
-    Expression literalExpression = RequestUtils.getLiteralExpression(Float.valueOf(0.06f));
-    assertEquals((literalExpression.getLiteral().getDoubleValue()), 0.06);
-  }
-
   @Test
   public void testGetLiteralExpressionForPrimitiveLong() {
     Expression literalExpression = RequestUtils.getLiteralExpression(4500L);
     assertTrue(literalExpression.getLiteral().isSetLongValue());
-    assertFalse(literalExpression.getLiteral().isSetDoubleValue());
     assertEquals(literalExpression.getLiteral().getLongValue(), 4500L);
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -138,14 +138,14 @@ public class CalciteSqlCompilerTest {
     Function greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
-    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getFieldValue(), "The quantity is greater than 30");
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getIntValue(), 30);
+    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getStringValue(), "The quantity is greater than 30");
     Function equalsFunc = caseFunc.getOperands().get(2).getFunctionCall();
     Assert.assertEquals(equalsFunc.getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(equalsFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(equalsFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
-    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), "The quantity is 30");
-    Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getFieldValue(), "The quantity is under 30");
+    Assert.assertEquals(equalsFunc.getOperands().get(1).getLiteral().getIntValue(), 30);
+    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getStringValue(), "The quantity is 30");
+    Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getStringValue(), "The quantity is under 30");
 
     //@formatter:off
     pinotQuery = compileToPinotQuery(
@@ -169,19 +169,19 @@ public class CalciteSqlCompilerTest {
     greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
-    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getFieldValue(), 3L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getIntValue(), 30);
+    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getIntValue(), 3);
     greatThanFunc = caseFunc.getOperands().get(2).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 20L);
-    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), 2L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getIntValue(), 20);
+    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getIntValue(), 2);
     greatThanFunc = caseFunc.getOperands().get(4).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 10L);
-    Assert.assertEquals(caseFunc.getOperands().get(5).getLiteral().getFieldValue(), 1L);
-    Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getIntValue(), 10);
+    Assert.assertEquals(caseFunc.getOperands().get(5).getLiteral().getIntValue(), 1);
+    Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getIntValue(), 0);
   }
 
   @Test
@@ -307,7 +307,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 100L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 100);
     }
 
     {
@@ -315,7 +315,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
     }
 
     {
@@ -323,7 +323,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 50L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 50);
     }
 
     {
@@ -331,8 +331,8 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 70L);
-      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 70);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getIntValue(), 80);
     }
 
     {
@@ -348,10 +348,10 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
-      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 12);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getIntValue(), 13);
       Assert.assertEquals(func.getOperands().get(3).getLiteral().getDoubleValue(), 15.2);
-      Assert.assertEquals(func.getOperands().get(4).getLiteral().getLongValue(), 17L);
+      Assert.assertEquals(func.getOperands().get(4).getLiteral().getIntValue(), 17);
     }
 
     {
@@ -476,7 +476,7 @@ public class CalciteSqlCompilerTest {
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "b");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery = compileToPinotQuery("select * from vegetables where 0 < a-b");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
@@ -485,7 +485,7 @@ public class CalciteSqlCompilerTest {
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "b");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery = compileToPinotQuery("select * from vegetables where b < 100 + c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
@@ -497,11 +497,11 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getLiteral().getLongValue(), 100L);
+            .getLiteral().getIntValue(), 100L);
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery = compileToPinotQuery("select * from vegetables where b -(100+c)< 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
@@ -512,11 +512,11 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getLiteral().getLongValue(), 100L);
+            .getLiteral().getIntValue(), 100);
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery = compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) <= foo2(bar2(c+d))");
     func = pinotQuery.getFilterExpression().getFunctionCall();
@@ -554,7 +554,7 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "d");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery = compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) - foo2(bar2(c+d)) <= 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
@@ -591,18 +591,18 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "d");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery = compileToPinotQuery("select * from vegetables where c >= 10");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
     pinotQuery = compileToPinotQuery("select * from vegetables where 10 <= c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
   }
 
   @Test
@@ -1038,9 +1038,9 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "numberOfGames");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 10);
+            .getLiteral().getIntValue(), 10);
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 100);
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 100);
 
     pinotQuery = compileToPinotQuery(
         "SELECT count(*) FROM mytable WHERE timeConvert(DaysSinceEpoch,'DAYS','SECONDS') = 1394323200");
@@ -1061,7 +1061,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(2)
             .getLiteral().getStringValue(), "SECONDS");
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
         1394323200);
   }
 
@@ -1151,7 +1151,7 @@ public class CalciteSqlCompilerTest {
     final Expression filter = pinotQuery.getFilterExpression();
     Assert.assertEquals(filter.getFunctionCall().getOperator(), "GREATER_THAN");
     Assert.assertEquals(filter.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c3");
-    Assert.assertEquals(filter.getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 100);
+    Assert.assertEquals(filter.getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 100);
 
     c1 = distinctFunction.getOperands().get(0).getIdentifier();
     c2 = distinctFunction.getOperands().get(1).getIdentifier();
@@ -1478,14 +1478,14 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "daysSinceEpoch");
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 18523);
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 18523);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "divide");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "secondsSinceEpoch");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 86400);
+        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 86400);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
 
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).
@@ -1552,7 +1552,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1);
+        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 1);
   }
 
   @Test
@@ -1563,12 +1563,12 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
+        pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5);
+        pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
@@ -1578,9 +1578,9 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "d");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 5);
+            .getLiteral().getIntValue(), 5);
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
+        pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
 
     pinotQuery = compileToPinotQuery("select a % 200 + b * 5  from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -1593,7 +1593,7 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 200);
+            .getLiteral().getIntValue(), 200);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
         "times");
@@ -1602,7 +1602,7 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "b");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 5);
+            .getLiteral().getIntValue(), 5);
   }
 
   /**
@@ -1749,19 +1749,20 @@ public class CalciteSqlCompilerTest {
   public void testCastTransformation() {
     PinotQuery pinotQuery = compileToPinotQuery("select CAST(25.65 AS int) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 25);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getIntValue(), 25);
 
     pinotQuery = compileToPinotQuery("SELECT CAST('20170825' AS LONG) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 20170825);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 20170825L);
 
     pinotQuery = compileToPinotQuery("SELECT CAST(20170825.0 AS Float) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals((float) pinotQuery.getSelectList().get(0).getLiteral().getDoubleValue(), 20170825.0F);
+    Assert.assertEquals(Float.intBitsToFloat(pinotQuery.getSelectList().get(0).getLiteral().getFloatValue()),
+        20170825.0f);
 
     pinotQuery = compileToPinotQuery("SELECT CAST(20170825.0 AS dOuble) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals((float) pinotQuery.getSelectList().get(0).getLiteral().getDoubleValue(), 20170825.0F);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getDoubleValue(), 20170825.0);
 
     pinotQuery = compileToPinotQuery("SELECT CAST(column1 AS STRING) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -2033,7 +2034,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2L);
+        pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
     Assert.assertEquals(pinotQuery.getGroupByList().get(2).getFunctionCall().getOperator(), "arraysum");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
@@ -2397,7 +2398,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(),
+    Assert.assertEquals(expression.getLiteral().getStringValue(),
         "key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
 
     expression = compileToExpression("decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')");
@@ -2406,7 +2407,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "key1=value 1&key2=value@!$2&key3=value%3");
+    Assert.assertEquals(expression.getLiteral().getStringValue(), "key1=value 1&key2=value@!$2&key3=value%3");
 
     expression = compileToExpression("reverse(playerName)");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2423,7 +2424,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "emaNreyalp");
+    Assert.assertEquals(expression.getLiteral().getStringValue(), "emaNreyalp");
 
     expression = compileToExpression("reverse(123)");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2431,7 +2432,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "321");
+    Assert.assertEquals(expression.getLiteral().getStringValue(), "321");
 
     expression = compileToExpression("count(*)");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2448,7 +2449,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "aGVsbG8h");
+    Assert.assertEquals(expression.getLiteral().getStringValue(), "aGVsbG8h");
 
     expression = compileToExpression("fromUtf8(fromBase64('aGVsbG8h'))");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2456,7 +2457,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(), "hello!");
+    Assert.assertEquals(expression.getLiteral().getStringValue(), "hello!");
 
     expression = compileToExpression("fromBase64(foo)");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2568,7 +2569,7 @@ public class CalciteSqlCompilerTest {
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
+            .getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 5);
 
     query = "SELECT col1+col2*5 AS col3 FROM foo GROUP BY col3";
     pinotQuery = compileToPinotQuery(query);
@@ -2594,8 +2595,8 @@ public class CalciteSqlCompilerTest {
         "col2");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
-        5L);
+            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
+        5);
   }
 
   @Test
@@ -2723,7 +2724,7 @@ public class CalciteSqlCompilerTest {
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), "sum");
-      Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "10");
+      Assert.assertEquals(operands.get(1).getLiteral().getIntValue(), 10);
     }
     {
       String query = "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 "
@@ -2779,7 +2780,7 @@ public class CalciteSqlCompilerTest {
       Assert.assertEquals(functionCall.getOperator(), FilterKind.GREATER_THAN.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
-      Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "0");
+      Assert.assertEquals(operands.get(1).getLiteral().getIntValue(), 0);
       functionCall = operands.get(0).getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), "minus");
       operands = functionCall.getOperands();
@@ -2837,16 +2838,15 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1L);
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 1);
   }
 
   /**
-   * This test shows that Calcite {@link SqlNumericLiteral#isInteger()} throws NPE. The issue has been fixed in
-   * Calcite through CALCITE-4199 (https://issues.apache.org/jira/browse/CALCITE-4199), but has not made it into a
-   * release yet.
+   * This test ensures that Calcite {@link SqlNumericLiteral#isInteger()} does not throw NPE. The issue has been fixed
+   * in Calcite through CALCITE-4199 (https://issues.apache.org/jira/browse/CALCITE-4199).
    */
   @Test
-  public void testSqlNumericalLiteralisIntegerNPE() {
+  public void testSqlNumericalLiteralIntegerNPE() {
     CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE floatColumn > " + Double.MAX_VALUE);
   }
 
@@ -3047,8 +3047,8 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "ts");
-    Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
-        123L);
+    Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
+        123);
     Assert.assertEquals(fun.getOperands().get(1).getLiteral().getStringValue(), "pst");
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/IdenticalPredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/IdenticalPredicateFilterOptimizer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.sql.FilterKind;
 
@@ -97,10 +98,7 @@ public class IdenticalPredicateFilterOptimizer extends BaseAndOrBooleanFilterOpt
   }
 
   private boolean isLiteralZero(Expression expression) {
-    if (!expression.isSetLiteral()) {
-      return false;
-    }
-    Object literalValue = expression.getLiteral().getFieldValue();
-    return literalValue.equals(0) || literalValue.equals(0L) || literalValue.equals(0d);
+    Literal literal = expression.getLiteral();
+    return literal != null && literal.isSetIntValue() && literal.getIntValue() == 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
@@ -146,7 +146,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
    */
   @SuppressWarnings("rawtypes")
   private static Comparable getComparable(Expression literalExpression, DataType dataType) {
-    return dataType.convertInternal(literalExpression.getLiteral().getFieldValue().toString());
+    return dataType.convertInternal(RequestUtils.getLiteralString(literalExpression));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -116,10 +116,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
     boolean result = kind == FilterKind.NOT_EQUALS;
 
     switch (rhs.getLiteral().getSetField()) {
-      case SHORT_VALUE:
       case INT_VALUE:
-        // No rewrites needed since SHORT and INT conversion to numeric column types (INT, LONG, FLOAT, and DOUBLE) is
-        // lossless and will be implicitly handled on the server side.
+        // No rewrites needed since INT conversion to numeric column types can be handled on the server side.
         break;
       case LONG_VALUE: {
         long actual = rhs.getLiteral().getLongValue();
@@ -162,6 +160,11 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
         }
         break;
       }
+      case FLOAT_VALUE: {
+        float actual = Float.intBitsToFloat(rhs.getLiteral().getFloatValue());
+        System.out.println(actual);
+        break;
+      }
       case DOUBLE_VALUE: {
         double actual = rhs.getLiteral().getDoubleValue();
         switch (dataType) {
@@ -190,8 +193,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
           default:
             break;
         }
+        break;
       }
-      break;
       default:
         break;
     }
@@ -205,10 +208,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
   private static Expression rewriteRangeExpression(Expression range, FilterKind kind, DataType dataType,
       Expression rhs) {
     switch (rhs.getLiteral().getSetField()) {
-      case SHORT_VALUE:
       case INT_VALUE:
-        // No rewrites needed since SHORT and INT conversion to numeric column types (INT, LONG, FLOAT, and DOUBLE) is
-        // lossless and will be implicitly handled on the server side.
+        // No rewrites needed since INT conversion to numeric column types can be handled on the server side.
         break;
       case LONG_VALUE: {
         long actual = rhs.getLiteral().getLongValue();
@@ -268,6 +269,11 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
           default:
             break;
         }
+        break;
+      }
+      case FLOAT_VALUE: {
+        float actual = Float.intBitsToFloat(rhs.getLiteral().getFloatValue());
+        System.out.println(actual);
         break;
       }
       case DOUBLE_VALUE: {
@@ -332,8 +338,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
           default:
             break;
         }
+        break;
       }
-      break;
       default:
         break;
     }
@@ -406,9 +412,9 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
     if (expression.getType() == ExpressionType.LITERAL) {
       Literal._Fields type = expression.getLiteral().getSetField();
       switch (type) {
-        case SHORT_VALUE:
         case INT_VALUE:
         case LONG_VALUE:
+        case FLOAT_VALUE:
         case DOUBLE_VALUE:
           return true;
         default:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
@@ -73,8 +73,8 @@ public class QueryOptimizerTest {
     assertEquals(secondChildFunction.getOperator(), FilterKind.AND.name());
     List<Expression> secondChildChildren = secondChildFunction.getOperands();
     assertEquals(secondChildChildren.size(), 3);
-    assertEquals(secondChildChildren.get(0), getEqFilterExpression("long", 5L));
-    assertEquals(secondChildChildren.get(1), getEqFilterExpression("float", 9f));
+    assertEquals(secondChildChildren.get(0), getEqFilterExpression("long", 5));
+    assertEquals(secondChildChildren.get(1), getEqFilterExpression("float", 9));
     assertEquals(secondChildChildren.get(2), getEqFilterExpression("double", 7.5));
   }
 
@@ -95,7 +95,7 @@ public class QueryOptimizerTest {
     List<Expression> children = filterFunction.getOperands();
     assertEquals(children.size(), 3);
     assertEquals(children.get(0), getEqFilterExpression("int", 1));
-    checkInFilterFunction(children.get(1).getFunctionCall(), "long", Arrays.asList(2L, 3L, 4L));
+    checkInFilterFunction(children.get(1).getFunctionCall(), "long", Arrays.asList(2, 3, 4));
 
     Function thirdChildFunction = children.get(2).getFunctionCall();
     assertEquals(thirdChildFunction.getOperator(), FilterKind.OR.name());
@@ -152,7 +152,7 @@ public class QueryOptimizerTest {
     assertEquals(secondChildFunction.getOperator(), FilterKind.AND.name());
     List<Expression> secondChildChildren = secondChildFunction.getOperands();
     assertEquals(secondChildChildren.size(), 2);
-    assertEquals(secondChildChildren.get(0), getEqFilterExpression("float", 6f));
+    assertEquals(secondChildChildren.get(0), getEqFilterExpression("float", 6));
     assertEquals(secondChildChildren.get(1), getRangeFilterExpression("float", "[6.0\0006.5)"));
 
     // Range filter on multi-value column should not be merged ([-5, 10] can match this filter)
@@ -387,16 +387,16 @@ public class QueryOptimizerTest {
   private static String getRangeString(FilterKind filterKind, List<Expression> operands) {
     switch (filterKind) {
       case GREATER_THAN:
-        return Range.LOWER_EXCLUSIVE + operands.get(1).getLiteral().getFieldValue().toString() + Range.UPPER_UNBOUNDED;
+        return Range.LOWER_EXCLUSIVE + RequestUtils.getLiteralString(operands.get(1)) + Range.UPPER_UNBOUNDED;
       case GREATER_THAN_OR_EQUAL:
-        return Range.LOWER_INCLUSIVE + operands.get(1).getLiteral().getFieldValue().toString() + Range.UPPER_UNBOUNDED;
+        return Range.LOWER_INCLUSIVE + RequestUtils.getLiteralString(operands.get(1)) + Range.UPPER_UNBOUNDED;
       case LESS_THAN:
-        return Range.LOWER_UNBOUNDED + operands.get(1).getLiteral().getFieldValue().toString() + Range.UPPER_EXCLUSIVE;
+        return Range.LOWER_UNBOUNDED + RequestUtils.getLiteralString(operands.get(1)) + Range.UPPER_EXCLUSIVE;
       case LESS_THAN_OR_EQUAL:
-        return Range.LOWER_UNBOUNDED + operands.get(1).getLiteral().getFieldValue().toString() + Range.UPPER_INCLUSIVE;
+        return Range.LOWER_UNBOUNDED + RequestUtils.getLiteralString(operands.get(1)) + Range.UPPER_INCLUSIVE;
       case BETWEEN:
-        return Range.LOWER_INCLUSIVE + operands.get(1).getLiteral().getFieldValue().toString() + Range.DELIMITER
-            + operands.get(2).getLiteral().getFieldValue().toString() + Range.UPPER_INCLUSIVE;
+        return Range.LOWER_INCLUSIVE + RequestUtils.getLiteralString(operands.get(1)) + Range.DELIMITER
+            + RequestUtils.getLiteralString(operands.get(2)) + Range.UPPER_INCLUSIVE;
       case RANGE:
         return operands.get(1).getLiteral().getStringValue();
       default:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
@@ -94,45 +94,45 @@ public class NumericalFilterOptimizerTest {
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn != 5.5"),
         "Expression(type:LITERAL, literal:<Literal boolValue:true>)");
 
-    // Test float column equals valid long value.
+    // Test float column equals valid int value.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn = 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
+            + "]))");
+
+    // Test float column not equals valid int value
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn != 5"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
 
     // Test float column equals invalid long value.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn = " + String.valueOf(Long.MAX_VALUE)),
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn = " + Long.MAX_VALUE),
         "Expression(type:LITERAL, literal:<Literal boolValue:false>)");
 
-    // Test float column not equals valid long value
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn != " + String.valueOf(Long.MAX_VALUE)),
+    // Test float column not equals invalid long value
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn != " + Long.MAX_VALUE),
         "Expression(type:LITERAL, literal:<Literal boolValue:true>)");
 
-    // Test float column not equals valid long value
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn != 5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
-            + "]))");
-
-    // test double column equals valid long value.
+    // test double column equals valid int value.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn = 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
+            + "]))");
+
+    // Test double column not equals valid int value.
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn != 5"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
+            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
 
     // Test double column equals invalid long value.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn = " + String.valueOf(Long.MAX_VALUE)),
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn = " + Long.MAX_VALUE),
         "Expression(type:LITERAL, literal:<Literal boolValue:false>)");
 
-    // Test double column not equals valid long value
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn != " + String.valueOf(Long.MAX_VALUE)),
+    // Test double column not equals invalid long value
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn != " + Long.MAX_VALUE),
         "Expression(type:LITERAL, literal:<Literal boolValue:true>)");
-
-    // Test double column not equals invalid long value.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn != 5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
-            + "]))");
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1188,7 +1188,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(columnNames.get(0).asText(), "1");
     assertEquals(columnNames.get(1).asText(), "currentTs");
     assertEquals(columnNames.get(2).asText(), "oneHourAgoTs");
-    assertEquals(columnNames.get(3).asText(), "abc");
+    assertEquals(columnNames.get(3).asText(), "'abc'");
     assertEquals(columnNames.get(4).asText(), "today");
     String nowColumnName = columnNames.get(5).asText();
     String oneHourAgoColumnName = columnNames.get(6).asText();
@@ -1198,7 +1198,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(columnNames.get(10).asText(), "fromBase64");
 
     JsonNode columnDataTypes = dataSchema.get("columnDataTypes");
-    assertEquals(columnDataTypes.get(0).asText(), "LONG");
+    assertEquals(columnDataTypes.get(0).asText(), "INT");
     assertEquals(columnDataTypes.get(1).asText(), "LONG");
     assertEquals(columnDataTypes.get(2).asText(), "LONG");
     assertEquals(columnDataTypes.get(3).asText(), "STRING");

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -198,19 +198,13 @@ public class CalciteRexExpressionParser {
 
   /**
    * Copy and modify from {@link RequestUtils#getLiteralExpression(Object)}.
-   *
+   * TODO: Revisit whether we should use internal value type (e.g. 0/1 for BOOLEAN, ByteArray for BYTES) here.
    */
   private static Expression compileLiteralExpression(Object object) {
     if (object instanceof ByteArray) {
-      return getLiteralExpression((ByteArray) object);
+      return RequestUtils.getLiteralExpression(((ByteArray) object).getBytes());
     }
     return RequestUtils.getLiteralExpression(object);
-  }
-
-  private static Expression getLiteralExpression(ByteArray object) {
-    Expression expression = RequestUtils.createNewLiteralExpression();
-    expression.getLiteral().setBinaryValue(object.getBytes());
-    return expression;
   }
 
   private static Expression inputRefToIdentifier(RexExpression.InputRef inputRef, PinotQuery pinotQuery) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -85,7 +85,7 @@ public class RelToPlanNodeConverterTest {
 
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DECIMAL, 14, 10)),
-        DataSchema.ColumnDataType.FLOAT);
+        DataSchema.ColumnDataType.DOUBLE);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DECIMAL, 30, 10)),
         DataSchema.ColumnDataType.DOUBLE);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -306,11 +306,7 @@ public class ServerPlanRequestUtils {
         }
         Arrays.sort(arrFloat);
         for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
-          // TODO: Create float literal when it is supported
-          // NOTE: We cannot directly cast float to double here because we want to preserve the exact value. E.g. 0.05f
-          //       will be casted to 0.05000000074505806. Predicate evaluation uses string format to match the values,
-          //       so here we need to create the double value based on the string format of the float value.
-          expressions.add(RequestUtils.getLiteralExpression(Double.parseDouble(Float.toString(arrFloat[rowIdx]))));
+          expressions.add(RequestUtils.getLiteralExpression(arrFloat[rowIdx]));
         }
         break;
       case DOUBLE:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -313,6 +313,19 @@ public class DateTimeFormatSpec {
     }
   }
 
+  public long fromFormatToMillis(long dateTimeValue) {
+    switch (_patternSpec.getTimeFormat()) {
+      case EPOCH:
+        return TimeUnit.MILLISECONDS.convert(dateTimeValue * _size, _unitSpec.getTimeUnit());
+      case TIMESTAMP:
+        return dateTimeValue;
+      case SIMPLE_DATE_FORMAT:
+        return _patternSpec.getDateTimeFormatter().parseMillis(Long.toString(dateTimeValue));
+      default:
+        throw new IllegalStateException("Unsupported time format: " + _patternSpec.getTimeFormat());
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
In #11763 we have added support to server to support both INT and FLOAT literal.
After one release (release 1.1), now we can move forward to send INT and FLOAT from broker side.

This PR also contains type related fixes and cleanups:
- Fix broker FLOAT/BYTES handling by not allowing using `Literal.getFieldValue()` because the field stored in thrift doesn't always reflect the actual Pinot value. Replaced with newly introduced helper functions in `RequestUtils`
- Cleanup unused BYTE/SHORT literal handling

## Backward Incompatible
This PR can cause incompatibility for the new added `VECTOR_SIMILARITY` function during upgrade. But since this feature is newly added and not in production, we won't wait another release to fix it