### PR TITLE
Avoid re-stringifying strings in JSON_FORMAT function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -79,6 +79,9 @@ public class JsonFunctions {
   @ScalarFunction(names = {"jsonFormat", "json_format"})
   public static String jsonFormat(Object object)
       throws JsonProcessingException {
+    if (object instanceof String) {
+      return (String) object;
+    }
     return JsonUtils.objectToString(object);
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -90,6 +90,24 @@ public class JsonFunctionsTest {
   }
 
   @Test
+  public void testJsonFormat() throws Exception {
+    Map<Object, Object> jsonMap = Map.of("data", Map.of("name", Map.of("full.name", "Peter1", "nick.name", "Pete1"),
+        "alias", "student1", "age", 24));
+
+    // Don't compare strings directly because JSON objects are unordered
+    assertEquals(
+        JsonUtils.stringToJsonNode(JsonFunctions.jsonFormat(jsonMap)),
+        JsonUtils.objectToJsonNode(jsonMap)
+    );
+
+    // Ensure that string values aren't "re-stringified"
+    assertEquals(
+        JsonUtils.stringToJsonNode(JsonFunctions.jsonFormat(JsonFunctions.jsonFormat(jsonMap))),
+        JsonUtils.objectToJsonNode(jsonMap)
+    );
+  }
+
+  @Test
   public void testJsonPathStringWithDefaultValue()
       throws JsonProcessingException {
     String jsonString = "{\"name\": \"Pete\", \"age\": 24}";


### PR DESCRIPTION
- The [JSON_FORMAT function](https://github.com/apache/pinot/blob/070e3dbd81f8223e5ad3872a3b8ae15db87bc543/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java#L82) currently just calls [JsonUtils::objectToString](https://github.com/apache/pinot/blob/070e3dbd81f8223e5ad3872a3b8ae15db87bc543/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java#L239) which in turn calls Jackson Databind's [ObjectMapper::writeValueAsStringMethod](https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/ObjectMapper.html#writeValueAsString-java.lang.Object-).
- If a JSON object that has already been formatted is passed to this function, the string is "re-stringified" and the result is an escaped string.
- For instance, taking the JSON object `{"data":{"alias":"student1","age":24,"name":{"full.name":"Peter1","nick.name":"Pete1"}}}`. Calling the `JSON_FORMAT` function on this will result in the string value `{"data":{"alias":"student1","age":24,"name":{"full.name":"Peter1","nick.name":"Pete1"}}}`.
- Calling the `JSON_FORMAT` function again on this string value will result in the escaped string - `"{\"data\":{\"alias\":\"student1\",\"age\":24,\"name\":{\"full.name\":\"Peter1\",\"nick.name\":\"Pete1\"}}}"`. Passing it through the function again will result in a doubly escaped string - `"\"{\\\"data\\\":{\\\"alias\\\":\\\"student1\\\",\\\"age\\\":24,\\\"name\\\":{\\\"full.name\\\":\\\"Peter1\\\",\\\"nick.name\\\":\\\"Pete1\\\"}}}\""`.
- This can lead to unexpected results in certain scenarios. For instance, let's say that we have a table with a `data` JSON column with the row - `{"data":{"alias":"student1","age":24,"name":{"full.name":"Peter1","nick.name":"Pete1"}}}`.
- Now suppose we want to add a new derived column `alias` using the ingestion transform function `JSON_PATH_STRING(JSON_FORMAT(data), '$.alias')` (via segment reload). Since JSON columns are stored as strings internally, calling `JSON_FORMAT` on its values will lead to escaped strings. This leads to an NPE [here](https://github.com/apache/pinot/blob/070e3dbd81f8223e5ad3872a3b8ae15db87bc543/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java#L592) because the `JSON_PATH_STRING` function returns a `null` as it will treat the escaped string argument as a literal JSON string value. This minor patch fixes this issue by avoiding re-stringifying strings in `JsonUtils::objectToString`.
- Note that the above behavior is especially confusing because if the ingestion transform function was added during table creation itself, ingestion goes through fine because the argument passed to the `JSON_FORMAT` function in this case would be the raw `HashMap` that hasn't been converted to a string yet.
- `bugfix`