### PR TITLE
Optimize unnecessary extra array allocation and conversion for raw derived column during segment reload

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -164,6 +164,10 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
     _totalNumberOfEntries += entries.length;
   }
 
+  protected void updateTotalNumberOfEntries(int newEntries) {
+    _totalNumberOfEntries += newEntries;
+  }
+
   public int getTotalNumberOfEntries() {
     return _totalNumberOfEntries;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -47,6 +47,14 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
 
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       updateTotalNumberOfEntries(values);
+    } else if (entry instanceof double[]) {
+      double[] values = (double[]) entry;
+      for (double value : values) {
+        _values.add(value);
+      }
+
+      _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
+      updateTotalNumberOfEntries(values.length);
     } else {
       double value = (double) entry;
       addressSorted(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -47,6 +47,14 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
 
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       updateTotalNumberOfEntries(values);
+    } else if (entry instanceof float[]) {
+      float[] values = (float[]) entry;
+      for (float value : values) {
+        _values.add(value);
+      }
+
+      _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
+      updateTotalNumberOfEntries(values.length);
     } else {
       float value = (float) entry;
       addressSorted(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -47,6 +47,14 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
 
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       updateTotalNumberOfEntries(values);
+    } else if (entry instanceof int[]) {
+      int[] values = (int[]) entry;
+      for (int value : values) {
+        _values.add(value);
+      }
+
+      _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
+      updateTotalNumberOfEntries(values.length);
     } else {
       int value = (int) entry;
       addressSorted(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -47,6 +47,14 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
 
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       updateTotalNumberOfEntries(values);
+    } else if (entry instanceof long[]) {
+      long[] values = (long[]) entry;
+      for (long value : values) {
+        _values.add(value);
+      }
+
+      _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
+      updateTotalNumberOfEntries(values.length);
     } else {
       long value = (long) entry;
       addressSorted(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.pinot.common.function.FunctionUtils;
 import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
@@ -598,11 +597,21 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
             if (isSingleValue) {
               outputValues[i] = outputValueType.toInt(outputValue);
             } else {
-              Integer[] values = outputValueType.toIntegerArray(outputValue);
-              if (values.length == 0) {
-                values = new Integer[]{(Integer) fieldSpec.getDefaultNullValue()};
+              if (createDictionary) {
+                // Use array of primitive wrapper class for dictionary
+                Integer[] values = outputValueType.toIntegerArray(outputValue);
+                if (values.length == 0) {
+                  values = new Integer[]{(Integer) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
+              } else {
+                // Use primitive array for raw encoded
+                int[] values = outputValueType.toPrimitiveIntArray(outputValue);
+                if (values.length == 0) {
+                  values = new int[]{(int) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
               }
-              outputValues[i] = values;
             }
           }
           IntColumnPreIndexStatsCollector statsCollector =
@@ -622,11 +631,21 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
             if (isSingleValue) {
               outputValues[i] = outputValueType.toLong(outputValue);
             } else {
-              Long[] values = outputValueType.toLongArray(outputValue);
-              if (values.length == 0) {
-                values = new Long[]{(Long) fieldSpec.getDefaultNullValue()};
+              if (createDictionary) {
+                // Use array of primitive wrapper class for dictionary
+                Long[] values = outputValueType.toLongArray(outputValue);
+                if (values.length == 0) {
+                  values = new Long[]{(Long) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
+              } else {
+                // Use primitive array for raw encoded
+                long[] values = outputValueType.toPrimitiveLongArray(outputValue);
+                if (values.length == 0) {
+                  values = new long[]{(long) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
               }
-              outputValues[i] = values;
             }
           }
           LongColumnPreIndexStatsCollector statsCollector =
@@ -646,11 +665,21 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
             if (isSingleValue) {
               outputValues[i] = outputValueType.toFloat(outputValue);
             } else {
-              Float[] values = outputValueType.toFloatArray(outputValue);
-              if (values.length == 0) {
-                values = new Float[]{(Float) fieldSpec.getDefaultNullValue()};
+              if (createDictionary) {
+                // Use array of primitive wrapper class for dictionary
+                Float[] values = outputValueType.toFloatArray(outputValue);
+                if (values.length == 0) {
+                  values = new Float[]{(Float) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
+              } else {
+                // Use primitive array for raw encoded
+                float[] values = outputValueType.toPrimitiveFloatArray(outputValue);
+                if (values.length == 0) {
+                  values = new float[]{(float) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
               }
-              outputValues[i] = values;
             }
           }
           FloatColumnPreIndexStatsCollector statsCollector =
@@ -670,11 +699,21 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
             if (isSingleValue) {
               outputValues[i] = outputValueType.toDouble(outputValue);
             } else {
-              Double[] values = outputValueType.toDoubleArray(outputValue);
-              if (values.length == 0) {
-                values = new Double[]{(Double) fieldSpec.getDefaultNullValue()};
+              if (createDictionary) {
+                // Use array of primitive wrapper class for dictionary
+                Double[] values = outputValueType.toDoubleArray(outputValue);
+                if (values.length == 0) {
+                  values = new Double[]{(Double) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
+              } else {
+                // Use primitive array for raw encoded
+                double[] values = outputValueType.toPrimitiveDoubleArray(outputValue);
+                if (values.length == 0) {
+                  values = new double[]{(double) fieldSpec.getDefaultNullValue()};
+                }
+                outputValues[i] = values;
               }
-              outputValues[i] = values;
             }
           }
           DoubleColumnPreIndexStatsCollector statsCollector =
@@ -854,16 +893,16 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
           switch (fieldSpec.getDataType().getStoredType()) {
             // Casts are safe here because we've already done the conversion in createDerivedColumnV1Indices
             case INT:
-              forwardIndexCreator.putIntMV(ArrayUtils.toPrimitive((Integer[]) outputValue));
+              forwardIndexCreator.putIntMV((int[]) outputValue);
               break;
             case LONG:
-              forwardIndexCreator.putLongMV(ArrayUtils.toPrimitive((Long[]) outputValue));
+              forwardIndexCreator.putLongMV((long[]) outputValue);
               break;
             case FLOAT:
-              forwardIndexCreator.putFloatMV(ArrayUtils.toPrimitive((Float[]) outputValue));
+              forwardIndexCreator.putFloatMV((float[]) outputValue);
               break;
             case DOUBLE:
-              forwardIndexCreator.putDoubleMV(ArrayUtils.toPrimitive((Double[]) outputValue));
+              forwardIndexCreator.putDoubleMV((double[]) outputValue);
               break;
             case STRING:
               forwardIndexCreator.putStringMV((String[]) outputValue);


### PR DESCRIPTION
- We added support for generating raw derived columns during segment reload recently in https://github.com/apache/pinot/pull/13037.
- An [optimization](https://github.com/apache/pinot/pull/13037#discussion_r1593104346) was pointed out where we could avoid an unnecessary extra array allocation and conversion from arrays of primitive wrapper classes to primitive arrays.
- This patch adds the optimization and also adds derived numeric MV columns to the existing integration test for segment reload so that these additional code paths are covered (they previously had no test coverage).
- Note that we can't simply use primitive arrays unconditionally because the [dictionary case](https://github.com/apache/pinot/blob/760e952616b79e455536bbf958edb84c8d0d3472/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java#L800) does [cast it](https://github.com/apache/pinot/blob/760e952616b79e455536bbf958edb84c8d0d3472/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java#L314) into an `Object[]` which isn't possible for primitive arrays.