### PR TITLE
Filter Reorder Optimization when the child operator is AND or OR

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriter.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+public class FilterOperatorRewriter {
+
+    private FilterOperatorRewriter() {
+    }
+
+    /**
+     * The function should be invoked after FilterPlanNode#constructPhysicalOperator to reorder the filter operators
+     * @param op
+     * @return priority of the operator
+     */
+    public static int reorder(QueryContext qc, BaseFilterOperator op) {
+        if (op instanceof EmptyFilterOperator || op instanceof MatchAllFilterOperator) {
+            throw new RuntimeException("Not expected to encounter empty or matchAll operators");
+        }
+        if (op instanceof AndFilterOperator) {
+            List<? extends Operator> kids = op.getChildOperators();
+            int len = kids.size();
+            // an array of (priority of child ops, the position of child ops)
+            int[][] priorities = new int[len][2];
+            int maxPriority = Integer.MIN_VALUE;
+            for (int i = 0; i < len; i++) {
+                BaseFilterOperator child = (BaseFilterOperator) kids.get(i);
+                priorities[i][0] = reorder(qc, child);
+                priorities[i][1] = i;
+                maxPriority = Math.max(maxPriority, priorities[i][0]);
+            }
+            Arrays.sort(priorities, Comparator.comparingInt(a -> a[0]));
+            Map<Operator, Integer> priorityMap = new HashMap<>();
+            for (int i = 0; i < len; i++) {
+                priorityMap.put(kids.get(priorities[i][1]), priorities[i][0]);
+            }
+            kids.sort(Comparator.comparingInt(priorityMap::get));
+            return maxPriority;
+        }
+        if (op instanceof OrFilterOperator) {
+            return op.getChildOperators().stream().map(child -> reorder(qc, (BaseFilterOperator) child))
+                    .max(Integer::compareTo).orElseThrow();
+        }
+        if (op instanceof NotFilterOperator) {
+            return reorder(qc, ((NotFilterOperator) op).getChildFilterOperator());
+        }
+        return getNonLogicalOperatorPriority(qc, op);
+    }
+
+    public static int getNonLogicalOperatorPriority(QueryContext queryContext, BaseFilterOperator op) {
+        if (op instanceof SortedIndexBasedFilterOperator) {
+            return PrioritizedFilterOperator.HIGH_PRIORITY;
+        }
+        if (op instanceof BitmapBasedFilterOperator) {
+            return PrioritizedFilterOperator.MEDIUM_PRIORITY;
+        }
+        if (op instanceof RangeIndexBasedFilterOperator
+                || op instanceof TextContainsFilterOperator
+                || op instanceof TextMatchFilterOperator || op instanceof JsonMatchFilterOperator
+                || op instanceof H3IndexFilterOperator
+                || op instanceof H3InclusionIndexFilterOperator) {
+            return PrioritizedFilterOperator.LOW_PRIORITY;
+        }
+        if (op instanceof ScanBasedFilterOperator) {
+            int basePriority = PrioritizedFilterOperator.SCAN_PRIORITY;
+            if (queryContext.isSkipScanFilterReorder()) {
+                return basePriority;
+            }
+
+            if (((ScanBasedFilterOperator) op).getDataSourceMetadata().isSingleValue()) {
+                return basePriority;
+            } else {
+                // Lower priority for multi-value column
+                return basePriority + 50;
+            }
+        }
+        if (op instanceof ExpressionFilterOperator) {
+            return PrioritizedFilterOperator.EXPRESSION_PRIORITY;
+        }
+        return PrioritizedFilterOperator.UNKNOWN_FILTER_PRIORITY;
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -216,19 +216,6 @@ public class FilterOperatorUtils {
               return priority.getAsInt();
             }
           }
-          if (filterOperator instanceof SortedIndexBasedFilterOperator) {
-            return PrioritizedFilterOperator.HIGH_PRIORITY;
-          }
-          if (filterOperator instanceof BitmapBasedFilterOperator) {
-            return PrioritizedFilterOperator.MEDIUM_PRIORITY;
-          }
-          if (filterOperator instanceof RangeIndexBasedFilterOperator
-              || filterOperator instanceof TextContainsFilterOperator
-              || filterOperator instanceof TextMatchFilterOperator || filterOperator instanceof JsonMatchFilterOperator
-              || filterOperator instanceof H3IndexFilterOperator
-              || filterOperator instanceof H3InclusionIndexFilterOperator) {
-            return PrioritizedFilterOperator.LOW_PRIORITY;
-          }
           if (filterOperator instanceof AndFilterOperator) {
             return PrioritizedFilterOperator.AND_PRIORITY;
           }
@@ -238,30 +225,9 @@ public class FilterOperatorUtils {
           if (filterOperator instanceof NotFilterOperator) {
             return getPriority(((NotFilterOperator) filterOperator).getChildFilterOperator());
           }
-          if (filterOperator instanceof ScanBasedFilterOperator) {
-            int basePriority = PrioritizedFilterOperator.SCAN_PRIORITY;
-            return getScanBasedFilterPriority(queryContext, (ScanBasedFilterOperator) filterOperator, basePriority);
-          }
-          if (filterOperator instanceof ExpressionFilterOperator) {
-            return PrioritizedFilterOperator.EXPRESSION_PRIORITY;
-          }
-          return PrioritizedFilterOperator.UNKNOWN_FILTER_PRIORITY;
+          return FilterOperatorRewriter.getNonLogicalOperatorPriority(queryContext, filterOperator);
         }
       });
-    }
-
-    public static int getScanBasedFilterPriority(QueryContext queryContext,
-        ScanBasedFilterOperator scanBasedFilterOperator, int basePriority) {
-      if (queryContext.isSkipScanFilterReorder()) {
-        return basePriority;
-      }
-
-      if (scanBasedFilterOperator.getDataSourceMetadata().isSingleValue()) {
-        return basePriority;
-      } else {
-        // Lower priority for multi-value column
-        return basePriority + 50;
-      }
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriterTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+public class FilterOperatorRewriterTest {
+
+
+    @Test
+    public void testNestedANDOR() {
+        // input: Expression OR (ScanBase AND (jsonMatch OR bitMap))
+        // output: Expression OR ((jsonMatch OR bitMap) AND ScanBase)
+        BitmapBasedFilterOperator bitmap = mock(BitmapBasedFilterOperator.class);
+        JsonMatchFilterOperator jsonMatch = mock(JsonMatchFilterOperator.class);
+        DataSourceMetadata ds = mock(DataSourceMetadata.class);
+        when(ds.isSingleValue()).thenReturn(true);
+        ScanBasedFilterOperator scanBasedFilterOperator = mock(ScanBasedFilterOperator.class);
+        when(scanBasedFilterOperator.getDataSourceMetadata()).thenReturn(ds);
+        ExpressionFilterOperator expr = mock(ExpressionFilterOperator.class);
+        QueryContext qc = mock(QueryContext.class);
+        when(qc.isSkipScanFilterReorder()).thenReturn(true);
+        OrFilterOperator or1 = new OrFilterOperator(Arrays.asList(jsonMatch, bitmap), null, 10, true);
+        AndFilterOperator and = new AndFilterOperator(Arrays.asList(or1, scanBasedFilterOperator), null, 10, true);
+        OrFilterOperator or2 = new OrFilterOperator(Arrays.asList(expr, and), null, 10, true);
+        int prio = FilterOperatorRewriter.reorder(qc, or2);
+        Assert.assertEquals(prio, PrioritizedFilterOperator.EXPRESSION_PRIORITY);
+        List<? extends Operator> kids = or2.getChildOperators();
+        assertTrue(kids.get(0) instanceof ExpressionFilterOperator);
+        assertTrue(kids.get(1) instanceof AndFilterOperator);
+        kids = ((AndFilterOperator) kids.get(1)).getChildOperators();
+        assertTrue(kids.get(0) instanceof OrFilterOperator);
+        assertTrue(kids.get(1) instanceof ScanBasedFilterOperator);
+        kids = ((OrFilterOperator) kids.get(0)).getChildOperators();
+        assertTrue(kids.get(0) instanceof JsonMatchFilterOperator);
+        assertTrue(kids.get(1) instanceof BitmapBasedFilterOperator);
+    }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

FilterPlanNode\.run calls FilterOperatorUtils to build AND filter then reorders operators via FilterOperatorRewriter, which recursively computes priorities and sorts AND/OR children\.

```mermaid
flowchart TD
  N0["FilterPlanNode#46;run #40;F3#41;"]:::stModified
  N1["FilterOperatorUtils#46;getAndFilterOperator #40;F2#41;"]:::stModified
  N2["FilterOperatorRewriter#46;reorder #40;F1#41;"]:::stAdded
  N3["FilterOperatorRewriter#46;getNonLogicalOperatorPriority #40;F1#41;"]:::stAdded
  N4["FilterOperatorUtils#46;getPriority #40;F2#41;"]:::stModified
  N0 -->|"calls"| N1
  N0 -->|"calls"| N2
  N2 -->|"recursive call"| N2
  N2 -->|"delegates to"| N3
  N4 -->|"recursive call for Not"| N4
  N4 -->|"delegates to"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriter\.java — [after](https://github.com/apache/pinot/blob/60a8cbf455b38e7e312e2ec3faa81c01db6aa0f0/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorRewriter.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils\.java — [before](https://github.com/apache/pinot/blob/da6823600b5bf13a2b9fdbfb60f5e29525496bbc/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java) · [after](https://github.com/apache/pinot/blob/60a8cbf455b38e7e312e2ec3faa81c01db6aa0f0/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode\.java — [before](https://github.com/apache/pinot/blob/da6823600b5bf13a2b9fdbfb60f5e29525496bbc/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java) · [after](https://github.com/apache/pinot/blob/60a8cbf455b38e7e312e2ec3faa81c01db6aa0f0/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRhNjgyMzYwMGI1YmYxM2EyYjlmZGJmYjYwZjVlMjk1MjU0OTZiYmMiLCJjb250ZXh0X2hhc2giOiJkMzY1MmY4NThiOGQ0Y2Y1YTAzYTE0MjU3ZDhiOTJhZWI0NDViZjk2MDFiZGY3ZTg1MDBjNWRjNDc2YWZkMDU4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzYwNjYwLCJoZWFkX3NoYSI6IjYwYThjYmY0NTViMzhlN2UzMTJlMmVjM2ZhYTgxYzAxZGI2YWEwZjAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI0MWRhZTcyYjgzMjNhOWJjMDgyZTU4MTllYjkxMzgyOWYyNGQ0MmZlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7a0542fd5eeec4b68219014280a11fab3f851ee62b53fe561e62ab8951ffb131 -->
<!-- pinot-pr-flow:end -->

The issue https://github.com/apache/pinot/issues/13081 says it at all. We should have recursively visited the child operators of AND / OR operator and use the lowest priority (largest value) of children as the priority of the current AND / OR operator. For AND's kids operator, reorder based on the priority.