### PR TITLE
Ensure brokerId and requestId are always set in BrokerResponse

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -124,6 +124,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     BrokerResponse brokerResponse =
         handleRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
             accessControl);
+    brokerResponse.setBrokerId(_brokerId);
+    brokerResponse.setRequestId(Long.toString(requestId));
     _brokerQueryEventListener.onQueryCompletion(requestContext);
 
     return brokerResponse;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -215,8 +215,6 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     updatePhaseTimingForTables(tableNames, BrokerQueryPhase.QUERY_EXECUTION, executionEndTimeNs - executionStartTimeNs);
 
     BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
-    brokerResponse.setBrokerId(_brokerId);
-    brokerResponse.setRequestId(Long.toString(requestId));
     brokerResponse.setResultTable(queryResults.getResultTable());
     // TODO: Add servers queried/responded stats
     brokerResponse.setBrokerReduceTimeMs(queryResults.getBrokerReduceTimeMs());
@@ -230,6 +228,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       brokerResponse.addException(QueryException.getException(QueryException.SERVER_SEGMENT_MISSING_ERROR,
           String.format("Find unavailable segments: %s for table: %s", unavailableSegments, tableName)));
     }
+    requestContext.setNumUnavailableSegments(numUnavailableSegments);
 
     fillOldBrokerResponseStats(brokerResponse, queryResults.getQueryStats(), dispatchableSubPlan);
 
@@ -244,8 +243,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     // Log query and stats
     _queryLogger.log(
-        new QueryLogger.QueryLogParams(query, tableNames.toString(), numUnavailableSegments, null, brokerResponse,
-            requesterIdentity));
+        new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse, requesterIdentity, null));
 
     return brokerResponse;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -105,9 +105,19 @@ public interface BrokerResponse {
   String getRequestId();
 
   /**
+   * Sets the request ID of the query.
+   */
+  void setRequestId(String requestId);
+
+  /**
    * Returns the broker ID that handled the query.
    */
   String getBrokerId();
+
+  /**
+   * Sets the broker ID that handled the query.
+   */
+  void setBrokerId(String brokerId);
 
   /**
    * Returns the number of documents selected (matching the filter) for the query.

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -217,6 +217,7 @@ public class BrokerResponseNative implements BrokerResponse {
     return _requestId;
   }
 
+  @Override
   public void setRequestId(String requestId) {
     _requestId = requestId;
   }
@@ -226,6 +227,7 @@ public class BrokerResponseNative implements BrokerResponse {
     return _brokerId;
   }
 
+  @Override
   public void setBrokerId(String brokerId) {
     _brokerId = brokerId;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -178,6 +178,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     return _requestId;
   }
 
+  @Override
   public void setRequestId(String requestId) {
     _requestId = requestId;
   }
@@ -187,6 +188,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     return _brokerId;
   }
 
+  @Override
   public void setBrokerId(String brokerId) {
     _brokerId = brokerId;
   }


### PR DESCRIPTION
- Always attach brokerId and requestId, even for errored request
- Set `numUnavailableSegments` into `RequestContext` for multi-stage query