### PR TITLE
Fix the ServletConfig loading issue with swagger.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -119,8 +119,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
     }
     register(JacksonFeature.class);
-    registerClasses(SwaggerApiListingResource.class);
-    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerApiListingResource.class);
+    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register(AuthenticationFilter.class);
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -89,8 +89,9 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
     PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
-    int timeoutMs = (int) brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
-        CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
+    int timeoutMs = (int) brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
+            CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
     connMgr.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutMs).build());
     Instant startTime = Instant.now();
     register(new AbstractBinder() {
@@ -115,8 +116,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(startTime).named(BrokerAdminApiApplication.START_TIME);
       }
     });
-    boolean enableBoundedJerseyThreadPoolExecutor =
-        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR,
+    boolean enableBoundedJerseyThreadPoolExecutor = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR,
             CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR);
     if (enableBoundedJerseyThreadPoolExecutor) {
       register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
@@ -138,6 +139,9 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
     if (_swaggerBrokerEnabled) {
       PinotReflectionUtils.runWithLock(this::setupSwagger);
+      PinotReflectionUtils.runWithLock(() ->
+          SwaggerSetupUtil.setupSwagger("broker", _brokerResourcePackages, _useHttps, false,
+              "/", BrokerAdminApiApplication.class.getClassLoader(), _httpServer));
     } else {
       LOGGER.info("Hiding Swagger UI for Broker, by {}", CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.broker;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -85,9 +86,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
     PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
-    int timeoutMs = (int) brokerConf
-        .getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
-            CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
+    int timeoutMs = (int) brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
+        CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
     connMgr.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutMs).build());
     Instant startTime = Instant.now();
     register(new AbstractBinder() {
@@ -112,15 +112,15 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(startTime).named(BrokerAdminApiApplication.START_TIME);
       }
     });
-    boolean enableBoundedJerseyThreadPoolExecutor = brokerConf
-        .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR,
+    boolean enableBoundedJerseyThreadPoolExecutor =
+        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR,
             CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR);
     if (enableBoundedJerseyThreadPoolExecutor) {
       register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
     }
     register(JacksonFeature.class);
     register(SwaggerApiListingResource.class);
-    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerSerializers.class);
     register(AuthenticationFilter.class);
   }
 
@@ -135,8 +135,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
     if (_swaggerBrokerEnabled) {
       PinotReflectionUtils.runWithLock(() ->
-          SwaggerSetupUtil.setupSwagger("broker", _brokerResourcePackages, _useHttps, false,
-              "/", BrokerAdminApiApplication.class.getClassLoader(), _httpServer));
+          SwaggerSetupUtil.setupSwagger("Broker", _brokerResourcePackages, _useHttps, "/", _httpServer));
     } else {
       LOGGER.info("Hiding Swagger UI for Broker, by {}", CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -34,7 +34,7 @@ import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
-import org.apache.pinot.common.swagger.SwaggerSetupUtil;
+import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
@@ -135,7 +135,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
     if (_swaggerBrokerEnabled) {
       PinotReflectionUtils.runWithLock(() ->
-          SwaggerSetupUtil.setupSwagger("Broker", _brokerResourcePackages, _useHttps, "/", _httpServer));
+          SwaggerSetupUtils.setupSwagger("Broker", _brokerResourcePackages, _useHttps, "/", _httpServer));
     } else {
       LOGGER.info("Hiding Swagger UI for Broker, by {}", CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED);
     }
@@ -143,11 +143,11 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
   private BrokerManagedAsyncExecutorProvider buildBrokerManagedAsyncExecutorProvider(PinotConfiguration brokerConf,
       BrokerMetrics brokerMetrics) {
-    int corePoolSize = brokerConf
-        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE,
+    int corePoolSize =
+        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE,
             CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE);
-    int maximumPoolSize = brokerConf
-        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE,
+    int maximumPoolSize =
+        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE,
             CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE);
     int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE,
         CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -19,10 +19,7 @@
 package org.apache.pinot.broker.broker;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -35,7 +32,8 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.PinotStaticHttpHandler;
+import org.apache.pinot.common.swagger.SwaggerApiListingResource;
+import org.apache.pinot.common.swagger.SwaggerSetupUtil;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
@@ -47,8 +45,6 @@ import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
-import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
-import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -123,7 +119,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
     }
     register(JacksonFeature.class);
-    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(SwaggerApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register(AuthenticationFilter.class);
   }
@@ -138,7 +134,6 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     }
 
     if (_swaggerBrokerEnabled) {
-      PinotReflectionUtils.runWithLock(this::setupSwagger);
       PinotReflectionUtils.runWithLock(() ->
           SwaggerSetupUtil.setupSwagger("broker", _brokerResourcePackages, _useHttps, false,
               "/", BrokerAdminApiApplication.class.getClassLoader(), _httpServer));
@@ -147,39 +142,13 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     }
   }
 
-  private void setupSwagger() {
-    BeanConfig beanConfig = new BeanConfig();
-    beanConfig.setTitle("Pinot Broker API");
-    beanConfig.setDescription("APIs for accessing Pinot broker information");
-    beanConfig.setContact("https://github.com/apache/pinot");
-    beanConfig.setVersion("1.0");
-    beanConfig.setExpandSuperTypes(false);
-    if (_useHttps) {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
-    } else {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
-    }
-    beanConfig.setBasePath("/");
-    beanConfig.setResourcePackage(_brokerResourcePackages);
-    beanConfig.setScan(true);
-
-    HttpHandler httpHandler = new CLStaticHttpHandler(BrokerAdminApiApplication.class.getClassLoader(), "/api/");
-    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
-
-    URL swaggerDistLocation =
-        BrokerAdminApiApplication.class.getClassLoader().getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
-    _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
-  }
-
   private BrokerManagedAsyncExecutorProvider buildBrokerManagedAsyncExecutorProvider(PinotConfiguration brokerConf,
       BrokerMetrics brokerMetrics) {
-    int corePoolSize =
-        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE,
+    int corePoolSize = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE,
             CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE);
-    int maximumPoolSize =
-        brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE,
+    int maximumPoolSize = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE,
             CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE);
     int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE,
         CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE);

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.swagger;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.listing.BaseApiListingResource;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.StringUtils;
+
+@Path("/swagger.{type:json|yaml}")
+public class SwaggerApiListingResource extends BaseApiListingResource {
+  @Context
+  ServletContext _context;
+
+  @Context
+  ServletConfig _servletConfig;
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON, "application/yaml"})
+  @ApiOperation(value = "The swagger definition in either JSON or YAML", hidden = true)
+  public Response getListing(
+      @Context Application app,
+      @Context HttpHeaders headers,
+      @Context UriInfo uriInfo,
+      @PathParam("type") String type) {
+    if (StringUtils.isNotBlank(type) && type.trim().equalsIgnoreCase("yaml")) {
+      return getListingYamlResponse(app, _context, _servletConfig, headers, uriInfo);
+    } else {
+      return getListingJsonResponse(app, _context, _servletConfig, headers, uriInfo);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
 
+
 /*
  This class is required to avoid the jersey2 warning messages regarding servlet config constructor missing while
  injecting the config. Please refer to Pinot issue 13047 & 5306 for more context.
@@ -50,10 +51,7 @@ public class SwaggerApiListingResource extends BaseApiListingResource {
   @GET
   @Produces({MediaType.APPLICATION_JSON, "application/yaml"})
   @ApiOperation(value = "The swagger definition in either JSON or YAML", hidden = true)
-  public Response getListing(
-      @Context Application app,
-      @Context HttpHeaders headers,
-      @Context UriInfo uriInfo,
+  public Response getListing(@Context Application app, @Context HttpHeaders headers, @Context UriInfo uriInfo,
       @PathParam("type") String type) {
     if (StringUtils.isNotBlank(type) && type.trim().equalsIgnoreCase("yaml")) {
       return getListingYamlResponse(app, _context, _servletConfig, headers, uriInfo);

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerApiListingResource.java
@@ -34,6 +34,11 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
 
+/*
+ This class is required to avoid the jersey2 warning messages regarding servlet config constructor missing while
+ injecting the config. Please refer to Pinot issue 13047 & 5306 for more context.
+ In this implementation, we added the ServletConfig as the class level member instead of injecting it.
+*/
 @Path("/swagger.{type:json|yaml}")
 public class SwaggerApiListingResource extends BaseApiListingResource {
   @Context

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
@@ -62,7 +62,8 @@ public class SwaggerSetupUtil {
     httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
 
     URL swaggerDistLocation = classLoader.getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    CLStaticHttpHandler swaggerDist =
+        new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}), "swagger-ui/");
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.UnknownHostException;
+import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
@@ -58,12 +59,11 @@ public class SwaggerSetupUtil {
 
     CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/");
-    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/", "/help/");
 
     URL swaggerDistLocation = classLoader.getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
     CLStaticHttpHandler swaggerDist =
-        new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}), "swagger-ui/");
+        new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.UnknownHostException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
@@ -36,8 +37,9 @@ public class SwaggerSetupUtil {
   public static void setupSwagger(String componentType, String resourcePackage,
       boolean useHttps, boolean setHost, String basePath, ClassLoader classLoader, HttpServer httpServer) {
     BeanConfig beanConfig = new BeanConfig();
-    beanConfig.setTitle("Pinot Server API");
-    beanConfig.setDescription(String.format("APIs for accessing Pinot %s information", componentType));
+    String capitalizeComponentType = StringUtils.capitalize(componentType);
+    beanConfig.setTitle(String.format("Pinot %s API", capitalizeComponentType));
+    beanConfig.setDescription(String.format("APIs for accessing Pinot %s information", capitalizeComponentType));
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
     beanConfig.setExpandSuperTypes(false);

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtil.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.swagger;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.UnknownHostException;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+
+
+public class SwaggerSetupUtil {
+  private SwaggerSetupUtil() {
+  }
+
+  public static void setupSwagger(String componentType, String resourcePackage,
+      boolean useHttps, boolean setHost, String basePath, ClassLoader classLoader, HttpServer httpServer) {
+    BeanConfig beanConfig = new BeanConfig();
+    beanConfig.setTitle("Pinot Server API");
+    beanConfig.setDescription(String.format("APIs for accessing Pinot %s information", componentType));
+    beanConfig.setContact("https://github.com/apache/pinot");
+    beanConfig.setVersion("1.0");
+    beanConfig.setExpandSuperTypes(false);
+    if (useHttps) {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
+    } else {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    }
+    beanConfig.setBasePath(basePath);
+    beanConfig.setResourcePackage(resourcePackage);
+    beanConfig.setScan(true);
+    if (setHost) {
+      try {
+        beanConfig.setHost(InetAddress.getLocalHost().getHostName());
+      } catch (UnknownHostException e) {
+        throw new RuntimeException("Cannot get localhost name");
+      }
+    }
+
+    CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");
+    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/");
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/help/");
+
+    URL swaggerDistLocation = classLoader.getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
+    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
@@ -29,8 +29,8 @@ import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 
 
-public class SwaggerSetupUtil {
-  private SwaggerSetupUtil() {
+public class SwaggerSetupUtils {
+  private SwaggerSetupUtils() {
   }
 
   public static void setupSwagger(String componentType, String resourcePackage, boolean useHttps, String basePath,
@@ -56,7 +56,7 @@ public class SwaggerSetupUtil {
       throw new RuntimeException("Cannot get localhost name");
     }
 
-    ClassLoader classLoader = SwaggerSetupUtil.class.getClassLoader();
+    ClassLoader classLoader = SwaggerSetupUtils.class.getClassLoader();
     CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
     httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/", "/help/");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -64,8 +64,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     }
     register(JacksonFeature.class);
     register(MultiPartFeature.class);
-    registerClasses(SwaggerApiListingResource.class);
-    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerApiListingResource.class);
+    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register(new CorsFilter());
     register(AuthenticationFilter.class);
     // property("jersey.config.server.tracing.type", "ALL");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -26,7 +26,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
-import org.apache.pinot.common.swagger.SwaggerSetupUtil;
+import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AuthenticationFilter;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
@@ -87,7 +87,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     }
     ClassLoader classLoader = ControllerAdminApiApplication.class.getClassLoader();
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Controller", _controllerResourcePackages, _useHttps, "/", _httpServer));
+        SwaggerSetupUtils.setupSwagger("Controller", _controllerResourcePackages, _useHttps, "/", _httpServer));
 
     // This is ugly from typical patterns to setup static resources but all our APIs are
     // at path "/". So, configuring static handler for path "/" does not work well.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -87,8 +87,10 @@ public class ControllerAdminApiApplication extends ResourceConfig {
       throw new RuntimeException("Failed to start http server", e);
     }
     PinotReflectionUtils.runWithLock(this::setupSwagger);
-
     ClassLoader classLoader = ControllerAdminApiApplication.class.getClassLoader();
+    PinotReflectionUtils.runWithLock(() ->
+        SwaggerSetupUtil.setupSwagger("Controller", _controllerResourcePackages, _useHttps, false,
+           "/", classLoader, _httpServer));
 
     // This is ugly from typical patterns to setup static resources but all our APIs are
     // at path "/". So, configuring static handler for path "/" does not work well.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api;
 
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
@@ -65,7 +66,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     register(JacksonFeature.class);
     register(MultiPartFeature.class);
     register(SwaggerApiListingResource.class);
-    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerSerializers.class);
     register(new CorsFilter());
     register(AuthenticationFilter.class);
     // property("jersey.config.server.tracing.type", "ALL");
@@ -86,8 +87,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     }
     ClassLoader classLoader = ControllerAdminApiApplication.class.getClassLoader();
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Controller", _controllerResourcePackages, _useHttps, false,
-           "/", classLoader, _httpServer));
+        SwaggerSetupUtil.setupSwagger("Controller", _controllerResourcePackages, _useHttps, "/", _httpServer));
 
     // This is ugly from typical patterns to setup static resources but all our APIs are
     // at path "/". So, configuring static handler for path "/" does not work well.

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -103,6 +103,7 @@ public abstract class ClusterTest extends ControllerTest {
   protected BaseMinionStarter _minionStarter;
 
   private String _brokerBaseApiUrl;
+  private String _minionBaseApiUrl;
 
   private boolean _useMultiStageQueryEngine = false;
 
@@ -127,6 +128,10 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected String getBrokerBaseApiUrl() {
     return _brokerBaseApiUrl;
+  }
+
+  public String getMinionBaseApiUrl() {
+    return _minionBaseApiUrl;
   }
 
   protected boolean useMultiStageQueryEngine() {
@@ -321,9 +326,10 @@ public abstract class ClusterTest extends ControllerTest {
     PinotConfiguration minionConf = getDefaultMinionConfiguration();
     minionConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     minionConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
-    minionConf.setProperty(CommonConstants.Helix.KEY_OF_MINION_PORT,
-        NetUtils.findOpenPort(CommonConstants.Minion.DEFAULT_HELIX_PORT));
+    int minionPort = NetUtils.findOpenPort(CommonConstants.Minion.DEFAULT_HELIX_PORT);
+    minionConf.setProperty(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort);
     minionConf.setProperty(CommonConstants.CONFIG_OF_TIMEZONE, "UTC");
+    _minionBaseApiUrl = "http://localhost:" + minionPort;
     _minionStarter = new MinionStarter();
     _minionStarter.init(minionConf);
     _minionStarter.start();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.minion;
 
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -74,7 +75,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
     });
 
     register(SwaggerApiListingResource.class);
-    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerSerializers.class);
   }
 
   public void start(List<ListenerConfig> listenerConfigs) {
@@ -86,8 +87,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
       throw new RuntimeException("Failed to start http server", e);
     }
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, false,
-            "/", MinionAdminApiApplication.class.getClassLoader(), _httpServer));
+        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, "/", _httpServer));
   }
 
   public void stop() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -73,8 +73,8 @@ public class MinionAdminApiApplication extends ResourceConfig {
       }
     });
 
-    registerClasses(SwaggerApiListingResource.class);
-    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerApiListingResource.class);
+    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
   }
 
   public void start(List<ListenerConfig> listenerConfigs) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.time.Instant;
 import java.util.List;
+import org.apache.pinot.common.swagger.SwaggerSetupUtil;
 import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
@@ -77,7 +78,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
       }
     });
 
-    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(SwaggerApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
   }
 
@@ -90,6 +91,9 @@ public class MinionAdminApiApplication extends ResourceConfig {
       throw new RuntimeException("Failed to start http server", e);
     }
     PinotReflectionUtils.runWithLock(this::setupSwagger);
+    PinotReflectionUtils.runWithLock(() ->
+        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, false,
+            "/", MinionAdminApiApplication.class.getClassLoader(), _httpServer));
   }
 
   private void setupSwagger() {
@@ -116,6 +120,9 @@ public class MinionAdminApiApplication extends ResourceConfig {
         MinionAdminApiApplication.class.getClassLoader().getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
     CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+    PinotReflectionUtils.runWithLock(() ->
+        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, false,
+            "/", MinionAdminApiApplication.class.getClassLoader(), _httpServer));
   }
 
   public void stop() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -18,14 +18,11 @@
  */
 package org.apache.pinot.minion;
 
-import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.time.Instant;
 import java.util.List;
+import org.apache.pinot.common.swagger.SwaggerApiListingResource;
 import org.apache.pinot.common.swagger.SwaggerSetupUtil;
-import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
@@ -34,8 +31,6 @@ import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
-import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
-import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -90,36 +85,6 @@ public class MinionAdminApiApplication extends ResourceConfig {
     } catch (IOException e) {
       throw new RuntimeException("Failed to start http server", e);
     }
-    PinotReflectionUtils.runWithLock(this::setupSwagger);
-    PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, false,
-            "/", MinionAdminApiApplication.class.getClassLoader(), _httpServer));
-  }
-
-  private void setupSwagger() {
-    BeanConfig beanConfig = new BeanConfig();
-    beanConfig.setTitle("Pinot Minion API");
-    beanConfig.setDescription("APIs for accessing Pinot Minion information");
-    beanConfig.setContact("https://github.com/apache/pinot");
-    beanConfig.setVersion("1.0");
-    beanConfig.setExpandSuperTypes(false);
-    if (_useHttps) {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
-    } else {
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
-    }
-    beanConfig.setBasePath("/");
-    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
-    beanConfig.setScan(true);
-
-    HttpHandler httpHandler = new CLStaticHttpHandler(MinionAdminApiApplication.class.getClassLoader(), "/api/");
-    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
-
-    URL swaggerDistLocation =
-        MinionAdminApiApplication.class.getClassLoader().getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
-    _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
     PinotReflectionUtils.runWithLock(() ->
         SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, false,
             "/", MinionAdminApiApplication.class.getClassLoader(), _httpServer));

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
-import org.apache.pinot.common.swagger.SwaggerSetupUtil;
+import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
@@ -87,7 +87,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
       throw new RuntimeException("Failed to start http server", e);
     }
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, "/", _httpServer));
+        SwaggerSetupUtils.setupSwagger("Minion", RESOURCE_PACKAGE, _useHttps, "/", _httpServer));
   }
 
   public void stop() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -91,8 +91,8 @@ public class AdminApiApplication extends ResourceConfig {
 
     register(JacksonFeature.class);
 
-    registerClasses(SwaggerApiListingResource.class);
-    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerApiListingResource.class);
+    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register(new ContainerResponseFilter() {
       @Override
       public void filter(ContainerRequestContext containerRequestContext,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -29,7 +29,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
-import org.apache.pinot.common.swagger.SwaggerSetupUtil;
+import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
@@ -123,7 +123,7 @@ public class AdminApiApplication extends ResourceConfig {
       boolean useHttps = Boolean.parseBoolean(
           pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS));
       PinotReflectionUtils.runWithLock(() ->
-          SwaggerSetupUtil.setupSwagger("Server", _adminApiResourcePackages, useHttps, "/", _httpServer));
+          SwaggerSetupUtils.setupSwagger("Server", _adminApiResourcePackages, useHttps, "/", _httpServer));
     }
     return true;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.server.api;
 
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -92,7 +93,7 @@ public class AdminApiApplication extends ResourceConfig {
     register(JacksonFeature.class);
 
     register(SwaggerApiListingResource.class);
-    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerSerializers.class);
     register(new ContainerResponseFilter() {
       @Override
       public void filter(ContainerRequestContext containerRequestContext,
@@ -122,8 +123,7 @@ public class AdminApiApplication extends ResourceConfig {
       boolean useHttps = Boolean.parseBoolean(
           pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS));
       PinotReflectionUtils.runWithLock(() ->
-          SwaggerSetupUtil.setupSwagger("server", _adminApiResourcePackages, useHttps, true,
-              "/", AdminApiApplication.class.getClassLoader(), _httpServer));
+          SwaggerSetupUtil.setupSwagger("Server", _adminApiResourcePackages, useHttps, "/", _httpServer));
     }
     return true;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -64,6 +64,7 @@ public class AdminApiApplication extends ResourceConfig {
   private HttpServer _httpServer;
   private final String _adminApiResourcePackages;
 
+
   public AdminApiApplication(ServerInstance instance, AccessControlFactory accessControlFactory,
       PinotConfiguration serverConf) {
     _serverInstance = instance;
@@ -124,6 +125,11 @@ public class AdminApiApplication extends ResourceConfig {
         CommonConstants.Server.DEFAULT_SWAGGER_SERVER_ENABLED)) {
       LOGGER.info("Starting swagger for the Pinot server.");
       PinotReflectionUtils.runWithLock(() -> setupSwagger(pinotConfiguration));
+      boolean useHttps = Boolean.parseBoolean(
+          pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS));
+      PinotReflectionUtils.runWithLock(() ->
+          SwaggerSetupUtil.setupSwagger("server", _adminApiResourcePackages, useHttps, true,
+              "/", AdminApiApplication.class.getClassLoader(), _httpServer));
     }
     return true;
   }
@@ -157,7 +163,7 @@ public class AdminApiApplication extends ResourceConfig {
 
     URL swaggerDistLocation =
         AdminApiApplication.class.getClassLoader().getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.service;
 
 import com.google.common.base.Preconditions;
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.net.URI;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
 import org.apache.pinot.common.swagger.SwaggerSetupUtil;
@@ -46,7 +47,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     });
     register(JacksonFeature.class);
     register(SwaggerApiListingResource.class);
-    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerSerializers.class);
   }
 
   public void start(int httpPort) {
@@ -54,8 +55,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
     _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Starter", RESOURCE_PACKAGE, false, false,
-            _baseUri.getPath(), PinotServiceManagerAdminApiApplication.class.getClassLoader(), _httpServer));
+        SwaggerSetupUtil.setupSwagger("Starter", RESOURCE_PACKAGE, false, _baseUri.getPath(), _httpServer));
   }
 
   public void stop() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -19,16 +19,10 @@
 package org.apache.pinot.tools.service;
 
 import com.google.common.base.Preconditions;
-import io.swagger.jaxrs.config.BeanConfig;
 import java.net.URI;
-import java.net.URL;
-import java.net.URLClassLoader;
+import org.apache.pinot.common.swagger.SwaggerApiListingResource;
 import org.apache.pinot.common.swagger.SwaggerSetupUtil;
-import org.apache.pinot.common.utils.PinotStaticHttpHandler;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
-import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
-import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
@@ -51,7 +45,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
       }
     });
     register(JacksonFeature.class);
-    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(SwaggerApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
   }
 
@@ -59,32 +53,9 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     Preconditions.checkArgument(httpPort > 0);
     _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
     _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
-    PinotReflectionUtils.runWithLock(this::setupSwagger);
     PinotReflectionUtils.runWithLock(() ->
         SwaggerSetupUtil.setupSwagger("Starter", RESOURCE_PACKAGE, false, false,
             _baseUri.getPath(), PinotServiceManagerAdminApiApplication.class.getClassLoader(), _httpServer));
-  }
-
-  private void setupSwagger() {
-    BeanConfig beanConfig = new BeanConfig();
-    beanConfig.setTitle("Pinot Starter API");
-    beanConfig.setDescription("APIs for accessing Pinot Starter information");
-    beanConfig.setContact("https://github.com/apache/pinot");
-    beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
-    beanConfig.setBasePath(_baseUri.getPath());
-    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
-    beanConfig.setScan(true);
-    beanConfig.setExpandSuperTypes(false);
-    HttpHandler httpHandler =
-        new CLStaticHttpHandler(PinotServiceManagerAdminApiApplication.class.getClassLoader(), "/api/");
-    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
-
-    URL swaggerDistLocation = PinotServiceManagerAdminApiApplication.class.getClassLoader()
-        .getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
-    _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 
   public void stop() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -23,6 +23,7 @@ import io.swagger.jaxrs.config.BeanConfig;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import org.apache.pinot.common.swagger.SwaggerSetupUtil;
 import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
@@ -59,6 +60,9 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
     _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
     PinotReflectionUtils.runWithLock(this::setupSwagger);
+    PinotReflectionUtils.runWithLock(() ->
+        SwaggerSetupUtil.setupSwagger("Starter", RESOURCE_PACKAGE, false, false,
+            _baseUri.getPath(), PinotServiceManagerAdminApiApplication.class.getClassLoader(), _httpServer));
   }
 
   private void setupSwagger() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -22,7 +22,7 @@ import com.google.common.base.Preconditions;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
 import java.net.URI;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
-import org.apache.pinot.common.swagger.SwaggerSetupUtil;
+import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -55,7 +55,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
     _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
     PinotReflectionUtils.runWithLock(() ->
-        SwaggerSetupUtil.setupSwagger("Starter", RESOURCE_PACKAGE, false, _baseUri.getPath(), _httpServer));
+        SwaggerSetupUtils.setupSwagger("Starter", RESOURCE_PACKAGE, false, _baseUri.getPath(), _httpServer));
   }
 
   public void stop() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -45,8 +45,8 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
       }
     });
     register(JacksonFeature.class);
-    registerClasses(SwaggerApiListingResource.class);
-    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    register(SwaggerApiListingResource.class);
+    register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
   }
 
   public void start(int httpPort) {


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/13047) and other [issue](https://github.com/apache/pinot/issues/5306), we are getting `java.lang.NoSuchMethodException` warning messages while loading the swagger endpoints using jersey2. This same issue is discussed here in [stackoverflow](https://stackoverflow.com/questions/49875277/swagger-hk2-service-reification-failed). For the solution; we are taking the same approach as mentioned in StackOverflow with some changes. 

Here are the changes 
- Introduced the new `SwaggerApiListingResource` class with ServletConfig as a class member. Jersey-hk2 is not trying to inject the class; hence, there is no reification warning. This new class will be used instead of the default `io.swagger.jaxrs.listing.ApiListingResource` to load the swagger response.
- Refactored the swagger bean config creation part. Pinot almost has a similar bean creation code in five different classes. Consolidate the code into one util class and use it.
- Added the minion swagger-ui test in `AdminConsoleIntegrationTest`

cc: @Jackie-Jiang 
