### PR TITLE
including the underlying exception in the logging output

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -661,7 +661,7 @@ public class PinotTaskRestletResource {
     } catch (NoTaskScheduledException e) {
       throw new ControllerApplicationException(LOGGER,
           "No task is generated for table: " + adhocTaskConfig.getTableName() + ", with task type: "
-              + adhocTaskConfig.getTaskType(), Response.Status.BAD_REQUEST);
+              + adhocTaskConfig.getTaskType(), Response.Status.BAD_REQUEST, e);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Failed to create adhoc task: " + ExceptionUtils.getStackTrace(e), Response.Status.INTERNAL_SERVER_ERROR, e);


### PR DESCRIPTION
This PR includes the underlying `NoTaskScheduledException` to the logging output. It currently isn't logged. This should help with triaging / debugging efforts in these situations.
