### PR TITLE
[Hotfix] Upsert compaction doesn't acknowledge maxLength info and trims string values

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.local.segment.readers.CompactedPinotSegmentRecor
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +100,8 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
 
     try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(indexDir,
         validDocIds)) {
-      SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName);
+      SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName,
+          getSchema(tableNameWithType));
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, compactedRecordReader);
       driver.build();
@@ -117,8 +119,8 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
   }
 
   private static SegmentGeneratorConfig getSegmentGeneratorConfig(File workingDir, TableConfig tableConfig,
-      SegmentMetadataImpl segmentMetadata, String segmentName) {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, segmentMetadata.getSchema());
+      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema) {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(workingDir.getPath());
     config.setSegmentName(segmentName);
     // Keep index creation time the same as original segment because both segments use the same raw data.


### PR DESCRIPTION
label:
`bugfix`

Recently, we found that post-compaction, string fields with length greater than default 512 characters got trimmed. On debugging, I found that we were using schema generated from `metadata.properties` file and not passing schema from ZK to SegmentGenerator class. This hotfix is related to passing ZK schema to this.

One of the other root-causes is `metadata.properties` file missing schema max length information for columns. Also while creating fieldSpec from metadata properties we don't pass maxlength anywhere -- https://github.com/apache/pinot/blob/0f48825d2d36e489c743d7e50bdb62bfc1f786ba/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java#L236
This leads to falling back to default 512 for string fields.

Sample metadata.properties values for a column:
```
column.Attr.cardinality = -2147483648
column.Attr.totalDocs = 1322868
column.Attr.dataType = STRING
column.Attr.bitsPerElement = 31
column.Attr.lengthOfEachEntry = 0
column.Attr.columnType = DIMENSION
column.Attr.isSorted = false
column.Attr.hasDictionary = false
column.Attr.isSingleValues = true
column.Attr.maxNumberOfMultiValues = 0
column.Attr.totalNumberOfEntries = 1322868
column.Attr.isAutoGenerated = false
column.Attr.minValue = null
column.Attr.minMaxValueInvalid = true
column.Attr.defaultNullValue = null
```
No schemaMaxLength field present here^^. 

Longer term fix I am planning as a follow-up is to persist maxLength info in metadata properties file and parsing that in the ColumnMetadataImpl file while creating FieldSpec.

cc @snleee @Jackie-Jiang 