### PR TITLE
Improved metrics for server grpc query

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -108,6 +108,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   GRPC_QUERIES("grpcQueries", true),
   GRPC_BYTES_RECEIVED("grpcBytesReceived", true),
   GRPC_BYTES_SENT("grpcBytesSent", true),
+  GRPC_TRANSPORT_READY("grpcTransport", true),
+  GRPC_TRANSPORT_TERMINATED("grpcTransport", true),
 
   NUM_SEGMENTS_PRUNED_INVALID("numSegmentsPrunedInvalid", false),
   NUM_SEGMENTS_PRUNED_BY_LIMIT("numSegmentsPrunedByLimit", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -53,6 +53,8 @@ public enum ServerTimer implements AbstractMetrics.Timer {
       "Total time taken to preload a table partition of an upsert table with upsert snapshot"),
   UPSERT_REMOVE_EXPIRED_PRIMARY_KEYS_TIME_MS("milliseconds", false,
       "Total time taken to delete expired primary keys based on metadataTTL or deletedKeysTTL"),
+  GRPC_QUERY_EXECUTION_MS("milliseconds", true, "Total execution time of a successful query over gRPC"),
+  GRPC_FAILED_QUERY_EXECUTION_MS("milliseconds", true, "Total execution time of a failing query over gRPC"),
   UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot");
 
   private final String _timerName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -53,8 +53,7 @@ public enum ServerTimer implements AbstractMetrics.Timer {
       "Total time taken to preload a table partition of an upsert table with upsert snapshot"),
   UPSERT_REMOVE_EXPIRED_PRIMARY_KEYS_TIME_MS("milliseconds", false,
       "Total time taken to delete expired primary keys based on metadataTTL or deletedKeysTTL"),
-  GRPC_QUERY_EXECUTION_MS("milliseconds", true, "Total execution time of a successful query over gRPC"),
-  GRPC_FAILED_QUERY_EXECUTION_MS("milliseconds", true, "Total execution time of a failing query over gRPC"),
+  GRPC_QUERY_EXECUTION_MS("milliseconds", false, "Total execution time of a successful query over gRPC"),
   UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot");
 
   private final String _timerName;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -89,9 +89,12 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
 
     @Override
     public void transportTerminated(Attributes transportAttrs) {
-      LOGGER.info("gRPC transportTerminated: REMOTE_ADDR {}",
-          transportAttrs != null ? transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR) : "null");
-      _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_TERMINATED, 1);
+      // transportTerminated can be called without transportReady before it, e.g. handshake fails
+      // So, don't emit metrics if transportAttrs is null
+      if (transportAttrs != null) {
+        LOGGER.info("gRPC transportTerminated: REMOTE_ADDR {}", transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+        _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_TERMINATED, 1);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -81,14 +81,16 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   private class GrpcQueryTransportFilter extends ServerTransportFilter {
     @Override
     public Attributes transportReady(Attributes transportAttrs) {
-      LOGGER.info("gRPC transportReady: REMOTE_ADDR {}", transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+      LOGGER.info("gRPC transportReady: REMOTE_ADDR {}",
+          transportAttrs != null ? transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR) : "null");
       _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_READY, 1);
       return super.transportReady(transportAttrs);
     }
 
     @Override
     public void transportTerminated(Attributes transportAttrs) {
-      LOGGER.info("gRPC transportTerminated: REMOTE_ADDR {}", transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+      LOGGER.info("gRPC transportTerminated: REMOTE_ADDR {}",
+          transportAttrs != null ? transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR) : "null");
       _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_TERMINATED, 1);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.transport.grpc;
 
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerTransportFilter;
@@ -80,12 +81,14 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   private class GrpcQueryTransportFilter extends ServerTransportFilter {
     @Override
     public Attributes transportReady(Attributes transportAttrs) {
+      LOGGER.info("gRPC transportReady: REMOTE_ADDR {}", transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
       _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_READY, 1);
       return super.transportReady(transportAttrs);
     }
 
     @Override
     public void transportTerminated(Attributes transportAttrs) {
+      LOGGER.info("gRPC transportTerminated: REMOTE_ADDR {}", transportAttrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
       _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_TRANSPORT_TERMINATED, 1);
     }
   }


### PR DESCRIPTION
Added transport filter to keep track of number of gRPC connections, and added metrics to keep track of total execution times of successful and failed queries.

Added bytes sent metric in GrpcResultsBlockStreamer method - [HERE](https://github.com/apache/pinot/pull/13177/files#diff-5decb7db858dfaddd3908835975d0f1a831c9b57bdef226583b686a1e7df2b94R53)

`observability`

