### PR TITLE
ensure inverse And/OrFilterOperator implementations match the query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -61,13 +61,11 @@ public class AndFilterOperator extends BaseFilterOperator {
   @Override
   protected BlockDocIdSet getFalses() {
     List<BlockDocIdSet> blockDocIdSets = new ArrayList<>(_filterOperators.size());
-    boolean matchedAll = false;
     for (BaseFilterOperator filterOperator : _filterOperators) {
       if (filterOperator.isResultEmpty()) {
         return new MatchAllDocIdSet(_numDocs);
       }
       if (filterOperator.isResultMatchingAll()) {
-        matchedAll = true;
         continue;
       }
       if (_nullHandlingEnabled) {
@@ -77,7 +75,7 @@ public class AndFilterOperator extends BaseFilterOperator {
       }
       blockDocIdSets.add(filterOperator.getTrues());
     }
-    if (blockDocIdSets.isEmpty() && matchedAll) {
+    if (blockDocIdSets.isEmpty()) {
       return EmptyDocIdSet.getInstance();
     }
     return new NotDocIdSet(new AndDocIdSet(blockDocIdSets, _queryOptions), _numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -60,7 +60,12 @@ public class AndFilterOperator extends BaseFilterOperator {
   protected BlockDocIdSet getFalses() {
     List<BlockDocIdSet> blockDocIdSets = new ArrayList<>(_filterOperators.size());
     for (BaseFilterOperator filterOperator : _filterOperators) {
-      blockDocIdSets.add(new OrDocIdSet(Arrays.asList(filterOperator.getTrues(), filterOperator.getNulls()), _numDocs));
+      if (_nullHandlingEnabled) {
+        blockDocIdSets.add(
+            new OrDocIdSet(Arrays.asList(filterOperator.getTrues(), filterOperator.getNulls()), _numDocs));
+      } else {
+        blockDocIdSets.add(filterOperator.getTrues());
+      }
     }
     return new NotDocIdSet(new AndDocIdSet(blockDocIdSets, _queryOptions), _numDocs);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -61,13 +61,13 @@ public class AndFilterOperator extends BaseFilterOperator {
   @Override
   protected BlockDocIdSet getFalses() {
     List<BlockDocIdSet> blockDocIdSets = new ArrayList<>(_filterOperators.size());
+    boolean matchedAll = false;
     for (BaseFilterOperator filterOperator : _filterOperators) {
       if (filterOperator.isResultEmpty()) {
-        blockDocIdSets.add(EmptyDocIdSet.getInstance());
-        continue;
+        return new MatchAllDocIdSet(_numDocs);
       }
       if (filterOperator.isResultMatchingAll()) {
-        blockDocIdSets.add(new MatchAllDocIdSet(_numDocs));
+        matchedAll = true;
         continue;
       }
       if (_nullHandlingEnabled) {
@@ -76,6 +76,9 @@ public class AndFilterOperator extends BaseFilterOperator {
         continue;
       }
       blockDocIdSets.add(filterOperator.getTrues());
+    }
+    if (blockDocIdSets.isEmpty() && matchedAll) {
+      return EmptyDocIdSet.getInstance();
     }
     return new NotDocIdSet(new AndDocIdSet(blockDocIdSets, _queryOptions), _numDocs);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -69,10 +69,12 @@ public class AndFilterOperator extends BaseFilterOperator {
       if (trues instanceof MatchAllDocIdSet) {
         continue;
       }
-      BlockDocIdSet nulls = filterOperator.getNulls();
-      if (_nullHandlingEnabled && !(nulls instanceof EmptyDocIdSet)) {
-        blockDocIdSets.add(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs));
-        continue;
+      if (_nullHandlingEnabled) {
+        BlockDocIdSet nulls = filterOperator.getNulls();
+        if (!(nulls instanceof EmptyDocIdSet)) {
+          blockDocIdSets.add(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs));
+          continue;
+        }
       }
       blockDocIdSets.add(trues);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -23,6 +23,7 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
+import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 import org.apache.pinot.core.operator.docidsets.NotDocIdSet;
 import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
 
@@ -102,11 +103,16 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
    * @return document IDs in which the predicate evaluates to false.
    */
   protected BlockDocIdSet getFalses() {
+    if (isResultMatchingAll()) {
+      return EmptyDocIdSet.getInstance();
+    }
+    if (isResultEmpty()) {
+      return new MatchAllDocIdSet(_numDocs);
+    }
     if (_nullHandlingEnabled) {
       return new NotDocIdSet(new OrDocIdSet(Arrays.asList(getTrues(), getNulls()), _numDocs),
           _numDocs);
-    } else {
-      return new NotDocIdSet(getTrues(), _numDocs);
     }
+    return new NotDocIdSet(getTrues(), _numDocs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -107,13 +107,13 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
     if (trues instanceof MatchAllDocIdSet) {
       return EmptyDocIdSet.getInstance();
     }
-    if (trues instanceof EmptyDocIdSet) {
-      return new MatchAllDocIdSet(_numDocs);
-    }
     BlockDocIdSet nulls = getNulls();
     if (_nullHandlingEnabled && !(nulls instanceof EmptyDocIdSet)) {
       return new NotDocIdSet(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs),
           _numDocs);
+    }
+    if (trues instanceof EmptyDocIdSet) {
+      return new MatchAllDocIdSet(_numDocs);
     }
     return new NotDocIdSet(trues, _numDocs);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -103,16 +103,18 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
    * @return document IDs in which the predicate evaluates to false.
    */
   protected BlockDocIdSet getFalses() {
-    if (isResultMatchingAll()) {
+    BlockDocIdSet trues = getTrues();
+    if (trues instanceof MatchAllDocIdSet) {
       return EmptyDocIdSet.getInstance();
     }
-    if (isResultEmpty()) {
+    if (trues instanceof EmptyDocIdSet) {
       return new MatchAllDocIdSet(_numDocs);
     }
-    if (_nullHandlingEnabled) {
-      return new NotDocIdSet(new OrDocIdSet(Arrays.asList(getTrues(), getNulls()), _numDocs),
+    BlockDocIdSet nulls = getNulls();
+    if (_nullHandlingEnabled && !(nulls instanceof EmptyDocIdSet)) {
+      return new NotDocIdSet(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs),
           _numDocs);
     }
-    return new NotDocIdSet(getTrues(), _numDocs);
+    return new NotDocIdSet(trues, _numDocs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -107,10 +107,12 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
     if (trues instanceof MatchAllDocIdSet) {
       return EmptyDocIdSet.getInstance();
     }
-    BlockDocIdSet nulls = getNulls();
-    if (_nullHandlingEnabled && !(nulls instanceof EmptyDocIdSet)) {
-      return new NotDocIdSet(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs),
-          _numDocs);
+    if (_nullHandlingEnabled) {
+      BlockDocIdSet nulls = getNulls();
+      if (!(nulls instanceof EmptyDocIdSet)) {
+        return new NotDocIdSet(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs),
+            _numDocs);
+      }
     }
     if (trues instanceof EmptyDocIdSet) {
       return new MatchAllDocIdSet(_numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -65,6 +65,7 @@ public class OrFilterOperator extends BaseFilterOperator {
         blockDocIdSets.add(filterOperator.getFalses());
       }
     }
+    // Consider handling this as the query is written, with OrDocIdSet, so that the explain plan reflects the execution
     return new AndDocIdSet(blockDocIdSets, _queryOptions);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -60,13 +60,13 @@ public class OrFilterOperator extends BaseFilterOperator {
   @Override
   protected BlockDocIdSet getFalses() {
     List<BlockDocIdSet> blockDocIdSets = new ArrayList<>(_filterOperators.size());
+    boolean foundEmpty = false;
     for (BaseFilterOperator filterOperator : _filterOperators) {
-      if (filterOperator.isResultEmpty()) {
-        blockDocIdSets.add(EmptyDocIdSet.getInstance());
-        continue;
-      }
       if (filterOperator.isResultMatchingAll()) {
-        blockDocIdSets.add(new MatchAllDocIdSet(_numDocs));
+        return EmptyDocIdSet.getInstance();
+      }
+      if (filterOperator.isResultEmpty()) {
+        foundEmpty = true;
         continue;
       }
       if (_nullHandlingEnabled) {
@@ -75,6 +75,9 @@ public class OrFilterOperator extends BaseFilterOperator {
         continue;
       }
       blockDocIdSets.add(filterOperator.getTrues());
+    }
+    if (blockDocIdSets.isEmpty() && foundEmpty) {
+      return new MatchAllDocIdSet(_numDocs);
     }
     return new NotDocIdSet(new OrDocIdSet(blockDocIdSets, _numDocs), _numDocs);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -68,10 +68,12 @@ public class OrFilterOperator extends BaseFilterOperator {
       if (trues instanceof EmptyDocIdSet) {
         continue;
       }
-      BlockDocIdSet nulls = filterOperator.getNulls();
-      if (_nullHandlingEnabled && !(nulls instanceof EmptyDocIdSet)) {
-        blockDocIdSets.add(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs));
-        continue;
+      if (_nullHandlingEnabled) {
+        BlockDocIdSet nulls = filterOperator.getNulls();
+        if (!(nulls instanceof EmptyDocIdSet)) {
+          blockDocIdSets.add(new OrDocIdSet(Arrays.asList(trues, nulls), _numDocs));
+          continue;
+        }
       }
       blockDocIdSets.add(trues);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -60,13 +60,11 @@ public class OrFilterOperator extends BaseFilterOperator {
   @Override
   protected BlockDocIdSet getFalses() {
     List<BlockDocIdSet> blockDocIdSets = new ArrayList<>(_filterOperators.size());
-    boolean foundEmpty = false;
     for (BaseFilterOperator filterOperator : _filterOperators) {
       if (filterOperator.isResultMatchingAll()) {
         return EmptyDocIdSet.getInstance();
       }
       if (filterOperator.isResultEmpty()) {
-        foundEmpty = true;
         continue;
       }
       if (_nullHandlingEnabled) {
@@ -76,7 +74,7 @@ public class OrFilterOperator extends BaseFilterOperator {
       }
       blockDocIdSets.add(filterOperator.getTrues());
     }
-    if (blockDocIdSets.isEmpty() && foundEmpty) {
+    if (blockDocIdSets.isEmpty()) {
       return new MatchAllDocIdSet(_numDocs);
     }
     return new NotDocIdSet(new OrDocIdSet(blockDocIdSets, _numDocs), _numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TestFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TestFilterOperator.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
+import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 import org.apache.pinot.segment.spi.Constants;
 
 
@@ -56,11 +58,20 @@ public class TestFilterOperator extends BaseFilterOperator {
 
   @Override
   protected BlockDocIdSet getTrues() {
+    if (_trueDocIds.length == _numDocs) {
+      return new MatchAllDocIdSet(_numDocs);
+    }
+    if (_trueDocIds.length == 0) {
+      return EmptyDocIdSet.getInstance();
+    }
     return new TestBlockDocIdSet(_trueDocIds);
   }
 
   @Override
   protected BlockDocIdSet getNulls() {
+    if (_nullDocIds.length == 0) {
+      return EmptyDocIdSet.getInstance();
+    }
     return new TestBlockDocIdSet(_nullDocIds);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
@@ -208,4 +208,19 @@ public class AndFilterOperatorTest {
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()),
         ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
   }
+
+  @Test
+  public void testAndWithNullOneFilterMatchesAll() {
+    int numDocs = 10;
+    int[] docIds1 = new int[]{1, 2, 3};
+    int[] nullDocIds1 = new int[]{4, 5, 6};
+
+    AndFilterOperator andFilterOperator = new AndFilterOperator(
+        Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs), new MatchAllFilterOperator(numDocs)), null,
+        numDocs, true);
+
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()), ImmutableList.of(1, 2, 3));
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()),
+        ImmutableList.of(0, 7, 8, 9));
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
@@ -179,6 +179,22 @@ public class AndFilterOperatorTest {
   }
 
   @Test
+  public void testAndWithNullHandlingDisabled() {
+    int numDocs = 4;
+    int[] docIds1 = new int[]{0, 3};
+    int[] docIds2 = new int[]{0, 1};
+    int[] nullDocIds1 = new int[]{};
+    int[] nullDocIds2 = new int[]{};
+
+    AndFilterOperator andFilterOperator = new AndFilterOperator(
+        Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs),
+            new TestFilterOperator(docIds2, nullDocIds2, numDocs)), null, numDocs, false);
+
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()), ImmutableList.of(0));
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()), ImmutableList.of(1, 2, 3));
+  }
+
+  @Test
   public void testAndWithNullOneFilterIsEmpty() {
     int numDocs = 10;
     int[] docIds1 = new int[]{1, 2, 3};

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
@@ -220,7 +220,18 @@ public class AndFilterOperatorTest {
         numDocs, true);
 
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()), ImmutableList.of(1, 2, 3));
-    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()),
-        ImmutableList.of(0, 7, 8, 9));
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()), ImmutableList.of(0, 7, 8, 9));
+  }
+
+  @Test
+  public void testAndWithAllMatchesAll() {
+    int numDocs = 10;
+    AndFilterOperator andFilterOperator =
+        new AndFilterOperator(Arrays.asList(new MatchAllFilterOperator(numDocs), new MatchAllFilterOperator(numDocs)),
+            null, numDocs, true);
+
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()),
+        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()), Collections.emptyList());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BaseFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BaseFilterOperatorTest.java
@@ -74,7 +74,6 @@ public class BaseFilterOperatorTest {
     int[] nullDocIds = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, nullDocIds, numDocs);
     Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()), Collections.emptyList());
-    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()),
-        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()), Collections.emptyList());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BaseFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BaseFilterOperatorTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BaseFilterOperatorTest {
+
+  @Test
+  public void testBaseWithFalses() {
+    int numDocs = 10;
+    int[] docIds = new int[]{0, 1, 2, 3};
+    TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, numDocs);
+
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()), ImmutableList.of(0, 1, 2, 3));
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()), ImmutableList.of(4, 5, 6, 7, 8, 9));
+  }
+
+  @Test
+  public void testBaseWithNullHandling() {
+    int numDocs = 10;
+    int[] docIds = new int[]{0, 1, 2, 3};
+    int[] nullDocIds = new int[]{4, 5, 6, 7, 8, 9};
+    TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, nullDocIds, numDocs);
+
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()), ImmutableList.of(0, 1, 2, 3));
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()), Collections.emptyList());
+  }
+
+  @Test
+  public void testBaseWithAllTrue() {
+    int numDocs = 10;
+    int[] docIds = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, numDocs);
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()),
+        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()), Collections.emptyList());
+  }
+
+  @Test
+  public void testBaseWithAllFalse() {
+    int numDocs = 10;
+    int[] docIds = new int[]{};
+    TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, numDocs);
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()), Collections.emptyList());
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()),
+        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+  }
+
+  @Test
+  public void testBaseWithAllNulls() {
+    int numDocs = 10;
+    int[] docIds = new int[]{};
+    int[] nullDocIds = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    TestFilterOperator testFilterOperator = new TestFilterOperator(docIds, nullDocIds, numDocs);
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getTrues()), Collections.emptyList());
+    Assert.assertEquals(TestUtils.getDocIds(testFilterOperator.getFalses()),
+        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/OrFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/OrFilterOperatorTest.java
@@ -169,4 +169,16 @@ public class OrFilterOperatorTest {
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getTrues()), Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getFalses()), Collections.emptyList());
   }
+
+  @Test
+  public void testOrWithAllEmpty() {
+    int numDocs = 10;
+
+    OrFilterOperator orFilterOperator =
+        new OrFilterOperator(Arrays.asList(EmptyFilterOperator.getInstance(), EmptyFilterOperator.getInstance()), null,
+            numDocs, true);
+
+    Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getTrues()), Collections.emptyList());
+    Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getFalses()), Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+  }
 }


### PR DESCRIPTION
Problem: https://github.com/apache/pinot/pull/11185 added proper support for null handling. One side effect is that the order of execution was changed, which has performance implications for queries where a bitmap based filter operator can reduce evaluating some expression like `regexp_like` as many times. In summary, `NOT (a AND b)` is executed as `NOT a OR NOT b`.

For example, affected queries could look like:
```
NOT (text_match(col, '...') AND regexp_like(col, '...'))
```

In this case, the PR changed `NotFilterOperator` to use `AndFilterOperator.getFalses()` which [builds an `OrDocIdSet` from the false DocIdSets](https://github.com/apache/pinot/pull/11185/files#diff-13077035b35ccc6f9b73625c2315d9571a80fd9fedcec2d75f689f9b335e22aaR59-R68) instead of using a `NotDocIdIterator` built from the `AndDocIdSet` as was done in the old implementation.

This PR changes implementation back to the first, except also handles nulls properly. 

tags: `bugfix` `performance`