### PR TITLE
add metrics for IdeaState update

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -64,7 +64,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   TABLE_REBALANCE_FAILURE_DETECTED("TableRebalanceFailureDetected", false),
   TABLE_REBALANCE_RETRY("TableRebalanceRetry", false),
   TABLE_REBALANCE_RETRY_TOO_MANY_TIMES("TableRebalanceRetryTooManyTimes", false),
-  NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false);
+  NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false),
+  IDEA_STATE_UPDATE_FAILURE("IdeaStateUpdateError", true),
+  IDEA_STATE_UPDATE_RETRY("IdeaStateUpdateRetry", true);
 
 
   private final String _brokerMeterName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -65,8 +65,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   TABLE_REBALANCE_RETRY("TableRebalanceRetry", false),
   TABLE_REBALANCE_RETRY_TOO_MANY_TIMES("TableRebalanceRetryTooManyTimes", false),
   NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false),
-  IDEA_STATE_UPDATE_FAILURE("IdeaStateUpdateError", true),
-  IDEA_STATE_UPDATE_RETRY("IdeaStateUpdateRetry", true);
+  IDEA_STATE_UPDATE_FAILURE("IdeaStateUpdateFailure", false),
+  IDEA_STATE_UPDATE_RETRY("IdeaStateUpdateRetry", false);
 
 
   private final String _brokerMeterName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -65,8 +65,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   TABLE_REBALANCE_RETRY("TableRebalanceRetry", false),
   TABLE_REBALANCE_RETRY_TOO_MANY_TIMES("TableRebalanceRetryTooManyTimes", false),
   NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false),
-  IDEA_STATE_UPDATE_FAILURE("IdeaStateUpdateFailure", false),
-  IDEA_STATE_UPDATE_RETRY("IdeaStateUpdateRetry", false);
+  IDEAL_STATE_UPDATE_FAILURE("IdealStateUpdateFailure", false),
+  IDEAL_STATE_UPDATE_RETRY("IdealStateUpdateRetry", false);
 
 
   private final String _brokerMeterName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
@@ -28,7 +28,7 @@ import org.apache.pinot.common.Utils;
 public enum ControllerTimer implements AbstractMetrics.Timer {
   TABLE_REBALANCE_EXECUTION_TIME_MS("tableRebalanceExecutionTimeMs", false),
   CRON_SCHEDULER_JOB_EXECUTION_TIME_MS("cronSchedulerJobExecutionTimeMs", false),
-  IDEA_STATE_UPDATE_LATENCY("IdeaStateUpdateLatency", true);
+  IDEA_STATE_UPDATE_TIME_MS("IdeaStateUpdateTimeMs", false);
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
@@ -27,7 +27,8 @@ import org.apache.pinot.common.Utils;
  */
 public enum ControllerTimer implements AbstractMetrics.Timer {
   TABLE_REBALANCE_EXECUTION_TIME_MS("tableRebalanceExecutionTimeMs", false),
-  CRON_SCHEDULER_JOB_EXECUTION_TIME_MS("cronSchedulerJobExecutionTimeMs", false);
+  CRON_SCHEDULER_JOB_EXECUTION_TIME_MS("cronSchedulerJobExecutionTimeMs", false),
+  IDEA_STATE_UPDATE_LATENCY("IdeaStateUpdateLatency", true);
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
@@ -28,7 +28,7 @@ import org.apache.pinot.common.Utils;
 public enum ControllerTimer implements AbstractMetrics.Timer {
   TABLE_REBALANCE_EXECUTION_TIME_MS("tableRebalanceExecutionTimeMs", false),
   CRON_SCHEDULER_JOB_EXECUTION_TIME_MS("cronSchedulerJobExecutionTimeMs", false),
-  IDEA_STATE_UPDATE_TIME_MS("IdeaStateUpdateTimeMs", false);
+  IDEAL_STATE_UPDATE_TIME_MS("IdealStateUpdateTimeMs", false);
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -124,12 +124,9 @@ public class HelixHelper {
           try {
             updatedIdealState = updater.apply(idealStateCopy);
           } catch (PermanentUpdaterException e) {
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
             LOGGER.error("Caught permanent exception while updating ideal state for resource: {}", resourceName, e);
             throw e;
           } catch (Exception e) {
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
-            LOGGER.error("Caught exception while updating ideal state for resource: {}", resourceName, e);
             return false;
           }
 
@@ -157,16 +154,13 @@ public class HelixHelper {
                 idealStateWrapper._idealState = updatedIdealState;
                 return true;
               } else {
-                controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
                 LOGGER.warn("Failed to update ideal state for resource: {}", resourceName);
                 return false;
               }
             } catch (ZkBadVersionException e) {
-              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
               LOGGER.warn("Version changed while updating ideal state for resource: {}", resourceName);
               return false;
             } catch (Exception e) {
-              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
               LOGGER.warn("Caught exception while updating ideal state for resource: {} (compressed={})", resourceName,
                   enableCompression, e);
               return false;
@@ -178,7 +172,6 @@ public class HelixHelper {
               LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
             }
             idealStateWrapper._idealState = idealState;
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
             return true;
           }
         }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -124,11 +124,11 @@ public class HelixHelper {
           try {
             updatedIdealState = updater.apply(idealStateCopy);
           } catch (PermanentUpdaterException e) {
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
             LOGGER.error("Caught permanent exception while updating ideal state for resource: {}", resourceName, e);
             throw e;
           } catch (Exception e) {
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
             LOGGER.error("Caught exception while updating ideal state for resource: {}", resourceName, e);
             return false;
           }
@@ -157,16 +157,16 @@ public class HelixHelper {
                 idealStateWrapper._idealState = updatedIdealState;
                 return true;
               } else {
-                controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+                controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
                 LOGGER.warn("Failed to update ideal state for resource: {}", resourceName);
                 return false;
               }
             } catch (ZkBadVersionException e) {
-              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
               LOGGER.warn("Version changed while updating ideal state for resource: {}", resourceName);
               return false;
             } catch (Exception e) {
-              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+              controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
               LOGGER.warn("Caught exception while updating ideal state for resource: {} (compressed={})", resourceName,
                   enableCompression, e);
               return false;
@@ -178,7 +178,7 @@ public class HelixHelper {
               LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
             }
             idealStateWrapper._idealState = idealState;
-            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+            controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
             return true;
           }
         }
@@ -211,12 +211,12 @@ public class HelixHelper {
           return false;
         }
       });
-      controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_RETRY, retries);
-      controllerMetrics.addTimedValue(resourceName, ControllerTimer.IDEA_STATE_UPDATE_TIME_MS,
+      controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_RETRY, retries);
+      controllerMetrics.addTimedValue(resourceName, ControllerTimer.IDEAL_STATE_UPDATE_TIME_MS,
               System.currentTimeMillis() - updateStartTime, TimeUnit.MILLISECONDS);
       return idealStateWrapper._idealState;
     } catch (Exception e) {
-      controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEA_STATE_UPDATE_FAILURE, 1L);
+      controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);
       throw new RuntimeException("Caught exception while updating ideal state for resource: " + resourceName, e);
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -106,7 +106,7 @@ public class HelixHelper {
       final Function<IdealState, IdealState> updater, RetryPolicy policy, final boolean noChangeOk) {
     ControllerMetrics controllerMetrics = ControllerMetrics.get();
     try {
-      long updateStartTime = System.currentTimeMillis();
+      long startTimeMs = System.currentTimeMillis();
       IdealStateWrapper idealStateWrapper = new IdealStateWrapper();
       int retries = policy.attempt(new Callable<Boolean>() {
         @Override
@@ -127,6 +127,7 @@ public class HelixHelper {
             LOGGER.error("Caught permanent exception while updating ideal state for resource: {}", resourceName, e);
             throw e;
           } catch (Exception e) {
+            LOGGER.error("Caught exception while updating ideal state for resource: {}", resourceName, e);
             return false;
           }
 
@@ -206,7 +207,7 @@ public class HelixHelper {
       });
       controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_RETRY, retries);
       controllerMetrics.addTimedValue(resourceName, ControllerTimer.IDEAL_STATE_UPDATE_TIME_MS,
-              System.currentTimeMillis() - updateStartTime, TimeUnit.MILLISECONDS);
+              System.currentTimeMillis() - startTimeMs, TimeUnit.MILLISECONDS);
       return idealStateWrapper._idealState;
     } catch (Exception e) {
       controllerMetrics.addMeteredValue(resourceName, ControllerMeter.IDEAL_STATE_UPDATE_FAILURE, 1L);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/cleanup/SchemaCleanupTaskStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/cleanup/SchemaCleanupTaskStatelessTest.java
@@ -97,6 +97,7 @@ public class SchemaCleanupTaskStatelessTest extends ControllerTest {
   public void testSchemaCleanupTask()
       throws Exception {
     PinotMetricUtils.cleanUp();
+    PinotMetricUtils.getPinotMetricsRegistry();
     // 1. Add a schema
     addSchema(createDummySchema("t1"));
     addSchema(createDummySchema("t2"));
@@ -146,6 +147,7 @@ public class SchemaCleanupTaskStatelessTest extends ControllerTest {
   public void testSchemaCleanupTaskNormalCase()
       throws Exception {
     PinotMetricUtils.cleanUp();
+    PinotMetricUtils.getPinotMetricsRegistry();
     // 1. Add a schema
     addSchema(createDummySchema("t1"));
     addSchema(createDummySchema("t2"));
@@ -219,6 +221,7 @@ public class SchemaCleanupTaskStatelessTest extends ControllerTest {
   public void testMissingSchema()
       throws Exception {
     PinotMetricUtils.cleanUp();
+    PinotMetricUtils.getPinotMetricsRegistry();
     // 1. Add a schema
     addSchema(createDummySchema("t1"));
     addSchema(createDummySchema("t2"));


### PR DESCRIPTION
This PR adds 3 metrics (latency, retry counter and error) for IdeaState update. For more details, see https://github.com/apache/pinot/issues/13253

I tested on one of our test cluster and see all metrics emitted, example of latency metric
<img width="1907" alt="Screenshot 2024-05-30 at 10 30 06 AM" src="https://github.com/apache/pinot/assets/147551894/41112d4f-f506-4acb-a8f2-59c40859de19">
