### PR TITLE
Fix the issue that map flatten shouldn't remove the map field from the record

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -257,7 +257,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     for (String column : columns) {
       Object value = record.getValue(column);
       if (value instanceof Map) {
-        Map<String, Object> map = (Map) record.getValue(column);
+        Map<String, Object> map = (Map) value;
         List<String> mapColumns = new ArrayList<>();
         for (Map.Entry<String, Object> entry : new ArrayList<>(map.entrySet())) {
           String flattenName = concat(column, entry.getKey());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -257,7 +257,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     for (String column : columns) {
       Object value = record.getValue(column);
       if (value instanceof Map) {
-        Map<String, Object> map = (Map) record.removeValue(column);
+        Map<String, Object> map = (Map) record.getValue(column);
         List<String> mapColumns = new ArrayList<>();
         for (Map.Entry<String, Object> entry : new ArrayList<>(map.entrySet())) {
           String flattenName = concat(column, entry.getKey());

--- a/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
@@ -16,6 +16,10 @@
       {
         "columnName": "created_at_timestamp",
         "transformFunction": "fromDateTime(created_at, 'yyyy-MM-dd''T''HH:mm:ss''Z''')"
+      },
+      {
+        "columnName": "payload_str",
+        "transformFunction": "jsonFormat(payload)"
       }
     ],
     "complexTypeConfig": {

--- a/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_schema.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_schema.json
@@ -9,6 +9,14 @@
       "dataType": "STRING"
     },
     {
+      "name": "payload",
+      "dataType": "JSON"
+    },
+    {
+      "name": "payload_str",
+      "dataType": "STRING"
+    },
+    {
       "name": "payload.push_id",
       "dataType": "LONG"
     },


### PR DESCRIPTION
Fix the bug that If a table is configured with `complexTypeConfig`, during the ingestion `ComplexTypeTransformer#flattenMap` would remove all the maps inside the payload.

So it's not able to apply transform function on the map field later.

