### PR TITLE
Add back 'numRowsResultSet' to BrokerResponse, and retain it when result table is hidden

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -53,11 +53,10 @@ public interface BrokerResponse {
    */
   void setResultTable(@Nullable ResultTable resultTable);
 
-  @JsonIgnore
-  default int getNumRowsResultSet() {
-    ResultTable resultTable = getResultTable();
-    return resultTable != null ? resultTable.getRows().size() : 0;
-  }
+  /**
+   * Returns the number of rows in the result table.
+   */
+  int getNumRowsResultSet();
 
   /**
    * Returns whether the query doesn't guarantee to have the complete result due to exceptions or limits.

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -42,9 +42,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * This class can be used to serialize/deserialize the broker response.
  */
 @JsonPropertyOrder({
-    "resultTable", "partialResult", "exceptions", "numGroupsLimitReached", "timeUsedMs", "requestId", "brokerId",
-    "numDocsScanned", "totalDocs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numServersQueried",
-    "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched",
+    "resultTable", "numRowsResultSet", "partialResult", "exceptions", "numGroupsLimitReached", "timeUsedMs",
+    "requestId", "brokerId", "numDocsScanned", "totalDocs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
+    "numServersQueried", "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched",
     "numConsumingSegmentsQueried", "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched",
     "minConsumingFreshnessTimeMs", "numSegmentsPrunedByBroker", "numSegmentsPrunedByServer",
     "numSegmentsPrunedInvalid", "numSegmentsPrunedByLimit", "numSegmentsPrunedByValue", "brokerReduceTimeMs",
@@ -63,6 +63,7 @@ public class BrokerResponseNative implements BrokerResponse {
   public static final BrokerResponseNative BROKER_ONLY_EXPLAIN_PLAN_OUTPUT = getBrokerResponseExplainPlanOutput();
 
   private ResultTable _resultTable;
+  private int _numRowsResultSet = 0;
   private List<QueryProcessingException> _exceptions = new ArrayList<>();
   private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
@@ -142,6 +143,20 @@ public class BrokerResponseNative implements BrokerResponse {
   @Override
   public void setResultTable(@Nullable ResultTable resultTable) {
     _resultTable = resultTable;
+    // NOTE: Update _numRowsResultSet when setting non-null result table. We might set null result table when user wants
+    //       to hide the result but only show the stats, in which case we should not update _numRowsResultSet.
+    if (resultTable != null) {
+      _numRowsResultSet = resultTable.getRows().size();
+    }
+  }
+
+  @Override
+  public int getNumRowsResultSet() {
+    return _numRowsResultSet;
+  }
+
+  public void setNumRowsResultSet(int numRowsResultSet) {
+    _numRowsResultSet = numRowsResultSet;
   }
 
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -36,7 +36,7 @@ import org.apache.pinot.common.response.ProcessingException;
  * TODO: Currently this class cannot be used to deserialize the JSON response.
  */
 @JsonPropertyOrder({
-    "resultTable", "partialResult", "exceptions", "numGroupsLimitReached", "maxRowsInJoinReached",
+    "resultTable", "numRowsResultSet", "partialResult", "exceptions", "numGroupsLimitReached", "maxRowsInJoinReached",
     "maxRowsInWindowReached", "timeUsedMs", "stageStats", "maxRowsInOperator", "requestId", "brokerId",
     "numDocsScanned", "totalDocs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numServersQueried",
     "numServersResponded", "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched",
@@ -52,6 +52,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   private final List<QueryProcessingException> _exceptions = new ArrayList<>();
 
   private ResultTable _resultTable;
+  private int _numRowsResultSet;
   private boolean _maxRowsInJoinReached;
   private boolean _maxRowsInWindowReached;
   private long _timeUsedMs;
@@ -83,6 +84,16 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @Override
   public void setResultTable(@Nullable ResultTable resultTable) {
     _resultTable = resultTable;
+    // NOTE: Update _numRowsResultSet when setting non-null result table. We might set null result table when user wants
+    //       to hide the result but only show the stats, in which case we should not update _numRowsResultSet.
+    if (resultTable != null) {
+      _numRowsResultSet = resultTable.getRows().size();
+    }
+  }
+
+  @Override
+  public int getNumRowsResultSet() {
+    return _numRowsResultSet;
   }
 
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)


### PR DESCRIPTION
This field was removed in #13179 