### PR TITLE
Properly handle complex type transformer in segment processor framework

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -104,10 +104,6 @@ public class CompositeTransformer implements RecordTransformer {
   public static CompositeTransformer composeAllTransformers(List<RecordTransformer> customTransformers,
       TableConfig tableConfig, Schema schema) {
     List<RecordTransformer> allTransformers = new ArrayList<>(customTransformers);
-    ComplexTypeTransformer complexTypeTransformer = ComplexTypeTransformer.getComplexTypeTransformer(tableConfig);
-    if (complexTypeTransformer != null) {
-      allTransformers.add(complexTypeTransformer);
-    }
     allTransformers.addAll(getDefaultTransformers(tableConfig, schema));
     return new CompositeTransformer(allTransformers);
   }


### PR DESCRIPTION
Although we added support for ComplexTypeTransformer in segment processor framework with #12942, we are not handling the unnesting of arrays/list correctly. 

The PR aims to fix this issue