### PR TITLE
#13123 MaxLength limiting included for Json Columns

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -115,7 +115,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
   LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
-  STREAM_DATA_LOSS("streamDataLoss", false);
+  STREAM_DATA_LOSS("streamDataLoss", false),
+  SANITIZED_MAX_LEN_COLUMNS_COUNT("numColsLimitedByMaxLength", false);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -614,9 +614,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           _segmentLogger.error(errorMessage, e);
           _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         }
-        if(_transformPipeline.getRecordTransformer().getSanitizedColsCount()>0) {
-          _serverMetrics.addMeteredTableValue(_tableNameWithType, String.valueOf(_partitionGroupId), ServerMeter.SANITIZED_MAX_LEN_COLUMNS_COUNT,
-              _transformPipeline.getRecordTransformer().getSanitizedColsCount());
+        if (_transformPipeline.getRecordTransformer().getSanitizedColValuesCount() > 0) {
+          _serverMetrics.addMeteredTableValue(_tableNameWithType, String.valueOf(_partitionGroupId),
+              ServerMeter.SANITIZED_MAX_LEN_COLUMNS_COUNT,
+              _transformPipeline.getRecordTransformer().getSanitizedColValuesCount());
         }
         if (reusedResult.getSkippedRowCount() > 0) {
           realtimeRowsDroppedMeter = _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FILTERED,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -614,6 +614,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           _segmentLogger.error(errorMessage, e);
           _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         }
+        if(_transformPipeline.getRecordTransformer().getSanitizedColsCount()>0) {
+          _serverMetrics.addMeteredTableValue(_tableNameWithType, String.valueOf(_partitionGroupId), ServerMeter.SANITIZED_MAX_LEN_COLUMNS_COUNT,
+              _transformPipeline.getRecordTransformer().getSanitizedColsCount());
+        }
         if (reusedResult.getSkippedRowCount() > 0) {
           realtimeRowsDroppedMeter = _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FILTERED,
               reusedResult.getSkippedRowCount(), realtimeRowsDroppedMeter);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
@@ -44,7 +44,7 @@ public interface RecordTransformer extends Serializable {
   @Nullable
   GenericRow transform(GenericRow record);
 
-  default Long getSanitizedColsCount() {
+  default Long getSanitizedColValuesCount() {
     return 0L;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
@@ -43,4 +43,8 @@ public interface RecordTransformer extends Serializable {
    */
   @Nullable
   GenericRow transform(GenericRow record);
+
+  default Long getSanitizedColsCount() {
+    return 0L;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -64,6 +64,14 @@ public class TransformPipeline {
   }
 
   /**
+   * return the record transformer for this pipeline
+   * @return the record transformer
+   */
+  public RecordTransformer getRecordTransformer() {
+    return _recordTransformer;
+  }
+
+  /**
    * Returns a pass through pipeline that does not transform the record.
    */
   public static TransformPipeline getPassThroughPipeline() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -50,8 +50,9 @@ public class RecordTransformerTest {
       .addSingleValueDimension("svFloat", DataType.FLOAT).addSingleValueDimension("svDouble", DataType.DOUBLE)
       .addSingleValueDimension("svBoolean", DataType.BOOLEAN).addSingleValueDimension("svTimestamp", DataType.TIMESTAMP)
       .addSingleValueDimension("svBytes", DataType.BYTES).addMultiValueDimension("mvInt", DataType.INT)
-      .addSingleValueDimension("svJson", DataType.JSON).addMultiValueDimension("mvLong", DataType.LONG)
-      .addMultiValueDimension("mvFloat", DataType.FLOAT).addMultiValueDimension("mvDouble", DataType.DOUBLE)
+      .addSingleValueDimension("svJson", DataType.JSON).addSingleValueDimension("svJsonWithLengthLimit", DataType.JSON)
+      .addMultiValueDimension("mvLong", DataType.LONG).addMultiValueDimension("mvFloat", DataType.FLOAT)
+      .addMultiValueDimension("mvDouble", DataType.DOUBLE)
       // For sanitation
       .addSingleValueDimension("svStringWithNullCharacters", DataType.STRING)
       .addSingleValueDimension("svStringWithLengthLimit", DataType.STRING)
@@ -69,6 +70,7 @@ public class RecordTransformerTest {
 
   static {
     SCHEMA.getFieldSpecFor("svStringWithLengthLimit").setMaxLength(2);
+    SCHEMA.getFieldSpecFor("svJsonWithLengthLimit").setMaxLength(5);
     SCHEMA.addField(new DimensionFieldSpec("$virtual", DataType.STRING, true, Object.class));
   }
 
@@ -86,6 +88,7 @@ public class RecordTransformerTest {
     record.putValue("svTimestamp", "2020-02-02 22:22:22.222");
     record.putValue("svBytes", "7b7b"/*new byte[]{123, 123}*/);
     record.putValue("svJson", "{\"first\": \"daffy\", \"last\": \"duck\"}");
+    record.putValue("svJsonWithLengthLimit", "{\"first\": \"daffy\", \"last\": \"duck\"}");
     record.putValue("mvInt", new Object[]{123L});
     record.putValue("mvLong", Collections.singletonList(123f));
     record.putValue("mvFloat", new Double[]{123d});
@@ -267,11 +270,13 @@ public class RecordTransformerTest {
       record = transformer.transform(record);
       assertNotNull(record);
       assertEquals(record.getValue("svStringWithNullCharacters"), "1");
+      assertEquals(record.getValue("svJsonWithLengthLimit"), "$SKIPPED$");
       assertEquals(record.getValue("svStringWithLengthLimit"), "12");
       assertEquals(record.getValue("mvString1"), new Object[]{"123", "123", "123", "123.0", "123.0"});
       assertEquals(record.getValue("mvString2"), new Object[]{"123", "123", "123.0", "123.0", "123"});
       assertNull(record.getValue("$virtual"));
       assertTrue(record.getNullValueFields().isEmpty());
+      assertEquals(transformer.getSanitizedColsCount(), 3L);
     }
   }
 
@@ -304,8 +309,8 @@ public class RecordTransformerTest {
     // Build Schema and ingestionConfig in such a way that all the transformers are loaded.
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("svInt", DataType.INT)
         .addSingleValueDimension("svDouble", DataType.DOUBLE)
-        .addSingleValueDimension("expressionTestColumn", DataType.INT)
-        .addSingleValueDimension("svNaN", DataType.FLOAT).addMultiValueDimension("mvNaN", DataType.FLOAT)
+        .addSingleValueDimension("expressionTestColumn", DataType.INT).addSingleValueDimension("svNaN", DataType.FLOAT)
+        .addMultiValueDimension("mvNaN", DataType.FLOAT)
         .addSingleValueDimension("emptyDimensionForNullValueTransformer", DataType.FLOAT)
         .addSingleValueDimension("svStringNull", DataType.STRING)
         .addSingleValueDimension("indexableExtras", DataType.JSON)
@@ -638,6 +643,7 @@ public class RecordTransformerTest {
       assertEquals(record.getValue("mvDouble"), new Object[]{123d});
       assertEquals(record.getValue("svStringWithNullCharacters"), "1");
       assertEquals(record.getValue("svStringWithLengthLimit"), "12");
+      assertEquals(record.getValue("svJsonWithLengthLimit"), "$SKIPPED$");
       assertEquals(record.getValue("mvString1"), new Object[]{"123", "123", "123", "123.0", "123.0"});
       assertEquals(record.getValue("mvString2"), new Object[]{"123", "123", "123.0", "123.0", "123"});
       assertNull(record.getValue("$virtual"));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -276,7 +276,7 @@ public class RecordTransformerTest {
       assertEquals(record.getValue("mvString2"), new Object[]{"123", "123", "123.0", "123.0", "123"});
       assertNull(record.getValue("$virtual"));
       assertTrue(record.getNullValueFields().isEmpty());
-      assertEquals(transformer.getSanitizedColsCount(), 3L);
+      assertEquals(transformer.getSanitizedColValuesCount(), 3L);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -385,10 +385,7 @@ public class JsonUtils {
     // Value
     if (node.isValueNode()) {
       String valueAsText = node.asText();
-      int maxValueLength = jsonIndexConfig.getMaxValueLength();
-      if (0 < maxValueLength && maxValueLength < valueAsText.length()) {
-        valueAsText = SKIPPED_VALUE_REPLACEMENT;
-      }
+      valueAsText = getSanitizedString(jsonIndexConfig.getMaxValueLength(), valueAsText);
       return Collections.singletonList(Collections.singletonMap(VALUE_KEY, valueAsText));
     }
 
@@ -529,6 +526,13 @@ public class JsonUtils {
       unnestResults(nestedResultsList.get(0), nestedResultsList, 1, nonNestedResult, results);
       return results;
     }
+  }
+
+  public static String getSanitizedString(int maxLength, String valueAsText) {
+    if (0 < maxLength && maxLength < valueAsText.length()) {
+      valueAsText = SKIPPED_VALUE_REPLACEMENT;
+    }
+    return valueAsText;
   }
 
   private static IncludeResult shouldInclude(JsonIndexConfig jsonIndexConfig, String path) {


### PR DESCRIPTION
https://github.com/apache/pinot/issues/13123
**Fix:**
1) Added code to sanitize the json column to "$SKIPPED$". The way it is in JsonIndex.
2) Exposed Server metric for the sanitized values (numColsLimitedByMaxLength)


There seems to be duplication with the below PR:
https://github.com/apache/pinot/pull/13103
