### PR TITLE
Use parameterized log messages instead of string concatenation

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
@@ -98,7 +98,7 @@ public class BrokerManagedAsyncExecutorProvider extends ThreadPoolExecutorProvid
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_REJECTED_EXCEPTIONS, 1L);
-      LOGGER.error("Task " + r + " rejected from " + executor);
+      LOGGER.error("Task {} rejected from {}", r, executor);
 
       throw new ServiceUnavailableException(Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(
           "Pinot Broker thread pool can not accommodate more requests now. " + "Request is rejected from " + executor)

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -87,7 +87,7 @@ public class PinotDriver implements Driver {
       if (!this.acceptsURL(url)) {
         return null;
       }
-      LOGGER.info("Initiating connection to database for url: " + url);
+      LOGGER.info("Initiating connection to database for url: {}", url);
 
       Map<String, String> urlParams = DriverUtils.getURLParams(url);
       info.putAll(urlParams);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -283,8 +283,8 @@ public class HttpClient implements AutoCloseable {
       if (response.containsHeader(CommonConstants.Controller.HOST_HTTP_HEADER)) {
         String controllerHost = response.getFirstHeader(CommonConstants.Controller.HOST_HTTP_HEADER).getValue();
         String controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
-        LOGGER.info("Sending request: " + request.getURI() + " to controller: " + controllerHost + ", version: "
-            + controllerVersion);
+        LOGGER.info("Sending request: {} to controller: {}, version: {}", request.getURI(), controllerHost,
+            controllerVersion);
       }
       int statusCode = response.getStatusLine().getStatusCode();
       if (statusCode >= 300) {

--- a/pinot-common/src/main/java/org/apache/pinot/serde/SerDe.java
+++ b/pinot-common/src/main/java/org/apache/pinot/serde/SerDe.java
@@ -61,7 +61,7 @@ public class SerDe {
     try {
       return _serializer.serialize(obj);
     } catch (TException e) {
-      LOGGER.error("Unable to serialize object :" + obj, e);
+      LOGGER.error("Unable to serialize object :{}", obj, e);
       return null;
     }
   }
@@ -70,7 +70,7 @@ public class SerDe {
     try {
       _deserializer.deserialize(obj, payload);
     } catch (TException e) {
-      LOGGER.error("Unable to deserialize to object :" + obj, e);
+      LOGGER.error("Unable to deserialize to object :{}", obj, e);
       return false;
     }
     return true;

--- a/pinot-common/src/test/java/org/apache/pinot/util/TestUtils.java
+++ b/pinot-common/src/test/java/org/apache/pinot/util/TestUtils.java
@@ -50,7 +50,7 @@ public class TestUtils {
         String extension = resourceUrlStr.substring(resourceUrlStr.lastIndexOf('.'));
         File tempFile = File.createTempFile("pinot-test-temp", extension);
         String tempFilePath = tempFile.getAbsolutePath();
-        LOGGER.info("Extracting from " + resourceUrlStr + " to " + tempFilePath);
+        LOGGER.info("Extracting from {} to {}", resourceUrlStr, tempFilePath);
         FileUtils.copyURLToFile(resourceUrl, tempFile);
         return tempFilePath;
       } catch (IOException e) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -282,7 +282,7 @@ public class StreamOp extends BaseOp {
       JsonNode errorCode = exceptions.get(ERROR_CODE);
       if (String.valueOf(QueryException.BROKER_INSTANCE_MISSING_ERROR).equals(String.valueOf(errorCode))
           && errorCode != null) {
-        LOGGER.warn(errorMsg + ".Trying again");
+        LOGGER.warn("{}.Trying again", errorMsg);
         return 0;
       }
       LOGGER.error(errorMsg);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -368,7 +368,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         setUpHelixController();
         break;
       default:
-        LOGGER.error("Invalid mode: " + _controllerMode);
+        LOGGER.error("Invalid mode: {}", _controllerMode);
         break;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/ControllerApplicationException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/ControllerApplicationException.java
@@ -44,7 +44,7 @@ public class ControllerApplicationException extends WebApplicationException {
       if (e == null) {
         logger.info(message);
       } else {
-        logger.info(message + " exception: " + e.getMessage());
+        logger.info("{} exception: {}", message, e.getMessage());
       }
     } else {
       if (e == null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -405,7 +405,7 @@ public class PinotQueryResource {
         LOGGER.debug("The request is - " + requestStr);
       }*/
 
-      LOGGER.info("url string passed is : " + urlStr);
+      LOGGER.info("url string passed is : {}", urlStr);
       final URL url = new URL(urlStr);
       conn = (HttpURLConnection) url.openConnection();
       conn.setDoOutput(true);
@@ -484,7 +484,7 @@ public class PinotQueryResource {
       final String pinotResultString = sendPostRaw(url, requestJson.toString(), headers);
 
       final long queryTime = System.currentTimeMillis() - startTime;
-      LOGGER.info("Query: " + query + " Time: " + queryTime);
+      LOGGER.info("Query: {} Time: {}", query, queryTime);
 
       return pinotResultString;
     } catch (final Exception ex) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1069,7 +1069,7 @@ public class PinotHelixResourceManager {
           "Failed to fetch broker tag for table " + tableNameWithType + " due to exception: " + e.getMessage());
     }
     if (tableConfig == null) {
-      LOGGER.warn("Table " + tableNameWithType + " does not exist");
+      LOGGER.warn("Table {} does not exist", tableNameWithType);
       throw new InvalidConfigException(
           "Invalid table configuration for table " + tableNameWithType + ". Table does not exist");
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -430,7 +430,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         _controllerMetrics.addValueToTableGauge(getCronJobName(tableWithType, taskType),
             ControllerGauge.CRON_SCHEDULER_JOB_SCHEDULED, 1L);
       } catch (Exception e) {
-        LOGGER.error("Failed to parse Cron expression - " + cronExprStr, e);
+        LOGGER.error("Failed to parse Cron expression - {}", cronExprStr, e);
         throw e;
       }
       Date nextRuntime = trigger.getNextFireTime();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
@@ -80,7 +80,7 @@ public class DataGenerator {
         IntRange range = _genSpec.getRangeMap().get(column);
         generator = GeneratorFactory.getGeneratorFor(dataType, range.getMinimumInteger(), range.getMaximumInteger());
       } else {
-        LOGGER.error("cardinality for this column does not exist : " + column);
+        LOGGER.error("cardinality for this column does not exist : {}", column);
         throw new RuntimeException("cardinality for this column does not exist");
       }
       generator.init();

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderFactory.java
@@ -43,7 +43,7 @@ public class DataTableBuilderFactory {
   }
 
   public static void setDataTableVersion(int version) {
-    LOGGER.info("Setting DataTable version to: " + version);
+    LOGGER.info("Setting DataTable version to: {}", version);
     if (version != DataTableFactory.VERSION_2 && version != DataTableFactory.VERSION_3
         && version != DataTableFactory.VERSION_4) {
       throw new IllegalArgumentException("Unsupported version: " + version);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -206,7 +206,7 @@ public class RealtimeConsumptionRateManager {
     try (StreamMetadataProvider streamMetadataProvider = factory.createStreamMetadataProvider(clientId)) {
       return streamMetadataProvider.fetchPartitionCount(/*maxWaitTimeMs*/10_000);
     } catch (Exception e) {
-      LOGGER.warn("Error fetching metadata for topic " + streamConfig.getTopicName(), e);
+      LOGGER.warn("Error fetching metadata for topic {}", streamConfig.getTopicName(), e);
       return null;
     }
   };

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -399,12 +399,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS,
         1L);
     if (_consecutiveErrorCount > MAX_CONSECUTIVE_ERROR_COUNT) {
-      _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after "
-          + _consecutiveErrorCount + " attempts", e);
+      _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after {} attempts",
+          _consecutiveErrorCount, e);
       throw e;
     } else {
-      _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count="
-          + _consecutiveErrorCount + ")", e);
+      _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count={})",
+          _consecutiveErrorCount, e);
       Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
       recreateStreamConsumer("Too many transient errors");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -123,9 +123,9 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
             //       exception into the query response, and the main thread might wait infinitely (until timeout) or
             //       throw unexpected exceptions (such as NPE).
             if (t instanceof Exception) {
-              LOGGER.error("Caught exception while processing query: " + _queryContext, t);
+              LOGGER.error("Caught exception while processing query: {}", _queryContext, t);
             } else {
-              LOGGER.error("Caught serious error while processing query: " + _queryContext, t);
+              LOGGER.error("Caught serious error while processing query: {}", _queryContext, t);
             }
             onProcessSegmentsException(t);
           } finally {

--- a/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTaskScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/periodictask/PeriodicTaskScheduler.java
@@ -149,7 +149,7 @@ public class PeriodicTaskScheduler {
     // level) whether the periodic task exists.
     PeriodicTask periodicTask = getPeriodicTask(periodicTaskName);
     if (periodicTask == null) {
-      LOGGER.error("Unknown Periodic Task " + periodicTaskName);
+      LOGGER.error("Unknown Periodic Task {}", periodicTaskName);
       return;
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
@@ -410,7 +410,7 @@ public class ResourceManagerAccountingTest {
               Tracing.ThreadAccountantOps.sample();
               if (Thread.interrupted() || thread.isInterrupted()) {
                 Tracing.ThreadAccountantOps.clear();
-                LOGGER.error("KilledWorker " + queryId + " " + finalJ);
+                LOGGER.error("KilledWorker {} {}", queryId, finalJ);
                 return;
               }
               a[i] = new long[200000];
@@ -429,7 +429,7 @@ public class ResourceManagerAccountingTest {
           for (int i = 0; i < 10; i++) {
             futuresThread[i].cancel(true);
           }
-          LOGGER.error("Killed " + queryId);
+          LOGGER.error("Killed {}", queryId);
         }
         Tracing.ThreadAccountantOps.clear();
       });

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -139,7 +139,7 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     testCountStarQuery(3, false);
     assertEquals(getCurrentCountStarResult(), expectedCountStarResult);
 
-    LOGGER.warn("Shutting down server " + _serverStarters.get(NUM_SERVERS - 1).getInstanceId());
+    LOGGER.warn("Shutting down server {}", _serverStarters.get(NUM_SERVERS - 1).getInstanceId());
     // Take a server and shut down its query server to mimic a hard failure
     BaseServerStarter serverStarter = _serverStarters.get(NUM_SERVERS - 1);
     try {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeConsumptionRateLimiterClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeConsumptionRateLimiterClusterIntegrationTest.java
@@ -158,8 +158,8 @@ public class RealtimeConsumptionRateLimiterClusterIntegrationTest extends BaseRe
         Thread.sleep(1000L);
         long currentCount = getCurrentCountStarResult(tableName);
         double currentRate = (currentCount - startCount) / (double) (System.currentTimeMillis() - startTime) * 1000;
-        LOGGER.info("Second = " + i + ", realtimeRowConsumedMeter = " + realtimeRowConsumedMeter.oneMinuteRate()
-            + ", currentCount = " + currentCount + ", currentRate = " + currentRate);
+        LOGGER.info("Second = {}, realtimeRowConsumedMeter = {}, currentCount = {}, currentRate = {}", i,
+            realtimeRowConsumedMeter.oneMinuteRate(), currentCount, currentRate);
         Assert.assertTrue(realtimeRowConsumedMeter.oneMinuteRate() < SERVER_RATE_LIMIT,
             "Rate should be less than " + SERVER_RATE_LIMIT);
         Assert.assertTrue(currentRate < SERVER_RATE_LIMIT * 1.5, // Put some leeway for the rate calculation
@@ -211,11 +211,11 @@ public class RealtimeConsumptionRateLimiterClusterIntegrationTest extends BaseRe
         double currentRate1 = (currentCount1 - startCount1) / (double) (currentTimeMillis - startTime) * 1000;
         double currentRate2 = (currentCount2 - startCount2) / (double) (currentTimeMillis - startTime) * 1000;
         double currentServerRate = currentRate1 + currentRate2;
-        LOGGER.info("Second = " + i + ", serverRowConsumedMeter = " + serverRowConsumedMeter.oneMinuteRate()
-            + ", currentCount1 = " + currentCount1 + ", currentRate1 = " + currentRate1
-            + ", currentCount2 = " + currentCount2 + ", currentRate2 = " + currentRate2
-            + ", currentServerCount = " + currentServerCount + ", currentServerRate = " + currentServerRate
-        );
+        LOGGER.info(
+            "Second = {}, serverRowConsumedMeter = {}, currentCount1 = {}, currentRate1 = {}, currentCount2 = {}, "
+                + "currentRate2 = {}, currentServerCount = {}, currentServerRate = {}",
+            i, serverRowConsumedMeter.oneMinuteRate(), currentCount1, currentRate1, currentCount2, currentRate2,
+            currentServerCount, currentServerRate);
 
         Assert.assertTrue(serverRowConsumedMeter.oneMinuteRate() < SERVER_RATE_LIMIT,
             "Rate should be less than " + SERVER_RATE_LIMIT + ", serverOneMinuteRate = " + serverRowConsumedMeter

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
@@ -166,7 +166,7 @@ public class RealtimeKinesisIntegrationTest extends BaseClusterIntegrationTestSe
         try {
           return getCurrentCountStarResult() >= _totalRecordsPushedInStream;
         } catch (Exception e) {
-          LOGGER.warn("Could not fetch current number of rows in pinot table " + getTableName(), e);
+          LOGGER.warn("Could not fetch current number of rows in pinot table {}", getTableName(), e);
           return null;
         }
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -98,7 +98,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
         }
         return getTotalDocs(tableName) == rowCnt;
       } catch (Exception e) {
-        LOGGER.error("Failed to get expected totalDocs: " + rowCnt, e);
+        LOGGER.error("Failed to get expected totalDocs: {}", rowCnt, e);
         return false;
       }
     }, 5000L, 600_000L, "Failed to load " + rowCnt + " documents", true);
@@ -143,7 +143,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
         }
         return getTotalDocs(tableName) == rowCnt;
       } catch (Exception e) {
-        LOGGER.error("Failed to get expected totalDocs: " + rowCnt, e);
+        LOGGER.error("Failed to get expected totalDocs: {}", rowCnt, e);
         return false;
       }
     }, 5000L, 600_000L, "Failed to load " + rowCnt + " documents", true);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/access/CertBasedTlsChannelAccessControlFactory.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/access/CertBasedTlsChannelAccessControlFactory.java
@@ -61,8 +61,9 @@ public class CertBasedTlsChannelAccessControlFactory implements AccessControlFac
         Principal principal = x509.getSubjectX500Principal();
         return _aclPrincipalAllowlist.contains(principal.toString());
       } catch (CertificateException | SSLPeerUnverifiedException e) {
-        _logger.error("Access denied - caught exception while validating access to server, with channelHandlerContext:"
-            + channelHandlerContext, e);
+        _logger.error(
+            "Access denied - caught exception while validating access to server, with channelHandlerContext:{}",
+            channelHandlerContext, e);
         return false;
       }
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -332,7 +332,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     LOGGER.info("Shutting down admin application");
     _minionAdminApplication.stop();
 
-    LOGGER.info("Stopping Pinot minion: " + _instanceId);
+    LOGGER.info("Stopping Pinot minion: {}", _instanceId);
     _helixManager.disconnect();
     LOGGER.info("Deregistering service status handler");
     ServiceStatus.removeServiceStatusCallback(_instanceId);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -329,7 +329,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
       try {
         files = inputDirFS.listFiles(inputDirURI, true);
       } catch (IOException e) {
-        LOGGER.error("Unable to list files under URI: " + inputDirURI, e);
+        LOGGER.error("Unable to list files under URI: {}", inputDirURI, e);
         return Collections.emptyList();
       }
       PathMatcher includeFilePathMatcher = null;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -108,9 +108,9 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
         if (offsetAndTimestamp == null) {
           offset = _consumer.endOffsets(Collections.singletonList(_topicPartition), Duration.ofMillis(timeoutMillis))
               .get(_topicPartition);
-          LOGGER.warn("initial offset type is period and its value evaluates "
-              + "to null hence proceeding with offset " + offset + "for topic " + _topicPartition.topic()
-              + " partition " + _topicPartition.partition());
+          LOGGER.warn(
+              "initial offset type is period and its value evaluates to null hence proceeding with offset {} for "
+                  + "topic {} partition {}", offset, _topicPartition.topic(), _topicPartition.partition());
         } else {
           offset = offsetAndTimestamp.offset();
         }
@@ -120,9 +120,9 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
         if (offsetAndTimestamp == null) {
           offset = _consumer.endOffsets(Collections.singletonList(_topicPartition), Duration.ofMillis(timeoutMillis))
               .get(_topicPartition);
-          LOGGER.warn("initial offset type is timestamp and its value evaluates "
-              + "to null hence proceeding with offset " + offset + "for topic " + _topicPartition.topic()
-              + " partition " + _topicPartition.partition());
+          LOGGER.warn(
+              "initial offset type is timestamp and its value evaluates to null hence proceeding with offset {} for "
+                  + "topic {} partition {}", offset, _topicPartition.topic(), _topicPartition.partition());
         } else {
           offset = offsetAndTimestamp.offset();
         }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataServerStartable.java
@@ -128,9 +128,9 @@ public class KafkaDataServerStartable implements StreamDataServerStartable {
         }
         Thread.sleep(checkIntervalMs);
       } catch (Exception e) {
-        LOGGER.error("Caught exception while checking the condition" + errorMessageSuffix, e);
+        LOGGER.error("Caught exception while checking the condition{}", errorMessageSuffix, e);
       }
     }
-    LOGGER.error("Failed to meet condition in " + timeoutMs + "ms" + errorMessageSuffix);
+    LOGGER.error("Failed to meet condition in {}ms{}", timeoutMs, errorMessageSuffix);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -170,7 +170,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(message, throwable);
     } else {
-      LOGGER.warn(message + ": " + throwable.getMessage());
+      LOGGER.warn("{}: {}", message, throwable.getMessage());
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
@@ -113,9 +113,9 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
       if (shard == null) { // Shard has expired
         shardsEnded.add(shardId);
         String lastConsumedSequenceID = kinesisStartCheckpoint.getSequenceNumber();
-        LOGGER.warn("Kinesis shard with id: " + shardId
-            + " has expired. Data has been consumed from the shard till sequence number: " + lastConsumedSequenceID
-            + ". There can be potential data loss.");
+        LOGGER.warn(
+            "Kinesis shard with id: {} has expired. Data has been consumed from the shard till sequence number: {}. "
+                + "There can be potential data loss.", shardId, lastConsumedSequenceID);
         continue;
       }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
@@ -111,9 +111,9 @@ public class KinesisDataServerStartable implements StreamDataServerStartable {
         }
       }, 1000L, 30000, "Kinesis stream " + topic + " is not created or is not in active state");
 
-      LOGGER.info("Kinesis stream created successfully: " + topic);
+      LOGGER.info("Kinesis stream created successfully: {}", topic);
     } catch (Exception e) {
-      LOGGER.warn("Error occurred while creating topic: " + topic, e);
+      LOGGER.warn("Error occurred while creating topic: {}", topic, e);
     }
   }
 
@@ -137,9 +137,9 @@ public class KinesisDataServerStartable implements StreamDataServerStartable {
         }
         Thread.sleep(checkIntervalMs);
       } catch (Exception e) {
-        LOGGER.error("Caught exception while checking the condition" + errorMessageSuffix, e);
+        LOGGER.error("Caught exception while checking the condition{}", errorMessageSuffix, e);
       }
     }
-    LOGGER.error("Failed to meet condition in " + timeoutMs + "ms" + errorMessageSuffix);
+    LOGGER.error("Failed to meet condition in {}ms{}", timeoutMs, errorMessageSuffix);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -113,8 +113,8 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
       }
       return new MessageIdStreamOffset(offset);
     } catch (PulsarClientException e) {
-      LOGGER.error("Cannot fetch offsets for partition " + _partition + " and topic " + _topic + " and offsetCriteria "
-          + offsetCriteria, e);
+      LOGGER.error("Cannot fetch offsets for partition {} and topic {} and offsetCriteria {}", _partition, _topic,
+          offsetCriteria, e);
       return null;
     }
   }
@@ -161,14 +161,13 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
                   new PartitionGroupMetadata(p, new MessageIdStreamOffset(lastMessageId)));
             }
           } catch (PulsarClientException pce) {
-            LOGGER.warn(
-                "Error encountered while calculating partition group metadata for topic " + _config.getPulsarTopicName()
-                    + " partition " + partitionedTopicNameList.get(p), pce);
+            LOGGER.warn("Error encountered while calculating partition group metadata for topic {} partition {}",
+                _config.getPulsarTopicName(), partitionedTopicNameList.get(p), pce);
           }
         }
       }
     } catch (Exception e) {
-      LOGGER.warn("Error encountered when trying to fetch partition list for pulsar topic " + _topic, e);
+      LOGGER.warn("Error encountered when trying to fetch partition list for pulsar topic {}", _topic, e);
     }
     return newPartitionGroupMetadataList;
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/server/PulsarDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/server/PulsarDataProducer.java
@@ -73,7 +73,7 @@ public class PulsarDataProducer implements StreamDataProducer {
     try (Producer<byte[]> producer = _pulsarClient.newProducer().topic(topic).create()) {
       producer.send(payload);
     } catch (PulsarClientException e) {
-      LOGGER.error("Failed to produce message for topic: " + topic, e);
+      LOGGER.error("Failed to produce message for topic: {}", topic, e);
     }
   }
 
@@ -82,7 +82,7 @@ public class PulsarDataProducer implements StreamDataProducer {
     try (Producer<byte[]> producer = _pulsarClient.newProducer().topic(topic).create()) {
       producer.newMessage().key(Base64.getEncoder().encodeToString(key)).value(payload).send();
     } catch (PulsarClientException e) {
-      LOGGER.error("Failed to produce message for topic: " + topic, e);
+      LOGGER.error("Failed to produce message for topic: {}", topic, e);
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/ExecutorServiceUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/ExecutorServiceUtils.java
@@ -69,7 +69,7 @@ public class ExecutorServiceUtils {
     try {
       if (!executorService.awaitTermination(terminationMillis, TimeUnit.SECONDS)) {
         List<Runnable> runnables = executorService.shutdownNow();
-        LOGGER.warn("Around " + runnables.size() + " didn't finish in time after a shutdown");
+        LOGGER.warn("Around {} didn't finish in time after a shutdown", runnables.size());
       }
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
@@ -256,7 +256,7 @@ public class MultiStageQueryStats {
           myStats.merge(otherStatsForStage);
         }
       } catch (IllegalArgumentException | IllegalStateException ex) {
-        LOGGER.warn("Error merging stats on stage " + i + ". Ignoring the new stats", ex);
+        LOGGER.warn("Error merging stats on stage {}. Ignoring the new stats", i, ex);
       }
     }
   }
@@ -284,9 +284,9 @@ public class MultiStageQueryStats {
             myStats.merge(dis);
           }
         } catch (IOException ex) {
-          LOGGER.warn("Error deserializing stats on stage " + i + ". Considering the new stats empty", ex);
+          LOGGER.warn("Error deserializing stats on stage {}. Considering the new stats empty", i, ex);
         } catch (IllegalArgumentException | IllegalStateException ex) {
-          LOGGER.warn("Error merging stats on stage " + i + ". Ignoring the new stats", ex);
+          LOGGER.warn("Error merging stats on stage {}. Ignoring the new stats", i, ex);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
@@ -533,26 +533,27 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
 
     if (shingleIndexOverlapLength >= valLength) {
       if (_logger.isDebugEnabled()) {
-        _logger.warn("The shingleIndexOverlapLength " + shingleIndexOverlapLength + " is longer than the value length "
-            + valLength + ". Shingling will not be applied since only one document will be generated.");
+        _logger.warn(
+            "The shingleIndexOverlapLength {} is longer than the value length {}. Shingling will not be applied since "
+                + "only one document will be generated.", shingleIndexOverlapLength, valLength);
       }
       generateTextIndexLuceneDocument(kv, shingleIndexDocuments, shingleIndexMaxLength);
       return;
     }
 
     if (minDocumentLength > MAXIMUM_LUCENE_DOCUMENT_SIZE) {
-      _logger.debug("The minimum document length " + minDocumentLength + " (" + MIN_DOCUMENT_LENGTH_DESCRIPTION + ") "
-          + " exceeds the limit of maximum Lucene document size " + MAXIMUM_LUCENE_DOCUMENT_SIZE + ". Value will be "
-          + "truncated and shingling will not be applied.");
+      _logger.debug("The minimum document length {} (" + MIN_DOCUMENT_LENGTH_DESCRIPTION
+          + ")  exceeds the limit of maximum Lucene document size " + MAXIMUM_LUCENE_DOCUMENT_SIZE
+          + ". Value will be truncated and shingling will not be applied.", minDocumentLength);
       generateTextIndexLuceneDocument(kv, shingleIndexDocuments, shingleIndexMaxLength);
       return;
     }
 
     // This logging becomes expensive if user accidentally sets a very low shingleIndexMaxLength
     if (shingleIndexMaxLength < minDocumentLength) {
-      _logger.debug("The shingleIndexMaxLength " + shingleIndexMaxLength + " is smaller than the minimum document "
-          + "length " + minDocumentLength + " (" + MIN_DOCUMENT_LENGTH_DESCRIPTION + "). Increasing the "
-          + "shingleIndexMaxLength to maximum Lucene document size " + MAXIMUM_LUCENE_DOCUMENT_SIZE + ".");
+      _logger.debug("The shingleIndexMaxLength {} is smaller than the minimum document length {} ("
+          + MIN_DOCUMENT_LENGTH_DESCRIPTION + "). Increasing the shingleIndexMaxLength to maximum Lucene document size "
+          + MAXIMUM_LUCENE_DOCUMENT_SIZE + ".", shingleIndexMaxLength, minDocumentLength);
       shingleIndexMaxLength = MAXIMUM_LUCENE_DOCUMENT_SIZE;
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -133,7 +133,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
       Preconditions.checkState(fieldSpec != null, "Failed to find column: %s in the schema", columnName);
       if (fieldSpec.isVirtualColumn()) {
-        LOGGER.warn("Ignoring index creation for virtual column " + columnName);
+        LOGGER.warn("Ignoring index creation for virtual column {}", columnName);
         continue;
       }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
@@ -423,8 +423,8 @@ public final class RangeIndexCreator implements CombinedInvertedIndexCreator {
     }
     rangeOffsets.append(" ]");
     rangeValues.append(" ]");
-    LOGGER.info("rangeOffsets = " + rangeOffsets);
-    LOGGER.info("rangeValues = " + rangeValues);
+    LOGGER.info("rangeOffsets = {}", rangeOffsets);
+    LOGGER.info("rangeValues = {}", rangeValues);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
@@ -90,7 +90,7 @@ public class LuceneFSTIndexCreator implements FSTIndexCreator {
   @Override
   public void seal()
       throws IOException {
-    LOGGER.info("Sealing FST index: " + _fstIndexFile.getAbsolutePath());
+    LOGGER.info("Sealing FST index: {}", _fstIndexFile.getAbsolutePath());
     FileOutputStream fileOutputStream = null;
     try {
       fileOutputStream = new FileOutputStream(_fstIndexFile);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -119,16 +119,16 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
       for (final String column : _columnStatsCollectorMap.keySet()) {
         AbstractColumnStatisticsCollector statisticsCollector = _columnStatsCollectorMap.get(column);
 
-        LOGGER.info("********** logging for column : " + column + " ********************* ");
-        LOGGER.info("min value : " + statisticsCollector.getMinValue());
-        LOGGER.info("max value : " + statisticsCollector.getMaxValue());
-        LOGGER.info("cardinality : " + statisticsCollector.getCardinality());
-        LOGGER.info("length of largest column : " + statisticsCollector.getLengthOfLargestElement());
-        LOGGER.info("is sorted : " + statisticsCollector.isSorted());
-        LOGGER.info("column type : " + _statsCollectorConfig.getSchema().getFieldSpecFor(column).getDataType());
+        LOGGER.info("********** logging for column : {} ********************* ", column);
+        LOGGER.info("min value : {}", statisticsCollector.getMinValue());
+        LOGGER.info("max value : {}", statisticsCollector.getMaxValue());
+        LOGGER.info("cardinality : {}", statisticsCollector.getCardinality());
+        LOGGER.info("length of largest column : {}", statisticsCollector.getLengthOfLargestElement());
+        LOGGER.info("is sorted : {}", statisticsCollector.isSorted());
+        LOGGER.info("column type : {}", _statsCollectorConfig.getSchema().getFieldSpecFor(column).getDataType());
 
         if (statisticsCollector.getPartitionFunction() != null) {
-          LOGGER.info("partitions: " + statisticsCollector.getPartitions().toString());
+          LOGGER.info("partitions: {}", statisticsCollector.getPartitions().toString());
         }
         LOGGER.info("***********************************************");
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
@@ -100,7 +100,7 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
   @Override
   public void seal() {
     try {
-      LOGGER.info("Sealing HNSW index for column: " + _vectorColumn);
+      LOGGER.info("Sealing HNSW index for column: {}", _vectorColumn);
       _indexWriter.forceMerge(1);
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while sealing the HNSW index for column: " + _vectorColumn, e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -61,7 +61,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
             _readersByIndex.put(indexType, reader);
           }
         } catch (IndexReaderConstraintException ex) {
-          LOGGER.warn("Constraint violation when indexing " + columnName + " with " + indexType + " index", ex);
+          LOGGER.warn("Constraint violation when indexing {} with {} index", columnName, indexType, ex);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -62,10 +62,10 @@ public class ConsistentDataPushUtils {
   public static Map<URI, String> preUpload(SegmentGenerationJobSpec spec, List<String> segmentsTo)
       throws Exception {
     String rawTableName = spec.getTableSpec().getTableName();
-    LOGGER.info("Start consistent push for table: " + rawTableName);
+    LOGGER.info("Start consistent push for table: {}", rawTableName);
     Map<URI, List<String>> uriToExistingOfflineSegments = getSegmentsToReplace(spec, rawTableName);
-    LOGGER.info("Existing segments for table {}: " + uriToExistingOfflineSegments, rawTableName);
-    LOGGER.info("New segments for table: {}: " + segmentsTo, rawTableName);
+    LOGGER.info("Existing segments for table {}: {}", rawTableName, uriToExistingOfflineSegments);
+    LOGGER.info("New segments for table: {}: {}", rawTableName, segmentsTo);
     return startReplaceSegments(spec, uriToExistingOfflineSegments, segmentsTo);
   }
 
@@ -77,7 +77,7 @@ public class ConsistentDataPushUtils {
       throws Exception {
     String rawTableName = spec.getTableSpec().getTableName();
     if (uriToLineageEntryIdMap != null && !uriToLineageEntryIdMap.isEmpty()) {
-      LOGGER.info("End consistent push for table: " + rawTableName);
+      LOGGER.info("End consistent push for table: {}", rawTableName);
       endReplaceSegments(spec, uriToLineageEntryIdMap);
     }
   }
@@ -112,7 +112,7 @@ public class ConsistentDataPushUtils {
     String rawTableName = spec.getTableSpec().getTableName();
     Map<URI, URI> segmentsUris = getStartReplaceSegmentUris(spec, rawTableName);
     AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
-    LOGGER.info("Start replace segment URIs: " + segmentsUris);
+    LOGGER.info("Start replace segment URIs: {}", segmentsUris);
 
     for (Map.Entry<URI, URI> entry : segmentsUris.entrySet()) {
       URI controllerUri = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/NativeFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/NativeFSTIndexCreator.java
@@ -77,7 +77,7 @@ public class NativeFSTIndexCreator implements FSTIndexCreator {
   @Override
   public void seal()
       throws IOException {
-    LOGGER.info("Sealing FST index: " + _fstIndexFile.getAbsolutePath());
+    LOGGER.info("Sealing FST index: {}", _fstIndexFile.getAbsolutePath());
     try (FileOutputStream fileOutputStream = new FileOutputStream(_fstIndexFile)) {
       FST fst = _fstBuilder.complete();
       fst.save(fileOutputStream);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -77,21 +77,21 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "OFFLINE", to = "CONSUMING")
     public void onBecomeConsumingFromOffline(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeConsumingFromOffline() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeConsumingFromOffline() : {}", message);
       _instanceDataManager.addConsumingSegment(message.getResourceName(), message.getPartitionName());
     }
 
     @Transition(from = "CONSUMING", to = "ONLINE")
     public void onBecomeOnlineFromConsuming(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromConsuming() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromConsuming() : {}", message);
       _instanceDataManager.addOnlineSegment(message.getResourceName(), message.getPartitionName());
     }
 
     @Transition(from = "CONSUMING", to = "OFFLINE")
     public void onBecomeOfflineFromConsuming(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromConsuming() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromConsuming() : {}", message);
       String realtimeTableName = message.getResourceName();
       String segmentName = message.getPartitionName();
       _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
@@ -101,7 +101,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "CONSUMING", to = "DROPPED")
     public void onBecomeDroppedFromConsuming(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromConsuming() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromConsuming() : {}", message);
       String realtimeTableName = message.getResourceName();
       String segmentName = message.getPartitionName();
       _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
@@ -127,21 +127,21 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "OFFLINE", to = "ONLINE")
     public void onBecomeOnlineFromOffline(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline() : {}", message);
       _instanceDataManager.addOnlineSegment(message.getResourceName(), message.getPartitionName());
     }
 
     @Transition(from = "ONLINE", to = "OFFLINE")
     public void onBecomeOfflineFromOnline(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromOnline() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromOnline() : {}", message);
       _instanceDataManager.offloadSegment(message.getResourceName(), message.getPartitionName());
     }
 
     @Transition(from = "OFFLINE", to = "DROPPED")
     public void onBecomeDroppedFromOffline(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOffline() : {}", message);
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
       _instanceDataManager.deleteSegment(tableNameWithType, segmentName);
@@ -159,7 +159,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "ONLINE", to = "DROPPED")
     public void onBecomeDroppedFromOnline(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOnline() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOnline() : {}", message);
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
       _instanceDataManager.offloadSegment(tableNameWithType, segmentName);
@@ -168,13 +168,13 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
 
     @Transition(from = "ERROR", to = "OFFLINE")
     public void onBecomeOfflineFromError(Message message, NotificationContext context) {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromError() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromError() : {}", message);
     }
 
     @Transition(from = "ERROR", to = "DROPPED")
     public void onBecomeDroppedFromError(Message message, NotificationContext context)
         throws Exception {
-      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromError() : " + message);
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromError() : {}", message);
       _instanceDataManager.deleteSegment(message.getResourceName(), message.getPartitionName());
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricUtils.java
@@ -129,8 +129,8 @@ public class PinotMetricUtils {
           LOGGER.info("Registering metricsRegistry to listener {}", listenerClassName);
           addMetricsRegistryRegistrationListener(listener);
         } catch (Exception e) {
-          LOGGER
-              .warn("Caught exception while initializing MetricsRegistryRegistrationListener " + listenerClassName, e);
+          LOGGER.warn("Caught exception while initializing MetricsRegistryRegistrationListener {}", listenerClassName,
+              e);
         }
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
@@ -82,7 +82,7 @@ public class PinotToolLauncher {
     LOGGER.info("Usage: pinot-tools.sh <subCommand>");
     LOGGER.info("Valid subCommands are:");
     for (Map.Entry<String, Command> subCommand : this.getSubCommands().entrySet()) {
-      LOGGER.info("\t" + subCommand.getKey() + "\t<" + subCommand.getValue().description() + ">");
+      LOGGER.info("\t{}\t<{}>", subCommand.getKey(), subCommand.getValue().description());
     }
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotZKChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotZKChanger.java
@@ -85,9 +85,8 @@ public class PinotZKChanger {
       for (String server : mapIS.keySet()) {
         String state = mapIS.get(server);
         if (mapEV == null || mapEV.get(server) == null || !mapEV.get(server).equals(state)) {
-          LOGGER.info(
-              "Mismatch: segment " + segment + " server:" + server + " expected state:" + state + " actual state:" + (
-                  (mapEV == null || mapEV.get(server) == null) ? "null" : mapEV.get(server)));
+          LOGGER.info("Mismatch: segment {} server:{} expected state:{} actual state:{}", segment, server, state,
+              (mapEV == null || mapEV.get(server) == null) ? "null" : mapEV.get(server));
           numDiff = numDiff + 1;
         }
       }
@@ -109,9 +108,8 @@ public class PinotZKChanger {
       if (diff == 0) {
         break;
       } else {
-        LOGGER.info(
-            "Waiting for externalView to match idealstate for table:" + resourceName + " Num segments difference:"
-                + diff);
+        LOGGER.info("Waiting for externalView to match idealstate for table:{} Num segments difference:{}",
+            resourceName, diff);
         Thread.sleep(30000);
       }
     } while (diff > 0);
@@ -133,7 +131,7 @@ public class PinotZKChanger {
     DescriptiveStatistics stats = new DescriptiveStatistics();
     for (String server : serverToSegmentMapping.keySet()) {
       List<String> list = serverToSegmentMapping.get(server);
-      LOGGER.info("server " + server + " has " + list.size() + " segments");
+      LOGGER.info("server {} has {} segments", server, list.size());
       stats.addValue(list.size());
     }
     LOGGER.info("Segment Distrbution stat");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
@@ -127,7 +127,7 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
   private void init() {
-    LOGGER.info("Trying to connect to " + _zkAddress + " cluster " + _clusterName);
+    LOGGER.info("Trying to connect to {} cluster {}", _zkAddress, _clusterName);
     _helixAdmin = new ZKHelixAdmin(_zkAddress);
     ZNRecordSerializer serializer = new ZNRecordSerializer();
     String path = PropertyPathBuilder.propertyStore(_clusterName);
@@ -154,7 +154,7 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
       throws Exception {
     IdealState idealState = _helixAdmin.getResourceIdealState(_clusterName, tableName);
     if (idealState == null) {
-      LOGGER.info("No IDEALSTATE found for table " + tableName);
+      LOGGER.info("No IDEALSTATE found for table {}", tableName);
       return;
     }
     Map<String, Map<String, String>> mapFieldsIS = idealState.getRecord().getMapFields();
@@ -168,20 +168,20 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
           if (_fix) {
             mapIS.put(server, TO_STATE);
           } else {
-            LOGGER.info("Table:" + tableName + ",Segment:" + segment + ",Server:" + server + ":" + FROM_STATE);
+            LOGGER.info("Table:{},Segment:{},Server:{}:" + FROM_STATE, tableName, segment, server);
           }
           nChanges++;
         }
       }
     }
     if (nChanges == 0) {
-      LOGGER.info("No segments detected in " + FROM_STATE + " state for table " + tableName);
+      LOGGER.info("No segments detected in " + FROM_STATE + " state for table {}", tableName);
     } else {
       if (_fix) {
-        LOGGER.info("Replacing IDEALSTATE for table " + tableName + " with " + nChanges + " changes");
+        LOGGER.info("Replacing IDEALSTATE for table {} with {} changes", tableName, nChanges);
         _helixAdmin.setResourceIdealState(_clusterName, tableName, idealState);
       } else {
-        LOGGER.info("Detected " + nChanges + " instances in " + FROM_STATE + " in table " + tableName);
+        LOGGER.info("Detected {} instances in " + FROM_STATE + " in table {}", nChanges, tableName);
       }
     }
   }
@@ -201,16 +201,16 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
 
     if (_tenantName != null) {
       // Do this for all tenant tables
-      LOGGER.info("Working on all tables for tenant " + _tenantName);
+      LOGGER.info("Working on all tables for tenant {}", _tenantName);
       List<String> tableNames = getAllTenantTables();
-      LOGGER.info("Found " + tableNames.size() + " tables for tenant " + _tenantName);
+      LOGGER.info("Found {} tables for tenant {}", tableNames.size(), _tenantName);
       if (!tableNames.isEmpty()) {
         for (String tableName : tableNames) {
           fixTableIdealState(tableName);
         }
       }
     } else {
-      LOGGER.info("Working on table " + _tableName);
+      LOGGER.info("Working on table {}", _tableName);
       fixTableIdealState(_tableName);
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -189,7 +189,7 @@ public class PinotAdministrator {
     LOGGER.info("Usage: pinot-admin.sh <subCommand>");
     LOGGER.info("Valid subCommands are:");
     for (Map.Entry<String, Command> subCommand : this.getSubCommands().entrySet()) {
-      LOGGER.info("\t" + subCommand.getKey() + "\t<" + subCommand.getValue().description() + ">");
+      LOGGER.info("\t{}\t<{}>", subCommand.getKey(), subCommand.getValue().description());
     }
     LOGGER.info("For other crud operations, please refer to ${ControllerAddress}/help.");
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -162,13 +162,13 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
     }
 
     if (!_exec) {
-      LOGGER.warn("Dry Running Command: " + toString());
+      LOGGER.warn("Dry Running Command: {}", toString());
       LOGGER.warn("Use the -exec option to actually execute the command.");
       return true;
     }
 
     File schemaFile = new File(_schemaFile);
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     if (!schemaFile.exists()) {
       throw new FileNotFoundException("file does not exist, + " + _schemaFile);
     }
@@ -183,7 +183,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
               AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken,
               _user, _password)), Collections.emptyList());
     } catch (Exception e) {
-      LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);
+      LOGGER.error("Got Exception to upload Pinot Schema: {}", schema.getSchemaName(), e);
       return false;
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -227,7 +227,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
   public boolean execute()
       throws Exception {
     if (!_exec) {
-      LOGGER.warn("Dry Running Command: " + toString());
+      LOGGER.warn("Dry Running Command: {}", toString());
       LOGGER.warn("Use the -exec option to actually execute the command.");
       return true;
     }
@@ -237,7 +237,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     }
     _controllerAddress = _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort;
 
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
 
     String rawTableName = null;
     TableConfig offlineTableConfig = null;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -145,12 +145,12 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     }
 
     if (!_exec) {
-      LOGGER.warn("Dry Running Command: " + toString());
+      LOGGER.warn("Dry Running Command: {}", toString());
       LOGGER.warn("Use the -exec option to actually execute the command.");
       return true;
     }
 
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteClusterCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteClusterCommand.java
@@ -80,7 +80,7 @@ public class DeleteClusterCommand extends AbstractBaseAdminCommand implements Co
     ZkClient zkClient = new ZkClient(_zkAddress, 5000);
     String helixClusterName = "/" + _clusterName;
 
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     if (!zkClient.exists(helixClusterName)) {
       LOGGER.error("Cluster {} does not exist.", _clusterName);
       return false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
@@ -141,19 +141,19 @@ public class DeleteSchemaCommand extends AbstractBaseAdminCommand implements Com
     }
 
     if (!_exec) {
-      LOGGER.warn("Dry Running Command: " + toString());
+      LOGGER.warn("Dry Running Command: {}", toString());
       LOGGER.warn("Use the -exec option to actually execute the command.");
       return true;
     }
 
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.getHttpClient().sendDeleteRequest(
           FileUploadDownloadClient.getDeleteSchemaURI(_controllerProtocol, _controllerHost,
               Integer.parseInt(_controllerPort), _schemaName), Collections.emptyMap(),
           AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
     } catch (Exception e) {
-      LOGGER.error("Got Exception while deleting Pinot Schema: " + _schemaName, e);
+      LOGGER.error("Got Exception while deleting Pinot Schema: {}", _schemaName, e);
       return false;
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
@@ -164,19 +164,19 @@ public class DeleteTableCommand extends AbstractBaseAdminCommand implements Comm
     }
 
     if (!_exec) {
-      LOGGER.warn("Dry Running Command: " + toString());
+      LOGGER.warn("Dry Running Command: {}", toString());
       LOGGER.warn("Use the -exec option to actually execute the command.");
       return true;
     }
 
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.getHttpClient().sendDeleteRequest(FileUploadDownloadClient
           .getDeleteTableURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort),
               _tableName, _type, _retention), Collections.emptyMap(), AuthProviderUtils.makeAuthProvider(_authProvider,
           _authTokenUrl, _authToken, _user, _password));
     } catch (Exception e) {
-      LOGGER.error("Got Exception while deleting Pinot Table: " + _tableName, e);
+      LOGGER.error("Got Exception while deleting Pinot Table: {}", _tableName, e);
       return false;
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -113,7 +113,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
   @Override
   public boolean execute()
       throws Exception {
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
 
     if ((_numRecords < 0) || (_numFiles < 0)) {
       throw new RuntimeException("Cannot generate negative number of records/files.");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
@@ -88,7 +88,7 @@ public class OfflineSegmentIntervalCheckerCommand extends AbstractBaseAdminComma
   @Override
   public boolean execute()
       throws Exception {
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
 
     ZKHelixAdmin helixAdmin = new ZKHelixAdmin.Builder().setZkAddress(_zkAddress).build();
     _propertyStore = new ZkHelixPropertyStore<>(_zkAddress, new ZNRecordSerializer(),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -149,7 +149,7 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     if (_controllerHost == null) {
       _controllerHost = NetUtils.getHostAddress();
     }
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
     if (StringUtils.isEmpty(_config) && !_operation.equalsIgnoreCase("GET")) {
       throw new UnsupportedOperationException("Empty config: " + _config);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -139,7 +139,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     if (_brokerHost == null) {
       _brokerHost = NetUtils.getHostAddress();
     }
-    LOGGER.info("Executing command: " + this);
+    LOGGER.info("Executing command: {}", this);
     String url = _brokerProtocol + "://" + _brokerHost + ":" + _brokerPort + "/query/sql";
     Map<String, String> payload = new HashMap<>();
     payload.put(Request.SQL, _query);
@@ -155,7 +155,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   public boolean execute()
       throws Exception {
     String result = run();
-    LOGGER.info("Result: " + result);
+    LOGGER.info("Result: {}", result);
     return true;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -159,7 +159,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: " + toString());
+      LOGGER.info("Executing command: {}", toString());
       Map<String, Object> brokerConf = getBrokerConf();
       StartServiceManagerCommand startServiceManagerCommand =
           new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -180,7 +180,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: " + toString());
+      LOGGER.info("Executing command: {}", toString());
       Map<String, Object> controllerConf = getControllerConf();
       StartServiceManagerCommand startServiceManagerCommand =
           new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
@@ -85,7 +85,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }
     _kafkaStarter.start();
-    LOGGER.info("Start kafka at localhost:" + _port + " in thread " + Thread.currentThread().getName());
+    LOGGER.info("Start kafka at localhost:{} in thread {}", _port, Thread.currentThread().getName());
     savePID(System.getProperty("java.io.tmpdir") + File.separator + ".kafka.pid");
     return true;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -119,7 +119,7 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: " + toString());
+      LOGGER.info("Executing command: {}", toString());
       Map<String, Object> minionConf = getMinionConf();
       StartServiceManagerCommand startServiceManagerCommand =
           new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -231,7 +231,7 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: " + toString());
+      LOGGER.info("Executing command: {}", toString());
       Map<String, Object> serverConf = getServerConf();
       StartServiceManagerCommand startServiceManagerCommand =
           new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -173,7 +173,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: " + toString());
+      LOGGER.info("Executing command: {}", toString());
       if (!startPinotService("SERVICE_MANAGER", this::startServiceManager)) {
         return false;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
@@ -92,7 +92,7 @@ public class StartZookeeperCommand extends AbstractBaseAdminCommand implements C
   @Override
   public boolean execute()
       throws IOException {
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
 
     IDefaultNameSpace defaultNameSpace = new IDefaultNameSpace() {
       @Override
@@ -103,7 +103,7 @@ public class StartZookeeperCommand extends AbstractBaseAdminCommand implements C
 
     _zookeeperInstance = ZkStarter.startLocalZkServer(_zkPort, _dataDir);
 
-    LOGGER.info("Start zookeeper at localhost:" + _zkPort + " in thread " + Thread.currentThread().getName());
+    LOGGER.info("Start zookeeper at localhost:{} in thread {}", _zkPort, Thread.currentThread().getName());
 
     savePID(System.getProperty("java.io.tmpdir") + File.separator + ".zooKeeper.pid");
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StopProcessCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StopProcessCommand.java
@@ -95,7 +95,7 @@ public class StopProcessCommand extends AbstractBaseAdminCommand implements Comm
   @Override
   public boolean execute()
       throws Exception {
-    LOGGER.info("Executing command: " + toString());
+    LOGGER.info("Executing command: {}", toString());
 
     Map<String, String> processes = new HashMap<String, String>();
     String prefix = System.getProperty("java.io.tmpdir") + File.separator;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
@@ -121,7 +121,7 @@ public class ValidateConfigCommand extends AbstractBaseCommand implements Comman
   private void validateTableConfig()
       throws Exception {
     List<String> tableNames = getTableNames();
-    LOGGER.info("Validating table config for tables: " + tableNames);
+    LOGGER.info("Validating table config for tables: {}", tableNames);
     for (String tableName : tableNames) {
       LOGGER.info("  Validating table config for table: \"{}\"", tableName);
       try {
@@ -139,7 +139,7 @@ public class ValidateConfigCommand extends AbstractBaseCommand implements Comman
   private void validateSchema()
       throws Exception {
     List<String> schemaNames = getSchemaNames();
-    LOGGER.info("Validating schemas: " + schemaNames);
+    LOGGER.info("Validating schemas: {}", schemaNames);
     for (String schemaName : schemaNames) {
       LOGGER.info("  Validating schema: \"{}\"", schemaName);
       try {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
@@ -111,7 +111,7 @@ public class VerifySegmentState extends AbstractBaseCommand implements Command {
             error = true;
           }
         }
-        LOGGER.info(resourceName + " = " + (error ? "ERROR" : "OK"));
+        LOGGER.info("{} = {}", resourceName, error ? "ERROR" : "OK");
       }
     }
     return true;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/PinotDataAndQueryAnonymizer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/PinotDataAndQueryAnonymizer.java
@@ -233,7 +233,7 @@ public class PinotDataAndQueryAnonymizer {
     File segmentParentDirectory = new File(_segmentDir);
     _segmentDirectories = segmentParentDirectory.list();
     _numFilesToGenerate = _segmentDirectories.length;
-    LOGGER.info("Total number of segments: " + _numFilesToGenerate);
+    LOGGER.info("Total number of segments: {}", _numFilesToGenerate);
 
     if (_globalDictionaryColumns.isEmpty()) {
       LOGGER.info("Set of global dictionary columns is empty. Not building global dictionaries");
@@ -266,7 +266,7 @@ public class PinotDataAndQueryAnonymizer {
 
   private void getSchemaFromFirstSegment(String segmentDirectory)
       throws Exception {
-    LOGGER.info("Reading metadata from segment: " + segmentDirectory);
+    LOGGER.info("Reading metadata from segment: {}", segmentDirectory);
     File segmentIndexDir = new File(segmentDirectory);
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segmentIndexDir);
     pinotToAvroSchema(segmentMetadata);
@@ -278,8 +278,8 @@ public class PinotDataAndQueryAnonymizer {
       _pinotSchema = segmentMetadata.getSchema();
       anonymizeColumnNames(_pinotSchema);
       _avroSchema = getAvroSchemaFromPinotSchema(_pinotSchema);
-      LOGGER.info("Pinot schema: " + _pinotSchema.toPrettyJsonString());
-      LOGGER.info("Avro schema: " + _avroSchema.toString(true));
+      LOGGER.info("Pinot schema: {}", _pinotSchema.toPrettyJsonString());
+      LOGGER.info("Avro schema: {}", _avroSchema.toString(true));
     }
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/GitHubAPICaller.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/GitHubAPICaller.java
@@ -114,7 +114,7 @@ public class GitHubAPICaller {
           githubAPIResponse.setResetTimeMs(Long.parseLong(resetTimeSeconds) * 1000);
         }
       } catch (NumberFormatException e) {
-        LOGGER.warn("Could not parse remainingLimit: " + remainingLimit);
+        LOGGER.warn("Could not parse remainingLimit: {}", remainingLimit);
       }
       if (statusLine.getStatusCode() == 200) {
         githubAPIResponse.setEtag(httpResponse.getFirstHeader(ETAG_HEADER).getValue());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/GithubPullRequestSourceGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/GithubPullRequestSourceGenerator.java
@@ -54,7 +54,7 @@ public class GithubPullRequestSourceGenerator implements PinotSourceDataGenerato
     try {
       _avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(org.apache.pinot.spi.data.Schema.fromFile(schemaFile));
     } catch (Exception e) {
-      LOGGER.error("Got exception while reading Pinot schema from file: [" + schemaFile.getName() + "]");
+      LOGGER.error("Got exception while reading Pinot schema from file: [{}]", schemaFile.getName());
       throw e;
     }
     _gitHubAPICaller = new GitHubAPICaller(personalAccessToken);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -78,7 +78,7 @@ public class PullRequestMergedEventsStream {
         pinotSchema = new File(schemaFilePath);
       }
     } catch (Exception e) {
-      LOGGER.error("Got exception while reading Pinot schema from file: [" + schemaFilePath + "]");
+      LOGGER.error("Got exception while reading Pinot schema from file: [{}]", schemaFilePath);
       throw e;
     }
     return pinotSchema;


### PR DESCRIPTION
- Non-constant string concatenations are evaluated at runtime even when the actual log message isn't emitted and this has a non-zero performance impact.
- Using parameterized log messages helps avoid this issue since the string evaluation will only occur if the logger is enabled.
- While this change is particularly impactful for `debug` and `trace` log messages since the default log level is `info`, we should ideally use parameterized log messages instead of string concatenation for all log levels since log levels for loggers can be adjusted, and parameterized log messages are considered best practice.
- This patch doesn't modify log messages that are inside a log level check if block ([here](https://github.com/apache/pinot/blob/7ccd2164018505a25c1f91de437088f730e969ec/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java#L96-L98), for instance).