### PR TITLE
do not fail on duplicate relaxed vars

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -231,7 +231,15 @@ public class PinotConfiguration {
 
   private static Map<String, String> relaxEnvironmentVariables(Map<String, String> environmentVariables) {
     return environmentVariables.entrySet().stream()
-        .collect(Collectors.toMap(PinotConfiguration::relaxEnvVarName, Entry::getValue));
+        // Sort by key to ensure choosing a consistent env var if there are collisions
+        .sorted(Entry.comparingByKey())
+        .collect(Collectors.toMap(
+            PinotConfiguration::relaxEnvVarName,
+            Entry::getValue,
+            // Nothing prevents users from setting env variables like foo_bar and foo.bar
+            // This should not prevent Pinot from starting.
+            (existingValue, newValue) -> existingValue
+        ));
   }
 
   private static String relaxEnvVarName(Entry<String, String> envVarEntry) {


### PR DESCRIPTION
This is a `bugfix` to enforce unique, relaxed env variables when loading the PinotConfiguration related to #12307.

Our build system adds the same env variable in 2 formats, and the conversion from `_` to `.` formatting in `PinotConfiguration::relaxEnvVarName` causes an `IllegalStateException` because the variables end up with the same name. This change effectively enforces we always take the alphabetically sorted first value instead.

This has no impact on existing users since they would have seen exceptions if they were doing this.