### PR TITLE
Fixed infer logical type name from avro union schema

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.UUID;
 import org.apache.avro.Schema;
 import org.testng.Assert;
@@ -79,5 +82,44 @@ public class AvroSchemaUtilTest {
 
     Assert.assertTrue(result instanceof UUID);
     Assert.assertEquals(UUID.fromString(value), result);
+  }
+
+  @Test
+  public void testLogicalTypesWithUnionSchema() {
+    String valString1 = "125.24350000";
+    ByteBuffer amount1 = decimalToBytes(new BigDecimal(valString1), 8);
+    // union schema for the logical field with "null" and "decimal" as types
+    String fieldSchema1 = "{\"type\":\"record\",\"name\":\"Event\",\"fields\":[{\"name\":\"amount\","
+        + "\"type\":[\"null\",{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":8}]}]}";
+    Schema schema1 = new Schema.Parser().parse(fieldSchema1);
+    Object result1 = AvroSchemaUtil.applyLogicalType(schema1.getField("amount"), amount1);
+    Assert.assertTrue(result1 instanceof BigDecimal);
+    Assert.assertEquals(valString1, ((BigDecimal) result1).toPlainString());
+
+    String valString2 = "125.53172";
+    ByteBuffer amount2 = decimalToBytes(new BigDecimal(valString2), 5);
+    // "null" not present within the union schema for the logical field amount
+    String fieldSchema2 = "{\"type\":\"record\",\"name\":\"Event\",\"fields\":[{\"name\":\"amount\","
+        + "\"type\":[{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":5}]}]}";
+    Schema schema2 = new Schema.Parser().parse(fieldSchema2);
+    Object result2 = AvroSchemaUtil.applyLogicalType(schema2.getField("amount"), amount2);
+    Assert.assertTrue(result2 instanceof BigDecimal);
+    Assert.assertEquals(valString2, ((BigDecimal) result2).toPlainString());
+
+    String valString3 = "211.53172864999";
+    ByteBuffer amount3 = decimalToBytes(new BigDecimal(valString3), 11);
+    // "null" present at the second position within the union schema for the logical field amount
+    String fieldSchema3 = "{\"type\":\"record\",\"name\":\"Event\",\"fields\":[{\"name\":\"amount\","
+        + "\"type\":[{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":11}, \"null\"]}]}";
+    Schema schema3 = new Schema.Parser().parse(fieldSchema3);
+    Object result3 = AvroSchemaUtil.applyLogicalType(schema3.getField("amount"), amount3);
+    Assert.assertTrue(result3 instanceof BigDecimal);
+    Assert.assertEquals(valString3, ((BigDecimal) result3).toPlainString());
+  }
+
+  private static ByteBuffer decimalToBytes(BigDecimal decimal, int scale) {
+    BigDecimal scaledValue = decimal.setScale(scale, RoundingMode.DOWN);
+    byte[] unscaledBytes = scaledValue.unscaledValue().toByteArray();
+    return ByteBuffer.wrap(unscaledBytes);
   }
 }


### PR DESCRIPTION
Prior to this change, the logical type conversion won't work correctly if the field level schema is of union type. Example schema below that did not work previously and works with this change.

```
{
  "type": "record",
  "name": "Event",
  "fields": [
    "null",
    {
      "name": "amount",
      "type": [
        {
          "type": "bytes",
          "logicalType": "decimal",
          "precision": 20,
          "scale": 11
        }
      ]
    }
  ]
}
```