### PR TITLE
fixing swagger setup using localhost as host name

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
@@ -19,10 +19,8 @@
 package org.apache.pinot.common.swagger;
 
 import io.swagger.jaxrs.config.BeanConfig;
-import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.UnknownHostException;
 import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
@@ -49,12 +47,6 @@ public class SwaggerSetupUtils {
     beanConfig.setBasePath(basePath);
     beanConfig.setResourcePackage(resourcePackage);
     beanConfig.setScan(true);
-
-    try {
-      beanConfig.setHost(InetAddress.getLocalHost().getHostName());
-    } catch (UnknownHostException e) {
-      throw new RuntimeException("Cannot get localhost name");
-    }
 
     ClassLoader classLoader = SwaggerSetupUtils.class.getClassLoader();
     CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");


### PR DESCRIPTION
Introduced https://github.com/apache/pinot/pull/13122/files#diff-7c6118ecbf342922f9e9288c5fbaf9c8dd3f158895d2a7e4e5582762249ecd06R54

We shouldn't set swagger hostname as localhost, which might not be accessible from the external environment.

E.g. pinot deployed in k8s will using `pinot-controller-1` as lcoalhost name, but this hostname is not exposed outside.

Current Behavior is using machine hostname:
<img width="608" alt="image" src="https://github.com/apache/pinot/assets/1202120/b6a03dab-55d9-4f88-994c-1e173788e5ac">

<img width="1481" alt="image" src="https://github.com/apache/pinot/assets/1202120/de84e599-971b-46c3-898c-5a13343819e4">

After fix:
<img width="572" alt="image" src="https://github.com/apache/pinot/assets/1202120/41a45231-1223-45ad-8dcb-79bead8b5037">

<img width="1525" alt="image" src="https://github.com/apache/pinot/assets/1202120/b3c79643-147b-4267-9cab-a7bb2db063e6">
