### PR TITLE
Throttling logs change to not confuse users about rate limitting. #12742

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -222,6 +222,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentDataManager.class);
   public static final String RESOURCE_TEMP_DIR_NAME = "_tmp";
 
   private static final int MINIMUM_CONSUME_TIME_MINUTES = 10;
@@ -535,7 +536,14 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private boolean processStreamEvents(MessageBatch messageBatch, long idlePipeSleepTimeMillis) {
     int messageCount = messageBatch.getMessageCount();
     _partitionRateLimiter.throttle(messageCount);
+    RealtimeConsumptionRateManager consumptionRateManager = RealtimeConsumptionRateManager.getInstance();
+    LOGGER.info("A consumption rate limiter is set up for topic {} in table {} with rate limit: {} "
+            + "(topic rate limit: {}, partition count: {})", _streamConfig.getTopicName(), _tableNameWithType,
+        consumptionRateManager.getParitionCount(), consumptionRateManager.getTopicRateLimit(),
+        consumptionRateManager.getParitionCount());
     _serverRateLimiter.throttle(messageCount);
+    LOGGER.info("A server consumption rate limiter is set up with rate limit: {}",
+        consumptionRateManager.getServerRateLimit());
 
     PinotMeter realtimeRowsConsumedMeter = null;
     PinotMeter realtimeRowsDroppedMeter = null;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Rate limiter configuration logs relocated to event processing point

```mermaid
flowchart TD
  N0["Set rate limits in RealtimeConsumptionRateManager #40;F1#41;"]:::stAdded
  N1["Get RealtimeConsumptionRateManager instance #40;F2#41;"]:::stAdded
  N2["Log topic#47;partition rate limiter config #40;F2#41;"]:::stAdded
  N3["Log server rate limiter config #40;F2#41;"]:::stAdded
  N0 -->|"data flow"| N1
  N1 -->|"call sequence"| N2
  N1 -->|"call sequence"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager\.java — [before](https://github.com/apache/pinot/blob/e84f3f5667d5e78db60f5b09de61e89dae532c7e/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java) · [after](https://github.com/apache/pinot/blob/880cfb161a65dc12cf0a3ae6d6970dcb90379a28/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/e84f3f5667d5e78db60f5b09de61e89dae532c7e/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/880cfb161a65dc12cf0a3ae6d6970dcb90379a28/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU4NGYzZjU2NjdkNWU3OGRiNjBmNWIwOWRlNjFlODlkYWU1MzJjN2UiLCJjb250ZXh0X2hhc2giOiI5MDg1Mzg3M2MxNmE0OTlmY2I1Y2UxMTVhN2M2ZGI1N2JjNDM0YjI4OTZlODY3YzZlODlkNjE3ODYzYTJiMTkyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzY4ODY3LCJoZWFkX3NoYSI6Ijg4MGNmYjE2MWE2NWRjMTJjZjBhM2FlNmQ2OTcwZGNiOTAzNzlhMjgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlODRmM2Y1NjY3ZDVlNzhkYjYwZjViMDlkZTYxZTg5ZGFlNTMyYzdlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 25b72ff28542b9e9cfc6075b122455d1e43c5d1bd329b49d3249cbda02cbc701 -->
<!-- pinot-pr-flow:end -->

#https://github.com/apache/pinot/issues/12742

Enhancement for the comment given to change the log : https://github.com/apache/pinot/pull/12930