### PR TITLE
broker & server api for realtime table freshness

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -30,10 +30,12 @@ import io.swagger.annotations.SwaggerDefinition;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -110,6 +112,55 @@ public class PinotBrokerDebug {
       return timeBoundaryInfo;
     } else {
       throw new WebApplicationException("Cannot find time boundary for table: " + tableName, Response.Status.NOT_FOUND);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/tableFreshness/{tableName}")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_TABLE_FRESHNESS)
+  @ApiOperation(value = "Get the minimum ingestion timestamp among consuming segments for a hybrid/realtime table.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "The minimum ingestion timestamp among consuming segments"),
+      @ApiResponse(code = 404, message = "Freshness not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Long> getTableFreshness(
+      @ApiParam(value = "Name of the table", example = "myTable | myTable_REALTIME",
+          required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Timeout in milliseconds") @QueryParam("timeoutMs") @DefaultValue("10000") long timeoutMs) {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(realtimeTableName);
+    if (TableType.OFFLINE == tableType) {
+      throw new WebApplicationException("Only hybrid/realtime table is supported: " + tableName,
+          Response.Status.BAD_REQUEST);
+    }
+
+    BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(
+        "SELECT * FROM " + realtimeTableName);
+    long requestId = getRequestId();
+    try {
+      Map<String, Long> freshnessInfo = _routingManager.getTableFreshness(brokerRequest, requestId, timeoutMs);
+
+      if (freshnessInfo != null) {
+        Optional<Long> minValueInMap = freshnessInfo.values()
+            .stream()
+            .min(Long::compare);
+
+        if (minValueInMap.isPresent()) {
+          Map<String, Long> returnValue = new HashMap<>();
+          returnValue.put("timestamp-ms", minValueInMap.get());
+          return returnValue;
+        } else {
+          throw new WebApplicationException("There are no consuming segments for " + realtimeTableName,
+              Response.Status.NOT_FOUND);
+        }
+      } else {
+        throw new WebApplicationException("Cannot find freshness for table, could not determine routing: "
+            + realtimeTableName, Response.Status.NOT_FOUND);
+      }
+    } catch (Exception e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.broker.routing;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +29,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
@@ -39,6 +50,13 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.apache.pinot.broker.broker.helix.ClusterChangeHandler;
 import org.apache.pinot.broker.routing.adaptiveserverselector.AdaptiveServerSelector;
 import org.apache.pinot.broker.routing.adaptiveserverselector.AdaptiveServerSelectorFactory;
@@ -115,6 +133,11 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
   private Set<String> _routableServers;
+
+  public static final ExecutorService SERVER_ADMIN_EXECUTOR_SERVICE = Executors.newFixedThreadPool(8);
+  public static final CloseableHttpClient SERVER_ADMIN_CLIENT = HttpClientBuilder.create().build();
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
 
   public BrokerRoutingManager(BrokerMetrics brokerMetrics, ServerRoutingStatsManager serverRoutingStatsManager,
       PinotConfiguration pinotConfig) {
@@ -678,6 +701,70 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     }
     TimeBoundaryManager timeBoundaryManager = routingEntry.getTimeBoundaryManager();
     return timeBoundaryManager != null ? timeBoundaryManager.getTimeBoundaryInfo() : null;
+  }
+
+  /**
+   * Returns a mapping of consuming segment -> ingestion timestamp-ms for involved segments in the broker request.
+   */
+  public Map<String, Long> getTableFreshness(BrokerRequest brokerRequest, long requestId, long timeoutMs) {
+    String tableNameWithType = brokerRequest.getQuerySource().getTableName();
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    if (routingEntry == null) {
+      throw new IllegalStateException("Failed to find routing for table: " + tableNameWithType);
+    }
+
+    InstanceSelector.SelectionResult selectionResult = routingEntry.calculateRouting(brokerRequest, requestId);
+    Map<ServerInstance, Pair<List<String>, List<String>>> serverInstanceMap =
+        getServerInstanceToSegmentsMap(tableNameWithType, selectionResult);
+
+    if (serverInstanceMap.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, Long> freshnessMap = new ConcurrentHashMap<>();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    serverInstanceMap.forEach((k, v) -> {
+      List<String> segments = v.getLeft();
+      String adminEndpoint = k.getAdminEndpoint();
+      String url = String.format("%s/tables/%s/consumingSegmentsFreshnessInfo", adminEndpoint, tableNameWithType);
+
+      CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+        try {
+          HttpPost request = new HttpPost(url);
+          String jsonPayload = "[" + segments.stream().map(s -> "\"" + s + "\"").collect(
+              Collectors.joining(",")) + "]";
+          request.setEntity(new StringEntity(jsonPayload));
+          request.setHeader("Content-Type", "application/json");
+
+          HttpResponse response = SERVER_ADMIN_CLIENT.execute(request);
+          int statusCode = response.getStatusLine().getStatusCode();
+          if (statusCode == HttpStatus.SC_OK) {
+            Map<String, Long> segmentFreshness = OBJECT_MAPPER.readValue(
+                EntityUtils.toString(response.getEntity()),
+                new TypeReference<Map<String, Long>>() { });
+
+            freshnessMap.putAll(segmentFreshness);
+          } else {
+            throw new IOException("Failed to get freshness info from server instance: "
+                + k.getHostname() + " with status code: " + statusCode);
+          }
+
+          return null;
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+      }, SERVER_ADMIN_EXECUTOR_SERVICE);
+      futures.add(future);
+    });
+
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException("Failed to get freshness info from server instances", e);
+    }
+
+    return freshnessMap;
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -110,6 +110,7 @@ public class Actions {
     public static final String FORCE_COMMIT = "ForceCommit";
     public static final String GET_BROKER = "GetBroker";
     public static final String GET_CONSUMING_SEGMENTS = "GetConsumingSegments";
+    public static final String GET_SEGMENTS_FRESHNESS = "GetSegmentsFreshness";
     public static final String GET_CONTROLLER_JOBS = "GetControllerJobs";
     public static final String GET_DEBUG_INFO = "GetDebugInfo";
     public static final String GET_EXTERNAL_VIEW = "GetExternalView";
@@ -119,6 +120,7 @@ public class Actions {
     public static final String GET_METADATA = "GetMetadata";
     public static final String GET_PAUSE_STATUS = "GetPauseStatus";
     public static final String GET_ROUTING_TABLE = "GetRoutingTable";
+    public static final String GET_TABLE_FRESHNESS = "GetTableFreshness";
     public static final String GET_SCHEMA = "GetSchema";
     public static final String GET_SEGMENT = "GetSegment";
     public static final String GET_SEGMENT_LINEAGE = "GetSegmentLineage";

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +77,9 @@ import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.Authorize;
+import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
@@ -822,6 +826,59 @@ public class TablesResource {
       tableDataManager.releaseSegment(segmentDataManager);
     }
   }
+
+  @POST
+  @Path("/tables/{realtimeTableName}/consumingSegmentsFreshnessInfo")
+  @Authorize(targetType = TargetType.TABLE, paramName = "realtimeTableName",
+      action = Actions.Table.GET_SEGMENTS_FRESHNESS)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Returns ingestion timestamp ms for given segments",
+      notes = "Any segments that are not consuming will be excluded")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 404, message = "Table not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Long> getSegmentsFreshnessInfo(
+      @ApiParam(value = "Realtime table name with or without type", required = true,
+          example = "myTable | myTable_REALTIME") @PathParam("realtimeTableName") String realtimeTableName,
+      @ApiParam(value = "List of segment names", required = true) String[]
+          segmentNames) {
+
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(realtimeTableName);
+      if (TableType.OFFLINE == tableType) {
+        throw new IllegalStateException("Cannot get freshness info for OFFLINE table: " + realtimeTableName);
+      }
+      List<String> segmentList = Arrays.asList(segmentNames);
+      Set<String> segmentSet = new HashSet<>(segmentList);
+      String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(realtimeTableName);
+      TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance,
+          tableNameWithType);
+      RealtimeTableDataManager realtimeTableDataManager = (RealtimeTableDataManager) tableDataManager;
+      Map<String, Long> freshnessInfo = new HashMap<>();
+      List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireSegments(segmentList, new ArrayList<>());
+      try {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          if (segmentDataManager instanceof RealtimeSegmentDataManager) {
+            RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
+            String segmentName = realtimeSegmentDataManager.getSegmentName();
+            if (segmentSet.contains(segmentName)) {
+              long ingestionTimeMs = realtimeTableDataManager.getPartitionIngestionTimeMs(segmentName);
+              freshnessInfo.put(segmentName, ingestionTimeMs);
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error("Caught exception when getting freshness info for table: {}", realtimeTableName, e);
+        throw new WebApplicationException("Caught exception when getting freshness info for table: "
+            + realtimeTableName + " " + e.getMessage());
+      } finally {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
+      return freshnessInfo;
+    }
 
   @GET
   @Path("tables/{realtimeTableName}/consumingSegmentsInfo")


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow for broker table freshness API: request → routing → parallel server calls → aggregation → min timestamp response\.

```mermaid
flowchart TD
  N0["Broker debug resource receives GET #47;debug#47;tableFreshness#47;#123;table#125; #40;F3#41;"]:::stModified
  N1["Build BrokerRequest and call routing manager getTableFreshness #40;F3#44; F1#41;"]:::stModified
  N2["Determine routing and initiate parallel server freshness requests #40;F1#41;"]:::stModified
  N3["Server freshness endpoint processes POST#44; validates table#44; returns ingestion tim #40;F4#41;"]:::stModified
  N4["Broker aggregates responses#44; computes min timestamp#44; returns JSON #40;F1#44; F3#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"invokes"| N2
  N2 -->|"HTTP POST"| N3
  N3 -->|"response"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager\.java — [before](https://github.com/apache/pinot/blob/2c51d4269ba62d6a1cd32f8e90c03c201e000815/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java) · [after](https://github.com/apache/pinot/blob/dbf1aef238a65ab7ffd4ea3c4f71217dd02a1880/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java)
- F3: pinot\-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug\.java — [before](https://github.com/apache/pinot/blob/2c51d4269ba62d6a1cd32f8e90c03c201e000815/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java) · [after](https://github.com/apache/pinot/blob/dbf1aef238a65ab7ffd4ea3c4f71217dd02a1880/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java)
- F4: pinot\-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource\.java — [before](https://github.com/apache/pinot/blob/2c51d4269ba62d6a1cd32f8e90c03c201e000815/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java) · [after](https://github.com/apache/pinot/blob/dbf1aef238a65ab7ffd4ea3c4f71217dd02a1880/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjJjNTFkNDI2OWJhNjJkNmExY2QzMmY4ZTkwYzAzYzIwMWUwMDA4MTUiLCJjb250ZXh0X2hhc2giOiI4NjQxNDM2ZGJhOTMxMTU3YTU2Yjg5ODllNWU3OWYwNWZiNjYyYTc2ZTRjMjc2Nzc5NzMyZTk2ODMwZDg5MTgwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjM0MTcxLCJoZWFkX3NoYSI6ImRiZjFhZWYyMzhhNjVhYjdmZmQ0ZWEzYzRmNzEyMTdkZDAyYTE4ODAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyYzUxZDQyNjliYTYyZDZhMWNkMzJmOGU5MGMwM2MyMDFlMDAwODE1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c6399329f8bfd3041f7655acc24c04a4334bfbf30ea5ced85ff1760a99ed3068 -->
<!-- pinot-pr-flow:end -->

One of the potential solutions to https://github.com/apache/pinot/issues/12477 was a broker api that returns table freshness info.

This PR:
- adds a new broker api `/debug/tableFreshness/{table}?timeoutMs=1000` that returns the minimum ingestion lag timestamp reported by servers across all the consuming segments. Underneath, the broker uses a new server api, `/tables/{table}/consumingSegmentsFreshnessInfo` that takes in a list of segments and returns the ingestion lag timestamp for the consuming segments among them
- the broker was chosen because it is a component designed to be highly available, fast, & the information needed is right there: the routing map.
- the api will route to 1 of the replica's based on whatever config is set, just as it does for any normal query

Example usage from broker:
```
❯ curl -i 'http://localhost:8000/debug/tableFreshness/airlineStats_REALTIME?timeoutMs=1000'
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 30

{"timestamp-ms":1716915412399}%
```

Example server usage:
```
❯ curl -X POST -H "Content-Type: application/json" \
-d '["airlineStats__0__0__20240528T1641Z", "airlineStats__4__0__20240528T1641Z"]' \
http://localhost:7500/tables/airlineStats/consumingSegmentsFreshnessInfo

{"airlineStats__4__0__20240528T1641Z":1716915549395,"airlineStats__0__0__20240528T1641Z":1716915552629}%
```

Possible improvements in future PRs:
- collect this data periodically via a "FreshnessManager" of sorts
cc @Jackie-Jiang 

--------
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
