### PR TITLE
Do not pause ingestion when upsert snapshot flow errors out

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -847,6 +847,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       long duration = System.currentTimeMillis() - startTime;
       _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS, duration,
           TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      _logger.warn("Error encountered while taking snapshot", e);
     } finally {
       _snapshotLock.writeLock().unlock();
       finishOperation();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -848,7 +848,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS, duration,
           TimeUnit.MILLISECONDS);
     } catch (Exception e) {
-      _logger.warn("Error encountered while taking snapshot", e);
+      _logger.warn("Caught exception while taking snapshot", e);
     } finally {
       _snapshotLock.writeLock().unlock();
       finishOperation();


### PR DESCRIPTION
label:
`upsert` 
`bugfix`

Saw this in our Uber cluster today where ingestion got stopped due to some exception in snapshot flow. The following was the error we encountered (pinot-version-build: 1.0.0):
```
java.lang.IllegalArgumentException: 
Path: /data/upinot/stream-pinot-server/dataDir/<tableName>/<tableName>__3__31__20240427T0642Z is not a directory at 
com.google.common.base.Preconditions.checkArgument(Preconditions.java:210) at 
org.apache.pinot.segment.spi.store.SegmentDirectoryPaths.findSegmentDirectory(SegmentDirectoryPaths.java:50) at 
org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl.getValidDocIdsSnapshotFile(ImmutableSegmentImpl.java:172) at 
org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl.hasValidDocIdsSnapshotFile(ImmutableSegmentImpl.java:152) at 
org.apache.pinot.segment.local.upsert.BasePartitionUpsertMetadataManager.doTakeSnapshot(BasePartitionUpsertMetadataManager.java:667) at 
org.apache.pinot.segment.local.upsert.BasePartitionUpsertMetadataManager.takeSnapshot(BasePartitionUpsertMetadataManager.java:637) at 
org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:679) 
at java.base/java.lang.Thread.run(Thread.java:829)
```

Ideally the segment was actually deleted but somehow was still a part of `trackedSegments`. 

This patch prevents the consumption thread from erroring out if the snapshot flow has encountered any issue. 

cc @Jackie-Jiang @klsince 