### PR TITLE
Hack to fix some problematic queries

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterExpandSearchRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterExpandSearchRule.java
@@ -28,6 +28,18 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 
+/**
+ * Rule to expand search condition in filter.
+ * <p>
+ * For example, the filter condition:
+ * <p>
+ *   <code>SEARCH(col1, Sarg[[1..2)])</code>
+ * </p>
+ * Is expanded to:
+ * <p>
+ *   <code>AND(>=(col1, 1), <(col1, 2))</code>
+ *
+ */
 public class PinotFilterExpandSearchRule extends RelOptRule {
   public static final PinotFilterExpandSearchRule INSTANCE =
       new PinotFilterExpandSearchRule(PinotRuleUtils.PINOT_REL_FACTORY);

--- a/pinot-query-planner/src/test/resources/log4j2.xml
+++ b/pinot-query-planner/src/test/resources/log4j2.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration>
+
+  <Properties>
+    <Property name="LOG_PATTERN">%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Property>
+  </Properties>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="${env:LOG_PATTERN}"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Root>
+    <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <Logger name="org.apache.calcite.plan.RelOptPlanner" level="debug" additivity="false">
+<!--      Change FULL_PLAN marker from onMatch="DENY" to onMatch='ACCEPT" to see the full plan before and after each
+          rule that modifies the plan is applied -->
+<!--      <MarkerFilter marker="FULL_PLAN" onMatch="ACCEPT" onMismatch="NEUTRAL"/>-->
+      <MarkerFilter marker="FULL_PLAN" onMatch="DENY" onMismatch="NEUTRAL"/>
+      <AppenderRef ref="console"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/pinot-query-planner/src/test/resources/log4j2.xml
+++ b/pinot-query-planner/src/test/resources/log4j2.xml
@@ -34,12 +34,13 @@
       <AppenderRef ref="console"/>
     </Root>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
-    <Logger name="org.apache.calcite.plan.RelOptPlanner" level="debug" additivity="false">
+<!--    Tip: Uncomment this in case you need to debug query transformation -->
+<!--    <Logger name="org.apache.calcite.plan.RelOptPlanner" level="debug" additivity="false">-->
 <!--      Change FULL_PLAN marker from onMatch="DENY" to onMatch='ACCEPT" to see the full plan before and after each
           rule that modifies the plan is applied -->
 <!--      <MarkerFilter marker="FULL_PLAN" onMatch="ACCEPT" onMismatch="NEUTRAL"/>-->
-      <MarkerFilter marker="FULL_PLAN" onMatch="DENY" onMismatch="NEUTRAL"/>
-      <AppenderRef ref="console"/>
-    </Logger>
+<!--      <MarkerFilter marker="FULL_PLAN" onMatch="DENY" onMismatch="NEUTRAL"/>-->
+<!--      <AppenderRef ref="console"/>-->
+<!--    </Logger>-->
   </Loggers>
 </Configuration>

--- a/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
@@ -259,5 +259,49 @@
         "expectedException": ".*No match found for function signature nonExistFun.*"
       }
     ]
+  },
+  "literal_planning_cte_test": {
+    "comment": "Tests for CTEs in literal planning. The SQL parser cannot get rid of expressions that cross CTE, so this is useful to check that the expressions are simplified in the logical plan.",
+    "queries": [
+      {
+        "description": "Simple filter on constants is simplified",
+        "sql": "EXPLAIN PLAN FOR WITH CTE_B AS (SELECT 1692057600000 AS __ts FROM a GROUP BY __ts) SELECT 1692057600000 AS __ts FROM CTE_B WHERE __ts >= 1692057600000 GROUP BY __ts",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(__ts=[1692057600000:BIGINT])",
+          "\n  LogicalAggregate(group=[{0}])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalAggregate(group=[{0}])",
+          "\n        LogicalProject(__ts=[1692057600000:BIGINT])",
+          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "And filter on constants is simplified",
+        "sql": "EXPLAIN PLAN FOR WITH CTE_B AS (SELECT 1692057600000 AS __ts FROM a GROUP BY __ts) SELECT 1692057600000 AS __ts FROM CTE_B WHERE __ts >= 1692057600000 AND __ts < 1693267200000 GROUP BY __ts",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(__ts=[1692057600000:BIGINT])",
+          "\n  LogicalAggregate(group=[{0}])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalAggregate(group=[{0}])",
+          "\n        LogicalProject(__ts=[1692057600000:BIGINT])",
+          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Search + OR filter on constants is simplified",
+        "sql": "EXPLAIN PLAN FOR WITH tmp2 AS (SELECT CASE WHEN col2 = 'VAL1' THEN 'A' ELSE col2 END AS cased FROM a) SELECT 1 FROM tmp2 WHERE ((cased = 'B') OR (cased = 'A'))",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(EXPR$0=[1])",
+          "\n  LogicalFilter(condition=[SEARCH($1, Sarg[_UTF-8'A':VARCHAR CHARACTER SET \"UTF-8\", _UTF-8'B':VARCHAR CHARACTER SET \"UTF-8\", _UTF-8'VAL1':VARCHAR CHARACTER SET \"UTF-8\"]:VARCHAR CHARACTER SET \"UTF-8\")])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      }
+    ]
   }
 }

--- a/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
@@ -297,7 +297,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[1])",
-          "\n  LogicalFilter(condition=[SEARCH($1, Sarg[_UTF-8'A':VARCHAR CHARACTER SET \"UTF-8\", _UTF-8'B':VARCHAR CHARACTER SET \"UTF-8\", _UTF-8'VAL1':VARCHAR CHARACTER SET \"UTF-8\"]:VARCHAR CHARACTER SET \"UTF-8\")])",
+          "\n  LogicalFilter(condition=[OR(=($1, _UTF-8'A'), =($1, _UTF-8'B'), =($1, _UTF-8'VAL1'))])",
           "\n    LogicalTableScan(table=[[default, a]])",
           "\n"
         ]


### PR DESCRIPTION
Queries like:
```sql
WITH CTE_B AS (
  SELECT 1 AS __ts FROM a GROUP BY __ts
) 
SELECT 1 
FROM CTE_B 
WHERE __ts >= 1 AND __ts < 2
```

Fail when they are executed. The reason is that very tricky, but mostly is due to:
- Our rules are not able to get rid of the tautology (`1 >= 1 and 1 < 2` is always true), so it is pushed into the leaf stage
- The leaf stage generates an equivalent V1 query, but does not apply `CompileTimeFunctionsInvoker`, so these tautologies are not removed from the expression tree
- V1 row-by-row engine doesn't know how to execute these tautologies because it only expects expressions like `col1 > doubleLiteral`.

These tautologies are generated in `PinotFilterExpandSearchRule`. We have two rules that should ideally remove them:
- `PinotEvaluateLiteralRule` (which evaluates the expressions using V1 semantics)
- `CoreRules.FILTER_REDUCE_EXPRESSIONS` (which evalautes the expressions using Calcite semantics)

Alternatively, we should be able to call `CompileTimeFunctionsInvoker` rewriter in the leaf stage. This invoker is also using V1 semantics.

But any of these changes works.
1. `PinotEvaluateLiteralRule` and `CompileTimeFunctionsInvoker` partially work because V1 can execute `=` assuming each operand is a number. Things like `1=1` or `'123'='123'` but cannot execute `'a' = 'a'`.
2. `CoreRules.FILTER_REDUCE_EXPRESSIONS` can get rid of the tautologies, but in some scenarios it creates just another `SEARCH` operation. V1 cannot execute them.

I'm not proud of the solution found in this PR. It basically consist of applying the pair `PinotFilterExpandSearchRule`, `CoreRules.FILTER_REDUCE_EXPRESSIONS` twice.  Although it seems to be working in all cases I tried, I'm sure there will be cases were this solution is not good enough.

IMO it would be better to:
1. Have a centralized function register, as suggested by @walterddr long ago.
2. Support `search` in V1.

Do you have other ideas on how to fix this problem?

