### PR TITLE
Fix an overflow in PinotDataBuffer.readFrom

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
@@ -521,13 +521,15 @@ public abstract class PinotDataBuffer implements Closeable {
    * Given an array of bytes, writes the content in the specified position.
    */
   public void readFrom(long offset, byte[] buffer, int srcOffset, int size) {
-    assert offset <= Integer.MAX_VALUE;
-    int intOffset = (int) offset;
-
+    if (offset + size > size()) {
+      throw new IndexOutOfBoundsException("Buffer overflow: offset = " + offset + ", size = " + size
+          + ", buffer size = " + size());
+    }
     if (size <= BULK_BYTES_PROCESSING_THRESHOLD) {
+      long currentOffset = offset;
       int end = srcOffset + size;
       for (int i = srcOffset; i < end; i++) {
-        putByte(intOffset++, buffer[i]);
+        putByte(currentOffset++, buffer[i]);
       }
     } else {
       toDirectByteBuffer(offset, size).put(buffer, srcOffset, size);


### PR DESCRIPTION
Fix an error on PinotDataBuffer when calling `readFrom` with an offset that was larger than Integer.MAX_VALUE

In fact this error only affected `UnsafePinotBuffer` because it was the only buffer using the default implementation. In the previous code the read failed when it wasn't problematic at all.