### PR TITLE
bugfix: fix flakey test, avoid early finalization

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/TlsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/TlsUtilsTest.java
@@ -182,8 +182,9 @@ public class TlsUtilsTest {
     Certificate certForPrivateKey = x509ExtendedKeyManager.getCertificateChain(KEY_NAME_ALIAS)[0];
     X509Certificate acceptedIssuerForCert = x509ExtendedTrustManager.getAcceptedIssuers()[0];
 
-    // start a new thread to reload the ssl factory when the tls files change
-    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    // Start a new thread to reload the ssl factory when the tls files change
+    // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
     executorService.execute(
         () -> {
           try {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -174,7 +174,8 @@ public class CombineSlowOperatorsTest {
 
   private void testCancelCombineOperator(BaseCombineOperator combineOperator, CountDownLatch ready) {
     AtomicReference<Exception> exp = new AtomicReference<>();
-    ExecutorService combineExecutor = Executors.newSingleThreadExecutor();
+    // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
+    ExecutorService combineExecutor = Executors.newFixedThreadPool(1);
     try {
       Future<?> future = combineExecutor.submit(() -> {
         try {

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -140,7 +140,8 @@ public class CombinePlanNodeTest {
     _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
     AtomicReference<Exception> exp = new AtomicReference<>();
-    ExecutorService combineExecutor = Executors.newSingleThreadExecutor();
+    // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
+    ExecutorService combineExecutor = Executors.newFixedThreadPool(1);
     try {
       Future<?> future = combineExecutor.submit(() -> {
         try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -99,7 +99,8 @@ public class LuceneMutableTextIndexTest {
       expectedExceptionsMessageRegExp = ".*TEXT_MATCH query timeout on realtime consuming segment.*")
   public void testQueryCancellationIsSuccessful()
       throws InterruptedException, ExecutionException {
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
+    ExecutorService executor = Executors.newFixedThreadPool(1);
     Future<MutableRoaringBitmap> res = executor.submit(() -> _realtimeLuceneTextIndex.getDocIds("/.*read.*/"));
     executor.shutdownNow();
     res.get();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -114,7 +114,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     // Stop and close the metadata manager
     AtomicBoolean stopped = new AtomicBoolean();
     AtomicBoolean closed = new AtomicBoolean();
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
+    ExecutorService executor = Executors.newFixedThreadPool(1);
     executor.submit(() -> {
       upsertMetadataManager.stop();
       stopped.set(true);


### PR DESCRIPTION
Addresses a flakey test issue noticed by @Jackie-Jiang [here](https://github.com/apache/pinot/pull/13050#issuecomment-2091927090). Also addresses other tests that could be flakey for the same reason. 

For background, see: https://julien.ponge.org/blog/not-all-java-single-threaded-executors-are-created-equal-a-java-finalizer-horror-story/ and https://bugs.openjdk.org/browse/JDK-8145304. `Executors.newSingleThreadExecutor` can only be used in this manner safely in Java 21+. 

Also verified that non-test code using `Executors.newSingleThreadExecutor` looks safe.

tags: `bugfix`