### PR TITLE
Optimise Sorting in SegmentProcessorFramework [WIP]

### DIFF
--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -177,6 +177,12 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analysis-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-parquet</artifactId>
+      <version>1.2.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
     <!-- Lucene dependencies end -->
   </dependencies>
   <profiles>

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
@@ -172,9 +172,9 @@ public class GenericRowDeserializer {
     }
   }
 
-  public List<Object> getSortedColumnValueList(long offset, int numFieldsToCompare) {
+  public List<Object> getSortedColumnValueList(long offset, int numSortedColumnValueList) {
     List<Object> sortedColumnList = new ArrayList<>();
-    for (int i = 0; i < numFieldsToCompare; i++) {
+    for (int i = 0; i < numSortedColumnValueList; i++) {
       switch (_storedTypes[i]) {
         case INT:
           sortedColumnList.add(_dataBuffer.getInt(offset));

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileReader.java
@@ -82,6 +82,10 @@ public class GenericRowFileReader implements Closeable {
     return _deserializer.compare(offset1, offset2, _numSortFields);
   }
 
+  public List<Object> getSortedColumnValueList(int rowId) {
+    long offset = _offsetBuffer.getLong((long) rowId << 3); // rowId * Long.BYTES
+    return _deserializer.getSortedColumnValueList(offset, _numSortFields);
+  }
   /**
    * Returns a record reader for the rows within the file. Records are sorted if sort order is configured.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowParquetWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowParquetWriter.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.genericrow;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.pinot.plugin.inputformat.parquet.ParquetUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * File writer for {@link GenericRow}. The writer will generate to 2 files, one for the offsets (BIG_ENDIAN) and one for
+ * the actual data (NATIVE_ORDER). The generated files can be read by the {@link GenericRowFileReader}. There is no
+ * version control for the files generated because the files should only be used as intermediate format and read in the
+ * same host (different host might have different NATIVE_ORDER).
+ *
+ * TODO: Consider using ByteBuffer instead of OutputStream.
+ */
+public class GenericRowParquetWriter implements FileWriter<GenericRow> {
+  private final Schema _pinotSchema;
+  private final org.apache.avro.Schema _avroSchema;
+  private File _dataFile;
+
+  public GenericRowParquetWriter(File dataFile, Schema pinotSchema)
+      throws FileNotFoundException {
+    _pinotSchema = pinotSchema;
+    _dataFile = dataFile;
+    _avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(pinotSchema);
+  }
+
+  private GenericRecord convertGenericRowToGenericRecord(GenericRow genericRow) {
+    GenericRecord record = new GenericData.Record(_avroSchema);
+    for (FieldSpec fieldSpec : _pinotSchema.getAllFieldSpecs()) {
+      record.put(fieldSpec.getName(), genericRow.getValue(fieldSpec.getName()));
+    }
+    return record;
+  }
+
+  /**
+   * Writes the given row into the files.
+   */
+  public void write(GenericRow genericRow)
+      throws IOException {
+    GenericRecord record = convertGenericRowToGenericRecord(genericRow);
+    try (ParquetWriter<GenericRecord> writer = ParquetUtils.getParquetAvroWriter(
+        new Path(_dataFile.getAbsolutePath()), _avroSchema)) {
+      writer.write(record);
+    }
+  }
+
+  public long writeData(GenericRow genericRow)
+      throws IOException {
+    GenericRecord record = convertGenericRowToGenericRecord(genericRow);
+    ParquetWriter<GenericRecord> writer =
+        ParquetUtils.getParquetAvroWriter(new Path(_dataFile.getAbsolutePath()), _avroSchema);
+    writer.write(record);
+    return writer.getDataSize();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
@@ -26,12 +26,16 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.schema.MessageType;
 
 
@@ -82,6 +86,14 @@ public class ParquetUtils {
       Map<String, String> metaData = reader.getFileMetaData().getKeyValueMetaData();
       return metaData.containsKey(AVRO_SCHEMA_METADATA_KEY) || metaData.containsKey(OLD_AVRO_SCHEMA_METADATA_KEY);
     }
+  }
+
+  public static ParquetWriter<GenericRecord> getParquetAvroWriter(Path path, Schema schema)
+      throws IOException {
+    OutputFile outputFile = HadoopOutputFile.fromPath(path, ParquetUtils.getParquetHadoopConfiguration());
+    return AvroParquetWriter.<GenericRecord>builder(outputFile).withSchema(schema)
+        .withConf(ParquetUtils.getParquetHadoopConfiguration())
+        .build();
   }
 
   public static Configuration getParquetHadoopConfiguration() {


### PR DESCRIPTION
Load only the sort columns in memory and call compare on the loaded columns instead of calling compare on the whole memory mapped datafile.