### PR TITLE
Don't enforce -realTimeInstanceCount and -offlineInstanceCount options when creating broker tenants

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -54,12 +54,13 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
   @CommandLine.Option(names = {"-instanceCount"}, required = true, description = "Number of instances.")
   private int _instanceCount;
 
-  @CommandLine.Option(names = {"-offlineInstanceCount"}, required = true, description = "Number of offline instances.")
-  private int _offlineInstanceCount;
+  @CommandLine.Option(names = {"-offlineInstanceCount"}, required = false,
+      description = "Number of offline instances.")
+  private Integer _offlineInstanceCount;
 
-  @CommandLine.Option(names = {"-realTimeInstanceCount"}, required = true,
+  @CommandLine.Option(names = {"-realTimeInstanceCount"}, required = false,
       description = "Number of realtime instances.")
-  private int _realtimeInstanceCount;
+  private Integer _realtimeInstanceCount;
 
   @CommandLine.Option(names = {"-exec"}, required = false, description = "Execute the command.")
   private boolean _exec;
@@ -151,6 +152,14 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     }
 
     LOGGER.info("Executing command: {}", toString());
+
+    if (_role == TenantRole.SERVER) {
+      if (_offlineInstanceCount == null || _realtimeInstanceCount == null) {
+        throw new IllegalArgumentException("-offlineInstanceCount and -realTimeInstanceCount should be set when "
+            + "creating a server tenant.");
+      }
+    }
+
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),


### PR DESCRIPTION
- Currently, the CLI options `-realTimeInstanceCount` and `-offlineInstanceCount` are marked as required for the `AddTenant` command.
- However, these options are only needed when creating server tenants and not when creating broker tenants (see [here](https://github.com/apache/pinot/blob/518fd180981ffa614042b8a5236650a2af41bfe5/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java#L1312-L1363)). We shouldn't unnecessarily require users to also configure these CLI options when creating broker tenants (also, it's not documented here - https://docs.pinot.apache.org/basics/concepts/components/cluster/tenant#broker-tenant).