### PR TITLE
Do not add leaf stage time into broker time

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -551,7 +551,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
 
   public enum StatKey implements StatMap.Key {
     TABLE(StatMap.Type.STRING, null),
-    EXECUTION_TIME_MS(StatMap.Type.LONG, BrokerResponseNativeV2.StatKey.TIME_USED_MS) {
+    EXECUTION_TIME_MS(StatMap.Type.LONG, null) {
       @Override
       public boolean includeDefaultInJson() {
         return true;


### PR DESCRIPTION
Fix the bug where we add the leaf stage execution time into the query time.
Query time should be the wall clock time captured on the broker side