### PR TITLE
Include ALL modifier for set operators in multi-stage query engine physical explain plan

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/SetOpNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/SetOpNode.java
@@ -57,7 +57,7 @@ public class SetOpNode extends AbstractPlanNode {
 
   @Override
   public String explain() {
-    return _setOpType.toString();
+    return _all ? _setOpType.toString() + "_ALL" : _setOpType.toString();
   }
 
   @Override


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/13151 added support for `INTERSECT ALL` and `EXCEPT ALL` set operators in the multi-stage query engine.
- The logical plan for queries using these operators does contain whether or not the `ALL` modifier was used.
- For instance, the output for `EXPLAIN PLAN FOR SELECT * FROM (SELECT a FROM A) EXCEPT ALL (SELECT b FROM B);` looks like this (Calcite syntax):
```
LogicalMinus(all=[true])
  PinotLogicalExchange(distribution=[hash[0]])
    LogicalProject(a=[$3])
      LogicalTableScan(table=[[default, A]])
  PinotLogicalExchange(distribution=[hash[0]])
    LogicalProject(b=[$3])
      LogicalTableScan(table=[[default, B]])
```
- The physical plan for queries, however, currently doesn't include whether or not the `ALL` modifier was used. So the output for both `EXPLAIN IMPLEMENTATION PLAN FOR SELECT * FROM (SELECT a FROM A) EXCEPT ALL (SELECT b FROM B);` and `EXPLAIN IMPLEMENTATION PLAN FOR SELECT * FROM (SELECT a FROM A) EXCEPT (SELECT b FROM B);` would look the same:
```
[0]@192.168.29.25:64480|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)
└── [1]@192.168.29.25:64487|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.29.25:64480|[0]}
    └── [1]@192.168.29.25:64487|[0] MINUS
        └── [1]@192.168.29.25:64487|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)
        └── [1]@192.168.29.25:64487|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)
```
- This PR fixes the issue by updating `SetOpNode::explain` which is called in the `PhysicalExplainPlanVisitor` [here](https://github.com/apache/pinot/blob/0f48825d2d36e489c743d7e50bdb62bfc1f786ba/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PhysicalExplainPlanVisitor.java#L120). The output for `EXPLAIN IMPLEMENTATION PLAN FOR SELECT * FROM (SELECT a FROM A) EXCEPT ALL (SELECT b FROM B);` now looks like:
```
[0]@192.168.29.25:64480|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)
└── [1]@192.168.29.25:64487|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.29.25:64480|[0]}
    └── [1]@192.168.29.25:64487|[0] MINUS_ALL
        └── [1]@192.168.29.25:64487|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)
        └── [1]@192.168.29.25:64487|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)
```