### PR TITLE
Introduce brokerResized in broker reduce phase

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -731,6 +731,11 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
             1);
       }
 
+      // Track number of queries with results being resized
+      if (brokerResponse.isBrokerResized()) {
+        _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.BROKER_RESPONSES_WITH_BROKER_RESIZED, 1);
+      }
+
       // Set total query processing time
       long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();
       brokerResponse.setTimeUsedMs(totalTimeMs);

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -83,14 +83,16 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   BROKER_RESPONSES_WITH_PROCESSING_EXCEPTIONS("badResponses", false),
   // This metric tracks the number of broker responses with unavailable segments.
   BROKER_RESPONSES_WITH_UNAVAILABLE_SEGMENTS("badResponses", false),
-  // This metric track the number of broker responses with not all servers responded.
+  // This metric tracks the number of broker responses with not all servers responded.
   // (numServersQueried > numServersResponded)
   BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED("badResponses", false),
 
   BROKER_RESPONSES_WITH_TIMEOUTS("badResponses", false),
 
-  // This metric track the number of broker responses with number of groups limit reached (potential bad responses).
+  // This metric tracks the number of broker responses with number of groups limit reached (potential bad responses).
   BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED("badResponses", false),
+  // This metric tracks the number of broker responses with response being resized (potential bad responses).
+  BROKER_RESPONSES_WITH_BROKER_RESIZED("badResponses", false),
 
   // These metrics track the cost of the query.
   DOCUMENTS_SCANNED("documents", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -85,6 +85,11 @@ public interface BrokerResponse {
   boolean isNumGroupsLimitReached();
 
   /**
+   * Returns whether resizing is done in the broker reduce phase.
+   */
+  boolean isBrokerResized();
+
+  /**
    * Returns whether the limit for max rows in join has been reached.
    */
   boolean isMaxRowsInJoinReached();

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -66,6 +66,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private int _numRowsResultSet = 0;
   private List<QueryProcessingException> _exceptions = new ArrayList<>();
   private boolean _numGroupsLimitReached = false;
+  private boolean _brokerResized = false;
   private long _timeUsedMs = 0L;
   private String _requestId;
   private String _brokerId;
@@ -162,7 +163,7 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @Override
   public boolean isPartialResult() {
-    return getExceptionsSize() > 0 || isNumGroupsLimitReached();
+    return getExceptionsSize() > 0 || isNumGroupsLimitReached() || isBrokerResized();
   }
 
   @Override
@@ -189,6 +190,15 @@ public class BrokerResponseNative implements BrokerResponse {
 
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  @Override
+  public boolean isBrokerResized() {
+    return _brokerResized;
+  }
+
+  public void setBrokerResized(boolean brokerResized) {
+    _brokerResized = brokerResized;
   }
 
   @JsonIgnore

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -99,7 +99,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @Override
   public boolean isPartialResult() {
-    return getExceptionsSize() > 0 || isNumGroupsLimitReached() || isMaxRowsInJoinReached();
+    return getExceptionsSize() > 0 || isNumGroupsLimitReached() || isMaxRowsInJoinReached() || isBrokerResized();
   }
 
   @Override
@@ -122,6 +122,15 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
 
   public void mergeNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _brokerStats.merge(StatKey.NUM_GROUPS_LIMIT_REACHED, numGroupsLimitReached);
+  }
+
+  @Override
+  public boolean isBrokerResized() {
+    return _brokerStats.getBoolean(StatKey.BROKER_RESIZED);
+  }
+
+  public void mergeBrokerResized(boolean brokerResized) {
+    _brokerStats.merge(StatKey.BROKER_RESIZED, brokerResized);
   }
 
   @Override
@@ -371,7 +380,8 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     NUM_SEGMENTS_PRUNED_INVALID(StatMap.Type.INT),
     NUM_SEGMENTS_PRUNED_BY_LIMIT(StatMap.Type.INT),
     NUM_SEGMENTS_PRUNED_BY_VALUE(StatMap.Type.INT),
-    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN);
+    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    BROKER_RESIZED(StatMap.Type.BOOLEAN);
 
     private final StatMap.Type _type;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -48,6 +48,7 @@ public abstract class IndexedTable extends BaseTable {
 
   protected Collection<Record> _topRecords;
   private int _numResizes;
+  private boolean _isResized = false;
   private long _resizeTimeNs;
 
   /**
@@ -138,7 +139,7 @@ public abstract class IndexedTable extends BaseTable {
   protected void resize() {
     assert _hasOrderBy;
     long startTimeNs = System.nanoTime();
-    _tableResizer.resizeRecordsMap(_lookupMap, _trimSize);
+    _isResized |= _tableResizer.resizeRecordsMap(_lookupMap, _trimSize);
     long resizeTimeNs = System.nanoTime() - startTimeNs;
     _numResizes++;
     _resizeTimeNs += resizeTimeNs;
@@ -184,6 +185,10 @@ public abstract class IndexedTable extends BaseTable {
 
   public int getNumResizes() {
     return _numResizes;
+  }
+
+  public boolean isResized() {
+    return _isResized;
   }
 
   public long getResizeTimeMs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -174,10 +174,10 @@ public class TableResizer {
   /**
    * Resizes the recordsMap to the given size.
    */
-  public void resizeRecordsMap(Map<Key, Record> recordsMap, int size) {
+  public boolean resizeRecordsMap(Map<Key, Record> recordsMap, int size) {
     int numRecordsToEvict = recordsMap.size() - size;
     if (numRecordsToEvict <= 0) {
-      return;
+      return false;
     }
     if (numRecordsToEvict <= size) {
       // Fewer records to evict than retain, make a heap of records to evict
@@ -195,6 +195,7 @@ public class TableResizer {
         recordsMap.put(recordToRetain._key, recordToRetain._record);
       }
     }
+    return true;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -148,6 +148,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
       brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.NUM_RESIZES, indexedTable.getNumResizes());
       brokerMetrics.addValueToTableGauge(rawTableName, BrokerGauge.RESIZE_TIME_MS, indexedTable.getResizeTimeMs());
     }
+    // Set brokerResized if resizing is done in the broker reduce phase.
+    brokerResponseNative.setBrokerResized(indexedTable.isResized());
     int numRecords = indexedTable.size();
     Iterator<Record> sortedIterator = indexedTable.iterator();
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -459,7 +459,8 @@ public class AggregateOperator extends MultiStageOperator {
         return true;
       }
     },
-    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN);
+    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    BROKER_RESIZED(StatMap.Type.BOOLEAN);
 
     private final StatMap.Type _type;
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -173,6 +173,7 @@ public abstract class MultiStageOperator
         StatMap<AggregateOperator.StatKey> stats = (StatMap<AggregateOperator.StatKey>) map;
         response.mergeNumGroupsLimitReached(stats.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED));
         response.mergeMaxRowsInOperator(stats.getLong(AggregateOperator.StatKey.EMITTED_ROWS));
+        response.mergeBrokerResized(stats.getBoolean(AggregateOperator.StatKey.BROKER_RESIZED));
       }
     },
     FILTER(FilterOperator.StatKey.class) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -303,6 +303,8 @@ public class AggregateOperatorTest {
         OperatorTestUtil.getStatMap(AggregateOperator.StatKey.class, block2);
     Assert.assertTrue(aggrStats.getBoolean(AggregateOperator.StatKey.NUM_GROUPS_LIMIT_REACHED),
         "num groups limit should be reached");
+    Assert.assertFalse(aggrStats.getBoolean(AggregateOperator.StatKey.BROKER_RESIZED),
+        "broker resized should be false.");
   }
 
   private static RexExpression.FunctionCall getSum(RexExpression arg) {


### PR DESCRIPTION
Currently if the indexed table gets resized because the `trimSize` limit is reached, the accuracy of the results will be affected. 
Thus, this PR introduces `brokerResized` in the query execution reduce phase, so that user is able to be aware of the impact for the accuracy.