### PR TITLE
allow resetting server stats; reset individual server stats when newly enabled

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -303,6 +303,14 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       return;
     }
 
+    if (_serverRoutingStatsManager.shouldResetStatsForNewServers()) {
+      // If a server is newly enabled but already has stats, that likely means it was
+      // restarted or replaced, so the old stats are no longer relevant.
+      for (String instance: newEnabledServers) {
+        _serverRoutingStatsManager.resetServerStats(instance);
+      }
+    }
+
     // Update routing entry for all tables
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -72,6 +72,7 @@ public class Actions {
     public static final String INGEST_FILE = "IngestFile";
     public static final String RECOMMEND_CONFIG = "RecommendConfig";
     public static final String RESET_SEGMENT = "ResetSegment";
+    public static final String RESET_SERVER_ROUTING_STATS = "ResetServerRoutingStats";
     public static final String RESUME_TASK = "ResumeTask";
     public static final String STOP_TASK = "StopTask";
     public static final String UPDATE_BROKER_RESOURCE = "UpdateBrokerResource";

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -99,20 +99,14 @@ public class ServerRoutingStatsManagerTest {
 
     List<Pair<String, Integer>> numInFlightReqList = manager.fetchNumInFlightRequestsForAllServers();
     assertTrue(numInFlightReqList.isEmpty());
-    Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer("testServer");
-    assertNull(numInFlightReq);
 
     List<Pair<String, Double>> latencyList = manager.fetchEMALatencyForAllServers();
     assertTrue(latencyList.isEmpty());
 
-    Double latency = manager.fetchEMALatencyForServer("testServer");
-    assertNull(latency);
-
     List<Pair<String, Double>> scoreList = manager.fetchHybridScoreForAllServers();
     assertTrue(scoreList.isEmpty());
 
-    Double score = manager.fetchHybridScoreForServer("testServer");
-    assertNull(score);
+    assertStatsNullForInstance(manager, "testServer");
   }
 
   @Test
@@ -309,6 +303,29 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(score, 10.0);
     score = manager.fetchHybridScoreForServer("server1");
     assertEquals(score, 54.0);
+
+    // assert true to ensure server1 is in the stats map
+    assertTrue(manager.resetServerStats("server1"));
+
+    // ensure server2 has not changeed
+    score = manager.fetchHybridScoreForServer("server2");
+    assertEquals(score, 10.0);
+    assertStatsNullForInstance(manager, "server1");
+
+    manager.resetAllServersStats();
+    assertStatsNullForInstance(manager, "server1");
+    assertStatsNullForInstance(manager, "server2");
+  }
+
+  private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {
+    Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer(instanceId);
+    assertNull(numInFlightReq);
+
+    Double latency = manager.fetchEMALatencyForServer(instanceId);
+    assertNull(latency);
+
+    Double score = manager.fetchHybridScoreForServer(instanceId);
+    assertNull(score);
   }
 
   private void waitForStatsUpdate(ServerRoutingStatsManager serverRoutingStatsManager, long taskCount) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -486,6 +486,12 @@ public class CommonConstants {
       public static final String CONFIG_OF_ENABLE_STATS_COLLECTION = CONFIG_PREFIX + ".enable.stats.collection";
       public static final boolean DEFAULT_ENABLE_STATS_COLLECTION = false;
 
+      // Determines whether the broker routing manager should reset stats when it sees a newly enabled server.
+      // When servers are restarted or replaced but keep the same instance id, it may not make sense to keep
+      // reusing the old stats. This config allows the broker to reset the stats for such servers.
+      public static final String CONFIG_OF_RESET_STATS_FOR_NEW_SERVERS = CONFIG_PREFIX + ".reset.stats.newServer";
+      public static final boolean DEFAULT_RESET_STATS_FOR_NEW_SERVERS = false;
+
       // Parameters to tune exponential moving average.
 
       // The weightage to be given for a new incoming value. For example, alpha=0.30 will give 30% weightage to the


### PR DESCRIPTION
This is a `feature` to allow
1. an API call to reset adaptive routing stats for 1 instance or all instances
2. add a config to automatically reset server stats for a new instance

This is a response to an issue we had a few months ago where adaptive routing was sending an outsized number of queries to 2 replicas out of 3 we had configured. Restarting the brokers fixed the issue.

Adding the API feels non-controversial, and we've added this to our incident playbooks as a potential remediation when we see skewed routing.

While we've tested the configuration to automatically reset server stats, we have not enabled it by default. It's not immediately clear if this is more valuable than just relying on autodecay, but as far as I can tell, if a server is removed and re-added, there's really no reason to keep the previous stats around as they will be invalid.

Unfortunately, it has been impossible to replicate the original incident, so we've mostly observed metrics in steady state or under synthetic load.

