### PR TITLE
Refactored CommonsConfigurationUtils for loading properties configuration.

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -122,8 +122,6 @@ public class CommonsConfigurationUtils {
     // check if file exists, load the properties otherwise set the file.
     if (file.exists()) {
       fileHandler.load(file);
-    } else {
-      fileHandler.setFile(file);
     }
     return config;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -84,11 +84,15 @@ public class CommonsConfigurationUtils {
    * @param setDefaultDelimiter representing to set the default list delimiter.
    * @return a {@link PropertiesConfiguration} instance.
    */
-  public static PropertiesConfiguration fromPath(String path, boolean setIOFactory, boolean setDefaultDelimiter)
+  public static PropertiesConfiguration fromPath(@Nullable String path, boolean setIOFactory,
+      boolean setDefaultDelimiter)
       throws ConfigurationException {
     PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
-    FileHandler fileHandler = new FileHandler(config);
-    fileHandler.load(path);
+    // if provided path is non-empty, load the existing properties from provided file path
+    if (StringUtils.isNotEmpty(path)) {
+      FileHandler fileHandler = new FileHandler(config);
+      fileHandler.load(path);
+    }
     return config;
   }
 
@@ -99,12 +103,15 @@ public class CommonsConfigurationUtils {
    * @param setDefaultDelimiter representing to set the default list delimiter.
    * @return a {@link PropertiesConfiguration} instance.
    */
-  public static PropertiesConfiguration fromInputStream(InputStream stream, boolean setIOFactory,
+  public static PropertiesConfiguration fromInputStream(@Nullable InputStream stream, boolean setIOFactory,
       boolean setDefaultDelimiter)
       throws ConfigurationException {
     PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
-    FileHandler fileHandler = new FileHandler(config);
-    fileHandler.load(stream);
+    // if provided stream is not null, load the existing properties from provided input stream.
+    if (stream != null) {
+      FileHandler fileHandler = new FileHandler(config);
+      fileHandler.load(stream);
+    }
     return config;
   }
 
@@ -115,12 +122,12 @@ public class CommonsConfigurationUtils {
    * @param setDefaultDelimiter representing to set the default list delimiter.
    * @return a {@link PropertiesConfiguration} instance.
    */
-  public static PropertiesConfiguration fromFile(File file, boolean setIOFactory, boolean setDefaultDelimiter)
+  public static PropertiesConfiguration fromFile(@Nullable File file, boolean setIOFactory, boolean setDefaultDelimiter)
       throws ConfigurationException {
     PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
-    FileHandler fileHandler = new FileHandler(config);
-    // check if file exists, load the properties otherwise set the file.
-    if (file.exists()) {
+    // check if file exists, load the existing properties.
+    if (file != null && file.exists()) {
+      FileHandler fileHandler = new FileHandler(config);
       fileHandler.load(file);
     }
     return config;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
@@ -19,8 +19,11 @@
 package org.apache.pinot.spi.env;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -118,5 +122,45 @@ public class CommonsConfigurationUtilsTest {
     recoveredValue = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(
         (String) configuration.getProperty(PROPERTY_KEY));
     assertEquals(recoveredValue, value);
+  }
+
+  @Test
+  public void testPropertiesConfigurationFromFile()
+      throws ConfigurationException {
+    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromFile(null, false, true);
+    assertNotNull(configuration);
+    configuration.setProperty("Test Key", "Test Value");
+    CommonsConfigurationUtils.saveToFile(configuration, CONFIG_FILE);
+
+    configuration = CommonsConfigurationUtils.fromFile(CONFIG_FILE, false, true);
+    assertNotNull(configuration);
+    assertEquals(configuration.getProperty("Test Key"), "Test Value");
+  }
+
+  @Test
+  public void testPropertiesConfigurationFromPath()
+      throws ConfigurationException {
+    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromPath(null, false, true);
+    assertNotNull(configuration);
+    configuration.setProperty("Test Key", "Test Value");
+    CommonsConfigurationUtils.saveToFile(configuration, CONFIG_FILE);
+
+    configuration = CommonsConfigurationUtils.fromPath(CONFIG_FILE.getPath(), false, true);
+    assertNotNull(configuration);
+    assertEquals(configuration.getProperty("Test Key"), "Test Value");
+  }
+
+  @Test
+  public void testPropertiesConfigurationFromInputStream()
+      throws ConfigurationException, FileNotFoundException {
+    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromInputStream(null, false, true);
+    assertNotNull(configuration);
+    configuration.setProperty("Test Key", "Test Value");
+    CommonsConfigurationUtils.saveToFile(configuration, CONFIG_FILE);
+
+    FileInputStream inputStream = new FileInputStream(CONFIG_FILE);
+    configuration = CommonsConfigurationUtils.fromInputStream(inputStream, false, true);
+    assertNotNull(configuration);
+    assertEquals(configuration.getProperty("Test Key"), "Test Value");
   }
 }


### PR DESCRIPTION

As per the [PR comment ](https://github.com/apache/pinot/pull/12440#discussion_r1608770485), we are unnecessarily [setting the file](https://github.com/apache/pinot/blob/ca7ab248dca7e1247ec6739fd6068aadc98255b7/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java#L126) in case it doesn't exist. 

Similarly, for the other functions
- In util function `fromPath`([reference](https://github.com/apache/pinot/blob/ca7ab248dca7e1247ec6739fd6068aadc98255b7/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java#L91)), there is a possibility of `ConfigurationException,` if provided path value is null.
- In util function `fromInputStream`([reference](https://github.com/apache/pinot/blob/ca7ab248dca7e1247ec6739fd6068aadc98255b7/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java#L107)), again there is the possibility of the `ConfigurationException`

In this PR, we handle such scenarios and add the UTs corresponding to the util function.

cc: @klsince / @Jackie-Jiang 