### PR TITLE
Update consuming freshness field in query resp to be backed by the server reported ingestion delay timestamp

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -325,7 +325,7 @@ public class IngestionDelayTracker {
     // Not protected as this will only be invoked when metric is installed which happens after server ready
     IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
     if (currentMeasure == null) { // Guard just in case we read the metric without initializing it
-      return 0;
+      return Long.MIN_VALUE;
     }
     return currentMeasure._ingestionTimeMs;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -315,6 +315,22 @@ public class IngestionDelayTracker {
   }
 
   /*
+   * Method to get timestamp used for the ingestion delay for a given partition.
+   *
+   * @param partitionGroupId partition for which we are retrieving the delay
+   *
+   * @return ingestion delay timestamp in milliseconds for the given partition ID.
+   */
+  public long getPartitionIngestionTimeMs(int partitionGroupId) {
+    // Not protected as this will only be invoked when metric is installed which happens after server ready
+    IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
+    if (currentMeasure == null) { // Guard just in case we read the metric without initializing it
+      return 0;
+    }
+    return currentMeasure._ingestionTimeMs;
+  }
+
+  /*
    * Method to get ingestion delay for a given partition.
    *
    * @param partitionGroupId partition for which we are retrieving the delay

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -272,6 +272,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   /*
+   * Method used during query execution (ServerQueryExecutorV1Impl) to get the current timestamp for the ingestion
+   * delay for a partition
+   *
+   * @param segmentNameStr name of segment for which we want the ingestion delay timestamp.
+   * @return timestamp of the ingestion delay for the partition.
+   */
+  public long getPartitionIngestionTimeMs(String segmentNameStr) {
+    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
+    int partitionGroupId = segmentName.getPartitionGroupId();
+    return _ingestionDelayTracker.getPartitionIngestionTimeMs(partitionGroupId);
+  }
+
+  /*
    * Method to handle CONSUMING -> DROPPED segment state transitions:
    * We stop tracking partitions whose segments are dropped.
    *

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -236,7 +236,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           if (indexTimeMs > 0) {
             minIndexTimeMs = Math.min(minIndexTimeMs, indexTimeMs);
           }
-          long ingestionTimeMs = segmentMetadata.getLatestIngestionTimestamp();
+          long ingestionTimeMs = ((RealtimeTableDataManager)
+              tableDataManager).getPartitionIngestionTimeMs(indexSegment.getSegmentName());
           if (ingestionTimeMs > 0) {
             minIngestionTimeMs = Math.min(minIngestionTimeMs, ingestionTimeMs);
           }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -50,6 +50,10 @@ public class IngestionDelayTrackerTest {
     // Test regular constructor
     IngestionDelayTracker ingestionDelayTracker =
         new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, () -> true);
+
+    Clock clock = Clock.systemUTC();
+    ingestionDelayTracker.setClock(clock);
+
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), 0);
     ingestionDelayTracker.shutdown();
@@ -60,7 +64,8 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), 0);
     // Test bad timer args to the constructor
     try {
-      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, 0, () -> true);
+      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
+          0, () -> true);
       Assert.fail("Must have asserted due to invalid arguments"); // Constructor must assert
     } catch (Exception e) {
       if ((e instanceof NullPointerException) || !(e instanceof RuntimeException)) {
@@ -218,7 +223,8 @@ public class IngestionDelayTrackerTest {
       // Untracked partitions must return 0
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionGroupId), 0);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionGroupId), 0);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionGroupId), 0);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(
+          partitionGroupId), 0);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -55,13 +55,13 @@ public class IngestionDelayTrackerTest {
     ingestionDelayTracker.setClock(clock);
 
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
     ingestionDelayTracker.shutdown();
     // Test constructor with timer arguments
     ingestionDelayTracker = new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
         TIMER_THREAD_TICK_INTERVAL_MS, () -> true);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
     // Test bad timer args to the constructor
     try {
       new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
@@ -224,7 +224,7 @@ public class IngestionDelayTrackerTest {
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionGroupId), 0);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionGroupId), 0);
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(
-          partitionGroupId), 0);
+          partitionGroupId), Long.MIN_VALUE);
     }
   }
 


### PR DESCRIPTION
This updates the `minConsumingFreshnessTimestampMs` query response metadata field to be backed by the `REALTIME_INGESTION_DELAY_MS metric's timestamp` (backed by the [IngestionDelayTracker](https://github.com/apache/pinot/blob/29c560f523bab4529e6685c7df061105d8dc3df1/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java#L43) class).
The current implementation can cause false positives because low volume partitions, even on a high-volume table could make it seem like there is lag where this is not in reality. This makes it hard to reliably trust/use this metric to make any decisions

**Previous behaviour:**
- uses the last ingestion timestamp & low volume partitions will cause this metric to suggest there is lag when there may not be

**New behaviour:**
- uses the last ingestion timestamp, though partitions with no messages to consume will be reported as near-realtime (preventing low volume partitions from inflating the lag). If there is real lag, the metric will ofcourse spike when an incoming messages' last ingestion timestamp is indexed. This is how the [IngestionDelayTracker](https://github.com/apache/pinot/blob/29c560f523bab4529e6685c7df061105d8dc3df1/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java#L43) works

**Unchanged:**
- will report as 0 if no consuming segments are queried 

This is prone to the issue described in https://github.com/apache/pinot/issues/11448, which we should prioritize fixing but I do think the benefits still outweigh that con in terms of this PR

**Testing:**
- updated tests
- did a load test on internally in stripe to compare before/after incase there is performance diffs related to `getPartitionIngestionTimeMs` but turned out to be no diff
- test failures look unrelated, I think random failures, likely pass on re-running
