### PR TITLE
Address Bug Related to Map fields Containing Multiple Entries in DataTypeTransformer

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
@@ -200,5 +200,21 @@ public class DataTypeTransformerTest {
       // Expected
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+
+    // Tests for Map with multi-entries List as values.
+    Map<String, List<String>> testMapWithMultiValueList = new HashMap<>();
+    testMapWithMultiValueList.put("testKey1", Arrays.asList("testValue1", "testValue2"));
+    values = new Object[]{
+        new Object[0], testMapWithMultiValueList
+    };
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+
+    // Tests for Map with multi-entries Object[] as values.
+    Map<String, Object[]> testMapWithObjectArray = new HashMap<>();
+    testMapWithObjectArray.put("testKey1", new Object[]{"testValue1", "testValue2"});
+    values = new Object[]{
+        new Object[0], testMapWithObjectArray
+    };
+    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
@@ -201,7 +201,7 @@ public class DataTypeTransformerTest {
     }
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
 
-    // Tests for Map with multi-entries List as values.
+    // Tests for Map with multi-entry List as values.
     Map<String, List<String>> testMapWithMultiValueList = new HashMap<>();
     testMapWithMultiValueList.put("testKey1", Arrays.asList("testValue1", "testValue2"));
     values = new Object[]{
@@ -209,12 +209,35 @@ public class DataTypeTransformerTest {
     };
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
 
-    // Tests for Map with multi-entries Object[] as values.
+    // Tests for Map with multi-entry Object[] as values.
     Map<String, Object[]> testMapWithObjectArray = new HashMap<>();
     testMapWithObjectArray.put("testKey1", new Object[]{"testValue1", "testValue2"});
     values = new Object[]{
         new Object[0], testMapWithObjectArray
     };
     assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
+
+    // Test for Map with multi key and multi-entry List as values.
+
+    Map<String, List<String>> testMapWithMultiKeyMultiValueList = new HashMap<>();
+    testMapWithMultiKeyMultiValueList.put("testKey1", Arrays.asList("testValue1", "testValue2"));
+    testMapWithMultiKeyMultiValueList.put("testKey2", Arrays.asList("testValue3", "testValue4"));
+    values = new Object[]{
+        new Object[0], testMapWithMultiKeyMultiValueList
+    };
+    Object[] expectedValuesNew =
+        new Object[]{new Object[]{"testValue1", "testValue2"}, new Object[]{"testValue3", "testValue4"}};
+    Object[] result = (Object[]) DataTypeTransformer.standardize(COLUMN, values, false);
+    Arrays.deepEquals(expectedValuesNew, result);
+
+    // Test for Map with multi key and multi-entry Object[] as values.
+    Map<String, Object[]> testMapWithMultiKeyMultiValueObjectArray = new HashMap<>();
+    testMapWithMultiKeyMultiValueObjectArray.put("testKey1", new Object[]{"testValue1", "testValue2"});
+    testMapWithMultiKeyMultiValueObjectArray.put("testKey2", new Object[]{"testValue3", "testValue4"});
+    values = new Object[]{
+        new Object[0], testMapWithMultiKeyMultiValueObjectArray
+    };
+    result = (Object[]) DataTypeTransformer.standardize(COLUMN, values, false);
+    Arrays.deepEquals(expectedValuesNew, result);
   }
 }


### PR DESCRIPTION
# Issue

In `standardize` method of `DataTypeTransformer`, we loop through the values if the value itself is an instance of `object[]` , we process each of the values of `object[]`  and set the `isSingleValue`  factor true assuming every value here is `singleValue` and again call `standardize` . We will get an exception in the case where the value field of a map is multivalued.

We will get an exception when 1. The map has multiple key entries and 2. If either values of the key entries are multivalue (`List` or `Object[]`)

Example Code to Recreate the Issue:

```
public void testMap() {
    Map<String, List<String>> testMapWithMultiValueList = new HashMap<>();
    testMapWithMultiValueList.put("testKey1", Arrays.asList("testValue1", "testValue2"));
    Object[] values = new Object[]{
        new Object[0], testMapWithMultiValueList
    };
    Object[] expectedValues = new Object[]{"testValue1", "testValue2"};
    assertEqualsNoOrder((Object[]) DataTypeTransformer.standardize(COLUMN, values, false), expectedValues);
  }
```

Thrown exception :

```
java.lang.IllegalStateException: Cannot read single-value from Collection: [testValue1, testValue2] for column: testColumn

	at com.google.common.base.Preconditions.checkState(Preconditions.java:838)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.standardizeCollection(DataTypeTransformer.java:197)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.standardize(DataTypeTransformer.java:138)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.standardizeCollection(DataTypeTransformer.java:181)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.standardize(DataTypeTransformer.java:141)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.standardize(DataTypeTransformer.java:154)
	at org.apache.pinot.segment.local.recordtransformer.DataTypeTransformerTest.testMap(DataTypeTransformerTest.java:211)
```

# Solution

Detect multivalued entries in the Object[] and modify the `isSingleValue` field accordingly.