### PR TITLE
Returning tables names failing authorization in Exception of Multi State Engine Queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -52,6 +52,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
+  @Deprecated
   default boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
     return true;
   }
@@ -79,6 +80,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
+  @Deprecated
   default boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
     return true;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.broker.api;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.auth.FineGrainedAccessControl;
@@ -117,6 +116,7 @@ public interface AccessControl extends FineGrainedAccessControl {
   default TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
     // Taking all tables when hasAccess Failed , to not break existing implementations
     // It will say all tables names failed AuthZ even only some failed AuthZ - which is same as just boolean output
-    return new TableAuthorizationResult(hasAccess(requesterIdentity, tables) ? new HashSet<>() : tables);
+    return hasAccess(requesterIdentity, tables) ? TableAuthorizationResult.success()
+        : new TableAuthorizationResult(tables);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -23,6 +23,8 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.auth.FineGrainedAccessControl;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 
 
 @InterfaceAudience.Public
@@ -48,7 +50,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
-  boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest);
+  AuthorizationResult hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest);
 
   /**
    * Fine-grained access control on pinot tables.
@@ -58,5 +60,5 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
-  boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables);
+  TableAuthorizationResult hasAccess(RequesterIdentity requesterIdentity, Set<String> tables);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -46,7 +46,7 @@ public interface AccessControl extends FineGrainedAccessControl {
 
   /**
    * Fine-grained access control on parsed broker request. May check table, column, permissions, etc.
-   *
+   * The default implementation is kept to have backward compatibility with the existing implementations
    * @param requesterIdentity requester identity
    * @param brokerRequest broker request (incl query)
    *
@@ -57,12 +57,23 @@ public interface AccessControl extends FineGrainedAccessControl {
     return true;
   }
 
+  /**
+   * Verify access control on parsed broker request. May check table, column, permissions, etc.
+   * The default implementation returns a {@link BasicAuthorizationResultImpl} with the result of the hasAccess() of
+   * the implementation
+   *
+   * @param requesterIdentity requester identity
+   * @param brokerRequest broker request (incl query)
+   *
+   * @return {@code AuthorizationResult} with the result of the access control check
+   */
   default AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
     return new BasicAuthorizationResultImpl(hasAccess(requesterIdentity, brokerRequest));
   }
 
   /**
    * Fine-grained access control on pinot tables.
+   * The default implementation is kept to have backward compatibility with the existing implementations
    *
    * @param requesterIdentity requester identity
    * @param tables Set of pinot tables used in the query. Table name can be with or without tableType.
@@ -74,6 +85,16 @@ public interface AccessControl extends FineGrainedAccessControl {
     return true;
   }
 
+  /**
+   * Verify access control on pinot tables.
+   * The default implementation returns a {@link TableAuthorizationResult} with the result of the hasAccess() of the
+   * implementation
+   *
+   * @param requesterIdentity requester identity
+   * @param tables Set of pinot tables used in the query. Table name can be with or without tableType.
+   *
+   * @return {@code TableAuthorizationResult} with the result of the access control check
+   */
   default TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
     // Taking all tables when hasAccess Failed , to not break existing implementations
     // It will say all tables names failed AuthZ even only some failed AuthZ - which is same as just boolean output

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -35,13 +35,28 @@ public interface AccessControl extends FineGrainedAccessControl {
   /**
    * First-step access control when processing broker requests. Decides whether request is allowed to acquire resources
    * for further processing. Request may still be rejected at table-level later on.
-   *
+   * The default implementation is kept to have backward compatibility with the existing implementations
    * @param requesterIdentity requester identity
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
+  @Deprecated
   default boolean hasAccess(RequesterIdentity requesterIdentity) {
     return true;
+  }
+
+  /**
+   * First-step access control when processing broker requests. Decides whether request is allowed to acquire resources
+   * for further processing. Request may still be rejected at table-level later on.
+   * The default implementation returns a {@link BasicAuthorizationResultImpl} with the result of the hasAccess() of
+   * the implementation
+   *
+   * @param requesterIdentity requester identity
+   *
+   * @return {@code AuthorizationResult} with the result of the access control check
+   */
+  default AuthorizationResult authorize(RequesterIdentity requesterIdentity) {
+    return new BasicAuthorizationResultImpl(hasAccess(requesterIdentity));
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -52,7 +52,6 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
-
   default boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
     return true;
   }
@@ -67,7 +66,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code AuthorizationResult} with the result of the access control check
    */
-  default AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+  default AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
     return new BasicAuthorizationResultImpl(hasAccess(requesterIdentity, brokerRequest));
   }
 
@@ -80,7 +79,6 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */
-
   default boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
     return true;
   }
@@ -95,7 +93,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    *
    * @return {@code TableAuthorizationResult} with the result of the access control check
    */
-  default TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+  default TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
     // Taking all tables when hasAccess Failed , to not break existing implementations
     // It will say all tables names failed AuthZ even only some failed AuthZ - which is same as just boolean output
     return new TableAuthorizationResult(hasAccess(requesterIdentity, tables) ? new HashSet<>() : tables);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -54,7 +54,9 @@ public interface AccessControl extends FineGrainedAccessControl {
    */
   @Deprecated
   default boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-    return true;
+    throw new UnsupportedOperationException(
+        "Both hasAccess() and authorize() are not implemented . Do implement authorize() method for new "
+            + "implementations.");
   }
 
   /**
@@ -82,7 +84,9 @@ public interface AccessControl extends FineGrainedAccessControl {
    */
   @Deprecated
   default boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
-    return true;
+    throw new UnsupportedOperationException(
+        "Both hasAccess() and authorize() are not implemented . Do implement authorize() method for new "
+            + "implementations.");
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -23,6 +23,7 @@ import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -44,7 +45,7 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
   private static class AllowAllAccessControl implements AccessControl {
     @Override
     public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-      return TableAuthorizationResult.noFailureResult();
+      return BasicAuthorizationResultImpl.noFailureResult();
     }
 
     @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -43,12 +43,12 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
 
   private static class AllowAllAccessControl implements AccessControl {
     @Override
-    public AuthorizationResult hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       return TableAuthorizationResult.noFailureResult();
     }
 
     @Override
-    public TableAuthorizationResult hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       return TableAuthorizationResult.noFailureResult();
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -45,12 +45,12 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
   private static class AllowAllAccessControl implements AccessControl {
     @Override
     public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-      return BasicAuthorizationResultImpl.noFailureResult();
+      return BasicAuthorizationResultImpl.success();
     }
 
     @Override
     public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
-      return TableAuthorizationResult.noFailureResult();
+      return TableAuthorizationResult.success();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -44,12 +44,12 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
 
   private static class AllowAllAccessControl implements AccessControl {
     @Override
-    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       return BasicAuthorizationResultImpl.noFailureResult();
     }
 
     @Override
-    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
       return TableAuthorizationResult.noFailureResult();
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -41,13 +43,13 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
 
   private static class AllowAllAccessControl implements AccessControl {
     @Override
-    public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-      return true;
+    public AuthorizationResult hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+      return TableAuthorizationResult.noFailureResult();
     }
 
     @Override
-    public boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
-      return true;
+    public TableAuthorizationResult hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+      return TableAuthorizationResult.noFailureResult();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -38,6 +38,7 @@ import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
+import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.glassfish.grizzly.http.server.Request;
 
 /**
@@ -82,9 +83,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
     HttpRequesterIdentity httpRequestIdentity = HttpRequesterIdentity.fromRequest(request);
 
-    // default authorization handling
-    if (!accessControl.hasAccess(httpRequestIdentity)) {
-      throw new WebApplicationException("Failed access check for " + httpRequestIdentity.getEndpointUrl(),
+    AuthorizationResult authorizationResult = accessControl.authorize(httpRequestIdentity);
+
+    if (!authorizationResult.hasAccess()) {
+      throw new WebApplicationException(
+          "Failed access check for " + httpRequestIdentity.getEndpointUrl() + " ,with reason: "
+              + authorizationResult.getFailureMessage(),
           Response.Status.FORBIDDEN);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
@@ -86,9 +87,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     AuthorizationResult authorizationResult = accessControl.authorize(httpRequestIdentity);
 
     if (!authorizationResult.hasAccess()) {
+      String failureMessage = authorizationResult.getFailureMessage();
+      if (StringUtils.isNotBlank(failureMessage)) {
+        failureMessage = "Reason: " + failureMessage;
+      }
       throw new WebApplicationException(
-          "Failed access check for " + httpRequestIdentity.getEndpointUrl() + " ,with reason: "
-              + authorizationResult.getFailureMessage(),
+          "Failed access check for " + httpRequestIdentity.getEndpointUrl() + "." + failureMessage,
           Response.Status.FORBIDDEN);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -81,11 +81,11 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return hasAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
+      return verifyAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
     }
 
     @Override
-    public AuthorizationResult hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
 
       if (!principalOpt.isPresent()) {
@@ -106,7 +106,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
-    public TableAuthorizationResult hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
 
       if (!principalOpt.isPresent()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -81,11 +81,11 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return verifyAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
+      return authorize(requesterIdentity, (BrokerRequest) null).hasAccess();
     }
 
     @Override
-    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
 
       if (!principalOpt.isPresent()) {
@@ -106,7 +106,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
-    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
       Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
 
       if (!principalOpt.isPresent()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -80,8 +80,8 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return authorize(requesterIdentity, (BrokerRequest) null).hasAccess();
+    public AuthorizationResult authorize(RequesterIdentity requesterIdentity) {
+      return authorize(requesterIdentity, (BrokerRequest) null);
     }
 
     @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -134,7 +134,6 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
         return TableAuthorizationResult.success();
       }
       return new TableAuthorizationResult(failedTables);
-
     }
 
     private Optional<BasicAuthPrincipal> getPrincipalOpt(RequesterIdentity requesterIdentity) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -122,7 +122,6 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
       if (tables == null || tables.isEmpty()) {
         return TableAuthorizationResult.success();
       }
-      TableAuthorizationResult tableAuthorizationResult = new TableAuthorizationResult();
       BasicAuthPrincipal principal = principalOpt.get();
       Set<String> failedTables = new HashSet<>();
       for (String table : tables) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -84,8 +84,8 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return authorize(requesterIdentity, (BrokerRequest) null).hasAccess();
+    public AuthorizationResult authorize(RequesterIdentity requesterIdentity) {
+      return authorize(requesterIdentity, (BrokerRequest) null);
     }
 
     @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -85,22 +85,22 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return hasAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
+      return verifyAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
     }
 
     @Override
-    public AuthorizationResult hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       if (brokerRequest == null || !brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource()
           .isSetTableName()) {
         // no table restrictions? accept
         return TableAuthorizationResult.noFailureResult();
       }
 
-      return hasAccess(requesterIdentity, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
+      return verifyAccess(requesterIdentity, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
     }
 
     @Override
-    public TableAuthorizationResult hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       Optional<ZkBasicAuthPrincipal> principalOpt = getPrincipalAuth(requesterIdentity);
       if (!principalOpt.isPresent()) {
         throw new NotAuthorizedException("Basic");

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -85,22 +85,22 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return verifyAccess(requesterIdentity, (BrokerRequest) null).hasAccess();
+      return authorize(requesterIdentity, (BrokerRequest) null).hasAccess();
     }
 
     @Override
-    public AuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       if (brokerRequest == null || !brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource()
           .isSetTableName()) {
         // no table restrictions? accept
         return TableAuthorizationResult.noFailureResult();
       }
 
-      return verifyAccess(requesterIdentity, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
+      return authorize(requesterIdentity, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
     }
 
     @Override
-    public TableAuthorizationResult verifyAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+    public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
       Optional<ZkBasicAuthPrincipal> principalOpt = getPrincipalAuth(requesterIdentity);
       if (!principalOpt.isPresent()) {
         throw new NotAuthorizedException("Basic");

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -30,6 +30,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.broker.broker.AccessControlFactory;
@@ -111,7 +112,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
       requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
       _brokerQueryEventListener.onQueryCompletion(requestContext);
-      throw new WebApplicationException("Permission denied. Reason: " + authorizationResult.getFailureMessage(),
+      String failureMessage = authorizationResult.getFailureMessage();
+      if (StringUtils.isNotBlank(failureMessage)) {
+        failureMessage = "Reason: " + failureMessage;
+      }
+      throw new WebApplicationException("Permission denied." + failureMessage,
           Response.Status.FORBIDDEN);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -367,7 +367,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       BrokerRequest serverBrokerRequest =
           serverPinotQuery == pinotQuery ? brokerRequest : CalciteSqlCompiler.convertToBrokerRequest(serverPinotQuery);
       boolean hasTableAccess =
-          accessControl.hasAccess(requesterIdentity, serverBrokerRequest) && accessControl.hasAccess(httpHeaders,
+          accessControl.hasAccess(requesterIdentity, serverBrokerRequest).hasAccess() && accessControl.hasAccess(
+              httpHeaders,
               TargetType.TABLE, tableName, Actions.Table.QUERY);
 
       _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -368,10 +368,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       BrokerRequest brokerRequest = CalciteSqlCompiler.convertToBrokerRequest(pinotQuery);
       BrokerRequest serverBrokerRequest =
           serverPinotQuery == pinotQuery ? brokerRequest : CalciteSqlCompiler.convertToBrokerRequest(serverPinotQuery);
-      AuthorizationResult authorizationResult = accessControl.verifyAccess(requesterIdentity, serverBrokerRequest);
+      AuthorizationResult authorizationResult = accessControl.authorize(requesterIdentity, serverBrokerRequest);
       if (authorizationResult.hasAccess()) {
         authorizationResult = BasicAuthorizationResultImpl.joinResults(authorizationResult,
-            accessControl.verifyAccess(httpHeaders, TargetType.TABLE, tableName, Actions.Table.QUERY));
+            accessControl.authorize(httpHeaders, TargetType.TABLE, tableName, Actions.Table.QUERY));
       }
 
       _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -83,6 +83,8 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.GapfillUtils;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -366,19 +368,22 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       BrokerRequest brokerRequest = CalciteSqlCompiler.convertToBrokerRequest(pinotQuery);
       BrokerRequest serverBrokerRequest =
           serverPinotQuery == pinotQuery ? brokerRequest : CalciteSqlCompiler.convertToBrokerRequest(serverPinotQuery);
-      boolean hasTableAccess =
-          accessControl.hasAccess(requesterIdentity, serverBrokerRequest).hasAccess() && accessControl.hasAccess(
-              httpHeaders,
-              TargetType.TABLE, tableName, Actions.Table.QUERY);
+      AuthorizationResult authorizationResult = accessControl.verifyAccess(requesterIdentity, serverBrokerRequest);
+      if (authorizationResult.hasAccess()) {
+        authorizationResult = BasicAuthorizationResultImpl.joinResults(authorizationResult,
+            accessControl.verifyAccess(httpHeaders, TargetType.TABLE, tableName, Actions.Table.QUERY));
+      }
 
       _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,
           System.nanoTime() - compilationEndTimeNs);
 
-      if (!hasTableAccess) {
+      if (!authorizationResult.hasAccess()) {
         _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
-        LOGGER.info("Access denied for request {}: {}, table: {}", requestId, query, tableName);
+        LOGGER.info("Access denied for request {}: {}, table: {}, reason :{}", requestId, query, tableName,
+            authorizationResult.getFailureMessage());
         requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
-        throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
+        throw new WebApplicationException("Permission denied . Reason : " + authorizationResult.getFailureMessage(),
+            Response.Status.FORBIDDEN);
       }
 
       // Get the tables hit by the request

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -142,8 +142,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
           TableAuthorizationResult tableAuthorizationResult =
               hasTableAccess(requesterIdentity, tableNames, requestContext, httpHeaders);
           if (!tableAuthorizationResult.hasAccess()) {
-            throw new WebApplicationException(
-                "Permission denied . Message : " + tableAuthorizationResult.getFailureMessage(),
+            String failureMessage = tableAuthorizationResult.getFailureMessage();
+            if (StringUtils.isNotBlank(failureMessage)) {
+              failureMessage = "Reason: " + failureMessage;
+            }
+            throw new WebApplicationException("Permission denied. " + failureMessage,
                 Response.Status.FORBIDDEN);
           }
           return constructMultistageExplainPlan(query, plan);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -282,7 +282,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     final long startTimeNs = System.nanoTime();
     AccessControl accessControl = _accessControlFactory.create();
 
-    TableAuthorizationResult tableAuthorizationResult = accessControl.hasAccess(requesterIdentity, tableNames);
+    TableAuthorizationResult tableAuthorizationResult = accessControl.verifyAccess(requesterIdentity, tableNames);
 
     tableNames.stream()
         .filter(table -> !accessControl.hasAccess(httpHeaders, TargetType.TABLE, table, Actions.Table.QUERY))

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
@@ -191,7 +192,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     TableAuthorizationResult tableAuthorizationResult =
         hasTableAccess(requesterIdentity, tableNames, requestContext, httpHeaders);
     if (!tableAuthorizationResult.hasAccess()) {
-      throw new WebApplicationException("Permission denied . Message : " + tableAuthorizationResult.getFailureMessage(),
+      String failureMessage = tableAuthorizationResult.getFailureMessage();
+      if (StringUtils.isNotBlank(failureMessage)) {
+        failureMessage = "Reason: " + failureMessage;
+      }
+      throw new WebApplicationException("Permission denied." + failureMessage,
           Response.Status.FORBIDDEN);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -282,7 +282,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     final long startTimeNs = System.nanoTime();
     AccessControl accessControl = _accessControlFactory.create();
 
-    TableAuthorizationResult tableAuthorizationResult = accessControl.verifyAccess(requesterIdentity, tableNames);
+    TableAuthorizationResult tableAuthorizationResult = accessControl.authorize(requesterIdentity, tableNames);
 
     tableNames.stream()
         .filter(table -> !accessControl.hasAccess(httpHeaders, TargetType.TABLE, table, Actions.Table.QUERY))

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -34,7 +34,7 @@ public class AccessControlBackwardCompatibleTest {
     AccessControl accessControl = new AllFalseAccessControlImpl();
     HttpRequesterIdentity identity = new HttpRequesterIdentity();
     BrokerRequest request = new BrokerRequest();
-    assertFalse(accessControl.verifyAccess(identity, request).hasAccess());
+    assertFalse(accessControl.authorize(identity, request).hasAccess());
   }
 
   @Test
@@ -42,7 +42,7 @@ public class AccessControlBackwardCompatibleTest {
     AccessControl accessControl = new AllFalseAccessControlImpl();
     HttpRequesterIdentity identity = new HttpRequesterIdentity();
     Set<String> tables = Set.of("table1", "table2");
-    AuthorizationResult result = accessControl.verifyAccess(identity, tables);
+    AuthorizationResult result = accessControl.authorize(identity, tables);
     assertFalse(result.hasAccess());
     assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -55,7 +55,7 @@ public class AccessControlBackwardCompatibleTest {
     }
 
     @Override
-    public boolean hasAccess(RequesterIdentity requesterIdentity) {
+    public boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       return false;
     }
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api;
+
+import java.util.Set;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+
+public class AccessControlBackwardCompatibleTest {
+
+  @Test
+  public void testBackwardCompatibleHasAccessBrokerRequest() {
+    AccessControl accessControl = new AllFalseAccessControlImpl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    BrokerRequest request = new BrokerRequest();
+    assertFalse(accessControl.verifyAccess(identity, request).hasAccess());
+  }
+
+  @Test
+  public void testBackwardCompatibleHasAccessMutliTable() {
+    AccessControl accessControl = new AllFalseAccessControlImpl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    Set<String> tables = Set.of("table1", "table2");
+    AuthorizationResult result = accessControl.verifyAccess(identity, tables);
+    assertFalse(result.hasAccess());
+    assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
+  }
+
+  class AllFalseAccessControlImpl implements AccessControl {
+
+    @Override
+    public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+      return false;
+    }
+
+    @Override
+    public boolean hasAccess(RequesterIdentity requesterIdentity) {
+      return false;
+    }
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -44,7 +44,7 @@ public class AccessControlBackwardCompatibleTest {
     Set<String> tables = Set.of("table1", "table2");
     AuthorizationResult result = accessControl.authorize(identity, tables);
     assertFalse(result.hasAccess());
-    assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
+    assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }
 
   @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -47,6 +47,38 @@ public class AccessControlBackwardCompatibleTest {
     assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
   }
 
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testExceptionForNoImplAccessControlMultiTable() {
+    AccessControl accessControl = new NoImplAccessControl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    Set<String> tables = Set.of("table1", "table2");
+    accessControl.hasAccess(identity, tables);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testExceptionForNoImplAccessControlBrokerRequest() {
+    AccessControl accessControl = new NoImplAccessControl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    BrokerRequest request = new BrokerRequest();
+    accessControl.hasAccess(identity, request);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testExceptionForNoImplAccessControlAuthorizeMultiTable() {
+    AccessControl accessControl = new NoImplAccessControl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    Set<String> tables = Set.of("table1", "table2");
+    accessControl.authorize(identity, tables);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testExceptionForNoImplAccessControlAuthorizeBrokerRequest() {
+    AccessControl accessControl = new NoImplAccessControl();
+    HttpRequesterIdentity identity = new HttpRequesterIdentity();
+    BrokerRequest request = new BrokerRequest();
+    accessControl.authorize(identity, request);
+  }
+
   class AllFalseAccessControlImpl implements AccessControl {
 
     @Override
@@ -58,5 +90,8 @@ public class AccessControlBackwardCompatibleTest {
     public boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       return false;
     }
+  }
+
+  class NoImplAccessControl implements AccessControl {
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -67,7 +67,7 @@ public class BasicAuthAccessControlTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testNullEntity() {
-    _accessControl.hasAccess(null, (BrokerRequest) null);
+    _accessControl.verifyAccess(null, (BrokerRequest) null);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class BasicAuthAccessControlTest {
     identity.setHttpHeaders(headers);
 
     try {
-      _accessControl.hasAccess(identity, (BrokerRequest) null);
+      _accessControl.verifyAccess(identity, (BrokerRequest) null);
     } catch (WebApplicationException e) {
       Assert.assertEquals(e.getResponse().getStatus(), 401, "must return 401");
     }
@@ -98,8 +98,8 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.hasAccess(identity, request).hasAccess());
-    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames).hasAccess());
+    Assert.assertTrue(_accessControl.verifyAccess(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.verifyAccess(identity, _tableNames).hasAccess());
   }
 
   @Test
@@ -115,24 +115,24 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
-    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lessImportantStuff");
-    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lesserImportantStuff");
-    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
@@ -151,7 +151,7 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
     Assert.assertTrue(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(), "");
 
@@ -160,7 +160,7 @@ public class BasicAuthAccessControlTest {
     tableNames.add("veryImportantStuff");
     tableNames.add("lesserImportantStuff");
 
-    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
     Assert.assertTrue(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(), "");
   }
@@ -174,11 +174,11 @@ public class BasicAuthAccessControlTest {
     identity.setHttpHeaders(headers);
 
     BrokerRequest request = new BrokerRequest();
-    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
     Assert.assertTrue(authorizationResult.hasAccess());
 
     Set<String> tableNames = new HashSet<>();
-    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
     Assert.assertTrue(authorizationResult.hasAccess());
   }
 
@@ -196,7 +196,7 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.hasAccess(identity, request).hasAccess());
-    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames).hasAccess());
+    Assert.assertTrue(_accessControl.verifyAccess(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.verifyAccess(identity, _tableNames).hasAccess());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -67,7 +67,7 @@ public class BasicAuthAccessControlTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testNullEntity() {
-    _accessControl.verifyAccess(null, (BrokerRequest) null);
+    _accessControl.authorize(null, (BrokerRequest) null);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class BasicAuthAccessControlTest {
     identity.setHttpHeaders(headers);
 
     try {
-      _accessControl.verifyAccess(identity, (BrokerRequest) null);
+      _accessControl.authorize(identity, (BrokerRequest) null);
     } catch (WebApplicationException e) {
       Assert.assertEquals(e.getResponse().getStatus(), 401, "must return 401");
     }
@@ -98,8 +98,8 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.verifyAccess(identity, request).hasAccess());
-    Assert.assertTrue(_accessControl.verifyAccess(identity, _tableNames).hasAccess());
+    Assert.assertTrue(_accessControl.authorize(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.authorize(identity, _tableNames).hasAccess());
   }
 
   @Test
@@ -115,24 +115,24 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.authorize(identity, request);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
-    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
+    authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lessImportantStuff");
-    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
+    authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lesserImportantStuff");
-    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
+    authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
         "Authorization Failed for tables: veryImportantStuff,");
@@ -151,7 +151,7 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.authorize(identity, request);
     Assert.assertTrue(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(), "");
 
@@ -160,7 +160,7 @@ public class BasicAuthAccessControlTest {
     tableNames.add("veryImportantStuff");
     tableNames.add("lesserImportantStuff");
 
-    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
+    authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertTrue(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(), "");
   }
@@ -174,11 +174,11 @@ public class BasicAuthAccessControlTest {
     identity.setHttpHeaders(headers);
 
     BrokerRequest request = new BrokerRequest();
-    AuthorizationResult authorizationResult = _accessControl.verifyAccess(identity, request);
+    AuthorizationResult authorizationResult = _accessControl.authorize(identity, request);
     Assert.assertTrue(authorizationResult.hasAccess());
 
     Set<String> tableNames = new HashSet<>();
-    authorizationResult = _accessControl.verifyAccess(identity, tableNames);
+    authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertTrue(authorizationResult.hasAccess());
   }
 
@@ -196,7 +196,7 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.verifyAccess(identity, request).hasAccess());
-    Assert.assertTrue(_accessControl.verifyAccess(identity, _tableNames).hasAccess());
+    Assert.assertTrue(_accessControl.authorize(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.authorize(identity, _tableNames).hasAccess());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -118,24 +118,24 @@ public class BasicAuthAccessControlTest {
     AuthorizationResult authorizationResult = _accessControl.authorize(identity, request);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff,");
+        "Authorization Failed for tables: [veryImportantStuff]");
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
     authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff,");
+        "Authorization Failed for tables: [veryImportantStuff]");
     tableNames.add("lessImportantStuff");
     authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff,");
+        "Authorization Failed for tables: [veryImportantStuff]");
     tableNames.add("lesserImportantStuff");
     authorizationResult = _accessControl.authorize(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff,");
+        "Authorization Failed for tables: [veryImportantStuff]");
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -97,8 +98,8 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.hasAccess(identity, request));
-    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames));
+    Assert.assertTrue(_accessControl.hasAccess(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames).hasAccess());
   }
 
   @Test
@@ -114,16 +115,27 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-
-    Assert.assertFalse(_accessControl.hasAccess(identity, request));
+    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    Assert.assertFalse(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(),
+        "Authorization Failed for tables: veryImportantStuff,");
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
+    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    Assert.assertFalse(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(),
+        "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lessImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
+    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    Assert.assertFalse(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(),
+        "Authorization Failed for tables: veryImportantStuff, lessImportantStuff,");
     tableNames.add("lesserImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
+    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    Assert.assertFalse(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(),
+        "Authorization Failed for tables: veryImportantStuff, lessImportantStuff, lesserImportantStuff,");
   }
 
   @Test
@@ -139,15 +151,18 @@ public class BasicAuthAccessControlTest {
 
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
-
-    Assert.assertTrue(_accessControl.hasAccess(identity, request));
+    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    Assert.assertTrue(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(), "");
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("lessImportantStuff");
     tableNames.add("veryImportantStuff");
     tableNames.add("lesserImportantStuff");
 
-    Assert.assertTrue(_accessControl.hasAccess(identity, tableNames));
+    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    Assert.assertTrue(authorizationResult.hasAccess());
+    Assert.assertEquals(authorizationResult.getFailureMessage(), "");
   }
 
   @Test
@@ -159,11 +174,12 @@ public class BasicAuthAccessControlTest {
     identity.setHttpHeaders(headers);
 
     BrokerRequest request = new BrokerRequest();
-
-    Assert.assertTrue(_accessControl.hasAccess(identity, request));
+    AuthorizationResult authorizationResult = _accessControl.hasAccess(identity, request);
+    Assert.assertTrue(authorizationResult.hasAccess());
 
     Set<String> tableNames = new HashSet<>();
-    Assert.assertTrue(_accessControl.hasAccess(identity, tableNames));
+    authorizationResult = _accessControl.hasAccess(identity, tableNames);
+    Assert.assertTrue(authorizationResult.hasAccess());
   }
 
   @Test
@@ -180,7 +196,7 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
     request.setQuerySource(source);
 
-    Assert.assertTrue(_accessControl.hasAccess(identity, request));
-    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames));
+    Assert.assertTrue(_accessControl.hasAccess(identity, request).hasAccess());
+    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames).hasAccess());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -130,12 +130,12 @@ public class BasicAuthAccessControlTest {
     authorizationResult = _accessControl.hasAccess(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff, lessImportantStuff,");
+        "Authorization Failed for tables: veryImportantStuff,");
     tableNames.add("lesserImportantStuff");
     authorizationResult = _accessControl.hasAccess(identity, tableNames);
     Assert.assertFalse(authorizationResult.hasAccess());
     Assert.assertEquals(authorizationResult.getFailureMessage(),
-        "Authorization Failed for tables: veryImportantStuff, lessImportantStuff, lesserImportantStuff,");
+        "Authorization Failed for tables: veryImportantStuff,");
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
@@ -51,7 +51,7 @@ public interface FineGrainedAccessControl {
    * @param action type to validate
    * @return An AuthorizationResult object, encapsulating whether the access is granted or not.
    */
-  default AuthorizationResult verifyAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId,
+  default AuthorizationResult authorize(HttpHeaders httpHeaders, TargetType targetType, String targetId,
       String action) {
     return new BasicAuthorizationResultImpl(hasAccess(httpHeaders, targetType, targetId, action));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
@@ -40,6 +40,17 @@ public interface FineGrainedAccessControl {
     return true;
   }
 
+  /**
+   * Verifies if the user has access to perform a specific action on a particular resource.
+   * The default implementation returns a {@link BasicAuthorizationResultImpl} with the result of the hasAccess() of
+   * the implementation
+   *
+   * @param httpHeaders HTTP headers
+   * @param targetType type of resource being accessed
+   * @param targetId id of the resource
+   * @param action type to validate
+   * @return An AuthorizationResult object, encapsulating whether the access is granted or not.
+   */
   default AuthorizationResult verifyAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId,
       String action) {
     return new BasicAuthorizationResultImpl(hasAccess(httpHeaders, targetType, targetId, action));

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.auth;
 
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 
 
 /**
@@ -36,6 +38,11 @@ public interface FineGrainedAccessControl {
    */
   default boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId, String action) {
     return true;
+  }
+
+  default AuthorizationResult verifyAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId,
+      String action) {
+    return new BasicAuthorizationResultImpl(hasAccess(httpHeaders, targetType, targetId, action));
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthorizationResult.java
@@ -18,8 +18,24 @@
  */
 package org.apache.pinot.spi.auth;
 
+/**
+ * The AuthorizationResult interface defines the contract for authorization results in the Pinot system.
+ * Implementations of this interface provide the access status and an optional failure message indicating
+ * the reason for denied access.
+ */
 public interface AuthorizationResult {
+
+  /**
+   * Indicates whether the access is granted.
+   *
+   * @return true if access is granted, false otherwise.
+   */
   boolean hasAccess();
 
+  /**
+   * Provides the failure message if access is denied.
+   *
+   * @return A string containing the failure message if access is denied, otherwise an empty string or null.
+   */
   String getFailureMessage();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthorizationResult.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.auth;
+
+public interface AuthorizationResult {
+  boolean hasAccess();
+
+  String getFailureMessage();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.auth;
+
+import org.apache.commons.lang3.StringUtils;
+
+
+public class BasicAuthorizationResultImpl implements AuthorizationResult {
+  private boolean _hasAccess;
+  private String _failureMessage;
+
+  public BasicAuthorizationResultImpl(boolean hasAccess, String failureMessage) {
+    _hasAccess = hasAccess;
+    _failureMessage = failureMessage;
+  }
+
+  public BasicAuthorizationResultImpl(boolean hasAccess) {
+    _hasAccess = hasAccess;
+    _failureMessage = StringUtils.EMPTY;
+  }
+
+  public static BasicAuthorizationResultImpl noFailureResult() {
+    return new BasicAuthorizationResultImpl(true);
+  }
+
+  public static BasicAuthorizationResultImpl joinResults(AuthorizationResult result1, AuthorizationResult result2) {
+    boolean hasAccess = result1.hasAccess() && result2.hasAccess();
+    if (hasAccess) {
+      return BasicAuthorizationResultImpl.noFailureResult();
+    }
+    String failureMessage = result1.getFailureMessage() + " ; " + result2.getFailureMessage();
+    failureMessage = failureMessage.trim();
+    return new BasicAuthorizationResultImpl(hasAccess, failureMessage);
+  }
+
+  public void setHasAccess(boolean hasAccess) {
+    _hasAccess = hasAccess;
+  }
+
+  @Override
+  public boolean hasAccess() {
+    return _hasAccess;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return _failureMessage;
+  }
+
+  public void setFailureMessage(String failureMessage) {
+    _failureMessage = failureMessage;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
@@ -62,26 +62,6 @@ public class BasicAuthorizationResultImpl implements AuthorizationResult {
   }
 
   /**
-   * Combines the results of two AuthorizationResult instances.
-   * If both results grant access, a new result with access granted and no failure message is returned.
-   * If either result denies access, a new result with access denied and a combined failure message is returned.
-   *
-   * @param result1 the first AuthorizationResult.
-   * @param result2 the second AuthorizationResult.
-   * @return a combined BasicAuthorizationResultImpl based on the two provided results.
-   */
-  public static BasicAuthorizationResultImpl joinResults(AuthorizationResult result1, AuthorizationResult result2) {
-    boolean hasAccess = result1.hasAccess() && result2.hasAccess();
-    if (hasAccess) {
-      return BasicAuthorizationResultImpl.success();
-    }
-    String failureMessage = result1.getFailureMessage() + " ; " + result2.getFailureMessage();
-    failureMessage = failureMessage.trim();
-    return new BasicAuthorizationResultImpl(hasAccess, failureMessage);
-  }
-
-
-  /**
    * Indicates whether access is granted.
    *
    * @return true if access is granted, false otherwise.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
@@ -26,8 +26,10 @@ import org.apache.commons.lang3.StringUtils;
  * authorization results including access status and failure messages.
  */
 public class BasicAuthorizationResultImpl implements AuthorizationResult {
-  private boolean _hasAccess;
-  private String _failureMessage;
+
+  private static final BasicAuthorizationResultImpl SUCCESS = new BasicAuthorizationResultImpl(true);
+  private final boolean _hasAccess;
+  private final String _failureMessage;
 
   /**
    * Constructs a BasicAuthorizationResultImpl with the specified access status and failure message.
@@ -55,8 +57,8 @@ public class BasicAuthorizationResultImpl implements AuthorizationResult {
    *
    * @return a BasicAuthorizationResultImpl with access granted and an empty failure message.
    */
-  public static BasicAuthorizationResultImpl noFailureResult() {
-    return new BasicAuthorizationResultImpl(true);
+  public static BasicAuthorizationResultImpl success() {
+    return SUCCESS;
   }
 
   /**
@@ -71,21 +73,13 @@ public class BasicAuthorizationResultImpl implements AuthorizationResult {
   public static BasicAuthorizationResultImpl joinResults(AuthorizationResult result1, AuthorizationResult result2) {
     boolean hasAccess = result1.hasAccess() && result2.hasAccess();
     if (hasAccess) {
-      return BasicAuthorizationResultImpl.noFailureResult();
+      return BasicAuthorizationResultImpl.success();
     }
     String failureMessage = result1.getFailureMessage() + " ; " + result2.getFailureMessage();
     failureMessage = failureMessage.trim();
     return new BasicAuthorizationResultImpl(hasAccess, failureMessage);
   }
 
-  /**
-   * Sets the access status of this result.
-   *
-   * @param hasAccess true to grant access, false to deny access.
-   */
-  public void setHasAccess(boolean hasAccess) {
-    _hasAccess = hasAccess;
-  }
 
   /**
    * Indicates whether access is granted.
@@ -105,14 +99,5 @@ public class BasicAuthorizationResultImpl implements AuthorizationResult {
   @Override
   public String getFailureMessage() {
     return _failureMessage;
-  }
-
-  /**
-   * Sets the failure message for this result.
-   *
-   * @param failureMessage the failure message to set.
-   */
-  public void setFailureMessage(String failureMessage) {
-    _failureMessage = failureMessage;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImpl.java
@@ -21,24 +21,53 @@ package org.apache.pinot.spi.auth;
 import org.apache.commons.lang3.StringUtils;
 
 
+/**
+ * Implementation of the AuthorizationResult interface that provides basic
+ * authorization results including access status and failure messages.
+ */
 public class BasicAuthorizationResultImpl implements AuthorizationResult {
   private boolean _hasAccess;
   private String _failureMessage;
 
+  /**
+   * Constructs a BasicAuthorizationResultImpl with the specified access status and failure message.
+   *
+   * @param hasAccess      true if access is granted, false otherwise.
+   * @param failureMessage the failure message if access is denied.
+   */
   public BasicAuthorizationResultImpl(boolean hasAccess, String failureMessage) {
     _hasAccess = hasAccess;
     _failureMessage = failureMessage;
   }
 
+  /**
+   * Constructs a BasicAuthorizationResultImpl with the specified access status and an empty failure message.
+   *
+   * @param hasAccess true if access is granted, false otherwise.
+   */
   public BasicAuthorizationResultImpl(boolean hasAccess) {
     _hasAccess = hasAccess;
     _failureMessage = StringUtils.EMPTY;
   }
 
+  /**
+   * Creates a BasicAuthorizationResultImpl with access granted and no failure message.
+   *
+   * @return a BasicAuthorizationResultImpl with access granted and an empty failure message.
+   */
   public static BasicAuthorizationResultImpl noFailureResult() {
     return new BasicAuthorizationResultImpl(true);
   }
 
+  /**
+   * Combines the results of two AuthorizationResult instances.
+   * If both results grant access, a new result with access granted and no failure message is returned.
+   * If either result denies access, a new result with access denied and a combined failure message is returned.
+   *
+   * @param result1 the first AuthorizationResult.
+   * @param result2 the second AuthorizationResult.
+   * @return a combined BasicAuthorizationResultImpl based on the two provided results.
+   */
   public static BasicAuthorizationResultImpl joinResults(AuthorizationResult result1, AuthorizationResult result2) {
     boolean hasAccess = result1.hasAccess() && result2.hasAccess();
     if (hasAccess) {
@@ -49,20 +78,40 @@ public class BasicAuthorizationResultImpl implements AuthorizationResult {
     return new BasicAuthorizationResultImpl(hasAccess, failureMessage);
   }
 
+  /**
+   * Sets the access status of this result.
+   *
+   * @param hasAccess true to grant access, false to deny access.
+   */
   public void setHasAccess(boolean hasAccess) {
     _hasAccess = hasAccess;
   }
 
+  /**
+   * Indicates whether access is granted.
+   *
+   * @return true if access is granted, false otherwise.
+   */
   @Override
   public boolean hasAccess() {
     return _hasAccess;
   }
 
+  /**
+   * Provides the failure message if access is denied.
+   *
+   * @return the failure message if access is denied, otherwise an empty string.
+   */
   @Override
   public String getFailureMessage() {
     return _failureMessage;
   }
 
+  /**
+   * Sets the failure message for this result.
+   *
+   * @param failureMessage the failure message to set.
+   */
   public void setFailureMessage(String failureMessage) {
     _failureMessage = failureMessage;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -80,7 +80,6 @@ public class TableAuthorizationResult implements AuthorizationResult {
     }
     StringBuilder sb = new StringBuilder();
     sb.append("Authorization Failed for tables: ");
-    // sort _failedTables into a list
 
     List<String> failedTablesList = new ArrayList<>(_failedTables);
     Collections.sort(failedTablesList); // Sort to make output deterministic

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -26,6 +26,10 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 
 
+/**
+ * Implementation of the AuthorizationResult interface that provides authorization results
+ * at the table level, including which tables failed authorization.
+ */
 public class TableAuthorizationResult implements AuthorizationResult {
   private Set<String> _failedTables;
 
@@ -37,6 +41,11 @@ public class TableAuthorizationResult implements AuthorizationResult {
     setFailedTables(failedTables);
   }
 
+  /**
+   * Creates a TableAuthorizationResult with no failed tables.
+   *
+   * @return a TableAuthorizationResult with no failed tables.
+   */
   public static TableAuthorizationResult noFailureResult() {
     return new TableAuthorizationResult();
   }
@@ -59,6 +68,11 @@ public class TableAuthorizationResult implements AuthorizationResult {
     _failedTables.add(failedTable);
   }
 
+  /**
+   * Provides the failure message indicating which tables failed authorization.
+   *
+   * @return a string containing the failure message if there are failed tables, otherwise an empty string.
+   */
   @Override
   public String getFailureMessage() {
     if (hasAccess()) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.spi.auth;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 
@@ -63,7 +66,12 @@ public class TableAuthorizationResult implements AuthorizationResult {
     }
     StringBuilder sb = new StringBuilder();
     sb.append("Authorization Failed for tables: ");
-    for (String table : _failedTables) {
+    // sort _failedTables into a list
+
+    List<String> failedTablesList = new ArrayList<>(_failedTables);
+    Collections.sort(failedTablesList); // Sort to make output deterministic
+
+    for (String table : failedTablesList) {
       sb.append(table);
       sb.append(", ");
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+
+
+public class TableAuthorizationResult implements AuthorizationResult {
+  private Set<String> _failedTables;
+
+  public TableAuthorizationResult() {
+    _failedTables = new HashSet<>();
+  }
+
+  public TableAuthorizationResult(Set<String> failedTables) {
+    setFailedTables(failedTables);
+  }
+
+  public static TableAuthorizationResult noFailureResult() {
+    return new TableAuthorizationResult();
+  }
+
+  @Override
+  public boolean hasAccess() {
+    return _failedTables.isEmpty();
+  }
+
+  public Set<String> getFailedTables() {
+    return _failedTables;
+  }
+
+  public void setFailedTables(Set<String> failedTables) {
+    _failedTables = new HashSet<>(failedTables);
+    ;
+  }
+
+  public void addFailedTable(String failedTable) {
+    _failedTables.add(failedTable);
+  }
+
+  @Override
+  public String getFailureMessage() {
+    if (hasAccess()) {
+      return StringUtils.EMPTY;
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("Authorization Failed for tables: ");
+    for (String table : _failedTables) {
+      sb.append(table);
+      sb.append(", ");
+    }
+    return sb.toString().trim();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -31,14 +31,16 @@ import org.apache.commons.lang.StringUtils;
  * at the table level, including which tables failed authorization.
  */
 public class TableAuthorizationResult implements AuthorizationResult {
-  private Set<String> _failedTables;
+
+  private static final TableAuthorizationResult SUCCESS = new TableAuthorizationResult(Set.of());
+  private final Set<String> _failedTables;
 
   public TableAuthorizationResult() {
     _failedTables = new HashSet<>();
   }
 
   public TableAuthorizationResult(Set<String> failedTables) {
-    setFailedTables(failedTables);
+    _failedTables = new HashSet<>(failedTables);
   }
 
   /**
@@ -46,8 +48,8 @@ public class TableAuthorizationResult implements AuthorizationResult {
    *
    * @return a TableAuthorizationResult with no failed tables.
    */
-  public static TableAuthorizationResult noFailureResult() {
-    return new TableAuthorizationResult();
+  public static TableAuthorizationResult success() {
+    return SUCCESS;
   }
 
   @Override
@@ -57,15 +59,6 @@ public class TableAuthorizationResult implements AuthorizationResult {
 
   public Set<String> getFailedTables() {
     return _failedTables;
-  }
-
-  public void setFailedTables(Set<String> failedTables) {
-    _failedTables = new HashSet<>(failedTables);
-    ;
-  }
-
-  public void addFailedTable(String failedTable) {
-    _failedTables.add(failedTable);
   }
 
   /**
@@ -78,16 +71,9 @@ public class TableAuthorizationResult implements AuthorizationResult {
     if (hasAccess()) {
       return StringUtils.EMPTY;
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append("Authorization Failed for tables: ");
 
     List<String> failedTablesList = new ArrayList<>(_failedTables);
     Collections.sort(failedTablesList); // Sort to make output deterministic
-
-    for (String table : failedTablesList) {
-      sb.append(table);
-      sb.append(", ");
-    }
-    return sb.toString().trim();
+    return "Authorization Failed for tables: " + failedTablesList;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -20,7 +20,6 @@ package org.apache.pinot.spi.auth;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
@@ -35,12 +34,8 @@ public class TableAuthorizationResult implements AuthorizationResult {
   private static final TableAuthorizationResult SUCCESS = new TableAuthorizationResult(Set.of());
   private final Set<String> _failedTables;
 
-  public TableAuthorizationResult() {
-    _failedTables = new HashSet<>();
-  }
-
   public TableAuthorizationResult(Set<String> failedTables) {
-    _failedTables = new HashSet<>(failedTables);
+    _failedTables = failedTables;
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
@@ -44,7 +44,7 @@ public class BasicAuthorizationResultImplTest {
 
   @Test
   public void testNoFailureResult() {
-    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.noFailureResult();
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.success();
     assertTrue(result.hasAccess());
     assertEquals("", result.getFailureMessage());
   }
@@ -73,7 +73,7 @@ public class BasicAuthorizationResultImplTest {
     AuthorizationResult result2 = new TableAuthorizationResult(new HashSet<>(Arrays.asList("table1", "table2")));
     BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
     assertFalse(result.hasAccess());
-    assertEquals("; Authorization Failed for tables: table1, table2,", result.getFailureMessage());
+    assertEquals("; Authorization Failed for tables: [table1, table2]", result.getFailureMessage());
   }
 
   @Test
@@ -87,15 +87,13 @@ public class BasicAuthorizationResultImplTest {
 
   @Test
   public void testSetHasAccess() {
-    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true);
-    result.setHasAccess(false);
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(false);
     assertFalse(result.hasAccess());
   }
 
   @Test
   public void testSetFailureMessage() {
-    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true);
-    result.setFailureMessage("New Failure Message");
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true, "New Failure Message");
     assertEquals("New Failure Message", result.getFailureMessage());
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.auth;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class BasicAuthorizationResultImplTest {
+  @Test
+  public void testConstructorWithAccessAndMessage() {
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true, "Failure Message");
+    assertTrue(result.hasAccess());
+    assertEquals("Failure Message", result.getFailureMessage());
+  }
+
+  @Test
+  public void testConstructorWithAccessOnly() {
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true);
+    assertTrue(result.hasAccess());
+    assertEquals("", result.getFailureMessage());
+  }
+
+  @Test
+  public void testNoFailureResult() {
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.noFailureResult();
+    assertTrue(result.hasAccess());
+    assertEquals("", result.getFailureMessage());
+  }
+
+  @Test
+  public void testJoinResultsBothHaveAccess() {
+    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
+    AuthorizationResult result2 = new BasicAuthorizationResultImpl(true);
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
+    assertTrue(result.hasAccess());
+    assertEquals("", result.getFailureMessage());
+  }
+
+  @Test
+  public void testJoinResultsOneHasNoAccess() {
+    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
+    AuthorizationResult result2 = new BasicAuthorizationResultImpl(false, "Access Denied");
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
+    assertFalse(result.hasAccess());
+    assertEquals("; Access Denied", result.getFailureMessage());
+  }
+
+  @Test
+  public void testJoinResultsOneHasNoAccessCrossImplementations() {
+    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
+    AuthorizationResult result2 = new TableAuthorizationResult(new HashSet<>(Arrays.asList("table1", "table2")));
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
+    assertFalse(result.hasAccess());
+    assertEquals("; Authorization Failed for tables: table1, table2,", result.getFailureMessage());
+  }
+
+  @Test
+  public void testJoinResultsBothHaveNoAccess() {
+    AuthorizationResult result1 = new BasicAuthorizationResultImpl(false, "Access Denied 1");
+    AuthorizationResult result2 = new BasicAuthorizationResultImpl(false, "Access Denied 2");
+    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
+    assertFalse(result.hasAccess());
+    assertEquals("Access Denied 1 ; Access Denied 2", result.getFailureMessage());
+  }
+
+  @Test
+  public void testSetHasAccess() {
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true);
+    result.setHasAccess(false);
+    assertFalse(result.hasAccess());
+  }
+
+  @Test
+  public void testSetFailureMessage() {
+    BasicAuthorizationResultImpl result = new BasicAuthorizationResultImpl(true);
+    result.setFailureMessage("New Failure Message");
+    assertEquals("New Failure Message", result.getFailureMessage());
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/BasicAuthorizationResultImplTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.spi.auth;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -47,42 +45,6 @@ public class BasicAuthorizationResultImplTest {
     BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.success();
     assertTrue(result.hasAccess());
     assertEquals("", result.getFailureMessage());
-  }
-
-  @Test
-  public void testJoinResultsBothHaveAccess() {
-    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
-    AuthorizationResult result2 = new BasicAuthorizationResultImpl(true);
-    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
-    assertTrue(result.hasAccess());
-    assertEquals("", result.getFailureMessage());
-  }
-
-  @Test
-  public void testJoinResultsOneHasNoAccess() {
-    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
-    AuthorizationResult result2 = new BasicAuthorizationResultImpl(false, "Access Denied");
-    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
-    assertFalse(result.hasAccess());
-    assertEquals("; Access Denied", result.getFailureMessage());
-  }
-
-  @Test
-  public void testJoinResultsOneHasNoAccessCrossImplementations() {
-    AuthorizationResult result1 = new BasicAuthorizationResultImpl(true);
-    AuthorizationResult result2 = new TableAuthorizationResult(new HashSet<>(Arrays.asList("table1", "table2")));
-    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
-    assertFalse(result.hasAccess());
-    assertEquals("; Authorization Failed for tables: [table1, table2]", result.getFailureMessage());
-  }
-
-  @Test
-  public void testJoinResultsBothHaveNoAccess() {
-    AuthorizationResult result1 = new BasicAuthorizationResultImpl(false, "Access Denied 1");
-    AuthorizationResult result2 = new BasicAuthorizationResultImpl(false, "Access Denied 2");
-    BasicAuthorizationResultImpl result = BasicAuthorizationResultImpl.joinResults(result1, result2);
-    assertFalse(result.hasAccess());
-    assertEquals("Access Denied 1 ; Access Denied 2", result.getFailureMessage());
   }
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
@@ -45,19 +45,17 @@ public class TableAuthorizationResultTest {
 
   @Test
   public void testAddFailedTable() {
-    TableAuthorizationResult result = new TableAuthorizationResult();
-    result.addFailedTable("table1");
+    TableAuthorizationResult result = new TableAuthorizationResult(Set.of("table1"));
     Assert.assertFalse(result.hasAccess());
-    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1,");
+    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1]");
   }
 
   @Test
   public void testSetGetFailedTables() {
-    TableAuthorizationResult result = new TableAuthorizationResult();
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
     failedTables.add("table2");
-    result.setFailedTables(failedTables);
+    TableAuthorizationResult result = new TableAuthorizationResult(failedTables);
     Assert.assertFalse(result.hasAccess());
     Assert.assertEquals(result.getFailedTables(), failedTables);
   }
@@ -66,15 +64,13 @@ public class TableAuthorizationResultTest {
   public void testGetFailureMessage() {
     TableAuthorizationResult result = new TableAuthorizationResult();
     Assert.assertEquals("", result.getFailureMessage());
-
-    result.addFailedTable("table1");
-    result.addFailedTable("table2");
-    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
+    result = new TableAuthorizationResult(Set.of("table1", "table2"));
+    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }
 
   @Test
   public void testNoFailureResult() {
-    TableAuthorizationResult result = TableAuthorizationResult.noFailureResult();
+    TableAuthorizationResult result = TableAuthorizationResult.success();
     Assert.assertTrue(result.hasAccess());
     Assert.assertEquals("", result.getFailureMessage());
   }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TableAuthorizationResultTest {
+
+  @Test
+  public void testDefaultConstructor() {
+    TableAuthorizationResult result = new TableAuthorizationResult();
+    Assert.assertTrue(result.hasAccess());
+    Assert.assertEquals("", result.getFailureMessage());
+  }
+
+  @Test
+  public void testParameterizedConstructor() {
+    Set<String> failedTables = new HashSet<>();
+    failedTables.add("table1");
+    TableAuthorizationResult result = new TableAuthorizationResult(failedTables);
+    Assert.assertFalse(result.hasAccess());
+    Assert.assertTrue(result.getFailureMessage().contains("table1"));
+  }
+
+  @Test
+  public void testAddFailedTable() {
+    TableAuthorizationResult result = new TableAuthorizationResult();
+    result.addFailedTable("table1");
+    Assert.assertFalse(result.hasAccess());
+    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1,");
+  }
+
+  @Test
+  public void testSetGetFailedTables() {
+    TableAuthorizationResult result = new TableAuthorizationResult();
+    Set<String> failedTables = new HashSet<>();
+    failedTables.add("table1");
+    failedTables.add("table2");
+    result.setFailedTables(failedTables);
+    Assert.assertFalse(result.hasAccess());
+    Assert.assertEquals(result.getFailedTables(), failedTables);
+  }
+
+  @Test
+  public void testGetFailureMessage() {
+    TableAuthorizationResult result = new TableAuthorizationResult();
+    Assert.assertEquals("", result.getFailureMessage());
+
+    result.addFailedTable("table1");
+    result.addFailedTable("table2");
+    Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: table1, table2,");
+  }
+
+  @Test
+  public void testNoFailureResult() {
+    TableAuthorizationResult result = TableAuthorizationResult.noFailureResult();
+    Assert.assertTrue(result.hasAccess());
+    Assert.assertEquals("", result.getFailureMessage());
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/TableAuthorizationResultTest.java
@@ -28,13 +28,6 @@ import org.testng.annotations.Test;
 public class TableAuthorizationResultTest {
 
   @Test
-  public void testDefaultConstructor() {
-    TableAuthorizationResult result = new TableAuthorizationResult();
-    Assert.assertTrue(result.hasAccess());
-    Assert.assertEquals("", result.getFailureMessage());
-  }
-
-  @Test
   public void testParameterizedConstructor() {
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
@@ -62,9 +55,7 @@ public class TableAuthorizationResultTest {
 
   @Test
   public void testGetFailureMessage() {
-    TableAuthorizationResult result = new TableAuthorizationResult();
-    Assert.assertEquals("", result.getFailureMessage());
-    result = new TableAuthorizationResult(Set.of("table1", "table2"));
+    TableAuthorizationResult result = new TableAuthorizationResult(Set.of("table1", "table2"));
     Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }
 


### PR DESCRIPTION
 - Resolves https://github.com/apache/pinot/issues/13162 
 - This introdues a new interface `AuthorizationResult` to hold the Authorization decision and the corresponding message to be send back to caller 
 - This also makes the hasAccess(), authorize() methods of AccessControl.java with a default implementation , so the existing implementations continue to be backward compatible 

Tags: 
- enhancement
- observability
- multi-stage