### PR TITLE
Fix race condition in AdaptiveServerSelection and misc fixes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -223,11 +223,14 @@ public class QueryException {
       case QueryException.ACCESS_DENIED_ERROR_CODE:
       case QueryException.JSON_COMPILATION_ERROR_CODE:
       case QueryException.JSON_PARSING_ERROR_CODE:
+      case QueryException.QUERY_CANCELLATION_ERROR_CODE:
       case QueryException.QUERY_VALIDATION_ERROR_CODE:
-      case QueryException.UNKNOWN_COLUMN_ERROR_CODE:
+      case QueryException.SERVER_OUT_OF_CAPACITY_ERROR_CODE:
+      case QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE:
       case QueryException.SQL_PARSING_ERROR_CODE:
       case QueryException.TOO_MANY_REQUESTS_ERROR_CODE:
       case QueryException.TABLE_DOES_NOT_EXIST_ERROR_CODE:
+      case QueryException.UNKNOWN_COLUMN_ERROR_CODE:
         return true;
       default:
         return false;


### PR DESCRIPTION
Contains 2 fixes

**1. Adaptive Server Selection - race condition:**

A race condition between jetty threads and netty threads can result in setting negative values for numInFlightRequests for servers. This can result in that particular server being overloaded when compared to other. 

It's difficult to reproduce this but the race-condition is obvious from code-reading. 

The race condition is explained below
Let's say a query is routed to 2 servers S1 and S2. Say the query has a timeout of 1s. The race condition timeline is as follows: 
T1: Query is routed to S1 and S2. The ADSS stats will look as follows:
`S1 Stats = {
  numInFlightRequests = 1
}
S2 Stats = {
  numInFlightRequests = 1
}
`

T2: S1 responds with the results (dataTable). The ADSS stats [will be updated ](https://github.com/apache/pinot/blob/70bfd4185ca18eb64658c5a35813e3578f7c843d/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java#L158) to look as follows. Note that this update is by the netty thread that receives the response. 
`S1 Stats = {
  numInFlightRequests = 0
}
S2 Stats = {
  numInFlightRequests = 1
}
`

T3: Let's say the query timed out. The jetty thread will update the ADSS stats for S2 as per [code](https://github.com/apache/pinot/blob/70bfd4185ca18eb64658c5a35813e3578f7c843d/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java#L97) to look as follows:
`S1 Stats = {
  numInFlightRequests = 0
}
S2 Stats = {
  numInFlightRequests = 0
}
`

T4: Before the [jetty thread removes the QueryResponse object ](https://github.com/apache/pinot/blob/70bfd4185ca18eb64658c5a35813e3578f7c843d/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java#L102)for the request, the server S2 could respond and the corresponding netty thread would update the ADSS stats incorrectly to look as follows 
`S1 Stats = {
  numInFlightRequests = 0
}
S2 Stats = {
  numInFlightRequests = -1
}
`


**2. Updates client error list to add a few more exceptions.** 
