### PR TITLE
Allow RequestContext to consider http-headers case-insensitivity

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -264,8 +264,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     requestContext.setRequestId(requestId);
     if (httpHeaders != null) {
       requestContext.setRequestHttpHeaders(httpHeaders.getRequestHeaders().entrySet().stream().filter(
-              entry -> PinotBrokerQueryEventListenerFactory.getAllowlistQueryRequestHeaders().contains(entry.getKey()))
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+              entry -> PinotBrokerQueryEventListenerFactory.getAllowlistQueryRequestHeaders()
+                  .contains(entry.getKey().toLowerCase()))
+          .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(), Map.Entry::getValue)));
     }
 
     // First-stage access control to prevent unauthenticated requests from using up resources. Secondary table-level

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
@@ -92,6 +92,7 @@ public class PinotBrokerQueryEventListenerFactory {
    * @param eventListenerConfiguration The subset of the configuration containing the event-listener-related keys
    */
   private static void initializeAllowlistQueryRequestHeaders(PinotConfiguration eventListenerConfiguration) {
+    // As HttpHeaders are case-insensitive, we will convert the configured list to all lower case while registering
     List<String> allowlistQueryRequestHeaders =
         Splitter.on(",").omitEmptyStrings().trimResults()
             .splitToList(eventListenerConfiguration.getProperty(CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS, ""))
@@ -135,6 +136,10 @@ public class PinotBrokerQueryEventListenerFactory {
     return getBrokerQueryEventListener(new PinotConfiguration(Collections.emptyMap()));
   }
 
+  /**
+   * @return the list of allowlisted headers passed as comma-separated string for "request.context.tracked.header.keys"
+   * The values are all in lower-case.
+   */
   @VisibleForTesting
   public static List<String> getAllowlistQueryRequestHeaders() {
     return _allowlistQueryRequestHeaders;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,7 +94,8 @@ public class PinotBrokerQueryEventListenerFactory {
   private static void initializeAllowlistQueryRequestHeaders(PinotConfiguration eventListenerConfiguration) {
     List<String> allowlistQueryRequestHeaders =
         Splitter.on(",").omitEmptyStrings().trimResults()
-            .splitToList(eventListenerConfiguration.getProperty(CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS, ""));
+            .splitToList(eventListenerConfiguration.getProperty(CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS, ""))
+            .stream().map(String::toLowerCase).collect(Collectors.toList());
 
     LOGGER.info("{}: allowlist headers will be used for PinotBrokerQueryEventListener", allowlistQueryRequestHeaders);
     registerAllowlistQueryRequestHeaders(allowlistQueryRequestHeaders);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -217,8 +217,16 @@ public interface RequestContext {
 
   void setProcessingExceptions(List<String> processingExceptions);
 
+  /**
+   * @return Map of allowlisted request header keys (in lowercase) to list of header values
+   */
   Map<String, List<String>> getRequestHttpHeaders();
 
+  /**
+   * While setting the http request headers here, we send the keys in lower-case to be in parity with the
+   * case-insensitive nature of Http.
+   * @param requestHttpHeaders Map of request header keys (in lowercase) to list of header values
+   */
   void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders);
 
   enum FanoutType {


### PR DESCRIPTION
label:
`improvement`

HttpHeaders are case-insensitive ([Ref](https://www.rfc-editor.org/rfc/rfc7230#section-3.2:~:text=consists%20of%20a-,case%2Dinsensitive,-field%20name%20followed)). Recently while testing the event-listener framework for custom headers I found that we were receiving the header in small case : `x-uber-rpc-caller:tibrewalpratik` 
This patch makes sure that broker-event-listener takes care of this case-insensitivity implicitly.

cc @ankitsultana 