### PR TITLE
update access control check error handling to catch throwable and log errors

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -70,9 +70,8 @@ public final class AccessControlUtils {
     } catch (Throwable t) {
       // catch and log Throwable for NoSuchMethodError which can happen when there are classpath conflicts
       // otherwise, grizzly will return a 500 without any logs or indication of what failed
-      LOGGER.error("Caught exception while validating permission for {}", userMessage, t);
-      throw new ControllerApplicationException(LOGGER, "Caught exception while validating permission for "
-          + userMessage, Response.Status.INTERNAL_SERVER_ERROR, t);
+      throw new ControllerApplicationException(LOGGER,
+          "Caught exception while validating permission for " + userMessage, Response.Status.INTERNAL_SERVER_ERROR, t);
     }
 
     throw new ControllerApplicationException(LOGGER, "Permission is denied for " + userMessage,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -67,9 +67,12 @@ public final class AccessControlUtils {
     } catch (WebApplicationException exception) {
       // throwing the exception if it's WebApplicationException
       throw exception;
-    } catch (Exception e) {
+    } catch (Throwable t) {
+      // catch and log Throwable for NoSuchMethodError which can happen when there are classpath conflicts
+      // otherwise, grizzly will return a 500 without any logs or indication of what failed
+      LOGGER.error("Caught exception while validating permission for {}", userMessage, t);
       throw new ControllerApplicationException(LOGGER, "Caught exception while validating permission for "
-          + userMessage, Response.Status.INTERNAL_SERVER_ERROR, e);
+          + userMessage, Response.Status.INTERNAL_SERVER_ERROR, t);
     }
 
     throw new ControllerApplicationException(LOGGER, "Permission is denied for " + userMessage,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.controller.api.access;
 
 import javax.ws.rs.core.HttpHeaders;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -27,19 +27,18 @@ import org.testng.annotations.Test;
 
 public class AccessControlUtilsTest {
 
-    private final String table = "testTable";
-    private final String endpoint = "/testEndpoint";
+    private final String _table = "testTable";
+    private final String _endpoint = "/testEndpoint";
 
     @Test
     public void testValidatePermissionAllowed() {
         AccessControl ac = Mockito.mock(AccessControl.class);
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-        Mockito.when(ac.hasAccess(table, AccessType.READ,
-            mockHttpHeaders, endpoint)).thenReturn(true);
+        Mockito.when(ac.hasAccess(_table, AccessType.READ,
+            mockHttpHeaders, _endpoint)).thenReturn(true);
 
-        AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
-                endpoint, ac);
+        AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
     }
 
     @Test
@@ -47,12 +46,11 @@ public class AccessControlUtilsTest {
         AccessControl ac = Mockito.mock(AccessControl.class);
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-        Mockito.when(ac.hasAccess(table, AccessType.READ,
-                mockHttpHeaders, endpoint)).thenReturn(false);
+        Mockito.when(ac.hasAccess(_table, AccessType.READ,
+                mockHttpHeaders, _endpoint)).thenReturn(false);
 
         try {
-            AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
-                    endpoint, ac);
+            AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
             Assert.fail("Expected ControllerApplicationException");
         } catch (ControllerApplicationException e) {
             Assert.assertTrue(e.getMessage().contains("Permission is denied"));
@@ -65,13 +63,12 @@ public class AccessControlUtilsTest {
         AccessControl ac = Mockito.mock(AccessControl.class);
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-        Mockito.when(ac.hasAccess(table, AccessType.READ,
-                mockHttpHeaders, endpoint))
+        Mockito.when(ac.hasAccess(_table, AccessType.READ,
+                mockHttpHeaders, _endpoint))
                 .thenThrow(new NoSuchMethodError("Method not found"));
 
         try {
-            AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
-                    endpoint, ac);
+            AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
         } catch (ControllerApplicationException e) {
             Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission"));
             Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -1,0 +1,60 @@
+package org.apache.pinot.controller.api.access;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AccessControlUtilsTest {
+    @Test
+    public void testValidatePermissionAllowed() {
+        AccessControl ac = Mockito.mock(AccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
+                Mockito.any(HttpHeaders.class), Mockito.anyString()))
+                .thenReturn(true);
+
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
+                "/testEndpoint", ac);
+    }
+
+    @Test
+    public void testValidatePermissionDenied() {
+        AccessControl ac = Mockito.mock(AccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
+                Mockito.any(HttpHeaders.class), Mockito.anyString()))
+                .thenReturn(false);
+
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        try {
+            AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
+                    "/testEndpoint", ac);
+            Assert.fail("Expected ControllerApplicationException");
+        } catch (ControllerApplicationException e) {
+            Assert.assertTrue(e.getMessage().contains("Permission is denied"));
+            Assert.assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+        }
+    }
+
+    @Test
+    public void testValidatePermissionWithNoSuchMethodError() {
+        AccessControl ac = Mockito.mock(AccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
+                Mockito.any(HttpHeaders.class), Mockito.anyString()))
+                .thenThrow(new NoSuchMethodError("Method not found"));
+
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        try {
+            AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
+                    "/testEndpoint", ac);
+        } catch (ControllerApplicationException e) {
+            Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission for testTable"));
+            Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        }
+    }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -26,31 +26,33 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class AccessControlUtilsTest {
+
+    private final String table = "testTable";
+    private final String endpoint = "/testEndpoint";
+
     @Test
     public void testValidatePermissionAllowed() {
         AccessControl ac = Mockito.mock(AccessControl.class);
-        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
-                Mockito.any(HttpHeaders.class), Mockito.anyString()))
-                .thenReturn(true);
-
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-        AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
-                "/testEndpoint", ac);
+        Mockito.when(ac.hasAccess(table, AccessType.READ,
+            mockHttpHeaders, endpoint)).thenReturn(true);
+
+        AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
+                endpoint, ac);
     }
 
     @Test
     public void testValidatePermissionDenied() {
         AccessControl ac = Mockito.mock(AccessControl.class);
-        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
-                Mockito.any(HttpHeaders.class), Mockito.anyString()))
-                .thenReturn(false);
-
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
+        Mockito.when(ac.hasAccess(table, AccessType.READ,
+                mockHttpHeaders, endpoint)).thenReturn(false);
+
         try {
-            AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
-                    "/testEndpoint", ac);
+            AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
+                    endpoint, ac);
             Assert.fail("Expected ControllerApplicationException");
         } catch (ControllerApplicationException e) {
             Assert.assertTrue(e.getMessage().contains("Permission is denied"));
@@ -61,17 +63,17 @@ public class AccessControlUtilsTest {
     @Test
     public void testValidatePermissionWithNoSuchMethodError() {
         AccessControl ac = Mockito.mock(AccessControl.class);
-        Mockito.when(ac.hasAccess(Mockito.anyString(), Mockito.any(AccessType.class),
-                Mockito.any(HttpHeaders.class), Mockito.anyString()))
-                .thenThrow(new NoSuchMethodError("Method not found"));
-
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
+        Mockito.when(ac.hasAccess(table, AccessType.READ,
+                mockHttpHeaders, endpoint))
+                .thenThrow(new NoSuchMethodError("Method not found"));
+
         try {
-            AccessControlUtils.validatePermission("testTable", AccessType.READ, mockHttpHeaders,
-                    "/testEndpoint", ac);
+            AccessControlUtils.validatePermission(table, AccessType.READ, mockHttpHeaders,
+                    endpoint, ac);
         } catch (ControllerApplicationException e) {
-            Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission for testTable"));
+            Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission"));
             Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAuthUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAuthUtils.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FineGrainedAuthUtils {
 
-  public static final Logger LOGGER = LoggerFactory.getLogger(FineGrainedAuthUtils.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FineGrainedAuthUtils.class);
 
   private FineGrainedAuthUtils() {
   }
@@ -117,8 +117,10 @@ public class FineGrainedAuthUtils {
       } catch (Throwable t) {
         // catch and log Throwable for NoSuchMethodError which can happen when there are classpath conflicts
         // otherwise, grizzly will return a 500 without any logs or indication of what failed
-        LOGGER.error("Failed to check for access", t);
-        throw new WebApplicationException("Failed to check for access", t, Response.Status.INTERNAL_SERVER_ERROR);
+        String errorMsg = String.format("Failed to check for access for target type %s and target ID %s with action %s",
+            auth.targetType(), targetId, auth.action());
+        LOGGER.error(errorMsg, t);
+        throw new WebApplicationException(errorMsg, t, Response.Status.INTERNAL_SERVER_ERROR);
       }
 
       // Check for access now

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAuthUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAuthUtils.java
@@ -95,8 +95,8 @@ public class FineGrainedAuthUtils {
 
         if (StringUtils.isEmpty(targetId)) {
           throw new WebApplicationException(
-                  "Could not find paramName " + auth.paramName() + " in path or query params of the API: "
-                          + uriInfo.getRequestUri(), Response.Status.INTERNAL_SERVER_ERROR);
+              "Could not find paramName " + auth.paramName() + " in path or query params of the API: "
+                  + uriInfo.getRequestUri(), Response.Status.INTERNAL_SERVER_ERROR);
         }
 
         // Table name may contain type, hence get raw table name for checking access
@@ -107,8 +107,8 @@ public class FineGrainedAuthUtils {
         accessDeniedMsg = "Access denied to " + auth.action() + " in the cluster";
       } else {
         throw new WebApplicationException(
-                "Unsupported targetType: " + auth.targetType() + " in API: " + uriInfo.getRequestUri(),
-                Response.Status.INTERNAL_SERVER_ERROR);
+            "Unsupported targetType: " + auth.targetType() + " in API: " + uriInfo.getRequestUri(),
+            Response.Status.INTERNAL_SERVER_ERROR);
       }
 
       boolean hasAccess;

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.auth;
 
 import java.lang.reflect.Method;

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -1,14 +1,13 @@
 package org.apache.pinot.core.auth;
 
-import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
+import java.lang.reflect.Method;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.lang.reflect.Method;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class FineGrainedAuthUtilsTest {
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -1,0 +1,69 @@
+package org.apache.pinot.core.auth;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.lang.reflect.Method;
+
+public class FineGrainedAuthUtilsTest {
+
+    @Test
+    public void testValidateFineGrainedAuthAllowed() {
+        FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+
+        UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+    }
+
+    @Test
+    public void testValidateFineGrainedAuthDenied() {
+        FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(false);
+
+        UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        try {
+            FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+            Assert.fail("Expected WebApplicationException");
+        } catch (WebApplicationException e) {
+            Assert.assertTrue(e.getMessage().contains("Access denied to testAction in the cluster"));
+            Assert.assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+        }
+    }
+
+    @Test
+    public void testValidateFineGrainedAuthWithNoSuchMethodError() {
+        FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
+        Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenThrow(new NoSuchMethodError("Method not found"));
+
+        UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
+        HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+
+        try {
+            FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+            Assert.fail("Expected WebApplicationException");
+        } catch (WebApplicationException e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to check for access"));
+            Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        }
+    }
+
+    private Method getClusterMethod() {
+        return new Object() {
+            @Authorize(targetType = TargetType.CLUSTER, action = "testAction")
+            void getClusterMethod() { }
+        }.getClass().getDeclaredMethods()[0];
+    }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -38,7 +38,7 @@ public class FineGrainedAuthUtilsTest {
         UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-        FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+        FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
     }
 
     @Test
@@ -51,10 +51,10 @@ public class FineGrainedAuthUtilsTest {
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
         try {
-            FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+            FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
             Assert.fail("Expected WebApplicationException");
         } catch (WebApplicationException e) {
-            Assert.assertTrue(e.getMessage().contains("Access denied to testAction in the cluster"));
+            Assert.assertTrue(e.getMessage().contains("Access denied to getCluster in the cluster"), "Unexpected message: " + e.getMessage());
             Assert.assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
         }
     }
@@ -69,7 +69,7 @@ public class FineGrainedAuthUtilsTest {
         HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
         try {
-            FineGrainedAuthUtils.validateFineGrainedAuth(getClusterMethod(), mockUriInfo, mockHttpHeaders, ac);
+            FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
             Assert.fail("Expected WebApplicationException");
         } catch (WebApplicationException e) {
             Assert.assertTrue(e.getMessage().contains("Failed to check for access"));
@@ -77,10 +77,16 @@ public class FineGrainedAuthUtilsTest {
         }
     }
 
-    private Method getClusterMethod() {
-        return new Object() {
-            @Authorize(targetType = TargetType.CLUSTER, action = "testAction")
-            void getClusterMethod() { }
-        }.getClass().getDeclaredMethods()[0];
+    static class TestResource {
+        @Authorize(targetType = TargetType.CLUSTER, action = "getCluster")
+        void getCluster() { }
+    }
+
+    private Method getAnnotatedMethod() {
+        try {
+            return TestResource.class.getDeclaredMethod("getCluster");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -54,7 +54,7 @@ public class FineGrainedAuthUtilsTest {
             FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
             Assert.fail("Expected WebApplicationException");
         } catch (WebApplicationException e) {
-            Assert.assertTrue(e.getMessage().contains("Access denied to getCluster in the cluster"), "Unexpected message: " + e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Access denied to getCluster in the cluster"));
             Assert.assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
         }
     }


### PR DESCRIPTION
Our Pinot access control plugin threw NoSuchMethodErrors due to classpath conflicts that caused Pinot's APIs to 500s and return vague grizzly errors and no logs for the exception. This made it hard to debug and identify the actual error.

This PR updates the error handling of `hasAccess` calls to both log the exception and throw an exception that grizzly will return a proper response body for.

Requests before this change:
<img width="1311" alt="Screenshot 2024-05-22 at 9 59 05 AM" src="https://github.com/apache/pinot/assets/50119799/3a80fe19-563c-417a-a277-f7a862866075">

Requests after this change:
<img width="966" alt="Screenshot 2024-05-22 at 11 11 37 PM" src="https://github.com/apache/pinot/assets/50119799/f8469be8-941c-4b2f-9765-9a94e08f662b">

cc @Jackie-Jiang @jadami10 