### PR TITLE
[partial-upsert] configure early release of _partitionGroupConsumerSemaphore in RealtimeSegmentDataManager

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -37,6 +37,9 @@ public class TableUpsertMetadataManagerFactory {
   public static final String UPSERT_DEFAULT_ENABLE_SNAPSHOT = "default.enable.snapshot";
   public static final String UPSERT_DEFAULT_ENABLE_PRELOAD = "default.enable.preload";
 
+  public static final String UPSERT_DEFAULT_ALLOW_PARTIAL_UPSERT_CONSUMPTION_DURING_COMMIT =
+      "default.allow.partial.upsert.consumption.during.commit";
+
   public static TableUpsertMetadataManager create(TableConfig tableConfig,
       @Nullable PinotConfiguration instanceUpsertConfig) {
     String tableNameWithType = tableConfig.getTableName();
@@ -60,6 +63,12 @@ public class TableUpsertMetadataManagerFactory {
       if (!upsertConfig.isEnablePreload()) {
         upsertConfig.setEnablePreload(
             Boolean.parseBoolean(instanceUpsertConfig.getProperty(UPSERT_DEFAULT_ENABLE_PRELOAD, "false")));
+      }
+
+      // server level config honoured only when table level config is not set to true
+      if (!upsertConfig.isAllowPartialUpsertConsumptionDuringCommit()) {
+        upsertConfig.setAllowPartialUpsertConsumptionDuringCommit(Boolean.parseBoolean(
+            instanceUpsertConfig.getProperty(UPSERT_DEFAULT_ALLOW_PARTIAL_UPSERT_CONSUMPTION_DURING_COMMIT, "false")));
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -94,6 +94,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to drop out-of-order record")
   private boolean _dropOutOfOrderRecord;
 
+  @JsonPropertyDescription("Whether to pause partial upsert table's partition consumption during commit")
+  private boolean _allowPartialUpsertConsumptionDuringCommit;
+
   public UpsertConfig(Mode mode) {
     _mode = mode;
   }
@@ -273,5 +276,14 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public void setMetadataManagerConfigs(Map<String, String> metadataManagerConfigs) {
     _metadataManagerConfigs = metadataManagerConfigs;
+  }
+
+  public void setAllowPartialUpsertConsumptionDuringCommit(
+      boolean allowPartialUpsertConsumptionDuringCommit) {
+    _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
+  }
+
+  public boolean isAllowPartialUpsertConsumptionDuringCommit() {
+    return _allowPartialUpsertConsumptionDuringCommit;
   }
 }


### PR DESCRIPTION
`bugfix` `upsert`

Relates to #13140 

This PR configures if we should do an early release of `_partitionGroupConsumerSemaphore` through `closeStreamConsumers()` during segment build and replace and segment download and replace.

By skipping to make this call early, we rely on segment.onDestroy() method to release the semaphore which ensures that the new consuming segment does not start consumption until the previous mutable segment is completely replaced during commit.

This helps in avoiding any unnecessary data inconsistencies between replicas for partial upsert tables but also leads to a stopped consumption during segment commit.

**New configs:**
Use server configuration: `"pinot.server.instance.upsert.default.allow.partial.upsert.consumption.during.commit": "true/false"` to toggle consumption during commit for partial upsert table. By defualt the consumption during commit will be paused from this commit onwards.

Use table upsert config: `allowPartialUpsertConsumptionDuringCommit: true/false` toggle consumption during commit for partial upsert table. If the table config is set as true then the server config is ignored.