### PR TITLE
Security fix for CLStaticHttpHandler

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/PinotCLStaticHttpHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/PinotCLStaticHttpHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller;
+
+import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+
+
+/**
+ * Extends {@link CLStaticHttpHandler} to prevent file/directory listing.
+ */
+public class PinotCLStaticHttpHandler extends CLStaticHttpHandler {
+
+  public PinotCLStaticHttpHandler(ClassLoader classLoader, String... docRoots) {
+    super(classLoader, docRoots);
+  }
+
+  @Override
+  protected boolean handle(String resourcePath, final Request request, final Response response)
+      throws Exception {
+    if (resourcePath.startsWith("/file:")) {
+      // Set resource to forbidden to prevent directory listing
+      response.setStatus(403);
+      response.getWriter().write("Forbidden");
+      return false;
+    }
+    return super.handle(resourcePath, request, response);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -28,6 +28,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.PinotCLStaticHttpHandler;
 import org.apache.pinot.controller.api.access.AuthenticationFilter;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.transport.ListenerConfig;
@@ -125,7 +126,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(apiStaticHttpHandler, "/help/");
 
     URL swaggerDistLocation = loader.getResource(CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH);
-    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    PinotCLStaticHttpHandler swaggerDist = new PinotCLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
@@ -69,6 +69,7 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
   private final List<ExpressionContext> _expressions;
   private final List<ExpressionContext> _stepExpressions;
   private final List<ExpressionContext> _correlateByExpressions;
+  private final List<ExpressionContext> _windowExpressions;
   private final int _numSteps;
 
   private final AggregationStrategy<A> _aggregationStrategy;
@@ -76,11 +77,12 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
   private final MergeStrategy<I> _mergeStrategy;
 
   public FunnelCountAggregationFunction(List<ExpressionContext> expressions, List<ExpressionContext> stepExpressions,
-      List<ExpressionContext> correlateByExpressions, AggregationStrategy<A> aggregationStrategy,
+      List<ExpressionContext> correlateByExpressions, List<ExpressionContext> windowExpressions, AggregationStrategy<A> aggregationStrategy,
       ResultExtractionStrategy<A, I> resultExtractionStrategy, MergeStrategy<I> mergeStrategy) {
     _expressions = expressions;
     _stepExpressions = stepExpressions;
     _correlateByExpressions = correlateByExpressions;
+    _windowExpressions = windowExpressions;
     _aggregationStrategy = aggregationStrategy;
     _resultExtractionStrategy = resultExtractionStrategy;
     _mergeStrategy = mergeStrategy;
@@ -98,6 +100,9 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
     final List<ExpressionContext> inputs = new ArrayList<>();
     inputs.addAll(_correlateByExpressions);
     inputs.addAll(_stepExpressions);
+    if (_windowExpressions != null && !_windowExpressions.isEmpty()) {
+      inputs.add(_windowExpressions.get(0));
+    }
     return inputs;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunctionFactory.java
@@ -57,6 +57,7 @@ public class FunnelCountAggregationFunctionFactory implements Supplier<Aggregati
   final List<ExpressionContext> _expressions;
   final List<ExpressionContext> _stepExpressions;
   final List<ExpressionContext> _correlateByExpressions;
+  final List<ExpressionContext> _windowExpressions;
   final ExpressionContext _primaryCorrelationCol;
   final int _numSteps;
   final int _nominalEntries;
@@ -70,6 +71,7 @@ public class FunnelCountAggregationFunctionFactory implements Supplier<Aggregati
     Option.validate(expressions);
     _correlateByExpressions = Option.CORRELATE_BY.getInputExpressions(expressions);
     _primaryCorrelationCol = _correlateByExpressions.get(0);
+    _windowExpressions = Option.WINDOW.getInputExpressions(expressions);
     _stepExpressions = Option.STEPS.getInputExpressions(expressions);
     _numSteps = _stepExpressions.size();
 
@@ -115,7 +117,7 @@ public class FunnelCountAggregationFunctionFactory implements Supplier<Aggregati
       AggregationStrategy<A> aggregationStrategy, ResultExtractionStrategy<A, I> resultExtractionStrategy,
       MergeStrategy<I> mergeStrategy) {
     return new FunnelCountAggregationFunction<>(_expressions, _stepExpressions, _correlateByExpressions,
-        aggregationStrategy, resultExtractionStrategy, mergeStrategy);
+        _windowExpressions, aggregationStrategy, resultExtractionStrategy, mergeStrategy);
   }
 
   private <A> FunnelCountAggregationFunction<A, List<Long>> createPartionedFunnelCountAggregationFunction(
@@ -123,10 +125,10 @@ public class FunnelCountAggregationFunctionFactory implements Supplier<Aggregati
       MergeStrategy<List<Long>> mergeStrategy) {
     if (_sortingSetting) {
       return new FunnelCountSortedAggregationFunction<>(_expressions, _stepExpressions, _correlateByExpressions,
-          aggregationStrategy, resultExtractionStrategy, mergeStrategy);
+          _windowExpressions, aggregationStrategy, resultExtractionStrategy, mergeStrategy);
     } else {
       return new FunnelCountAggregationFunction<>(_expressions, _stepExpressions, _correlateByExpressions,
-          aggregationStrategy, resultExtractionStrategy, mergeStrategy);
+          _windowExpressions, aggregationStrategy, resultExtractionStrategy, mergeStrategy);
     }
   }
 
@@ -177,7 +179,7 @@ public class FunnelCountAggregationFunctionFactory implements Supplier<Aggregati
   }
 
   enum Option {
-    STEPS("steps"), CORRELATE_BY("correlateby"), SETTINGS("settings");
+    STEPS("steps"), CORRELATE_BY("correlateby"), SETTINGS("settings"), WINDOW("window");
 
     final String _name;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountSortedAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountSortedAggregationFunction.java
@@ -54,10 +54,10 @@ public class FunnelCountSortedAggregationFunction<A> extends FunnelCountAggregat
 
   public FunnelCountSortedAggregationFunction(List<ExpressionContext> expressions,
       List<ExpressionContext> stepExpressions, List<ExpressionContext> correlateByExpressions,
-      AggregationStrategy<A> aggregationStrategy, ResultExtractionStrategy<A, List<Long>> resultExtractionStrategy,
-      MergeStrategy<List<Long>> mergeStrategy) {
-    super(expressions, stepExpressions, correlateByExpressions, aggregationStrategy, resultExtractionStrategy,
-        mergeStrategy);
+      List<ExpressionContext> windowExpressions, AggregationStrategy<A> aggregationStrategy,
+      ResultExtractionStrategy<A, List<Long>> resultExtractionStrategy, MergeStrategy<List<Long>> mergeStrategy) {
+    super(expressions, stepExpressions, correlateByExpressions, windowExpressions, aggregationStrategy,
+        resultExtractionStrategy, mergeStrategy);
     _sortedAggregationStrategy = new SortedAggregationStrategy(stepExpressions, correlateByExpressions);
     _sortedResultExtractionStrategy = SortedAggregationResult::extractResult;;
     _primaryCorrelationCol = correlateByExpressions.get(0);


### PR DESCRIPTION
Extend CLStaticHttpHandler to prevent the file/directory listing.
![image](https://github.com/apache/pinot/assets/1202120/70813b34-eb61-4f7e-a5f9-9b1083a1b772)
