### PR TITLE
Support StringJoin aggregation function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/BaseStringJoinFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/BaseStringJoinFunction.java
@@ -1,0 +1,188 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public abstract class BaseStringJoinFunction<I extends AbstractObjectCollection<String>>
+    extends BaseSingleInputAggregationFunction<I, String> {
+  protected final boolean _nullHandlingEnabled;
+  protected final String _separator;
+
+  public BaseStringJoinFunction(ExpressionContext expression, String separator, boolean nullHandlingEnabled) {
+    super(expression);
+    _nullHandlingEnabled = nullHandlingEnabled;
+    _separator = separator;
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.STRINGJOIN;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Override
+  public I merge(I intermediateResult1, I intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    intermediateResult1.addAll(intermediateResult2);
+    return intermediateResult1;
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        aggregateArrayWithNull(length, aggregationResultHolder, blockValSet, nullBitmap);
+        return;
+      }
+    }
+    aggregateArray(length, aggregationResultHolder, blockValSet);
+  }
+
+  protected abstract void aggregateArray(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet);
+
+  protected abstract void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, RoaringBitmap nullBitmap);
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        aggregateArrayGroupBySVWithNull(length, groupKeyArray, groupByResultHolder, blockValSet, nullBitmap);
+        return;
+      }
+    }
+    aggregateArrayGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet);
+  }
+
+  protected void aggregateArrayGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet blockValSet) {
+    String[] values = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
+    }
+  }
+
+  protected void aggregateArrayGroupBySVWithNull(int length, int[] groupKeyArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
+    String[] values = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        aggregateArrayGroupByMVWithNull(length, groupKeysArray, groupByResultHolder, blockValSet, nullBitmap);
+        return;
+      }
+    }
+    aggregateArrayGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet);
+  }
+
+  protected void aggregateArrayGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet blockValSet) {
+    String[] values = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      for (int groupKey : groupKeysArray[i]) {
+        setGroupByResult(groupByResultHolder, groupKey, values[i]);
+      }
+    }
+  }
+
+  protected void aggregateArrayGroupByMVWithNull(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
+    String[] values = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        for (int groupKey : groupKeysArray[i]) {
+          setGroupByResult(groupByResultHolder, groupKey, values[i]);
+        }
+      }
+    }
+  }
+
+  abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, String value);
+
+  @Override
+  public I extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return aggregationResultHolder.getResult();
+  }
+
+  @Override
+  public I extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  @Override
+  public String extractFinalResult(I stringCollection) {
+    return StringUtils.join(stringCollection, _separator);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/BaseStringJoinOrderByFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/BaseStringJoinOrderByFunction.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregationFunction;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public abstract class BaseStringJoinOrderByFunction<I>
+    extends BaseSingleInputAggregationFunction<I, String> {
+  protected final boolean _nullHandlingEnabled;
+  protected final String _separator;
+  protected final List<OrderByExpressionContext> _orderByExpressionContext;
+  protected final List<FieldSpec.DataType> _orderByDataTypes;
+
+  public BaseStringJoinOrderByFunction(ExpressionContext expression, String separator,
+      List<OrderByExpressionContext> orderByExpressionContext, List<FieldSpec.DataType> orderByDataTypes,
+      boolean nullHandlingEnabled) {
+    super(expression);
+    _nullHandlingEnabled = nullHandlingEnabled;
+    _separator = separator;
+    _orderByExpressionContext = orderByExpressionContext;
+    _orderByDataTypes = orderByDataTypes;
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.STRINGJOIN;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public List<ExpressionContext> getInputExpressions() {
+    ArrayList<ExpressionContext> inputExpressions = new ArrayList<>();
+    inputExpressions.add(_expression);
+    _orderByExpressionContext.stream()
+        .forEach(orderByExpressionContext -> inputExpressions.add(orderByExpressionContext.getExpression()));
+    return inputExpressions;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    List<BlockValSet> orderByBlockValSets =
+        _orderByExpressionContext.stream()
+            .map(expressionContext -> blockValSetMap.get(expressionContext.getExpression())).collect(
+                Collectors.toList());
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        aggregateArrayWithNull(length, aggregationResultHolder, blockValSet, orderByBlockValSets, nullBitmap);
+        return;
+      }
+    }
+    aggregateArray(length, aggregationResultHolder, blockValSet, orderByBlockValSets);
+  }
+
+  protected abstract void aggregateArray(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, List<BlockValSet> orderByBlockValSets);
+
+  protected abstract void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, List<BlockValSet> orderByBlockValSets, RoaringBitmap nullBitmap);
+
+  protected List<Object> extractOrderByValues(List<BlockValSet> orderByBlockValSets) {
+    int orderByExprSize = orderByBlockValSets.size();
+    List<Object> results = new ArrayList<>(orderByExprSize);
+    for (int i = 0; i < orderByExprSize; i++) {
+      FieldSpec.DataType dataType = _orderByDataTypes.get(i);
+      switch (dataType) {
+        case INT:
+          results.add(orderByBlockValSets.get(i).getIntValuesSV());
+          break;
+        case LONG:
+        case TIMESTAMP:
+          results.add(orderByBlockValSets.get(i).getLongValuesSV());
+          break;
+        case FLOAT:
+          results.add(orderByBlockValSets.get(i).getFloatValuesSV());
+          break;
+        case DOUBLE:
+          results.add(orderByBlockValSets.get(i).getDoubleValuesSV());
+          break;
+        case STRING:
+          results.add(orderByBlockValSets.get(i).getStringValuesSV());
+          break;
+        case BIG_DECIMAL:
+          results.add(orderByBlockValSets.get(i).getBigDecimalValuesSV());
+          break;
+        case BYTES:
+          results.add(orderByBlockValSets.get(i).getBytesValuesSV());
+          break;
+        default:
+          throw new RuntimeException("Unsupported data type for StringJoin OrderBy: " + dataType);
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    List<BlockValSet> orderByBlockValSets =
+        _orderByExpressionContext.stream()
+            .map(expressionContext -> blockValSetMap.get(expressionContext.getExpression())).collect(
+                Collectors.toList());
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        String[] valueExpr = blockValSet.getStringValuesSV();
+        List<Object> orderByExprs = extractOrderByValues(orderByBlockValSets);
+        for (int i = 0; i < length; i++) {
+          if (!nullBitmap.contains(i)) {
+            Object[] values = extractValues(valueExpr, orderByExprs, i);
+            setGroupByResult(groupByResultHolder, groupKeyArray[i], values);
+          }
+        }
+        return;
+      }
+    }
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExprs = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      Object[] values = extractValues(valueExpr, orderByExprs, i);
+      setGroupByResult(groupByResultHolder, groupKeyArray[i], values);
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    List<BlockValSet> orderByBlockValSets =
+        _orderByExpressionContext.stream()
+            .map(expressionContext -> blockValSetMap.get(expressionContext.getExpression())).collect(
+                Collectors.toList());
+    if (_nullHandlingEnabled) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+      if (nullBitmap != null && !nullBitmap.isEmpty()) {
+        String[] valueExpr = blockValSet.getStringValuesSV();
+        List<Object> orderByExprs = extractOrderByValues(orderByBlockValSets);
+        for (int i = 0; i < length; i++) {
+          if (!nullBitmap.contains(i)) {
+            for (int groupKey : groupKeysArray[i]) {
+              Object[] values = extractValues(valueExpr, orderByExprs, i);
+              setGroupByResult(groupByResultHolder, groupKey, values);
+            }
+          }
+        }
+        return;
+      }
+    }
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExprs = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      for (int groupKey : groupKeysArray[i]) {
+        Object[] values = extractValues(valueExpr, orderByExprs, i);
+        setGroupByResult(groupByResultHolder, groupKey, values);
+      }
+    }
+  }
+
+  @Override
+  public I extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return aggregationResultHolder.getResult();
+  }
+
+  @Override
+  public I extractGroupByResult(GroupByResultHolder groupByResultHolder,
+      int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  abstract void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, Object[] value);
+
+  protected Object[] extractValues(String[] valueExpr, List<Object> orderByExprs, int rowIdx) {
+    Object[] values = new Object[1 + orderByExprs.size()];
+    for (int j = 0; j < orderByExprs.size(); j++) {
+      Object arrayObject = orderByExprs.get(j);
+      FieldSpec.DataType dataType = _orderByDataTypes.get(j);
+      switch (dataType) {
+        case INT:
+          values[j] = ((int[]) arrayObject)[rowIdx];
+          break;
+        case LONG:
+        case TIMESTAMP:
+          values[j] = ((long[]) arrayObject)[rowIdx];
+          break;
+        case FLOAT:
+          values[j] = ((float[]) arrayObject)[rowIdx];
+          break;
+        case DOUBLE:
+          values[j] = ((double[]) arrayObject)[rowIdx];
+          break;
+        case STRING:
+          values[j] = ((String[]) arrayObject)[rowIdx];
+          break;
+        case BIG_DECIMAL:
+          values[j] = ((Object[]) arrayObject)[rowIdx];
+          break;
+        case BYTES:
+          values[j] = ((byte[][]) arrayObject)[rowIdx];
+          break;
+        default:
+          throw new RuntimeException("Unsupported data type for StringJoin OrderBy: " + dataType);
+      }
+    }
+    values[orderByExprs.size()] = valueExpr[rowIdx];
+    return values;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinAllFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinAllFunction.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.util.Arrays;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public class StringJoinAllFunction extends BaseStringJoinFunction<ObjectArrayList<String>> {
+
+  public StringJoinAllFunction(ExpressionContext expression, String separator, boolean nullHandlingEnabled) {
+    super(expression, separator, nullHandlingEnabled);
+  }
+
+  @Override
+  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
+    ObjectArrayList<String> valueArray = new ObjectArrayList<>(length);
+    String[] value = blockValSet.getStringValuesSV();
+    valueArray.addAll(Arrays.asList(value));
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
+    ObjectArrayList<String> valueArray = new ObjectArrayList<>(length);
+    String[] value = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        valueArray.add(value[i]);
+      }
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, String value) {
+    ObjectArrayList<String> valueArray = resultHolder.getResult(groupKey);
+    if (valueArray == null) {
+      valueArray = new ObjectArrayList<>();
+      resultHolder.setValueForKey(groupKey, valueArray);
+    }
+    valueArray.add(value);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinDistinctFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinDistinctFunction.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.util.Arrays;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public class StringJoinDistinctFunction
+    extends BaseStringJoinFunction<ObjectOpenHashSet<String>> {
+
+  public StringJoinDistinctFunction(ExpressionContext expression, String separator, boolean nullHandlingEnabled) {
+    super(expression, separator, nullHandlingEnabled);
+  }
+
+  @Override
+  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
+    ObjectOpenHashSet<String> valueArray = new ObjectOpenHashSet<>(length);
+    String[] value = blockValSet.getStringValuesSV();
+    valueArray.addAll(Arrays.asList(value));
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
+    ObjectOpenHashSet<String> valueArray = new ObjectOpenHashSet<>(length);
+    String[] value = blockValSet.getStringValuesSV();
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        valueArray.add(value[i]);
+      }
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, String value) {
+    ObjectOpenHashSet<String> valueSet = resultHolder.getResult(groupKey);
+    if (valueSet == null) {
+      valueSet = new ObjectOpenHashSet<>();
+      resultHolder.setValueForKey(groupKey, valueSet);
+    }
+    valueSet.add(value);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinOrderByDistinctFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinOrderByDistinctFunction.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeSet;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.utils.OrderByComparatorFactory;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public class StringJoinOrderByDistinctFunction
+    extends BaseStringJoinOrderByFunction<TreeSet<Object[]>> {
+
+  public StringJoinOrderByDistinctFunction(ExpressionContext expression, String separator,
+      List<OrderByExpressionContext> orderByExpressionContext, List<FieldSpec.DataType> orderByDataTypes,
+      boolean nullHandlingEnabled) {
+    super(expression, separator, orderByExpressionContext, orderByDataTypes, nullHandlingEnabled);
+  }
+
+  @Override
+  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet,
+      List<BlockValSet> orderByBlockValSets) {
+    TreeSet<Object[]> valueArray = createTreeSet();
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExpressions = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      Object[] values = extractValues(valueExpr, orderByExpressions, i);
+      valueArray.add(values);
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, List<BlockValSet> orderByBlockValSets, RoaringBitmap nullBitmap) {
+    TreeSet<Object[]> valueArray = createTreeSet();
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExpressions = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        Object[] values = extractValues(valueExpr, orderByExpressions, i);
+        valueArray.add(values);
+      }
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  public TreeSet<Object[]> merge(TreeSet<Object[]> intermediateResult1,
+      TreeSet<Object[]> intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    intermediateResult1.addAll(intermediateResult2);
+    return intermediateResult1;
+  }
+
+  public String extractFinalResult(TreeSet<Object[]> stringList) {
+    int valueIndex = _orderByExpressionContext.size();
+    StringBuilder finalResultStringBuilder = new StringBuilder();
+    finalResultStringBuilder.append(Objects.requireNonNull(stringList.pollFirst())[valueIndex]);
+    while (!stringList.isEmpty()) {
+      finalResultStringBuilder.append(_separator);
+      finalResultStringBuilder.append(Objects.requireNonNull(stringList.pollFirst())[valueIndex]);
+    }
+    return finalResultStringBuilder.toString();
+  }
+
+  protected void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, Object[] value) {
+    TreeSet<Object[]> valueArray = resultHolder.getResult(groupKey);
+    if (valueArray == null) {
+      valueArray = createTreeSet();
+      resultHolder.setValueForKey(groupKey, valueArray);
+    }
+    valueArray.add(value);
+  }
+
+  private TreeSet<Object[]> createTreeSet() {
+    List<OrderByExpressionContext> comparators = new ArrayList<>(_orderByExpressionContext);
+    comparators.add(new OrderByExpressionContext(_expression, true));
+    Comparator<Object[]> comparator = OrderByComparatorFactory.getComparator(comparators, false);
+    return new TreeSet<>(comparator);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinOrderByFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/string/StringJoinOrderByFunction.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.string;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayPriorityQueue;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.utils.OrderByComparatorFactory;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public class StringJoinOrderByFunction
+    extends BaseStringJoinOrderByFunction<ObjectArrayPriorityQueue<Object[]>> {
+
+  public StringJoinOrderByFunction(ExpressionContext expression, String separator,
+      List<OrderByExpressionContext> orderByExpressionContext, List<FieldSpec.DataType> orderByDataTypes,
+      boolean nullHandlingEnabled) {
+    super(expression, separator, orderByExpressionContext, orderByDataTypes, nullHandlingEnabled);
+  }
+
+  @Override
+  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet,
+      List<BlockValSet> orderByBlockValSets) {
+    ObjectArrayPriorityQueue<Object[]> valueArray = createObjectArrayPriorityQueue(length);
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExpressions = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      Object[] values = extractValues(valueExpr, orderByExpressions, i);
+      valueArray.enqueue(values);
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet blockValSet, List<BlockValSet> orderByBlockValSets, RoaringBitmap nullBitmap) {
+    ObjectArrayPriorityQueue<Object[]> valueArray = createObjectArrayPriorityQueue(length);
+    String[] valueExpr = blockValSet.getStringValuesSV();
+    List<Object> orderByExpressions = extractOrderByValues(orderByBlockValSets);
+    for (int i = 0; i < length; i++) {
+      if (!nullBitmap.contains(i)) {
+        Object[] values = extractValues(valueExpr, orderByExpressions, i);
+        valueArray.enqueue(values);
+      }
+    }
+    aggregationResultHolder.setValue(valueArray);
+  }
+
+  @Override
+  public ObjectArrayPriorityQueue<Object[]> merge(ObjectArrayPriorityQueue<Object[]> intermediateResult1,
+      ObjectArrayPriorityQueue<Object[]> intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    while (!intermediateResult2.isEmpty()) {
+      intermediateResult1.enqueue(intermediateResult2.dequeue());
+    }
+    return intermediateResult1;
+  }
+
+  public String extractFinalResult(ObjectArrayPriorityQueue<Object[]> stringList) {
+    int valueIndex = _orderByExpressionContext.size();
+    StringBuilder finalResultStringBuilder = new StringBuilder();
+    finalResultStringBuilder.append(stringList.dequeue()[valueIndex]);
+    while (!stringList.isEmpty()) {
+      finalResultStringBuilder.append(_separator);
+      finalResultStringBuilder.append(stringList.dequeue()[valueIndex]);
+    }
+    return finalResultStringBuilder.toString();
+  }
+
+  protected void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, Object[] value) {
+    ObjectArrayPriorityQueue<Object[]> valueArray = resultHolder.getResult(groupKey);
+    if (valueArray == null) {
+      valueArray = createObjectArrayPriorityQueue(0);
+      resultHolder.setValueForKey(groupKey, valueArray);
+    }
+    valueArray.enqueue(value);
+  }
+
+  private ObjectArrayPriorityQueue<Object[]> createObjectArrayPriorityQueue(int length) {
+    Comparator<Object[]> comparator = OrderByComparatorFactory.getComparator(_orderByExpressionContext, false);
+    return new ObjectArrayPriorityQueue<>(length, comparator);
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -322,7 +322,7 @@ public enum AggregationFunctionType {
   ARRAYAGG("arrayAgg", null, SqlKind.ARRAY_AGG, SqlFunctionCategory.USER_DEFINED_FUNCTION,
       OperandTypes.family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.STRING, SqlTypeFamily.BOOLEAN),
           ordinal -> ordinal > 1), ReturnTypes.TO_ARRAY, ReturnTypes.explicit(SqlTypeName.OTHER)),
-
+  STRINGJOIN("stringJoin"),
   // funnel aggregate functions
   // TODO: revisit support for funnel count in V2
   FUNNELCOUNT("funnelCount");


### PR DESCRIPTION
Support `StringJoin` aggregation function which is similar to `StringAgg` function.

Below syntax is just for v1, we need to rewrite v2 query to this syntax to use the v1 query engine for execution.
```
StringJoin(expression, separator, isDistinct, [orderByExpr, data Type, isAscending])
```

Example:
```
select 
    carrier, 
    stringjoin(
        concat(Origin, Dest, '||'), ',', true, 
        Dest, 'STRING', false, 
        Origin, 'STRING', true) 
from airlineStats 
group by carrier 
limit 10
```