### PR TITLE
Allow all raw index config in star-tree index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -512,7 +512,6 @@ public final class TableConfigUtils {
         }
       }
 
-
       // Transform configs
       List<TransformConfig> transformConfigs = ingestionConfig.getTransformConfigs();
       if (transformConfigs != null) {
@@ -652,13 +651,13 @@ public final class TableConfigUtils {
                 String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
           }
         }
-        boolean isAllowDownloadFromServer =
-              Boolean.parseBoolean(taskTypeConfig.getOrDefault(TableTaskConfig.MINION_ALLOW_DOWNLOAD_FROM_SERVER,
-                  String.valueOf(TableTaskConfig.DEFAULT_MINION_ALLOW_DOWNLOAD_FROM_SERVER)));
+        boolean isAllowDownloadFromServer = Boolean.parseBoolean(
+            taskTypeConfig.getOrDefault(TableTaskConfig.MINION_ALLOW_DOWNLOAD_FROM_SERVER,
+                String.valueOf(TableTaskConfig.DEFAULT_MINION_ALLOW_DOWNLOAD_FROM_SERVER)));
         if (isAllowDownloadFromServer) {
           Preconditions.checkState(tableConfig.getValidationConfig().getPeerSegmentDownloadScheme() != null,
               String.format("Table %s has task %s with allowDownloadFromServer set to true, but "
-                  + "peerSegmentDownloadScheme is not set in the table config", tableConfig.getTableName(),
+                      + "peerSegmentDownloadScheme is not set in the table config", tableConfig.getTableName(),
                   taskTypeConfigName));
         }
         // Task Specific validation for REALTIME_TO_OFFLINE_TASK_TYPE
@@ -773,9 +772,9 @@ public final class TableConfigUtils {
         tableConfig.getRoutingConfig() != null && isRoutingStrategyAllowedForUpsert(tableConfig.getRoutingConfig()),
         "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     Preconditions.checkState(tableConfig.getTenantConfig().getTagOverrideConfig() == null || (
-        tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeConsuming() == null
-            && tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeCompleted()
-            == null), "Invalid tenant tag override used for Upsert/Dedup table");
+            tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeConsuming() == null
+                && tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeCompleted() == null),
+        "Invalid tenant tag override used for Upsert/Dedup table");
 
     // specifically for upsert
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
@@ -802,15 +801,13 @@ public final class TableConfigUtils {
         Preconditions.checkState(fieldSpec.isSingleValueField(),
             String.format("The deleteRecordColumn - %s must be a single-valued column", deleteRecordColumn));
         DataType dataType = fieldSpec.getDataType();
-        Preconditions.checkState(
-            dataType == DataType.BOOLEAN || dataType == DataType.STRING || dataType.isNumeric(),
+        Preconditions.checkState(dataType == DataType.BOOLEAN || dataType == DataType.STRING || dataType.isNumeric(),
             String.format("The deleteRecordColumn - %s must be of type: String / Boolean / Numeric",
                 deleteRecordColumn));
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();
-      Preconditions.checkState(
-          outOfOrderRecordColumn == null || !upsertConfig.isDropOutOfOrderRecord(),
+      Preconditions.checkState(outOfOrderRecordColumn == null || !upsertConfig.isDropOutOfOrderRecord(),
           "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
 
       if (outOfOrderRecordColumn != null) {
@@ -846,8 +843,8 @@ public final class TableConfigUtils {
       String comparisonColumn = comparisonColumns.get(0);
       DataType comparisonColumnDataType = schema.getFieldSpecFor(comparisonColumn).getDataType();
       Preconditions.checkState(comparisonColumnDataType.isNumeric(),
-          "MetadataTTL / DeletedKeysTTL must have comparison column: %s in numeric type, found: %s",
-          comparisonColumn, comparisonColumnDataType);
+          "MetadataTTL / DeletedKeysTTL must have comparison column: %s in numeric type, found: %s", comparisonColumn,
+          comparisonColumnDataType);
     }
 
     if (upsertConfig.getMetadataTTL() > 0) {
@@ -878,14 +875,11 @@ public final class TableConfigUtils {
             tableConfig.getInstanceAssignmentConfigMap().get(instancePartitionsType.toString());
         if (instanceAssignmentConfig.getPartitionSelector()
             == InstanceAssignmentConfig.PartitionSelector.MIRROR_SERVER_SET_PARTITION_SELECTOR) {
-          Preconditions.checkState(
-              tableConfig.getInstancePartitionsMap().containsKey(instancePartitionsType),
+          Preconditions.checkState(tableConfig.getInstancePartitionsMap().containsKey(instancePartitionsType),
               String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap needed for %s, as "
-                      + "MIRROR_SERVER_SET_PARTITION_SELECTOR is used",
-                  instancePartitionsType));
+                  + "MIRROR_SERVER_SET_PARTITION_SELECTOR is used", instancePartitionsType));
         } else {
-          Preconditions.checkState(
-              !tableConfig.getInstancePartitionsMap().containsKey(instancePartitionsType),
+          Preconditions.checkState(!tableConfig.getInstancePartitionsMap().containsKey(instancePartitionsType),
               String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
                   instancePartitionsType));
         }
@@ -1109,7 +1103,6 @@ public final class TableConfigUtils {
     }
 
     List<StarTreeIndexConfig> starTreeIndexConfigList = indexingConfig.getStarTreeIndexConfigs();
-    Set<AggregationFunctionColumnPair> storedTypes = new HashSet<>();
     if (starTreeIndexConfigList != null) {
       for (StarTreeIndexConfig starTreeIndexConfig : starTreeIndexConfigList) {
         // Dimension split order cannot be null
@@ -1117,6 +1110,10 @@ public final class TableConfigUtils {
           columnNameToConfigMap.put(columnName, STAR_TREE_CONFIG_NAME);
         }
         List<String> functionColumnPairs = starTreeIndexConfig.getFunctionColumnPairs();
+        List<StarTreeAggregationConfig> aggregationConfigs = starTreeIndexConfig.getAggregationConfigs();
+        Preconditions.checkState(functionColumnPairs == null || aggregationConfigs == null,
+            "Only one of 'functionColumnPairs' or 'aggregationConfigs' can be specified in StarTreeIndexConfig");
+        Set<AggregationFunctionColumnPair> storedTypes = new HashSet<>();
         if (functionColumnPairs != null) {
           for (String functionColumnPair : functionColumnPairs) {
             AggregationFunctionColumnPair columnPair;
@@ -1137,7 +1134,6 @@ public final class TableConfigUtils {
             }
           }
         }
-        List<StarTreeAggregationConfig> aggregationConfigs = starTreeIndexConfig.getAggregationConfigs();
         if (aggregationConfigs != null) {
           for (StarTreeAggregationConfig aggregationConfig : aggregationConfigs) {
             AggregationFunctionColumnPair columnPair;
@@ -1341,9 +1337,8 @@ public final class TableConfigUtils {
     }
 
     Preconditions.checkState(!indexingConfig.isOptimizeDictionaryForMetrics() && !indexingConfig.isOptimizeDictionary(),
-        String.format(
-            "Dictionary override optimization options (OptimizeDictionary, optimizeDictionaryForMetrics)"
-                + " not supported with forward index for column: %s, disabled", columnName));
+        String.format("Dictionary override optimization options (OptimizeDictionary, optimizeDictionaryForMetrics)"
+            + " not supported with forward index for column: %s, disabled", columnName));
 
     boolean hasDictionary = fieldConfig.getEncodingType() == EncodingType.DICTIONARY;
     boolean hasInvertedIndex =
@@ -1421,9 +1416,9 @@ public final class TableConfigUtils {
               tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
-            throw new IllegalStateException(String.format(
-                "Exceeded storage size for dimension table. Requested size: %d, Max allowed size: %d",
-                quotaConfig.getStorageInBytes(), maxAllowedSizeInBytes));
+            throw new IllegalStateException(
+                String.format("Exceeded storage size for dimension table. Requested size: %d, Max allowed size: %d",
+                    quotaConfig.getStorageInBytes(), maxAllowedSizeInBytes));
           }
         }
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
@@ -67,7 +67,7 @@ public class StarTreeBuilderUtilsTest {
         Collections.singletonList(AggregationFunctionColumnPair.COUNT_STAR.toColumnName()), null, 200);
 
     // Create StartTreeAggregationConfigs with StarTreeAggregationConfig.
-    StarTreeAggregationConfig starTreeAggregationConfig1 = new StarTreeAggregationConfig("Distance", "MAX", null);
+    StarTreeAggregationConfig starTreeAggregationConfig1 = new StarTreeAggregationConfig("Distance", "MAX");
 
     // Different AggregationConfig.
     StarTreeIndexConfig starTreeIndexConfig5 = new StarTreeIndexConfig(Arrays.asList("Carrier", "Distance"), null, null,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1411,19 +1411,18 @@ public class TableConfigUtilsTest {
 
     // Although this config makes no sense, it should pass the validation phase
     StarTreeIndexConfig starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), null, 1);
+        new StarTreeIndexConfig(List.of("myCol"), List.of("myCol"), List.of("SUM__myCol"), null, 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
       Assert.fail("Should not fail for valid StarTreeIndex config column name");
     }
 
-    starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol2"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), null, 1);
+    starTreeIndexConfig = new StarTreeIndexConfig(List.of("myCol2"), List.of("myCol"), List.of("SUM__myCol"), null, 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in dimension split order");
@@ -1431,10 +1430,9 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol2"), Arrays.asList("SUM__myCol"), null, 1);
+    starTreeIndexConfig = new StarTreeIndexConfig(List.of("myCol"), List.of("myCol2"), List.of("SUM__myCol"), null, 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in skip star node for dimension");
@@ -1442,32 +1440,43 @@ public class TableConfigUtilsTest {
       // expected
     }
 
+    starTreeIndexConfig = new StarTreeIndexConfig(List.of("myCol"), List.of("myCol"), List.of("SUM__myCol2"), null, 1);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for invalid StarTreeIndex config column name in function column pair");
+    } catch (Exception e) {
+      // expected
+    }
+
     starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol2"), null, 1);
+        new StarTreeIndexConfig(List.of("myCol"), null, null, List.of(new StarTreeAggregationConfig("myCol2", "SUM")),
+            1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail for invalid StarTreeIndex config column name in function column pair");
+      Assert.fail("Should fail for invalid StarTreeIndex config column name in aggregation config");
     } catch (Exception e) {
       // expected
     }
 
-    starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList("myCol"), null, null,
-        Arrays.asList(new StarTreeAggregationConfig("myCol2", "SUM", CompressionCodec.LZ4)), 1);
+    starTreeIndexConfig = new StarTreeIndexConfig(List.of("myCol"), null, List.of("SUM__myCol"),
+        List.of(new StarTreeAggregationConfig("myCol", "SUM")), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail for invalid StarTreeIndex config column name in function column pair");
+      Assert.fail("Should fail for invalid StarTreeIndex config with both function column pair and aggregation config");
     } catch (Exception e) {
       // expected
     }
 
-    starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList("multiValCol"), Arrays.asList("multiValCol"),
-        Arrays.asList("SUM__multiValCol"), null, 1);
+    starTreeIndexConfig =
+        new StarTreeIndexConfig(List.of("multiValCol"), List.of("multiValCol"), List.of("SUM__multiValCol"), null, 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(List.of(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for multi-value column name in StarTreeIndex config");

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationSpec.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationSpec.java
@@ -18,22 +18,60 @@
  */
 package org.apache.pinot.segment.spi.index.startree;
 
+import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
+import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
 
 
 public class AggregationSpec {
-  public static final AggregationSpec DEFAULT = new AggregationSpec(ChunkCompressionType.PASS_THROUGH);
+  public static final CompressionCodec DEFAULT_COMPRESSION_CODEC = CompressionCodec.PASS_THROUGH;
+  public static final AggregationSpec DEFAULT = new AggregationSpec(null, null, null, null, null);
 
-  private final ChunkCompressionType _compressionType;
+  private final CompressionCodec _compressionCodec;
+  private final boolean _deriveNumDocsPerChunk;
+  private final int _indexVersion;
+  private final int _targetMaxChunkSizeBytes;
+  private final int _targetDocsPerChunk;
 
-  public AggregationSpec(ChunkCompressionType compressionType) {
-    _compressionType = compressionType;
+  public AggregationSpec(StarTreeAggregationConfig aggregationConfig) {
+    this(aggregationConfig.getCompressionCodec(), aggregationConfig.getDeriveNumDocsPerChunk(),
+        aggregationConfig.getIndexVersion(), aggregationConfig.getTargetMaxChunkSizeBytes(),
+        aggregationConfig.getTargetDocsPerChunk());
   }
 
-  public ChunkCompressionType getCompressionType() {
-    return _compressionType;
+  public AggregationSpec(@Nullable CompressionCodec compressionCodec, @Nullable Boolean deriveNumDocsPerChunk,
+      @Nullable Integer indexVersion, @Nullable Integer targetMaxChunkSizeBytes, @Nullable Integer targetDocsPerChunk) {
+    _indexVersion = indexVersion != null ? indexVersion : ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION;
+    _compressionCodec = compressionCodec != null ? compressionCodec : DEFAULT_COMPRESSION_CODEC;
+    _deriveNumDocsPerChunk = deriveNumDocsPerChunk != null ? deriveNumDocsPerChunk : false;
+    _targetMaxChunkSizeBytes = targetMaxChunkSizeBytes != null ? targetMaxChunkSizeBytes
+        : ForwardIndexConfig.DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES;
+    _targetDocsPerChunk =
+        targetDocsPerChunk != null ? targetDocsPerChunk : ForwardIndexConfig.DEFAULT_TARGET_DOCS_PER_CHUNK;
+  }
+
+  public CompressionCodec getCompressionCodec() {
+    return _compressionCodec;
+  }
+
+  public boolean isDeriveNumDocsPerChunk() {
+    return _deriveNumDocsPerChunk;
+  }
+
+  public int getIndexVersion() {
+    return _indexVersion;
+  }
+
+  public int getTargetMaxChunkSizeBytes() {
+    return _targetMaxChunkSizeBytes;
+  }
+
+  public int getTargetDocsPerChunk() {
+    return _targetDocsPerChunk;
   }
 
   @Override
@@ -45,17 +83,27 @@ public class AggregationSpec {
       return false;
     }
     AggregationSpec that = (AggregationSpec) o;
-    return _compressionType == that._compressionType;
+    return _deriveNumDocsPerChunk == that._deriveNumDocsPerChunk && _indexVersion == that._indexVersion
+        && _targetMaxChunkSizeBytes == that._targetMaxChunkSizeBytes && _targetDocsPerChunk == that._targetDocsPerChunk
+        && _compressionCodec == that._compressionCodec;
   }
 
   @Override
   public int hashCode() {
-    return _compressionType.hashCode();
+    return Objects.hash(_compressionCodec, _deriveNumDocsPerChunk, _indexVersion, _targetMaxChunkSizeBytes,
+        _targetDocsPerChunk);
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("compressionType", _compressionType)
+    //@formatter:off
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("compressionCodec", _compressionCodec)
+        .append("deriveNumDocsPerChunk", _deriveNumDocsPerChunk)
+        .append("indexVersion", _indexVersion)
+        .append("targetMaxChunkSizeBytes", _targetMaxChunkSizeBytes)
+        .append("targetDocsPerChunk", _targetDocsPerChunk)
         .toString();
+    //@formatter:on
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/StarTreeV2Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/StarTreeV2Constants.java
@@ -53,7 +53,11 @@ public class StarTreeV2Constants {
     public static final String AGGREGATION_PREFIX = "aggregation.";
     public static final String FUNCTION_TYPE = "function.type";
     public static final String COLUMN_NAME = "column.name";
+    public static final String INDEX_VERSION = "index.version";
     public static final String COMPRESSION_CODEC = "compression.codec";
+    public static final String DERIVE_NUM_DOCS_PER_CHUNK = "derive.num.docs.per.chunk";
+    public static final String TARGET_MAX_CHUNK_SIZE_BYTES = "target.max.chunk.size.bytes";
+    public static final String TARGET_DOCS_PER_CHUNK = "target.docs.per.chunk";
 
     public static String getStarTreePrefix(int index) {
       return STAR_TREE_PREFIX + index;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/StarTreeV2Metadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/StarTreeV2Metadata.java
@@ -21,12 +21,13 @@ package org.apache.pinot.segment.spi.index.startree;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants.MetadataKey;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 
 
 /**
@@ -56,10 +57,14 @@ public class StarTreeV2Metadata {
         // Lookup the stored aggregation type
         AggregationFunctionColumnPair storedType =
             AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair);
-        ChunkCompressionType compressionType =
-            ChunkCompressionType.valueOf(aggregationConfig.getString(MetadataKey.COMPRESSION_CODEC));
+        AggregationSpec aggregationSpec =
+            new AggregationSpec(aggregationConfig.getEnum(MetadataKey.COMPRESSION_CODEC, CompressionCodec.class, null),
+                aggregationConfig.getBoolean(MetadataKey.DERIVE_NUM_DOCS_PER_CHUNK, null),
+                aggregationConfig.getInteger(MetadataKey.INDEX_VERSION, null),
+                aggregationConfig.getInteger(MetadataKey.TARGET_MAX_CHUNK_SIZE_BYTES, null),
+                aggregationConfig.getInteger(MetadataKey.TARGET_DOCS_PER_CHUNK, null));
         // If there is already an equivalent functionColumnPair in the map for the stored type, do not load another.
-        _aggregationSpecs.putIfAbsent(storedType, new AggregationSpec(compressionType));
+        _aggregationSpecs.putIfAbsent(storedType, aggregationSpec);
       }
     } else {
       // Backward compatibility with columnName format
@@ -104,5 +109,35 @@ public class StarTreeV2Metadata {
 
   public Set<String> getSkipStarNodeCreationForDimensions() {
     return _skipStarNodeCreationForDimensions;
+  }
+
+  public static void writeMetadata(Configuration metadataProperties, int totalDocs, List<String> dimensionsSplitOrder,
+      TreeMap<AggregationFunctionColumnPair, AggregationSpec> aggregationSpecs, int maxLeafRecords,
+      Set<String> skipStarNodeCreationForDimensions) {
+    metadataProperties.setProperty(MetadataKey.TOTAL_DOCS, totalDocs);
+    metadataProperties.setProperty(MetadataKey.DIMENSIONS_SPLIT_ORDER, dimensionsSplitOrder);
+    metadataProperties.setProperty(MetadataKey.FUNCTION_COLUMN_PAIRS, aggregationSpecs.keySet());
+    metadataProperties.setProperty(MetadataKey.AGGREGATION_COUNT, aggregationSpecs.size());
+    int index = 0;
+    for (Map.Entry<AggregationFunctionColumnPair, AggregationSpec> entry : aggregationSpecs.entrySet()) {
+      AggregationFunctionColumnPair functionColumnPair = entry.getKey();
+      AggregationSpec aggregationSpec = entry.getValue();
+      String prefix = MetadataKey.AGGREGATION_PREFIX + index + '.';
+      metadataProperties.setProperty(prefix + MetadataKey.FUNCTION_TYPE,
+          functionColumnPair.getFunctionType().getName());
+      metadataProperties.setProperty(prefix + MetadataKey.COLUMN_NAME, functionColumnPair.getColumn());
+      metadataProperties.setProperty(prefix + MetadataKey.COMPRESSION_CODEC, aggregationSpec.getCompressionCodec());
+      metadataProperties.setProperty(prefix + MetadataKey.DERIVE_NUM_DOCS_PER_CHUNK,
+          aggregationSpec.isDeriveNumDocsPerChunk());
+      metadataProperties.setProperty(prefix + MetadataKey.INDEX_VERSION, aggregationSpec.getIndexVersion());
+      metadataProperties.setProperty(prefix + MetadataKey.TARGET_MAX_CHUNK_SIZE_BYTES,
+          aggregationSpec.getTargetMaxChunkSizeBytes());
+      metadataProperties.setProperty(prefix + MetadataKey.TARGET_DOCS_PER_CHUNK,
+          aggregationSpec.getTargetDocsPerChunk());
+      index++;
+    }
+    metadataProperties.setProperty(MetadataKey.MAX_LEAF_RECORDS, maxLeafRecords);
+    metadataProperties.setProperty(MetadataKey.SKIP_STAR_NODE_CREATION_FOR_DIMENSIONS,
+        skipStarNodeCreationForDimensions);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -124,17 +124,20 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   public enum CompressionCodec {
+    //@formatter:off
     PASS_THROUGH(true, false),
     SNAPPY(true, false),
     ZSTANDARD(true, false),
     LZ4(true, false),
-    // CLP is a special type of compression codec that isn't generally applicable to all RAW columns and has a
-    // special handling for log lines (see {@link CLPForwardIndexCreatorV1})
-    CLP(false, false),
     GZIP(true, false),
 
     // For MV dictionary encoded forward index, add a second level dictionary encoding for the multi-value entries
-    MV_ENTRY_DICT(false, true);
+    MV_ENTRY_DICT(false, true),
+
+    // CLP is a special type of compression codec that isn't generally applicable to all RAW columns and has a special
+    // handling for log lines (see {@link CLPForwardIndexCreatorV1})
+    CLP(false, false);
+    //@formatter:on
 
     private final boolean _applicableToRawIndex;
     private final boolean _applicableToDictEncodedIndex;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeAggregationConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeAggregationConfig.java
@@ -19,24 +19,46 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 
 
 public class StarTreeAggregationConfig extends BaseJsonConfig {
   private final String _columnName;
   private final String _aggregationFunction;
   private final CompressionCodec _compressionCodec;
+  private final Boolean _deriveNumDocsPerChunk;
+  private final Integer _indexVersion;
+  private final String _targetMaxChunkSize;
+  private final Integer _targetMaxChunkSizeBytes;
+  private final Integer _targetDocsPerChunk;
+
+  @VisibleForTesting
+  public StarTreeAggregationConfig(String columnName, String aggregationFunction) {
+    this(columnName, aggregationFunction, null, null, null, null, null);
+  }
 
   @JsonCreator
   public StarTreeAggregationConfig(@JsonProperty(value = "columnName", required = true) String columnName,
       @JsonProperty(value = "aggregationFunction", required = true) String aggregationFunction,
-      @JsonProperty(value = "compressionCodec") @Nullable CompressionCodec compressionCodec) {
+      @JsonProperty(value = "compressionCodec") @Nullable CompressionCodec compressionCodec,
+      @JsonProperty(value = "deriveNumDocsPerChunk") @Nullable Boolean deriveNumDocsPerChunk,
+      @JsonProperty(value = "indexVersion") @Nullable Integer indexVersion,
+      @JsonProperty(value = "targetMaxChunkSize") @Nullable String targetMaxChunkSize,
+      @JsonProperty(value = "targetDocsPerChunk") @Nullable Integer targetDocsPerChunk) {
     _columnName = columnName;
     _aggregationFunction = aggregationFunction;
-    _compressionCodec = compressionCodec != null ? compressionCodec : CompressionCodec.PASS_THROUGH;
+    _compressionCodec = compressionCodec;
+    _deriveNumDocsPerChunk = deriveNumDocsPerChunk;
+    _indexVersion = indexVersion;
+    _targetMaxChunkSize = targetMaxChunkSize;
+    _targetMaxChunkSizeBytes = targetMaxChunkSize != null ? (int) DataSizeUtils.toBytes(targetMaxChunkSize) : null;
+    _targetDocsPerChunk = targetDocsPerChunk;
   }
 
   public String getColumnName() {
@@ -47,7 +69,34 @@ public class StarTreeAggregationConfig extends BaseJsonConfig {
     return _aggregationFunction;
   }
 
+  @Nullable
   public CompressionCodec getCompressionCodec() {
     return _compressionCodec;
+  }
+
+  @Nullable
+  public Boolean getDeriveNumDocsPerChunk() {
+    return _deriveNumDocsPerChunk;
+  }
+
+  @Nullable
+  public Integer getIndexVersion() {
+    return _indexVersion;
+  }
+
+  @Nullable
+  public String getTargetMaxChunkSize() {
+    return _targetMaxChunkSize;
+  }
+
+  @JsonIgnore
+  @Nullable
+  public Integer getTargetMaxChunkSizeBytes() {
+    return _targetMaxChunkSizeBytes;
+  }
+
+  @Nullable
+  public Integer getTargetDocsPerChunk() {
+    return _targetDocsPerChunk;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
@@ -34,7 +34,7 @@ public class StarTreeIndexConfig extends BaseJsonConfig {
   private final List<String> _skipStarNodeCreationForDimensions;
   // Function column pairs with delimiter "__", e.g. SUM__col1, MAX__col2, COUNT__*
   private final List<String> _functionColumnPairs;
-  // Function column pairs config, currently only handling compression.
+  // Function column pairs config
   private final List<StarTreeAggregationConfig> _aggregationConfigs;
   // The upper bound of records to be scanned at the leaf node
   private final int _maxLeafRecords;


### PR DESCRIPTION
Add the following configs into `StarTreeAggregationConfig` as counterpart of `ForwardIndexConfig`:
- deriveNumDocsPerChunk
- indexVersion
- targetMaxChunkSize
- targetDocsPerChunk

During table config validation:
- Add a check to not allow only one of `functionColumnPairs` and `aggregationConfigs` to be configured
- Fix a bug where function duplicate check is mistakenly performed across multiple star-tree indices