### PR TITLE
Implement INTERSECT ALL, EXCEPT ALL set operations for the multi-stage query engine

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectAllOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectAllOperator.java
@@ -28,25 +28,26 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Minus/Except operator.
+ * INTERSECT ALL operator.
  */
-public class MinusOperator extends SetOperator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MinusOperator.class);
-  private static final String EXPLAIN_NAME = "MINUS";
+public class IntersectAllOperator extends SetOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IntersectAllOperator.class);
+  private static final String EXPLAIN_NAME = "INTERSECT ALL";
 
-  public MinusOperator(OpChainExecutionContext opChainExecutionContext, List<MultiStageOperator> upstreamOperators,
+  public IntersectAllOperator(OpChainExecutionContext opChainExecutionContext,
+      List<MultiStageOperator> upstreamOperators,
       DataSchema dataSchema) {
     super(opChainExecutionContext, upstreamOperators, dataSchema);
   }
 
   @Override
-  protected Logger logger() {
-    return LOGGER;
+  public Type getOperatorType() {
+    return Type.INTERSECT;
   }
 
   @Override
-  public Type getOperatorType() {
-    return Type.MINUS;
+  protected Logger logger() {
+    return LOGGER;
   }
 
   @Nullable
@@ -57,12 +58,6 @@ public class MinusOperator extends SetOperator {
 
   @Override
   protected boolean handleRowMatched(Object[] row) {
-    Record record = new Record(row);
-    if (_rightRowSet.contains(record)) {
-      return false;
-    } else {
-      _rightRowSet.add(record);
-      return true;
-    }
+    return _rightRowSet.remove(new Record(row));
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectAllOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectAllOperator.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IntersectAllOperator extends SetOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(IntersectAllOperator.class);
-  private static final String EXPLAIN_NAME = "INTERSECT ALL";
+  private static final String EXPLAIN_NAME = "INTERSECT_ALL";
 
   public IntersectAllOperator(OpChainExecutionContext opChainExecutionContext,
       List<MultiStageOperator> upstreamOperators,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectOperator.java
@@ -58,6 +58,7 @@ public class IntersectOperator extends SetOperator {
 
   @Override
   protected boolean handleRowMatched(Object[] row) {
-    return _rightRowSet.remove(new Record(row));
+    Record record = new Record(row);
+    return _rightRowSet.remove(record, _rightRowSet.count(record)) != 0;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/IntersectOperator.java
@@ -58,7 +58,6 @@ public class IntersectOperator extends SetOperator {
 
   @Override
   protected boolean handleRowMatched(Object[] row) {
-    Record record = new Record(row);
-    return _rightRowSet.remove(record, _rightRowSet.count(record)) != 0;
+    return _rightRowSet.setCount(new Record(row), 0) != 0;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MinusAllOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MinusAllOperator.java
@@ -28,13 +28,13 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Minus/Except operator.
+ * EXCEPT ALL operator.
  */
-public class MinusOperator extends SetOperator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MinusOperator.class);
-  private static final String EXPLAIN_NAME = "MINUS";
+public class MinusAllOperator extends SetOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MinusAllOperator.class);
+  private static final String EXPLAIN_NAME = "MINUS ALL";
 
-  public MinusOperator(OpChainExecutionContext opChainExecutionContext, List<MultiStageOperator> upstreamOperators,
+  public MinusAllOperator(OpChainExecutionContext opChainExecutionContext, List<MultiStageOperator> upstreamOperators,
       DataSchema dataSchema) {
     super(opChainExecutionContext, upstreamOperators, dataSchema);
   }
@@ -57,12 +57,6 @@ public class MinusOperator extends SetOperator {
 
   @Override
   protected boolean handleRowMatched(Object[] row) {
-    Record record = new Record(row);
-    if (_rightRowSet.contains(record)) {
-      return false;
-    } else {
-      _rightRowSet.add(record);
-      return true;
-    }
+    return !_rightRowSet.remove(new Record(row));
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MinusAllOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MinusAllOperator.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MinusAllOperator extends SetOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinusAllOperator.class);
-  private static final String EXPLAIN_NAME = "MINUS ALL";
+  private static final String EXPLAIN_NAME = "MINUS_ALL";
 
   public MinusAllOperator(OpChainExecutionContext opChainExecutionContext, List<MultiStageOperator> upstreamOperators,
       DataSchema dataSchema) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SetOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SetOperator.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datatable.StatMap;
@@ -44,7 +44,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
  * UnionOperator: The right child operator is consumed in a blocking manner.
  */
 public abstract class SetOperator extends MultiStageOperator {
-  protected final Set<Record> _rightRowSet;
+  protected final Multiset<Record> _rightRowSet;
 
   private final List<MultiStageOperator> _upstreamOperators;
   private final MultiStageOperator _leftChildOperator;
@@ -65,7 +65,7 @@ public abstract class SetOperator extends MultiStageOperator {
     _upstreamOperators = upstreamOperators;
     _leftChildOperator = getChildOperators().get(0);
     _rightChildOperator = getChildOperators().get(1);
-    _rightRowSet = new HashSet<>();
+    _rightRowSet = HashMultiset.create();
     _isRightSetBuilt = false;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -37,11 +37,13 @@ import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.apache.pinot.query.runtime.operator.AggregateOperator;
 import org.apache.pinot.query.runtime.operator.FilterOperator;
 import org.apache.pinot.query.runtime.operator.HashJoinOperator;
+import org.apache.pinot.query.runtime.operator.IntersectAllOperator;
 import org.apache.pinot.query.runtime.operator.IntersectOperator;
 import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
 import org.apache.pinot.query.runtime.operator.LiteralValueOperator;
 import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.query.runtime.operator.MinusAllOperator;
 import org.apache.pinot.query.runtime.operator.MinusOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
@@ -125,9 +127,13 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
       case UNION:
         return new UnionOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema());
       case INTERSECT:
-        return new IntersectOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema());
+        return setOpNode.isAll()
+            ? new IntersectAllOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema())
+            : new IntersectOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema());
       case MINUS:
-        return new MinusOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema());
+        return setOpNode.isAll()
+            ? new MinusAllOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema())
+            : new MinusOperator(context, inputs, setOpNode.getInputs().get(0).getDataSchema());
       default:
         throw new IllegalStateException();
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/IntersectAllOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/IntersectAllOperatorTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockTestUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class IntersectAllOperatorTest {
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private MultiStageOperator _leftOperator;
+
+  @Mock
+  private MultiStageOperator _rightOperator;
+
+  @Mock
+  private VirtualServerAddress _serverAddress;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    Mockito.when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testIntersectAllOperator() {
+    DataSchema schema = new DataSchema(new String[]{"int_col"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+
+    Mockito.when(_leftOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{3}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    Mockito.when(_rightOperator.nextBlock()).thenReturn(
+            OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{4}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+
+    IntersectAllOperator intersectOperator =
+        new IntersectAllOperator(OperatorTestUtil.getTracingContext(), ImmutableList.of(_leftOperator, _rightOperator),
+            schema);
+
+    TransferableBlock result = intersectOperator.nextBlock();
+    while (result.getType() != DataBlock.Type.ROW) {
+      result = intersectOperator.nextBlock();
+    }
+    List<Object[]> resultRows = result.getContainer();
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{1}, new Object[]{2});
+    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    for (int i = 0; i < resultRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
+  }
+
+  @Test
+  public void testIntersectAllOperatorWithDups() {
+    DataSchema schema = new DataSchema(new String[]{"int_col"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+
+    Mockito.when(_leftOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{2}, new Object[]{3},
+            new Object[]{3}, new Object[]{3}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    Mockito.when(_rightOperator.nextBlock()).thenReturn(
+            OperatorTestUtil.block(schema, new Object[]{2}, new Object[]{3}, new Object[]{3}, new Object[]{4}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+
+    IntersectAllOperator intersectOperator =
+        new IntersectAllOperator(OperatorTestUtil.getTracingContext(), ImmutableList.of(_leftOperator, _rightOperator),
+            schema);
+
+    TransferableBlock result = intersectOperator.nextBlock();
+    while (result.getType() != DataBlock.Type.ROW) {
+      result = intersectOperator.nextBlock();
+    }
+    List<Object[]> resultRows = result.getContainer();
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{2}, new Object[]{3}, new Object[]{3});
+    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    for (int i = 0; i < resultRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MinusAllOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MinusAllOperatorTest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockTestUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class MinusAllOperatorTest {
+  private AutoCloseable _mocks;
+
+  @Mock
+  private MultiStageOperator _leftOperator;
+
+  @Mock
+  private MultiStageOperator _rightOperator;
+
+  @Mock
+  private VirtualServerAddress _serverAddress;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    Mockito.when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testExceptAllOperator() {
+    DataSchema schema = new DataSchema(new String[]{"int_col"}, new DataSchema.ColumnDataType[]{
+        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    });
+    Mockito.when(_leftOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{3}, new Object[]{4}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    Mockito.when(_rightOperator.nextBlock()).thenReturn(
+            OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{5}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+
+    MinusAllOperator minusOperator =
+        new MinusAllOperator(OperatorTestUtil.getTracingContext(), ImmutableList.of(_leftOperator, _rightOperator),
+            schema);
+
+    TransferableBlock result = minusOperator.nextBlock();
+    while (result.getType() != DataBlock.Type.ROW) {
+      result = minusOperator.nextBlock();
+    }
+    List<Object[]> resultRows = result.getContainer();
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{3}, new Object[]{4});
+    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    for (int i = 0; i < resultRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
+  }
+
+  @Test
+  public void testExceptAllOperatorWithDups() {
+    DataSchema schema = new DataSchema(new String[]{"int_col"}, new DataSchema.ColumnDataType[]{
+        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    });
+    Mockito.when(_leftOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(schema, new Object[]{1}, new Object[]{2}, new Object[]{2}, new Object[]{2},
+            new Object[]{3}, new Object[]{3}, new Object[]{3}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    Mockito.when(_rightOperator.nextBlock()).thenReturn(
+            OperatorTestUtil.block(schema, new Object[]{2}, new Object[]{3}, new Object[]{3}, new Object[]{4}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+
+    MinusAllOperator minusOperator =
+        new MinusAllOperator(OperatorTestUtil.getTracingContext(), ImmutableList.of(_leftOperator, _rightOperator),
+            schema);
+
+    TransferableBlock result = minusOperator.nextBlock();
+    while (result.getType() != DataBlock.Type.ROW) {
+      result = minusOperator.nextBlock();
+    }
+    List<Object[]> resultRows = result.getContainer();
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{1}, new Object[]{2}, new Object[]{2}, new Object[]{3});
+    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    for (int i = 0; i < resultRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
+  }
+}


### PR DESCRIPTION
- This is a fix for https://github.com/apache/pinot/issues/13126 and https://github.com/apache/pinot/issues/13127
- The `SetOperator` has been modified slightly to use a multiset instead of a regular set so that we can support the `INTERSECT ALL` and `EXCEPT ALL` set operations.
- Alternatively, we could've extended the `SetOperator` class with a `MultisetOperator` class with the appropriate abstractions but since the hash multiset overhead isn't too high (essentially just an additional count maintained per element), this option was avoided in favor of the cleaner, uniform implementation.
- Suggested labels - either `feature` or `bugfix` since the `INTERSECT ALL`, `EXCEPT ALL` set operations currently erroneously return the same results as `INTERSECT`, `EXCEPT` respectively.

<hr>

Let's take an example to demonstrate the various set operation semantics and their differences. Suppose there's two tables `A` (with one column `'a'`) and `B` (with one column `'b'`) with the following rows:

<h3>A</h3>

```
a
--
1
2
2
3
3
3
```

<h3>B</h3>

```
b
--
2
3
3
4
```

Then, `SELECT * FROM (SELECT a FROM A) INTERSECT (SELECT b FROM B)` should return:

```
2
3
```

`SELECT * FROM (SELECT a FROM A) INTERSECT ALL (SELECT b FROM B)` should return:

```
2
3
3
```

`SELECT * FROM (SELECT a FROM A) EXCEPT (SELECT b FROM B)` should return:

```
1
```

and, `SELECT * FROM (SELECT a FROM A) EXCEPT ALL (SELECT b FROM B)` should return:

```
1
2
3
```