### PR TITLE
handle overflow for `MutableOffHeapByteArrayStore` buffer starting size

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -223,10 +223,10 @@ public class MutableOffHeapByteArrayStore implements Closeable {
     int index = buffer.add(value);
     if (index < 0) {
       // Need to expand the buffer
-      long nextBufferSize = buffer.getSize() << 1;
-      if (nextBufferSize > 0 && nextBufferSize <= Integer.MAX_VALUE) {
+      int currentBufferSize = buffer.getSize();
+      if ((currentBufferSize << 1) >= 0) {
         // The expanded buffer size should be enough for the current value
-        buffer = expand(Math.max((int) nextBufferSize, valueLength + Integer.BYTES));
+        buffer = expand(Math.max(currentBufferSize << 1, valueLength + Integer.BYTES));
       } else {
         // Int overflow
         buffer = expand(Integer.MAX_VALUE);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -178,7 +178,9 @@ public class MutableOffHeapByteArrayStore implements Closeable {
       int numArrays, int avgArrayLen) {
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
-    _startSize = numArrays * (avgArrayLen + 4); // For each array, we store the array and its startoffset (4 bytes)
+    int estimatedSize =
+        numArrays * (avgArrayLen + 4); // For each array, we store the array and its startoffset (4 bytes)
+    _startSize = estimatedSize > 0 ? estimatedSize : Integer.MAX_VALUE;
     expand(_startSize);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStoreTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/MutableOffHeapByteArrayStoreTest.java
@@ -57,6 +57,14 @@ public class MutableOffHeapByteArrayStoreTest {
   }
 
   @Test
+  public void startSizeOverflowTest()
+      throws Exception {
+    MutableOffHeapByteArrayStore store =
+        new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn", 3, 1024 * 1024 * 1024);
+    store.close();
+  }
+
+  @Test
   public void overflowTest()
       throws Exception {
     MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn", 1024, 32);


### PR DESCRIPTION
We've seen some state transition failrues from `OFFLINE -> CONSUMING` with the below stack trace. It looks like `_startSize` overflow isn't handled, so this change handles it. 

It also treats `0` as an overflow case during buffer expansion, since that would hit the same precondition check as well. 
```
java.lang.IllegalArgumentException: Illegal memory allocation -1710837370 for segment table__1__876__20240523T2008Z column table__1__876__20240523T2008Z:col.dict
  at com.google.common.base.Preconditions.checkArgument(Preconditions.java:135)
  at org.apache.pinot.segment.local.io.readerwriter.RealtimeIndexOffHeapMemoryManager.allocate(RealtimeIndexOffHeapMemoryManager.java:78)
  at org.apache.pinot.segment.local.io.writer.impl.MutableOffHeapByteArrayStore$Buffer.<init>(MutableOffHeapByteArrayStore.java:99)
  at org.apache.pinot.segment.local.io.writer.impl.MutableOffHeapByteArrayStore.expand(MutableOffHeapByteArrayStore.java:193)
  at org.apache.pinot.segment.local.io.writer.impl.MutableOffHeapByteArrayStore.<init>(MutableOffHeapByteArrayStore.java:182)
  at org.apache.pinot.segment.local.realtime.impl.dictionary.StringOffHeapMutableDictionary.<init>(StringOffHeapMutableDictionary.java:45)
  at org.apache.pinot.segment.local.realtime.impl.dictionary.MutableDictionaryFactory.getMutableDictionary(MutableDictionaryFactory.java:48)
  at org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType.createMutableDictionary(DictionaryIndexType.java:449)
  at org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl.<init>(MutableSegmentImpl.java:321) 
``` 

tag: `bugfix`