### PR TITLE
Refactor kinesis config and change default shard iterator type

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
@@ -200,7 +200,7 @@ public class RealtimeKinesisIntegrationTest extends BaseClusterIntegrationTestSe
         "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder");
     streamConfigMap.put(KinesisConfig.REGION, REGION);
     streamConfigMap.put(KinesisConfig.MAX_RECORDS_TO_FETCH, String.valueOf(MAX_RECORDS_TO_FETCH));
-    streamConfigMap.put(KinesisConfig.SHARD_ITERATOR_TYPE, ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString());
+    streamConfigMap.put(KinesisConfig.INIT_SHARD_ITERATOR_TYPE, ShardIteratorType.AFTER_SEQUENCE_NUMBER.toString());
     streamConfigMap.put(KinesisConfig.ENDPOINT, LOCALSTACK_KINESIS_ENDPOINT);
     streamConfigMap.put(KinesisConfig.ACCESS_KEY, getLocalAWSCredentials().resolveCredentials().accessKeyId());
     streamConfigMap.put(KinesisConfig.SECRET_KEY, getLocalAWSCredentials().resolveCredentials().secretAccessKey());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
@@ -36,7 +36,7 @@ public class KinesisConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(KinesisConfig.class);
 
   public static final String STREAM_TYPE = "kinesis";
-  public static final String SHARD_ITERATOR_TYPE = "shardIteratorType";
+  public static final String INIT_SHARD_ITERATOR_TYPE = "initShardIteratorType";
   public static final String REGION = "region";
   public static final String ACCESS_KEY = "accessKey";
   public static final String SECRET_KEY = "secretKey";
@@ -67,7 +67,7 @@ public class KinesisConfig {
 
   // TODO: this is a starting point, until a better default is figured out
   public static final String DEFAULT_MAX_RECORDS = "20";
-  public static final String DEFAULT_SHARD_ITERATOR_TYPE = ShardIteratorType.LATEST.toString();
+  public static final String DEFAULT_INIT_SHARD_ITERATOR_TYPE = ShardIteratorType.TRIM_HORIZON.toString();
   public static final String DEFAULT_IAM_ROLE_BASED_ACCESS_ENABLED = "false";
   public static final String DEFAULT_SESSION_DURATION_SECONDS = "900";
   public static final String DEFAULT_ASYNC_SESSION_UPDATED_ENABLED = "true";
@@ -76,7 +76,7 @@ public class KinesisConfig {
   private final String _streamTopicName;
   private final String _awsRegion;
   private final int _numMaxRecordsToFetch;
-  private final ShardIteratorType _shardIteratorType;
+  private final ShardIteratorType _initShardIteratorType;
   private final String _accessKey;
   private final String _secretKey;
   private final String _endpoint;
@@ -106,8 +106,8 @@ public class KinesisConfig {
       _rpsLimit = Integer.parseInt(DEFAULT_RPS_LIMIT);
     }
 
-    _shardIteratorType =
-        ShardIteratorType.fromValue(props.getOrDefault(SHARD_ITERATOR_TYPE, DEFAULT_SHARD_ITERATOR_TYPE));
+    _initShardIteratorType =
+        ShardIteratorType.fromValue(props.getOrDefault(INIT_SHARD_ITERATOR_TYPE, DEFAULT_INIT_SHARD_ITERATOR_TYPE));
     _accessKey = props.get(ACCESS_KEY);
     _secretKey = props.get(SECRET_KEY);
     _endpoint = props.get(ENDPOINT);
@@ -148,8 +148,8 @@ public class KinesisConfig {
     return _rpsLimit;
   }
 
-  public ShardIteratorType getShardIteratorType() {
-    return _shardIteratorType;
+  public ShardIteratorType getInitShardIteratorType() {
+    return _initShardIteratorType;
   }
 
   public String getAccessKey() {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -194,7 +194,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       requestBuilder = requestBuilder.startingSequenceNumber(sequenceNumber)
           .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER);
     } else {
-      requestBuilder = requestBuilder.shardIteratorType(_config.getShardIteratorType());
+      requestBuilder = requestBuilder.shardIteratorType(_config.getInitShardIteratorType());
     }
     return _kinesisClient.getShardIterator(requestBuilder.build()).shardIterator();
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
@@ -72,7 +72,7 @@ public class KinesisConsumerTest {
         "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder");
     props.put(KinesisConfig.REGION, AWS_REGION);
     props.put(KinesisConfig.MAX_RECORDS_TO_FETCH, String.valueOf(MAX_RECORDS_TO_FETCH));
-    props.put(KinesisConfig.SHARD_ITERATOR_TYPE, ShardIteratorType.AT_SEQUENCE_NUMBER.toString());
+    props.put(KinesisConfig.INIT_SHARD_ITERATOR_TYPE, ShardIteratorType.AT_SEQUENCE_NUMBER.toString());
     return new KinesisConfig(new StreamConfig(TABLE_NAME_WITH_TYPE, props));
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
@@ -59,7 +59,7 @@ public class KinesisStreamMetadataProviderTest {
     Map<String, String> props = new HashMap<>();
     props.put(KinesisConfig.REGION, AWS_REGION);
     props.put(KinesisConfig.MAX_RECORDS_TO_FETCH, "10");
-    props.put(KinesisConfig.SHARD_ITERATOR_TYPE, ShardIteratorType.AT_SEQUENCE_NUMBER.toString());
+    props.put(KinesisConfig.INIT_SHARD_ITERATOR_TYPE, ShardIteratorType.AT_SEQUENCE_NUMBER.toString());
     props.put(StreamConfigProperties.STREAM_TYPE, "kinesis");
     props.put("stream.kinesis.consumer.type", "lowLevel");
     props.put("stream.kinesis.topic.name", STREAM_NAME);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Refactored Kinesis config to use initShardIteratorType for initial shard positioning, defaulting to TRIM\_HORIZON

```mermaid
flowchart TD
  N0["KinesisConfig#58; constructor reads initShardIteratorType from props #40;F1#41;"]:::stModified
  N1["KinesisConfig#58; getInitShardIteratorType returns stored value #40;F1#41;"]:::stModified
  N2["KinesisConsumer#58; getShardIterator uses initShardIteratorType for initial shard #40;F2#41;"]:::stModified
  N0 -->|"field assignment and read"| N1
  N1 -->|"getter call in else branch"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-stream\-ingestion/pinot\-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig\.java — [before](https://github.com/apache/pinot/blob/20764c8c337cf2974db70aa978a979ea2bb42a8b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java) · [after](https://github.com/apache/pinot/blob/2112b569af683ab14f53d1b9e339296b3ad9deb9/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java)
- F2: pinot\-plugins/pinot\-stream\-ingestion/pinot\-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer\.java — [before](https://github.com/apache/pinot/blob/20764c8c337cf2974db70aa978a979ea2bb42a8b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java) · [after](https://github.com/apache/pinot/blob/2112b569af683ab14f53d1b9e339296b3ad9deb9/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjIwNzY0YzhjMzM3Y2YyOTc0ZGI3MGFhOTc4YTk3OWVhMmJiNDJhOGIiLCJjb250ZXh0X2hhc2giOiIxMmQ2OTAxYzQwZmZlZWJhMGNiMmQzMjAwMDYwOWExMDI5YzI1YTc1YjhkMjA0MmU3OWRhZDQ1MWQxOTU1NWI1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzY4NzQxLCJoZWFkX3NoYSI6IjIxMTJiNTY5YWY2ODNhYjE0ZjUzZDFiOWUzMzkyOTZiM2FkOWRlYjkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyMDc2NGM4YzMzN2NmMjk3NGRiNzBhYTk3OGE5NzllYTJiYjQyYThiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature d517a7f28e2979ef72ba895b6f3bb237a255dc602bee540a5f854c8f9b27618d -->
<!-- pinot-pr-flow:end -->

This config incorrectly communicates that we will start from this shard iterator type always

However it's meant to be honoured only during the initialization of the shards for the first time. 

Also, changing the default from LATEST to TRIM_HORIZON since that's what most users expect based on feedback

Not exactly a prerequisite but the changes in this PR would not get honoured unless https://github.com/apache/pinot/pull/13112 is merged