### PR TITLE
Fix class not found exception in GenericQuickstart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1014,7 +1014,7 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
Some recent change has changed the dependency to hadoop-mapreduce-client-core, making it end up as provided when in fact it is not. Unless it is clear who is the one providing the dependency, it should have compile scope