### PR TITLE
[HELM]: Added additional probes options and startup probe.

### DIFF
--- a/helm/pinot/templates/broker/statefulset.yaml
+++ b/helm/pinot/templates/broker/statefulset.yaml
@@ -92,9 +92,9 @@ spec:
         {{- if .Values.broker.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.broker.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.broker.probes.liveness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.broker.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.broker.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.broker.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
@@ -103,9 +103,9 @@ spec:
         {{- if .Values.broker.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.broker.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.broker.probes.readiness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.broker.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.broker.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.broker.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
@@ -114,9 +114,9 @@ spec:
         {{- if .Values.broker.probes.startupEnabled }}
         startupProbe:
           initialDelaySeconds: {{ .Values.broker.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.broker.probes.startup.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.broker.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold:{{ .Values.broker.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.broker.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}

--- a/helm/pinot/templates/broker/statefulset.yaml
+++ b/helm/pinot/templates/broker/statefulset.yaml
@@ -112,6 +112,7 @@ spec:
             port: {{ .Values.broker.service.port }}
         {{- end }}
         {{- if .Values.broker.probes.startupEnabled }}
+        startupProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.probes.failureThreshold }}

--- a/helm/pinot/templates/broker/statefulset.yaml
+++ b/helm/pinot/templates/broker/statefulset.yaml
@@ -93,6 +93,9 @@ spec:
         livenessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}
@@ -101,6 +104,19 @@ spec:
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          httpGet:
+            path: {{ .Values.broker.probes.endpoint }}
+            port: {{ .Values.broker.service.port }}
+        {{- end }}
+        {{- if .Values.broker.probes.startupEnabled }}
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}

--- a/helm/pinot/templates/broker/statefulset.yaml
+++ b/helm/pinot/templates/broker/statefulset.yaml
@@ -91,33 +91,33 @@ spec:
           {{- end }}
         {{- if .Values.broker.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.broker.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.broker.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.broker.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}
         {{- end }}
         {{- if .Values.broker.probes.readinessEnabled }}
         readinessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.broker.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.broker.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.broker.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}
         {{- end }}
         {{- if .Values.broker.probes.startupEnabled }}
         startupProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.broker.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.broker.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.broker.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}

--- a/helm/pinot/templates/controller/statefulset.yaml
+++ b/helm/pinot/templates/controller/statefulset.yaml
@@ -82,6 +82,9 @@ spec:
         livenessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}
@@ -90,6 +93,19 @@ spec:
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          httpGet:
+            path: {{ .Values.controller.probes.endpoint }}
+            port: {{ .Values.controller.service.port }}
+        {{- end }}
+        {{- if .Values.controller.probes.startupEnabled }}
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}

--- a/helm/pinot/templates/controller/statefulset.yaml
+++ b/helm/pinot/templates/controller/statefulset.yaml
@@ -101,6 +101,7 @@ spec:
             port: {{ .Values.controller.service.port }}
         {{- end }}
         {{- if .Values.controller.probes.startupEnabled }}
+        startupProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.probes.failureThreshold }}

--- a/helm/pinot/templates/controller/statefulset.yaml
+++ b/helm/pinot/templates/controller/statefulset.yaml
@@ -81,9 +81,9 @@ spec:
         {{- if .Values.controller.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.controller.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds:{{ .Values.controller.probes.liveness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.controller.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.controller.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.controller.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
@@ -92,9 +92,9 @@ spec:
         {{- if .Values.controller.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.controller.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.controller.probes.readiness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.controller.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.controller.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.controller.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
@@ -103,9 +103,9 @@ spec:
         {{- if .Values.controller.probes.startupEnabled }}
         startupProbe:
           initialDelaySeconds: {{ .Values.controller.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.controller.probes.startup.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.controller.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.controller.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.controller.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}

--- a/helm/pinot/templates/controller/statefulset.yaml
+++ b/helm/pinot/templates/controller/statefulset.yaml
@@ -80,33 +80,33 @@ spec:
 {{- end }}           
         {{- if .Values.controller.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.controller.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.controller.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.controller.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}
         {{- end }}
         {{- if .Values.controller.probes.readinessEnabled }}
         readinessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.controller.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.controller.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.controller.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}
         {{- end }}
         {{- if .Values.controller.probes.startupEnabled }}
         startupProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.controller.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.controller.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.controller.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}

--- a/helm/pinot/templates/minion-stateless/deployment.yaml
+++ b/helm/pinot/templates/minion-stateless/deployment.yaml
@@ -80,9 +80,9 @@ spec:
         {{- if .Values.minionStateless.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.minionStateless.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minionStateless.probes.liveness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minionStateless.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minionStateless.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minionStateless.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minionStateless.probes.endpoint }}
@@ -91,9 +91,9 @@ spec:
         {{- if .Values.minionStateless.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.minionStateless.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minionStateless.probes.readiness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minionStateless.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minionStateless.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minionStateless.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minionStateless.probes.endpoint }}
@@ -102,9 +102,9 @@ spec:
         {{- if .Values.minionStateless.probes.startupEnabled }}
         startupProbe:
           initialDelaySeconds: {{ .Values.minionStateless.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minionStateless.probes.startup.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minionStateless.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minionStateless.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minionStateless.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minionStateless.probes.endpoint }}

--- a/helm/pinot/templates/minion-stateless/deployment.yaml
+++ b/helm/pinot/templates/minion-stateless/deployment.yaml
@@ -79,20 +79,37 @@ spec:
 {{- end }}  
         {{- if .Values.minionStateless.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.minionStateless.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.minionStateless.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.minionStateless.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minionStateless.probes.endpoint }}
             port: {{ .Values.minionStateless.service.port }}
         {{- end }}
         {{- if .Values.minionStateless.probes.readinessEnabled }}
         readinessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.minionStateless.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.minionStateless.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.minionStateless.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minionStateless.probes.endpoint }}
             port: {{ .Values.minionStateless.service.port }}
         {{- end }}
+        {{- if .Values.minionStateless.probes.startupEnabled }}
+        startupProbe:
+          initialDelaySeconds: {{ .Values.minionStateless.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.minionStateless.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.minionStateless.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
+          httpGet:
+            path: {{ .Values.minionStateless.probes.endpoint }}
+            port: {{ .Values.minionStateless.service.port }}
+          {{- end }}
         volumeMounts:
           - name: config
             mountPath: /var/pinot/minion/config

--- a/helm/pinot/templates/minion/statefulset.yaml
+++ b/helm/pinot/templates/minion/statefulset.yaml
@@ -107,6 +107,7 @@ spec:
             port: {{ .Values.minion.service.port }}
         {{- end }}
         {{- if .Values.minion.probes.startupEnabled }}
+        startupProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.probes.failureThreshold }}

--- a/helm/pinot/templates/minion/statefulset.yaml
+++ b/helm/pinot/templates/minion/statefulset.yaml
@@ -87,9 +87,9 @@ spec:
         {{- if .Values.minion.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.minion.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minion.probes.liveness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minion.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minion.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minion.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
@@ -98,9 +98,9 @@ spec:
         {{- if .Values.minion.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.minion.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minion.probes.readiness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minion.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minion.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minion.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
@@ -109,9 +109,9 @@ spec:
         {{- if .Values.minion.probes.startupEnabled }}
         startupProbe:
           initialDelaySeconds: {{ .Values.minion.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.minion.probes.startup.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.minion.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.minion.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.minion.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}

--- a/helm/pinot/templates/minion/statefulset.yaml
+++ b/helm/pinot/templates/minion/statefulset.yaml
@@ -86,33 +86,33 @@ spec:
 {{- end }}     
         {{- if .Values.minion.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.minion.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.minion.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.minion.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}
         {{- end }}
         {{- if .Values.minion.probes.readinessEnabled }}
         readinessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.minion.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.minion.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.minion.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}
         {{- end }}
         {{- if .Values.minion.probes.startupEnabled }}
         startupProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.minion.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.minion.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.minion.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}

--- a/helm/pinot/templates/minion/statefulset.yaml
+++ b/helm/pinot/templates/minion/statefulset.yaml
@@ -88,6 +88,9 @@ spec:
         livenessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}
@@ -96,6 +99,19 @@ spec:
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          httpGet:
+            path: {{ .Values.minion.probes.endpoint }}
+            port: {{ .Values.minion.service.port }}
+        {{- end }}
+        {{- if .Values.minion.probes.startupEnabled }}
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}

--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -88,11 +88,11 @@ spec:
 {{- end }}   
         {{- if .Values.server.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.server.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.server.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.server.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
             path: {{ .Values.server.probes.livenessProbe.endpoint }}
@@ -103,11 +103,11 @@ spec:
         {{- end }}
         {{- if .Values.server.probes.readinessEnabled }}
         readinessProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.server.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.server.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.server.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.readinessProbe .Values.server.probes.readinessProbe.endpoint}}
             path: {{ .Values.server.probes.readinessProbe.endpoint }}
@@ -118,11 +118,11 @@ spec:
         {{- end }}
         {{- if .Values.server.probes.startupEnabled }}
         startupProbe:
-          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.server.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
-          failureThreshold: {{ .Values.probes.failureThreshold }}
+          failureThreshold: {{ .Values.server.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
           successThreshold: {{ .Values.probes.successThreshold }}
-          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.server.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
             path: {{ .Values.server.probes.livenessProbe.endpoint }}

--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -117,6 +117,7 @@ spec:
             port: {{ .Values.server.service.adminPort }}
         {{- end }}
         {{- if .Values.server.probes.startupEnabled }}
+        startupProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.probes.failureThreshold }}

--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -89,9 +89,9 @@ spec:
         {{- if .Values.server.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.server.probes.liveness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.server.probes.liveness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.server.probes.liveness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.server.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
@@ -104,9 +104,9 @@ spec:
         {{- if .Values.server.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.server.probes.readiness.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.server.probes.readiness.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.server.probes.readiness.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.server.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.readinessProbe .Values.server.probes.readinessProbe.endpoint}}
@@ -119,9 +119,9 @@ spec:
         {{- if .Values.server.probes.startupEnabled }}
         startupProbe:
           initialDelaySeconds: {{ .Values.server.probes.startup.initialDelaySeconds | default .Values.probes.initialDelaySeconds }}
-          periodSeconds: {{ .Values.probes.periodSeconds }}
+          periodSeconds: {{ .Values.server.probes.startup.periodSeconds | default .Values.probes.periodSeconds }}
           failureThreshold: {{ .Values.server.probes.startup.failureThreshold | default .Values.probes.failureThreshold }}
-          successThreshold: {{ .Values.probes.successThreshold }}
+          successThreshold: {{ .Values.server.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}

--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -90,6 +90,9 @@ spec:
         livenessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
             path: {{ .Values.server.probes.livenessProbe.endpoint }}
@@ -102,9 +105,26 @@ spec:
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
           httpGet:
             {{- if and .Values.server.probes.readinessProbe .Values.server.probes.readinessProbe.endpoint}}
             path: {{ .Values.server.probes.readinessProbe.endpoint }}
+            {{- else }}
+            path: {{ .Values.server.probes.endpoint }}
+            {{- end }}
+            port: {{ .Values.server.service.adminPort }}
+        {{- end }}
+        {{- if .Values.server.probes.startupEnabled }}
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          failureThreshold: {{ .Values.probes.failureThreshold }}
+          successThreshold: {{ .Values.probes.successThreshold }}
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+          httpGet:
+            {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
+            path: {{ .Values.server.probes.livenessProbe.endpoint }}
             {{- else }}
             path: {{ .Values.server.probes.endpoint }}
             {{- end }}

--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -94,11 +94,7 @@ spec:
           successThreshold: {{ .Values.server.probes.liveness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.liveness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
-            {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
-            path: {{ .Values.server.probes.livenessProbe.endpoint }}
-            {{- else }}
-            path: {{ .Values.server.probes.endpoint }}
-            {{- end }}
+            path: {{ .Values.server.probes.liveness.endpoint | default .Values.server.probes.endpoint }}
             port: {{ .Values.server.service.adminPort }}
         {{- end }}
         {{- if .Values.server.probes.readinessEnabled }}
@@ -109,11 +105,7 @@ spec:
           successThreshold: {{ .Values.server.probes.readiness.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.readiness.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
-            {{- if and .Values.server.probes.readinessProbe .Values.server.probes.readinessProbe.endpoint}}
-            path: {{ .Values.server.probes.readinessProbe.endpoint }}
-            {{- else }}
-            path: {{ .Values.server.probes.endpoint }}
-            {{- end }}
+            path: {{ .Values.server.probes.readiness.endpoint | default .Values.server.probes.endpoint }}
             port: {{ .Values.server.service.adminPort }}
         {{- end }}
         {{- if .Values.server.probes.startupEnabled }}
@@ -124,11 +116,7 @@ spec:
           successThreshold: {{ .Values.server.probes.startup.successThreshold | default .Values.probes.successThreshold }}
           timeoutSeconds: {{ .Values.server.probes.startup.timeoutSeconds | default .Values.probes.timeoutSeconds }}
           httpGet:
-            {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
-            path: {{ .Values.server.probes.livenessProbe.endpoint }}
-            {{- else }}
-            path: {{ .Values.server.probes.endpoint }}
-            {{- end }}
+            path: {{ .Values.server.probes.liveness.endpoint | default .Values.server.probes.endpoint }}
             port: {{ .Values.server.service.adminPort }}
         {{- end }}
         volumeMounts:

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -49,11 +49,13 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# default values of the probes i.e. liveness and readiness.
+# customization of values is present at the component level.
 probes:
   initialDelaySeconds: 60
   periodSeconds: 10
   failureThreshold: 10
-  # should be 1 for liveness and startup probe
+  # should be 1 for liveness and startup probe, as per K8s doc.
   successThreshold: 1
   timeoutSeconds: 10
 
@@ -98,19 +100,25 @@ controller:
     readinessEnabled: false
     startupEnabled: false
     liveness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     readiness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     startup:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
   persistence:
     enabled: true
@@ -239,19 +247,25 @@ broker:
     readinessEnabled: true
     startupEnabled: false
     liveness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     readiness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     startup:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
   persistence:
     extraVolumes: []
@@ -356,19 +370,25 @@ server:
     readinessEnabled: false
     startupEnabled: false
     liveness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     readiness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     startup:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
   dataDir: /var/pinot/server/data/index
   segmentTarDir: /var/pinot/server/data/segment
@@ -470,19 +490,25 @@ minion:
     readinessEnabled: true
     startupEnabled: false
     liveness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     readiness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     startup:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
@@ -575,19 +601,25 @@ minionStateless:
     readinessEnabled: true
     startupEnabled: true
     liveness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     readiness:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
     startup:
-      initialDelaySeconds:
-      failureThreshold:
-      timeoutSeconds:
+      initialDelaySeconds: 60
+      failureThreshold: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      periodSeconds: 10
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -52,9 +52,10 @@ securityContext: {}
 probes:
   initialDelaySeconds: 60
   periodSeconds: 10
-  failureThreshold: 1
+  failureThreshold: 10
+  # should be 1 for liveness and startup probe
   successThreshold: 1
-  timeoutSeconds: 1
+  timeoutSeconds: 10
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -96,6 +97,20 @@ controller:
     livenessEnabled: false
     readinessEnabled: false
     startupEnabled: false
+    liveness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    readiness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    startup:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
 
   persistence:
     enabled: true
@@ -223,6 +238,20 @@ broker:
     livenessEnabled: true
     readinessEnabled: true
     startupEnabled: false
+    liveness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    readiness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    startup:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
 
   persistence:
     extraVolumes: []
@@ -326,6 +355,20 @@ server:
     livenessEnabled: false
     readinessEnabled: false
     startupEnabled: false
+    liveness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    readiness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    startup:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
 
   dataDir: /var/pinot/server/data/index
   segmentTarDir: /var/pinot/server/data/segment
@@ -426,6 +469,20 @@ minion:
     livenessEnabled: true
     readinessEnabled: true
     startupEnabled: false
+    liveness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    readiness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    startup:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
@@ -516,6 +573,21 @@ minionStateless:
     endpoint: "/health"
     livenessEnabled: true
     readinessEnabled: true
+    startupEnabled: true
+    liveness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    readiness:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
+
+    startup:
+      initialDelaySeconds:
+      failureThreshold:
+      timeoutSeconds:
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -370,6 +370,7 @@ server:
     readinessEnabled: false
     startupEnabled: false
     liveness:
+      endpoint: "/health/liveness"
       initialDelaySeconds: 60
       failureThreshold: 10
       timeoutSeconds: 10
@@ -377,6 +378,7 @@ server:
       periodSeconds: 10
 
     readiness:
+      endpoint: "/health/readiness"
       initialDelaySeconds: 60
       failureThreshold: 10
       timeoutSeconds: 10
@@ -384,6 +386,7 @@ server:
       periodSeconds: 10
 
     startup:
+      endpoint: "/health/liveness"
       initialDelaySeconds: 60
       failureThreshold: 10
       timeoutSeconds: 10

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -52,6 +52,9 @@ securityContext: {}
 probes:
   initialDelaySeconds: 60
   periodSeconds: 10
+  failureThreshold: 1
+  successThreshold: 1
+  timeoutSeconds: 1
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -92,6 +95,7 @@ controller:
     endpoint: "/health"
     livenessEnabled: false
     readinessEnabled: false
+    startupEnabled: false
 
   persistence:
     enabled: true
@@ -218,6 +222,7 @@ broker:
     endpoint: "/health"
     livenessEnabled: true
     readinessEnabled: true
+    startupEnabled: false
 
   persistence:
     extraVolumes: []
@@ -320,6 +325,7 @@ server:
     endpoint: "/health"
     livenessEnabled: false
     readinessEnabled: false
+    startupEnabled: false
 
   dataDir: /var/pinot/server/data/index
   segmentTarDir: /var/pinot/server/data/segment
@@ -419,6 +425,7 @@ minion:
     endpoint: "/health"
     livenessEnabled: true
     readinessEnabled: true
+    startupEnabled: false
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/13073),

Added following more probes options
- `successThreshold`
- `failureThreshold`
- `timeoutSeconds`

And also added `startup probe`

Also, here is the output for the helm lint command
```bash
$ helm lint
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

And here is the output of the helm template command
<details>
<summary>helm template</summary>


```yaml

---
# Source: pinot/charts/zookeeper/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: release-name-zookeeper
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: zookeeper
  policyTypes:
    - Ingress
    - Egress
  egress:
    - {}
  ingress:
    # Allow inbound connections to ZooKeeper
    - ports:
        - port: 2181
    # Allow internal communications between nodes
    - ports:
        - port: 2888
        - port: 3888
      from:
        - podSelector:
            matchLabels:
              app.kubernetes.io/instance: release-name
              app.kubernetes.io/name: zookeeper
---
# Source: pinot/charts/zookeeper/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-zookeeper
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
    app.kubernetes.io/component: zookeeper
    role: zookeeper
automountServiceAccountToken: false
---
# Source: pinot/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-pinot
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
---
# Source: pinot/charts/zookeeper/templates/scripts-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-zookeeper-scripts
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
    app.kubernetes.io/component: zookeeper
data:
  init-certs.sh: |-
    #!/bin/bash
  setup.sh: |-
    #!/bin/bash

    # Execute entrypoint as usual after obtaining ZOO_SERVER_ID
    # check ZOO_SERVER_ID in persistent volume via myid
    # if not present, set based on POD hostname
    if [[ -f "/bitnami/zookeeper/data/myid" ]]; then
        export ZOO_SERVER_ID="$(cat /bitnami/zookeeper/data/myid)"
    else
        HOSTNAME="$(hostname -s)"
        if [[ $HOSTNAME =~ (.*)-([0-9]+)$ ]]; then
            ORD=${BASH_REMATCH[2]}
            export ZOO_SERVER_ID="$((ORD + 1 ))"
        else
            echo "Failed to get index from hostname $HOSTNAME"
            exit 1
        fi
    fi
    exec /entrypoint.sh /run.sh
---
# Source: pinot/templates/broker/configmap.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-pinot-broker-config
data:
  pinot-broker.conf: |-
    pinot.broker.client.queryPort=8099
    pinot.broker.routing.table.builder.class=random
    pinot.set.instance.id.to.hostname=true
    pinot.query.server.port=7321
    pinot.query.runner.port=7732
---
# Source: pinot/templates/controller/configmap.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-pinot-controller-config
data:
  pinot-controller.conf: |-
    controller.helix.cluster.name=pinot-quickstart
    controller.port=9000
    controller.data.dir=/var/pinot/controller/data
    controller.zk.str=release-name-zookeeper:2181
    pinot.set.instance.id.to.hostname=true
    controller.task.scheduler.enabled=true
---
# Source: pinot/templates/minion-stateless/configmap.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-pinot-minion-stateless-config
data:
  pinot-minion-stateless.conf: |-
    pinot.minion.port=9514
    dataDir=/var/pinot/minion/data
    pinot.set.instance.id.to.hostname=true
---
# Source: pinot/templates/server/configmap.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-pinot-server-config
data:
  pinot-server.conf: |-
    pinot.server.netty.port=8098
    pinot.server.adminapi.port=8097
    pinot.server.instance.dataDir=/var/pinot/server/data/index
    pinot.server.instance.segmentTarDir=/var/pinot/server/data/segment
    pinot.set.instance.id.to.hostname=true
    pinot.server.instance.realtime.alloc.offheap=true
    pinot.query.server.port=7321
    pinot.query.runner.port=7732
---
# Source: pinot/charts/zookeeper/templates/svc-headless.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-zookeeper-headless
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
    app.kubernetes.io/component: zookeeper
spec:
  type: ClusterIP
  clusterIP: None
  publishNotReadyAddresses: true
  ports:
    - name: tcp-client
      port: 2181
      targetPort: client
    - name: tcp-follower
      port: 2888
      targetPort: follower
    - name: tcp-election
      port: 3888
      targetPort: election
  selector:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/component: zookeeper
---
# Source: pinot/charts/zookeeper/templates/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-zookeeper
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
    app.kubernetes.io/component: zookeeper
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
    - name: tcp-client
      port: 2181
      targetPort: client
      nodePort: null
  selector:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/component: zookeeper
---
# Source: pinot/templates/broker/service-external.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-broker-external
  annotations:
    {}
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: broker
spec:
  type: LoadBalancer
  ports:
    - name: external-broker
      port: 8099
  selector:
    app: pinot
    release: release-name
    component: broker
---
# Source: pinot/templates/broker/service-headless.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-broker-headless
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: broker
spec:
  clusterIP: None
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: broker
      port: 8099
  selector:
    app: pinot
    release: release-name
    component: broker
---
# Source: pinot/templates/broker/service.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-broker
  annotations:
    {}
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: broker
spec:
  type: ClusterIP
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: broker
      port: 8099
  selector:
    app: pinot
    release: release-name
    component: broker
---
# Source: pinot/templates/controller/service-external.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-controller-external
  annotations:
    {}
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: controller
spec:
  type: LoadBalancer
  ports:
    - name: external-controller
      port: 9000
  selector:
    app: pinot
    release: release-name
    component: controller
---
# Source: pinot/templates/controller/service-headless.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-controller-headless
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: controller
spec:
  clusterIP: None
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: controller
      port: 9000
  selector:
    app: pinot
    release: release-name
    component: controller
---
# Source: pinot/templates/controller/service.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-controller
  annotations:
    {}
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: controller
spec:
  type: ClusterIP
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: controller
      port: 9000
  selector:
    app: pinot
    release: release-name
    component: controller
---
# Source: pinot/templates/server/service-headless.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-server-headless
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: server
spec:
  clusterIP: None
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: netty
      port: 8098
      protocol: TCP
    - name: admin
      port: 80
      targetPort: 8097
      protocol: TCP
  selector:
    app: pinot
    release: release-name
    component: server
---
# Source: pinot/templates/server/service.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: v1
kind: Service
metadata:
  name: release-name-pinot-server
  annotations:
    {}
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: server
spec:
  type: ClusterIP
  ports:
    # [pod_name].[service_name].[namespace].svc.cluster.local
    - name: netty
      port: 8098
      protocol: TCP
    - name: admin
      port: 80
      targetPort: 8097
      protocol: TCP
  selector:
    app: pinot
    release: release-name
    component: server
---
# Source: pinot/templates/minion-stateless/deployment.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-pinot-minion-stateless
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: minion-stateless
spec:
  selector:
    matchLabels:
      app: pinot
      release: release-name
      component: minion-stateless
  replicas: 1
  template:
    metadata:
      labels:
        helm.sh/chart: pinot-0.2.9-SNAPSHOT
        app: pinot
        release: release-name
        app.kubernetes.io/version: "1.0.0"
        app.kubernetes.io/managed-by: Helm
        heritage: Helm
        component: minion-stateless
      annotations:
        {}
    spec:
      terminationGracePeriodSeconds: 30
      serviceAccountName: release-name-pinot
      securityContext:
        {}
      nodeSelector:
        {}
      affinity:
        {}
      tolerations:
        []
      containers:
      - name: minion-stateless
        securityContext:
          {}
        image: "apachepinot/pinot:latest"
        imagePullPolicy: Always
        args: [
          "StartMinion",
          "-clusterName", "pinot-quickstart",
          "-zkAddress", "release-name-zookeeper:2181",
          "-configFileName", "/var/pinot/minion/config/pinot-minion-stateless.conf"
        ]
        env:
          - name: JAVA_OPTS
            value: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log -Dlog4j2.configurationFile=/opt/pinot/etc/conf/pinot-minion-log4j2.xml -Dplugins.dir=/opt/pinot/plugins"
          - name: LOG4J_CONSOLE_LEVEL
            value: info
        envFrom:
          []
        ports:
          - containerPort: 9514
            protocol: TCP
            name: minion
        livenessProbe:
          initialDelaySeconds: 60
          periodSeconds: 10
          httpGet:
            path: /health
            port: 9514
        readinessProbe:
          initialDelaySeconds: 60
          periodSeconds: 10
          httpGet:
            path: /health
            port: 9514
        volumeMounts:
          - name: config
            mountPath: /var/pinot/minion/config
        resources:
            requests:
              memory: 1.25Gi
      restartPolicy: Always
      volumes:
        - name: config
          configMap:
            name: release-name-pinot-minion-stateless-config
        - name: data
          emptyDir: {}
---
# Source: pinot/charts/zookeeper/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-zookeeper
  namespace: consumer
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: zookeeper
    app.kubernetes.io/version: 3.9.2
    helm.sh/chart: zookeeper-13.2.0
    app.kubernetes.io/component: zookeeper
    role: zookeeper
spec:
  replicas: 1
  revisionHistoryLimit: 10
  podManagementPolicy: Parallel
  selector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: zookeeper
      app.kubernetes.io/component: zookeeper
  serviceName: release-name-zookeeper-headless
  updateStrategy:
    rollingUpdate: {}
    type: RollingUpdate
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: zookeeper
        app.kubernetes.io/version: 3.9.2
        helm.sh/chart: zookeeper-13.2.0
        app.kubernetes.io/component: zookeeper
    spec:
      enableServiceLinks: true
      serviceAccountName: release-name-zookeeper
      
      automountServiceAccountToken: false
      affinity:
        podAffinity:
          
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/instance: release-name
                    app.kubernetes.io/name: zookeeper
                    app.kubernetes.io/component: zookeeper
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:
          
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      initContainers:
      containers:
        - name: zookeeper
          image: docker.io/bitnami/zookeeper:3.9.2-debian-12-r2
          imagePullPolicy: "IfNotPresent"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 1001
            runAsNonRoot: true
            runAsUser: 1001
            seLinuxOptions: {}
            seccompProfile:
              type: RuntimeDefault
          command:
            - /scripts/setup.sh
          resources:
            requests:
              memory: 1.25Gi
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: ZOO_DATA_LOG_DIR
              value: ""
            - name: ZOO_PORT_NUMBER
              value: "2181"
            - name: ZOO_TICK_TIME
              value: "2000"
            - name: ZOO_INIT_LIMIT
              value: "10"
            - name: ZOO_SYNC_LIMIT
              value: "5"
            - name: ZOO_PRE_ALLOC_SIZE
              value: "65536"
            - name: ZOO_SNAPCOUNT
              value: "100000"
            - name: ZOO_MAX_CLIENT_CNXNS
              value: "60"
            - name: ZOO_4LW_COMMANDS_WHITELIST
              value: "srvr, mntr, ruok"
            - name: ZOO_LISTEN_ALLIPS_ENABLED
              value: "no"
            - name: ZOO_AUTOPURGE_INTERVAL
              value: "1"
            - name: ZOO_AUTOPURGE_RETAIN_COUNT
              value: "5"
            - name: ZOO_MAX_SESSION_TIMEOUT
              value: "40000"
            - name: ZOO_SERVERS
              value: release-name-zookeeper-0.release-name-zookeeper-headless.consumer.svc.cluster.local:2888:3888::1 
            - name: ZOO_ENABLE_AUTH
              value: "no"
            - name: ZOO_ENABLE_QUORUM_AUTH
              value: "no"
            - name: ZOO_HEAP_SIZE
              value: "1024"
            - name: ZOO_LOG_LEVEL
              value: "ERROR"
            - name: ALLOW_ANONYMOUS_LOGIN
              value: "yes"
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.name
            - name: ZOO_ADMIN_SERVER_PORT_NUMBER
              value: "8080"
          ports:
            - name: client
              containerPort: 2181
            - name: http-admin
              containerPort: 8080
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 30
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/bash
                - -ec
                - ZOO_HC_TIMEOUT=2 /opt/bitnami/scripts/zookeeper/healthcheck.sh
          readinessProbe:
            failureThreshold: 6
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/bash
                - -ec
                - ZOO_HC_TIMEOUT=2 /opt/bitnami/scripts/zookeeper/healthcheck.sh
          volumeMounts:
            - name: empty-dir
              mountPath: /tmp
              subPath: tmp-dir
            - name: empty-dir
              mountPath: /opt/bitnami/zookeeper/conf
              subPath: app-conf-dir
            - name: empty-dir
              mountPath: /opt/bitnami/zookeeper/logs
              subPath: app-logs-dir
            - name: scripts
              mountPath: /scripts/setup.sh
              subPath: setup.sh
            - name: data
              mountPath: /bitnami/zookeeper
      volumes:
        - name: empty-dir
          emptyDir: {}
        - name: scripts
          configMap:
            name: release-name-zookeeper-scripts
            defaultMode: 493
  volumeClaimTemplates:
    - metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "8Gi"
---
# Source: pinot/templates/broker/statefulset.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-pinot-broker
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: broker
spec:
  selector:
    matchLabels:
      app: pinot
      release: release-name
      component: broker
  serviceName: release-name-pinot-broker-headless
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  podManagementPolicy: Parallel
  template:
    metadata:
      labels:
        helm.sh/chart: pinot-0.2.9-SNAPSHOT
        app: pinot
        release: release-name
        app.kubernetes.io/version: "1.0.0"
        app.kubernetes.io/managed-by: Helm
        heritage: Helm
        component: broker
      annotations:

        {}
    spec:
      terminationGracePeriodSeconds: 30
      serviceAccountName: release-name-pinot
      securityContext:
        {}
      nodeSelector:
        {}
      affinity:
        {}
      tolerations:
        []
      containers:
      - name: broker
        securityContext:
          {}
        image: "apachepinot/pinot:latest"
        imagePullPolicy: Always
        args: [
          "StartBroker",
          "-clusterName", "pinot-quickstart",
          "-zkAddress", "release-name-zookeeper:2181",
          "-configFileName", "/var/pinot/broker/config/pinot-broker.conf"
        ]
        env:
          - name: JAVA_OPTS
            value: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log -Dlog4j2.configurationFile=/opt/pinot/etc/conf/pinot-broker-log4j2.xml -Dplugins.dir=/opt/pinot/plugins"
          - name: LOG4J_CONSOLE_LEVEL
            value: info
        envFrom:
          []
        ports:
          - containerPort: 8099
            protocol: TCP
            name: broker                  
        volumeMounts:
          - name: config
            mountPath: /var/pinot/broker/config
        livenessProbe:
          initialDelaySeconds: 60
          periodSeconds: 10
          failureThreshold: 1
          successThreshold: 1
          timeoutSeconds: 1
          httpGet:
            path: /health
            port: 8099
        readinessProbe:
          initialDelaySeconds: 60
          periodSeconds: 10
          failureThreshold: 1
          successThreshold: 1
          timeoutSeconds: 1
          httpGet:
            path: /health
            port: 8099
        startupProbe:
          initialDelaySeconds: 60
          periodSeconds: 10
          failureThreshold: 1
          successThreshold: 1
          timeoutSeconds: 1
          httpGet:
            path: /health
            port: 8099
        resources:
            requests:
              memory: 1.25Gi
      restartPolicy: Always
      volumes:
        - name: config
          configMap:
            name: release-name-pinot-broker-config
---
# Source: pinot/templates/controller/statefulset.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-pinot-controller
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: controller
spec:
  selector:
    matchLabels:
      app: pinot
      release: release-name
      component: controller
  serviceName: release-name-pinot-controller-headless
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  podManagementPolicy: Parallel
  template:
    metadata:
      labels:
        helm.sh/chart: pinot-0.2.9-SNAPSHOT
        app: pinot
        release: release-name
        app.kubernetes.io/version: "1.0.0"
        app.kubernetes.io/managed-by: Helm
        heritage: Helm
        component: controller
      annotations:

        {}
    spec:
      terminationGracePeriodSeconds: 30
      serviceAccountName: release-name-pinot
      securityContext:
        {}
      nodeSelector:
        {}
      affinity:
        {}
      tolerations:
        []
      containers:
      - name: controller
        securityContext:
          {}
        image: "apachepinot/pinot:latest"
        imagePullPolicy: Always
        args: [ "StartController", "-configFileName", "/var/pinot/controller/config/pinot-controller.conf" ]
        env:
          - name: JAVA_OPTS
            value: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log -Dlog4j2.configurationFile=/opt/pinot/etc/conf/pinot-controller-log4j2.xml -Dplugins.dir=/opt/pinot/plugins"
          - name: LOG4J_CONSOLE_LEVEL
            value: info
        envFrom:
          []
        ports:
          - containerPort: 9000
            protocol: TCP
            name: controller
        volumeMounts:
          - name: config
            mountPath: /var/pinot/controller/config
          - name: data
            mountPath: "/var/pinot/controller/data"
        resources:
            requests:
              memory: 1.25Gi
      restartPolicy: Always
      volumes:
      - name: config
        configMap:
          name: release-name-pinot-controller-config
  volumeClaimTemplates:
    - metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "1G"
---
# Source: pinot/templates/server/statefulset.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-pinot-server
  labels:
    helm.sh/chart: pinot-0.2.9-SNAPSHOT
    app: pinot
    release: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: server
spec:
  selector:
    matchLabels:
      app: pinot
      release: release-name
      component: server
  serviceName: release-name-pinot-server-headless
  replicas: 1
  updateStrategy:
    type: RollingUpdate
  podManagementPolicy: Parallel
  template:
    metadata:
      labels:
        helm.sh/chart: pinot-0.2.9-SNAPSHOT
        app: pinot
        release: release-name
        app.kubernetes.io/version: "1.0.0"
        app.kubernetes.io/managed-by: Helm
        heritage: Helm
        component: server
      annotations:

        {}
    spec:
      terminationGracePeriodSeconds: 30
      serviceAccountName: release-name-pinot
      securityContext:
        {}
      nodeSelector:
        {}
      affinity:
        {}
      tolerations:
        []
      containers:
      - name: server
        securityContext:
          {}
        image: "apachepinot/pinot:latest"
        imagePullPolicy: Always
        args: [
          "StartServer",
          "-clusterName", "pinot-quickstart",
          "-zkAddress", "release-name-zookeeper:2181",
          "-configFileName", "/var/pinot/server/config/pinot-server.conf"
        ]
        env:
          - name: JAVA_OPTS
            value: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-server.log -Dlog4j2.configurationFile=/opt/pinot/etc/conf/pinot-server-log4j2.xml -Dplugins.dir=/opt/pinot/plugins"
          - name: LOG4J_CONSOLE_LEVEL
            value: info
        envFrom:
          []
        ports:
          - containerPort: 8098
            protocol: TCP
            name: netty
          - containerPort: 8097
            protocol: TCP
            name: admin
        volumeMounts:
          - name: config
            mountPath: /var/pinot/server/config
          - name: data
            mountPath: "/var/pinot/server/data"
        resources:
            requests:
              memory: 1.25Gi
      restartPolicy: Always
      volumes:
        - name: config
          configMap:
            name: release-name-pinot-server-config
  volumeClaimTemplates:
    - metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: 4G
---
# Source: pinot/templates/broker/service-external.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/controller/service-external.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/minion-stateless/pvc.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/minion/configmap.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/minion/service-headless.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/minion/service.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#
---
# Source: pinot/templates/minion/statefulset.yaml
#
# Licensed to the Apache Software Foundation (ASF) under one
# or more contributor license agreements.  See the NOTICE file
# distributed with this work for additional information
# regarding copyright ownership.  The ASF licenses this file
# to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance
# with the License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
# KIND, either express or implied.  See the License for the
# specific language governing permissions and limitations
# under the License.
#

```
