### PR TITLE
Adding config for having suffix for client ID for realtime consumer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1434,7 +1434,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _acquiredConsumerSemaphore = new AtomicBoolean(false);
     InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
     String clientIdSuffix =
-        instanceDataManagerConfig != null ? instanceDataManagerConfig.getRealtimeSegmentConsumerClientIdSuffix() : "";
+        instanceDataManagerConfig != null ? instanceDataManagerConfig.getConsumerClientIdSuffix() : "";
     if (StringUtils.isNotBlank(clientIdSuffix)) {
       clientIdSuffix = "-" + clientIdSuffix;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -67,6 +68,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -1430,7 +1432,13 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             _segmentZKMetadata.getStatus().toString());
     _partitionGroupConsumerSemaphore = partitionGroupConsumerSemaphore;
     _acquiredConsumerSemaphore = new AtomicBoolean(false);
-    _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId;
+    InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
+    String clientIdSuffix =
+        instanceDataManagerConfig != null ? instanceDataManagerConfig.getRealtimeSegmentConsumerClientIdSuffix() : "";
+    if (StringUtils.isNotBlank(clientIdSuffix)) {
+      clientIdSuffix = "-" + clientIdSuffix;
+    }
+    _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId + clientIdSuffix;
     _segmentLogger = LoggerFactory.getLogger(RealtimeSegmentDataManager.class.getName() + "_" + _segmentNameStr);
     _tableStreamName = _tableNameWithType + "_" + streamTopic;
     if (_indexLoadingConfig.isRealtimeOffHeapAllocation() && !_indexLoadingConfig.isDirectRealtimeOffHeapAllocation()) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -34,10 +34,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.spi.utils.CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI;
-import static org.apache.pinot.spi.utils.CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR;
-import static org.apache.pinot.spi.utils.CommonConstants.Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR;
-import static org.apache.pinot.spi.utils.CommonConstants.Server.DEFAULT_READ_MODE;
+import static org.apache.pinot.spi.utils.CommonConstants.Server.*;
 
 
 /**
@@ -208,6 +205,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public String getInstanceSegmentTarDir() {
     return _serverConfig.getProperty(INSTANCE_SEGMENT_TAR_DIR, DEFAULT_INSTANCE_SEGMENT_TAR_DIR);
+  }
+
+  @Override
+  public String getRealtimeSegmentConsumerClientIdSuffix() {
+    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX,
+        DEFAULT_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -208,9 +208,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public String getRealtimeSegmentConsumerClientIdSuffix() {
-    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX,
-        DEFAULT_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX);
+  public String getConsumerClientIdSuffix() {
+    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -39,7 +39,7 @@ public interface InstanceDataManagerConfig {
 
   String getSegmentStoreUri();
 
-  String getRealtimeSegmentConsumerClientIdSuffix();
+  String getConsumerClientIdSuffix();
 
   ReadMode getReadMode();
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -39,6 +39,8 @@ public interface InstanceDataManagerConfig {
 
   String getSegmentStoreUri();
 
+  String getRealtimeSegmentConsumerClientIdSuffix();
+
   ReadMode getReadMode();
 
   String getSegmentFormatVersion();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -699,9 +699,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_SEGMENT_STORE_URI = "segment.store.uri";
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.server.logger.root.dir";
 
-    public static final String CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX =
-        "realtime.consumer.client.id.suffix";
-    public static final String DEFAULT_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX = "";
+    public static final String CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX = "consumer.client.id.suffix";
 
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -699,6 +699,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_SEGMENT_STORE_URI = "segment.store.uri";
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.server.logger.root.dir";
 
+    public static final String CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX =
+        "realtime.consumer.client.id.suffix";
+    public static final String DEFAULT_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX = "";
+
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
 


### PR DESCRIPTION
**Context**
For the consuming source of Pinot this can be used to give more which specify like consuming server is having issue. 
As currently the info is _tableNameWithType,  streamTopic, _partitionGroupId which is going to be the same for all the replicas of the consuming real-time segment. 
Using this config can be used to provide more granular info which can used to speed up debugging.

**Tags** 
- new config

**Todo** 
- https://github.com/pinot-contrib/pinot-docs/pull/337
