### PR TITLE
Add support for nested exclusive predicates with JSON index; fix semantics for exclusive predicates

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
@@ -103,28 +103,10 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
       throw new BadQueryRequestException("Invalid json match filter: " + filterString);
     }
 
-    if (filter.getType() == FilterContext.Type.PREDICATE && isExclusive(filter.getPredicate().getType())) {
-      // Handle exclusive predicate separately because the flip can only be applied to the unflattened doc ids in order
-      // to get the correct result, and it cannot be nested
-      MutableRoaringBitmap matchingFlattenedDocIds = getMatchingFlattenedDocIds(filter.getPredicate());
-      MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-      matchingFlattenedDocIds.forEach((IntConsumer) flattenedDocId -> matchingDocIds.add(getDocId(flattenedDocId)));
-      matchingDocIds.flip(0, _numDocs);
-      return matchingDocIds;
-    } else {
-      MutableRoaringBitmap matchingFlattenedDocIds = getMatchingFlattenedDocIds(filter);
-      MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-      matchingFlattenedDocIds.forEach((IntConsumer) flattenedDocId -> matchingDocIds.add(getDocId(flattenedDocId)));
-      return matchingDocIds;
-    }
-  }
-
-  /**
-   * Returns {@code true} if the given predicate type is exclusive for json_match calculation, {@code false} otherwise.
-   */
-  private boolean isExclusive(Predicate.Type predicateType) {
-    return predicateType == Predicate.Type.NOT_EQ || predicateType == Predicate.Type.NOT_IN
-        || predicateType == Predicate.Type.IS_NULL;
+    MutableRoaringBitmap matchingFlattenedDocIds = getMatchingFlattenedDocIds(filter);
+    MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
+    matchingFlattenedDocIds.forEach((IntConsumer) flattenedDocId -> matchingDocIds.add(getDocId(flattenedDocId)));
+    return matchingDocIds;
   }
 
   /**
@@ -153,10 +135,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
         return matchingDocIds;
       }
       case PREDICATE: {
-        Predicate predicate = filter.getPredicate();
-        Preconditions
-            .checkArgument(!isExclusive(predicate.getType()), "Exclusive predicate: %s cannot be nested", predicate);
-        return getMatchingFlattenedDocIds(predicate);
+        return getMatchingFlattenedDocIds(filter.getPredicate());
       }
       default:
         throw new IllegalStateException();
@@ -165,8 +144,6 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
 
   /**
    * Returns the matching flattened doc ids for the given predicate.
-   * <p>Exclusive predicate is handled as the inclusive predicate, and the caller should flip the unflattened doc ids in
-   * order to get the correct exclusive predicate result.
    */
   private MutableRoaringBitmap getMatchingFlattenedDocIds(Predicate predicate) {
     ExpressionContext lhs = predicate.getLhs();
@@ -197,127 +174,215 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
     }
 
     Predicate.Type predicateType = predicate.getType();
-    if (predicateType == Predicate.Type.EQ || predicateType == Predicate.Type.NOT_EQ) {
-      String value = predicateType == Predicate.Type.EQ ? ((EqPredicate) predicate).getValue()
-          : ((NotEqPredicate) predicate).getValue();
-      String keyValuePair = key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value;
-      int dictId = _dictionary.indexOf(keyValuePair);
-      if (dictId >= 0) {
-        ImmutableRoaringBitmap matchingDocIdsForKeyValuePair = _invertedIndex.getDocIds(dictId);
-        if (matchingDocIds == null) {
-          matchingDocIds = matchingDocIdsForKeyValuePair.toMutableRoaringBitmap();
-        } else {
-          matchingDocIds.and(matchingDocIdsForKeyValuePair);
-        }
-        return matchingDocIds;
-      } else {
-        return new MutableRoaringBitmap();
-      }
-    } else if (predicateType == Predicate.Type.IN || predicateType == Predicate.Type.NOT_IN) {
-      List<String> values = predicateType == Predicate.Type.IN ? ((InPredicate) predicate).getValues()
-          : ((NotInPredicate) predicate).getValues();
-      MutableRoaringBitmap matchingDocIdsForKeyValuePairs = new MutableRoaringBitmap();
-      for (String value : values) {
+    switch (predicateType) {
+      case EQ: {
+        String value = ((EqPredicate) predicate).getValue();
         String keyValuePair = key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value;
         int dictId = _dictionary.indexOf(keyValuePair);
         if (dictId >= 0) {
-          matchingDocIdsForKeyValuePairs.or(_invertedIndex.getDocIds(dictId));
+          ImmutableRoaringBitmap matchingDocIdsForKeyValuePair = _invertedIndex.getDocIds(dictId);
+          if (matchingDocIds == null) {
+            matchingDocIds = matchingDocIdsForKeyValuePair.toMutableRoaringBitmap();
+          } else {
+            matchingDocIds.and(matchingDocIdsForKeyValuePair);
+          }
+          return matchingDocIds;
+        } else {
+          return new MutableRoaringBitmap();
         }
       }
-      if (matchingDocIds == null) {
-        matchingDocIds = matchingDocIdsForKeyValuePairs;
-      } else {
-        matchingDocIds.and(matchingDocIdsForKeyValuePairs);
-      }
-      return matchingDocIds;
-    } else if (predicateType == Predicate.Type.IS_NOT_NULL || predicateType == Predicate.Type.IS_NULL) {
-      int dictId = _dictionary.indexOf(key);
-      if (dictId >= 0) {
-        ImmutableRoaringBitmap matchingDocIdsForKey = _invertedIndex.getDocIds(dictId);
-        if (matchingDocIds == null) {
-          matchingDocIds = matchingDocIdsForKey.toMutableRoaringBitmap();
+
+      case NOT_EQ: {
+        String notEqualValue = ((NotEqPredicate) predicate).getValue();
+        int[] dictIds = getDictIdRangeForKey(key);
+        MutableRoaringBitmap result = null;
+
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
+          if (!notEqualValue.equals(value)) {
+            if (result == null) {
+              result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+            } else {
+              result.or(_invertedIndex.getDocIds(dictId));
+            }
+          }
+        }
+
+        if (result == null) {
+          return new MutableRoaringBitmap();
         } else {
-          matchingDocIds.and(matchingDocIdsForKey);
+          if (matchingDocIds == null) {
+            return result;
+          } else {
+            matchingDocIds.and(result);
+            return matchingDocIds;
+          }
+        }
+      }
+
+      case IN: {
+        List<String> values = ((InPredicate) predicate).getValues();
+        MutableRoaringBitmap matchingDocIdsForKeyValuePairs = new MutableRoaringBitmap();
+        for (String value : values) {
+          String keyValuePair = key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value;
+          int dictId = _dictionary.indexOf(keyValuePair);
+          if (dictId >= 0) {
+            matchingDocIdsForKeyValuePairs.or(_invertedIndex.getDocIds(dictId));
+          }
+        }
+        if (matchingDocIds == null) {
+          matchingDocIds = matchingDocIdsForKeyValuePairs;
+        } else {
+          matchingDocIds.and(matchingDocIdsForKeyValuePairs);
         }
         return matchingDocIds;
-      } else {
-        return new MutableRoaringBitmap();
       }
-    } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
-      Pattern pattern = ((RegexpLikePredicate) predicate).getPattern();
-      int[] dictIds = getDictIdRangeForKey(key);
 
-      MutableRoaringBitmap result = null;
-      for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
-        String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
-        if (pattern.matcher(value).matches()) {
-          if (result == null) {
-            result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
-          } else {
-            result.or(_invertedIndex.getDocIds(dictId));
+      case NOT_IN: {
+        List<String> notInValues = ((NotInPredicate) predicate).getValues();
+        int[] dictIds = getDictIdRangeForKey(key);
+        MutableRoaringBitmap result = null;
+
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
+          if (!notInValues.contains(value)) {
+            if (result == null) {
+              result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+            } else {
+              result.or(_invertedIndex.getDocIds(dictId));
+            }
           }
         }
-      }
-      if (result == null) {
-        return new MutableRoaringBitmap();
-      } else {
-        if (matchingDocIds == null) {
-          return result;
+
+        if (result == null) {
+          return new MutableRoaringBitmap();
         } else {
-          matchingDocIds.and(result);
-          return matchingDocIds;
-        }
-      }
-    } else if (predicateType == Predicate.Type.RANGE) {
-      RangePredicate rangePredicate = (RangePredicate) predicate;
-      FieldSpec.DataType rangeDataType = rangePredicate.getRangeDataType();
-      // Simplify to only support numeric and string types
-      if (rangeDataType.isNumeric()) {
-        rangeDataType = FieldSpec.DataType.DOUBLE;
-      } else {
-        rangeDataType = FieldSpec.DataType.STRING;
-      }
-
-      boolean lowerUnbounded = rangePredicate.getLowerBound().equals(RangePredicate.UNBOUNDED);
-      boolean upperUnbounded = rangePredicate.getUpperBound().equals(RangePredicate.UNBOUNDED);
-      boolean lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
-      boolean upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
-      Object lowerBound = lowerUnbounded ? null : rangeDataType.convert(rangePredicate.getLowerBound());
-      Object upperBound = upperUnbounded ? null : rangeDataType.convert(rangePredicate.getUpperBound());
-
-      int[] dictIds = getDictIdRangeForKey(key);
-      MutableRoaringBitmap result = null;
-      for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
-        String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
-        Object valueObj = rangeDataType.convert(value);
-        boolean lowerCompareResult =
-            lowerUnbounded || (lowerInclusive ? rangeDataType.compare(valueObj, lowerBound) >= 0
-                : rangeDataType.compare(valueObj, lowerBound) > 0);
-        boolean upperCompareResult =
-            upperUnbounded || (upperInclusive ? rangeDataType.compare(valueObj, upperBound) <= 0
-                : rangeDataType.compare(valueObj, upperBound) < 0);
-
-        if (lowerCompareResult && upperCompareResult) {
-          if (result == null) {
-            result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+          if (matchingDocIds == null) {
+            return result;
           } else {
-            result.or(_invertedIndex.getDocIds(dictId));
+            matchingDocIds.and(result);
+            return matchingDocIds;
           }
         }
       }
 
-      if (result == null) {
-        return new MutableRoaringBitmap();
-      } else {
-        if (matchingDocIds == null) {
-          return result;
-        } else {
-          matchingDocIds.and(result);
+      case IS_NOT_NULL: {
+        int dictId = _dictionary.indexOf(key);
+        if (dictId >= 0) {
+          ImmutableRoaringBitmap matchingDocIdsForKey = _invertedIndex.getDocIds(dictId);
+          if (matchingDocIds == null) {
+            matchingDocIds = matchingDocIdsForKey.toMutableRoaringBitmap();
+          } else {
+            matchingDocIds.and(matchingDocIdsForKey);
+          }
           return matchingDocIds;
+        } else {
+          return new MutableRoaringBitmap();
         }
       }
-    } else {
-      throw new IllegalStateException("Unsupported json_match predicate type: " + predicate);
+
+      case IS_NULL: {
+        int dictId = _dictionary.indexOf(key);
+        if (dictId >= 0) {
+          MutableRoaringBitmap matchingDocIdsForKey = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+          matchingDocIdsForKey.flip(0, _numFlattenedDocs);
+
+          if (matchingDocIds == null) {
+            matchingDocIds = matchingDocIdsForKey;
+          } else {
+            matchingDocIds.and(matchingDocIdsForKey);
+          }
+          return matchingDocIds;
+        } else {
+          if (matchingDocIds != null) {
+            return matchingDocIds;
+          } else {
+            MutableRoaringBitmap result = new MutableRoaringBitmap();
+            result.flip(0, _numFlattenedDocs);
+            return result;
+          }
+        }
+      }
+
+      case REGEXP_LIKE: {
+        Pattern pattern = ((RegexpLikePredicate) predicate).getPattern();
+        int[] dictIds = getDictIdRangeForKey(key);
+
+        MutableRoaringBitmap result = null;
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
+          if (pattern.matcher(value).matches()) {
+            if (result == null) {
+              result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+            } else {
+              result.or(_invertedIndex.getDocIds(dictId));
+            }
+          }
+        }
+        if (result == null) {
+          return new MutableRoaringBitmap();
+        } else {
+          if (matchingDocIds == null) {
+            return result;
+          } else {
+            matchingDocIds.and(result);
+            return matchingDocIds;
+          }
+        }
+      }
+
+      case RANGE: {
+        RangePredicate rangePredicate = (RangePredicate) predicate;
+        FieldSpec.DataType rangeDataType = rangePredicate.getRangeDataType();
+        // Simplify to only support numeric and string types
+        if (rangeDataType.isNumeric()) {
+          rangeDataType = FieldSpec.DataType.DOUBLE;
+        } else {
+          rangeDataType = FieldSpec.DataType.STRING;
+        }
+
+        boolean lowerUnbounded = rangePredicate.getLowerBound().equals(RangePredicate.UNBOUNDED);
+        boolean upperUnbounded = rangePredicate.getUpperBound().equals(RangePredicate.UNBOUNDED);
+        boolean lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
+        boolean upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+        Object lowerBound = lowerUnbounded ? null : rangeDataType.convert(rangePredicate.getLowerBound());
+        Object upperBound = upperUnbounded ? null : rangeDataType.convert(rangePredicate.getUpperBound());
+
+        int[] dictIds = getDictIdRangeForKey(key);
+        MutableRoaringBitmap result = null;
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String value = _dictionary.getStringValue(dictId).substring(key.length() + 1);
+          Object valueObj = rangeDataType.convert(value);
+          boolean lowerCompareResult =
+              lowerUnbounded || (lowerInclusive ? rangeDataType.compare(valueObj, lowerBound) >= 0
+                  : rangeDataType.compare(valueObj, lowerBound) > 0);
+          boolean upperCompareResult =
+              upperUnbounded || (upperInclusive ? rangeDataType.compare(valueObj, upperBound) <= 0
+                  : rangeDataType.compare(valueObj, upperBound) < 0);
+
+          if (lowerCompareResult && upperCompareResult) {
+            if (result == null) {
+              result = _invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
+            } else {
+              result.or(_invertedIndex.getDocIds(dictId));
+            }
+          }
+        }
+
+        if (result == null) {
+          return new MutableRoaringBitmap();
+        } else {
+          if (matchingDocIds == null) {
+            return result;
+          } else {
+            matchingDocIds.and(result);
+            return matchingDocIds;
+          }
+        }
+      }
+
+      default:
+        throw new IllegalStateException("Unsupported json_match predicate type: " + predicate);
     }
   }
 
@@ -344,14 +409,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
       } catch (Exception e) {
         throw new BadQueryRequestException("Invalid json match filter: " + filterString);
       }
-      if (filter.getType() == FilterContext.Type.PREDICATE && isExclusive(filter.getPredicate().getType())) {
-        // Handle exclusive predicate separately because the flip can only be applied to the
-        // unflattened doc ids in order to get the correct result, and it cannot be nested
-        filteredFlattenedDocIds = getMatchingFlattenedDocIds(filter.getPredicate()).toRoaringBitmap();
-        filteredFlattenedDocIds.flip(0, _numFlattenedDocs);
-      } else {
-        filteredFlattenedDocIds = getMatchingFlattenedDocIds(filter).toRoaringBitmap();
-      }
+      filteredFlattenedDocIds = getMatchingFlattenedDocIds(filter).toRoaringBitmap();
     }
     // Support 2 formats:
     // - JSONPath format (e.g. "$.a[1].b"='abc', "$[0]"=1, "$"='abc')

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
@@ -178,13 +178,10 @@ public class JsonIndexTest {
         Assert.assertEquals(matchingDocIds.toArray(), new int[0]);
 
         matchingDocIds = getMatchingDocIds(indexReader, "\"addresses[*].types[*]\" IS NULL");
-        Assert.assertEquals(matchingDocIds.toArray(), new int[]{0, 1, 2, 3});
+        Assert.assertEquals(matchingDocIds.toArray(), new int[]{0, 1, 2});
 
         matchingDocIds = getMatchingDocIds(indexReader, "\"addresses[*].types[*]\" IS NOT NULL");
         Assert.assertEquals(matchingDocIds.toArray(), new int[]{3});
-
-        matchingDocIds = getMatchingDocIds(indexReader, "\"addresses[1].types[*]\" IS NULL");
-        Assert.assertEquals(matchingDocIds.toArray(), new int[]{0, 1, 2, 3});
 
         matchingDocIds = getMatchingDocIds(indexReader, "\"addresses[1].types[*]\" IS NOT NULL");
         Assert.assertEquals(matchingDocIds.toArray(), new int[0]);


### PR DESCRIPTION
- The JSON index currently doesn't support nested (within `AND` / `OR`) exclusive predicates (`NOT IN`, `!=`, `IS NULL`) with the `JSON_MATCH` filter operator.
- The reason for this is the existing semantics for exclusive predicates that are inconsistent and confusing.
- A document like:
  - ```
     [
       {
         "key1": "value1",
         "key2": 1
       },
       {
         "key1": "value2",
         "key2": 2
       }
     ]
    ```
    matches `"$[*].key2" = 1`, but not `"$[*].key2" != 2` for example.
- Essentially, the wildcard array access for inclusive predicates means that we match the array when ANY value matches, but for exclusive predicates, we match the array when ALL values match.
- Furthermore, a document like:
  - ```
     [
       {
          "key1": "value1",
       }
     ]
    ```
    matches `"$[0].key2" != 2` which is counterintuitive since the object doesn’t contain `key2` at all.
- The reason for both of these inconsistencies and confusing semantics is the way that exclusive predicates are implemented. Exclusive predicates are currently handled by finding the [flattened doc ID](https://docs.pinot.apache.org/basics/indexing/json-index#example)s of the corresponding inclusive predicate, mapping them back to the corresponding unflattened doc IDs, and then inverting / flipping the resultant bitmap. And that is also the reason why nested exclusive predicates aren’t supported currently since the intermediate flattened doc ID results can’t be combined with flattened doc ID results from other child predicates while maintaining the same semantics.
- This patch fixes the above inconsistencies so that `[*]` now means the same for both exclusive (`NOT IN`, `!=`) and inclusive predicates, and documents where a key doesn't exist aren't matched for the exclusive predicates `NOT IN`, `!=`. It also adds support for nested exclusive predicates.
- The new implementation for `NOT IN`, `!=` make use of similar logic to the implementation for the regex and range predicates (https://github.com/apache/pinot/pull/12568).
- Essentially, we first get all the values for a corresponding key. Then, we iterate through the values - and for each value that matches the predicate, we add the list of corresponding flattened doc IDs to the result.
- The `IS NULL` predicate continues to remain an "exclusive" predicate and won't be supported for use in nested predicates as of now, because there isn't a straightforward way to efficiently treat it as an inclusive predicate (i.e., without scanning all the flattened docs). We can't simply flip the flattened doc ID result for the corresponding `IS NOT NULL` predicate either as that leads to incorrect results when `disableCrossArrayUnnest` is set to `true`, as well as certain other scenarios involving chained array accesses and wildcard accesses.
- Suggested labels: `feature`, `backward-incompat`, `release-notes`
