### PR TITLE
Bugfix: Validate minionInstanceTag during task-generation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -659,6 +659,11 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       try {
         if (numTasks > 0) {
           // This might lead to lot of logs, maybe sum it up and move outside the loop
+          if (_pinotHelixResourceManager.getInstancesWithTag(minionInstanceTag).isEmpty()) {
+            LOGGER.error("Skipping {} tasks for task type: {} with task configs: {} to invalid minionInstance: {}",
+                numTasks, taskType, pinotTaskConfigs, minionInstanceTag);
+            throw new IllegalArgumentException("No valid minion instance found for tag: " + minionInstanceTag);
+          }
           LOGGER.info("Submitting {} tasks for task type: {} to minionInstance: {} with task configs: {}", numTasks,
               taskType, minionInstanceTag, pinotTaskConfigs);
           String submittedTaskName = _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -658,12 +658,12 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       int numTasks = pinotTaskConfigs.size();
       try {
         if (numTasks > 0) {
-          // This might lead to lot of logs, maybe sum it up and move outside the loop
           if (_pinotHelixResourceManager.getInstancesWithTag(minionInstanceTag).isEmpty()) {
-            LOGGER.error("Skipping {} tasks for task type: {} with task configs: {} to invalid minionInstance: {}",
+            LOGGER.error("Skipping {} tasks for task type: {} with task configs: {} to invalid minionInstanceTag: {}",
                 numTasks, taskType, pinotTaskConfigs, minionInstanceTag);
             throw new IllegalArgumentException("No valid minion instance found for tag: " + minionInstanceTag);
           }
+          // This might lead to lot of logs, maybe sum it up and move outside the loop
           LOGGER.info("Submitting {} tasks for task type: {} to minionInstance: {} with task configs: {}", numTasks,
               taskType, minionInstanceTag, pinotTaskConfigs);
           String submittedTaskName = _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag,


### PR DESCRIPTION
label:
`bugfix`
`minion`

This patch validates whether the configured minionInstanceTag actually exists in the list of instance-tags or not. Before this, if a wrong instanceTag was configured for a task, Pinot scheduled those tasks and they got stuck in `IN_PROGRESS` state. Until the task is timed out, no another task scheduling for that table and task type was possible. Or you need to update some minion instance with the specified instanceTag. Ideally, we should error out by throwing an exception for instanceTag not found which this patch achieves.

There is a more proactive way of doing this at table-config updation itself. We will try to achieve that when we introduce `minionTenant` config itself.