### PR TITLE
Add PodDisruptionBudgets to the Pinot Helm chart

### DIFF
--- a/helm/pinot/templates/broker/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/broker/poddisruptionbudget.yaml
@@ -17,11 +17,13 @@
 # under the License.
 #
 
+{{- if .Values.broker.disruptionBudget.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
 spec:
-  minAvailable: {{ .Values.broker.minAvailable }}
+  minAvailable: {{ .Values.broker.disruptionBudget.minAvailable }}
   selector:
     {{- include "pinot.brokerMatchLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/pinot/templates/broker/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/broker/poddisruptionbudget.yaml
@@ -17,13 +17,18 @@
 # under the License.
 #
 
-{{- if .Values.broker.disruptionBudget.enabled -}}
+{{- if .Values.broker.pdb.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
 spec:
-  minAvailable: {{ .Values.broker.disruptionBudget.minAvailable }}
+  {{- if .Values.broker.pdb.minAvailable }}
+  minAvailable: {{ .Values.broker.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.broker.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.broker.pdb.maxUnavailable }}
+  {{- end }}
   selector:
     {{- include "pinot.brokerMatchLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/pinot/templates/broker/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/broker/poddisruptionbudget.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.broker.fullname" . }}
+spec:
+  minAvailable: {{ .Values.broker.minAvailable }}
+  selector:
+    {{- include "pinot.brokerMatchLabels" . | nindent 4 }}

--- a/helm/pinot/templates/controller/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/controller/poddisruptionbudget.yaml
@@ -17,11 +17,13 @@
 # under the License.
 #
 
+{{- if .Values.controller.disruptionBudget.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.controller.fullname" . }}
 spec:
-  minAvailable: {{ .Values.controller.minAvailable }}
+  minAvailable: {{ .Values.controller.disruptionBudget.minAvailable }}
   selector:
     {{- include "pinot.controllerMatchLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/pinot/templates/controller/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/controller/poddisruptionbudget.yaml
@@ -17,13 +17,18 @@
 # under the License.
 #
 
-{{- if .Values.controller.disruptionBudget.enabled -}}
+{{- if .Values.controller.pdb.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.controller.fullname" . }}
 spec:
-  minAvailable: {{ .Values.controller.disruptionBudget.minAvailable }}
+  {{- if .Values.controller.pdb.minAvailable }}
+  minAvailable: {{ .Values.controller.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.controller.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.pdb.maxUnavailable }}
+  {{- end }}
   selector:
     {{- include "pinot.controllerMatchLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/pinot/templates/controller/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/controller/poddisruptionbudget.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.controller.fullname" . }}
+spec:
+  minAvailable: {{ .Values.controller.minAvailable }}
+  selector:
+    {{- include "pinot.controllerMatchLabels" . | nindent 4 }}

--- a/helm/pinot/templates/server/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/server/poddisruptionbudget.yaml
@@ -17,11 +17,13 @@
 # under the License.
 #
 
+{{- if .Values.server.disruptionBudget.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.server.fullname" . }}
 spec:
-  minAvailable: {{ .Values.server.minAvailable }}
+  minAvailable: {{ .Values.server.disruptionBudget.minAvailable }}
   selector:
     {{- include "pinot.serverMatchLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/pinot/templates/server/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/server/poddisruptionbudget.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.server.fullname" . }}
+spec:
+  minAvailable: {{ .Values.server.minAvailable }}
+  selector:
+    {{- include "pinot.serverMatchLabels" . | nindent 4 }}

--- a/helm/pinot/templates/server/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/server/poddisruptionbudget.yaml
@@ -17,13 +17,18 @@
 # under the License.
 #
 
-{{- if .Values.server.disruptionBudget.enabled -}}
+{{- if .Values.server.pdb.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "pinot.server.fullname" . }}
 spec:
-  minAvailable: {{ .Values.server.disruptionBudget.minAvailable }}
+  {{- if .Values.server.pdb.minAvailable }}
+  minAvailable: {{ .Values.server.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.server.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.server.pdb.maxUnavailable }}
+  {{- end }}
   selector:
     {{- include "pinot.serverMatchLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -115,9 +115,10 @@ controller:
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-controller-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 
-  disruptionBudget:
-    enabled: false
-    minAvailable: 50%
+  pdb:
+    enabled: false 
+    minAvailable: ""
+    maxUnavailable: 50%
 
   service:
     annotations: {}
@@ -223,9 +224,10 @@ broker:
     extraVolumes: []
     extraVolumeMounts: []
 
-  disruptionBudget:
+  pdb:
     enabled: false
-    minAvailable: 50%
+    minAvailable: ""
+    maxUnavailable: 50%
 
   service:
     annotations: {}
@@ -339,9 +341,10 @@ server:
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-server-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 
-  disruptionBudget:
-    enabled: false
-    minAvailable: 50%
+  pdb:
+    enabled: false 
+    minAvailable: ""
+    maxUnavailable: 1
 
   service:
     annotations: {}

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -115,6 +115,8 @@ controller:
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-controller-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 
+  minAvailable: 50%
+
   service:
     annotations: {}
     clusterIP: "None"
@@ -218,6 +220,8 @@ broker:
   persistence:
     extraVolumes: []
     extraVolumeMounts: []
+
+  minAvailable: 50%
 
   service:
     annotations: {}
@@ -330,6 +334,8 @@ server:
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-server-log4j2.xml
   pluginsDir: /opt/pinot/plugins
+
+  minAvailable: 50%
 
   service:
     annotations: {}

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -115,7 +115,9 @@ controller:
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-controller-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 
-  minAvailable: 50%
+  disruptionBudget:
+    enabled: false
+    minAvailable: 50%
 
   service:
     annotations: {}
@@ -221,7 +223,9 @@ broker:
     extraVolumes: []
     extraVolumeMounts: []
 
-  minAvailable: 50%
+  disruptionBudget:
+    enabled: false
+    minAvailable: 50%
 
   service:
     annotations: {}
@@ -335,7 +339,9 @@ server:
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-server-log4j2.xml
   pluginsDir: /opt/pinot/plugins
 
-  minAvailable: 50%
+  disruptionBudget:
+    enabled: false
+    minAvailable: 50%
 
   service:
     annotations: {}


### PR DESCRIPTION
I've set these by default at allowing 50% of the servers/brokers/controllers to be unavailable, and exposed these settings in the configuration so the user can change them.

These prevent outages when the underlying kuberenetes cluster undergoes an upgrade.

You might configure these like so in your helm yaml settings:

```yaml
broker:
  replicaCount: 2
  pdb:
    enabled: true
    minAvailable: 50% # we could also set this to 1
    maxUnavailable: "" # can turn these off with empty string
controller:
  replicaCount: 2
  pdb:
    enabled: true
    minAvailable: 1 # we could also set this to 50%
    maxUnavailable: "" # can turn these off with empty string
server:
  replicaCount: 12
  pdb:
    enabled: true
    maxUnavailable: 1
    # minAvailable: 11 # these would be equivalent
```