### PR TITLE
Allow dynamically setting the log level even for loggers that aren't already explicitly configured

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
@@ -68,7 +68,7 @@ public class PinotBrokerLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
-    return LoggerUtils.getAllLoggers();
+    return LoggerUtils.getAllConfiguredLoggers();
   }
 
   @GET

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerUtils.java
@@ -64,7 +64,17 @@ public class LoggerUtils {
       loggerConfig = getLoggerConfig(config, loggerName);
       loggerConfig.setLevel(level);
     } else {
-      if (!getAllLoggers().contains(loggerName)) {
+      // Check if the loggerName exists by comparing it to all known loggers in the context
+      if (getAllLoggers().stream().noneMatch(logger -> {
+        if (!logger.startsWith(loggerName)) {
+          return false;
+        }
+        if (logger.equals(loggerName)) {
+          return true;
+        }
+        // Check if loggerName is a valid parent / descendant logger for any known logger
+        return logger.substring(loggerName.length()).startsWith(".");
+      })) {
         throw new RuntimeException("Logger - " + loggerName + " not found");
       }
       loggerConfig = new LoggerConfig(loggerName, level, true);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerUtils.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.spi.AbstractLogger;
 
 
 /**
@@ -45,21 +46,29 @@ public class LoggerUtils {
 
   /**
    * Set logger level at runtime.
-   * @param loggerName
-   * @param logLevel
+   * @param loggerName name of the logger whose level is to be changed
+   * @param logLevel the new log level
    * @return logger info
    */
   public static Map<String, String> setLoggerLevel(String loggerName, String logLevel) {
-    LoggerContext context = (LoggerContext) LogManager.getContext(false);
-    Configuration config = context.getConfiguration();
-    if (!getAllLoggers().contains(loggerName)) {
-      throw new RuntimeException("Logger - " + loggerName + " not found");
-    }
-    LoggerConfig loggerConfig = getLoggerConfig(config, loggerName);
+    Level level;
     try {
-      loggerConfig.setLevel(Level.valueOf(logLevel));
+      level = Level.valueOf(logLevel);
     } catch (Exception e) {
       throw new RuntimeException("Unrecognized logger level - " + logLevel, e);
+    }
+    LoggerContext context = (LoggerContext) LogManager.getContext(false);
+    Configuration config = context.getConfiguration();
+    LoggerConfig loggerConfig;
+    if (getAllConfiguredLoggers().contains(loggerName)) {
+      loggerConfig = getLoggerConfig(config, loggerName);
+      loggerConfig.setLevel(level);
+    } else {
+      if (!getAllLoggers().contains(loggerName)) {
+        throw new RuntimeException("Logger - " + loggerName + " not found");
+      }
+      loggerConfig = new LoggerConfig(loggerName, level, true);
+      config.addLogger(loggerName, loggerConfig);
     }
     // This causes all Loggers to re-fetch information from their LoggerConfig.
     context.updateLoggers();
@@ -75,7 +84,7 @@ public class LoggerUtils {
   public static Map<String, String> getLoggerInfo(String loggerName) {
     LoggerContext context = (LoggerContext) LogManager.getContext(false);
     Configuration config = context.getConfiguration();
-    if (!getAllLoggers().contains(loggerName)) {
+    if (!getAllConfiguredLoggers().contains(loggerName)) {
       return null;
     }
     LoggerConfig loggerConfig = getLoggerConfig(config, loggerName);
@@ -83,12 +92,20 @@ public class LoggerUtils {
   }
 
   /**
+   * @return a list of all the configured logger names
+   */
+  public static List<String> getAllConfiguredLoggers() {
+    LoggerContext context = (LoggerContext) LogManager.getContext(false);
+    Configuration config = context.getConfiguration();
+    return config.getLoggers().values().stream().map(LoggerConfig::toString).collect(Collectors.toList());
+  }
+
+  /**
    * @return a list of all the logger names
    */
   public static List<String> getAllLoggers() {
     LoggerContext context = (LoggerContext) LogManager.getContext(false);
-    Configuration config = context.getConfiguration();
-    return config.getLoggers().values().stream().map(LoggerConfig::toString).collect(Collectors.toList());
+    return context.getLoggers().stream().map(AbstractLogger::getName).collect(Collectors.toList());
   }
 
   private static LoggerConfig getLoggerConfig(Configuration config, String loggerName) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.common.utils;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -34,8 +36,8 @@ public class LoggerUtilsTest {
   private static final String PINOT = "org.apache.pinot";
 
   @Test
-  public void testGetAllLoggers() {
-    List<String> allLoggers = LoggerUtils.getAllLoggers();
+  public void testGetAllConfiguredLoggers() {
+    List<String> allLoggers = LoggerUtils.getAllConfiguredLoggers();
     assertEquals(allLoggers.size(), 2);
     assertTrue(allLoggers.contains(ROOT));
     assertTrue(allLoggers.contains(PINOT));
@@ -59,7 +61,7 @@ public class LoggerUtilsTest {
   }
 
   @Test
-  public void testChangeLoggerLevel() {
+  public void testChangeConfiguredLoggerLevel() {
     Map<String, String> pinotLoggerInfo = LoggerUtils.getLoggerInfo(PINOT);
     assertNotNull(pinotLoggerInfo);
     assertEquals(pinotLoggerInfo.get("level"), "WARN");
@@ -70,6 +72,25 @@ public class LoggerUtilsTest {
       assertNotNull(pinotLoggerInfo);
       assertEquals(pinotLoggerInfo.get("level"), level);
     }
+  }
+
+  @Test
+  public void testChangeNonConfiguredLoggerLevel() {
+    String loggerName = getClass().getCanonicalName();
+    // The logger for this test class is not explicitly configured and inherits the root logger's config
+    assertNull(LoggerUtils.getLoggerInfo(loggerName));
+
+    Map<String, String> loggerInfo = LoggerUtils.setLoggerLevel(loggerName, "DEBUG");
+    assertNotNull(loggerInfo);
+    assertEquals(loggerInfo.get("level"), "DEBUG");
+
+    // Verify that the logger for this test class now shows up in the configured loggers
+    loggerInfo = LoggerUtils.getLoggerInfo(loggerName);
+    assertNotNull(loggerInfo);
+    assertEquals(loggerInfo.get("level"), "DEBUG");
+
+    // Remove the logger configuration so that other tests aren't affected
+    ((LoggerContext) LogManager.getContext(false)).getConfiguration().removeLogger(loggerName);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
@@ -94,6 +94,25 @@ public class LoggerUtilsTest {
   }
 
   @Test
+  public void testChangeNonConfiguredAncestorLoggerLevel() {
+    String loggerName = getClass().getPackageName();
+    // The logger for this package is not explicitly configured and inherits the root logger's config
+    assertNull(LoggerUtils.getLoggerInfo(loggerName));
+
+    Map<String, String> loggerInfo = LoggerUtils.setLoggerLevel(loggerName, "DEBUG");
+    assertNotNull(loggerInfo);
+    assertEquals(loggerInfo.get("level"), "DEBUG");
+
+    // Verify that the logger for this package now shows up in the configured loggers
+    loggerInfo = LoggerUtils.getLoggerInfo(loggerName);
+    assertNotNull(loggerInfo);
+    assertEquals(loggerInfo.get("level"), "DEBUG");
+
+    // Remove the logger configuration so that other tests aren't affected
+    ((LoggerContext) LogManager.getContext(false)).getConfiguration().removeLogger(loggerName);
+  }
+
+  @Test
   public void testChangeLoggerLevelWithExceptions() {
     try {
       LoggerUtils.setLoggerLevel("notExistLogger", "INFO");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -92,7 +92,7 @@ public class PinotControllerLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
-    return LoggerUtils.getAllLoggers();
+    return LoggerUtils.getAllConfiguredLoggers();
   }
 
   @GET

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
@@ -64,7 +64,7 @@ public class PinotMinionLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
-    return LoggerUtils.getAllLoggers();
+    return LoggerUtils.getAllConfiguredLoggers();
   }
 
   @GET

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
@@ -64,7 +64,7 @@ public class PinotServerLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
-    return LoggerUtils.getAllLoggers();
+    return LoggerUtils.getAllConfiguredLoggers();
   }
 
   @GET

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerLogger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerLogger.java
@@ -56,7 +56,7 @@ public class PinotServiceManagerLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
-    return LoggerUtils.getAllLoggers();
+    return LoggerUtils.getAllConfiguredLoggers();
   }
 
   @GET


### PR DESCRIPTION
- This is a fix for https://github.com/apache/pinot/issues/13155
- Support for dynamic log configuration APIs was added in https://github.com/apache/pinot/pull/9180 and documented in https://github.com/pinot-contrib/pinot-docs/pull/132
- Currently, these APIs don't allow modifying the level of loggers that aren't explicitly configured.
- For instance, let's say that a Pinot controller process is started with the log4j configuration file containing log levels defined for the following loggers: `root`, `org.apache.pinot.tools.admin` and `org.reflections` (see [this log4j config file](https://github.com/apache/pinot/blob/0f48825d2d36e489c743d7e50bdb62bfc1f786ba/pinot-tools/src/main/resources/conf/log4j2.xml#L41-L48) for reference).
- Now, if we attempt to change the log level of the `org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager` class via `PUT /loggers/org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager?level=DEBUG`, this returns the following response: `{"code":500,"error":"Logger - org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager not found"}`
- This is because the check [here](https://github.com/apache/pinot/blob/0f48825d2d36e489c743d7e50bdb62bfc1f786ba/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerUtils.java#L55) only checks whether the logger name is in the list of loggers that are already explicitly configured.
- This severely limits the usefulness of the dynamic log configuration API as it prevents the modification of all loggers that aren't explicitly configured in the log4j configuration file.
- This patch allows dynamically setting the log level even for loggers that aren't already explicitly configured. ~~In a future enhancement, we could also allow dynamically setting the log level for an ancestor logger which would affect all the descendant loggers (see https://logging.apache.org/log4j/2.x/manual/architecture.html#logger-hierarchy)~~.
- This also allows dynamically configuring the log level for ancestor / parent loggers - for instance, `org.apache.pinot.controller.helix.core`. This will then also affect the log level for all the descendant / child loggers - for instance, `org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager` (see https://logging.apache.org/log4j/2.x/manual/architecture.html#logger-hierarchy).
- Suggested label: `bugfix` or `feature`