### PR TITLE
[bugfix] Handling null value for kafka client id suffix

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1435,11 +1435,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _acquiredConsumerSemaphore = new AtomicBoolean(false);
     InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
     String clientIdSuffix =
-        instanceDataManagerConfig != null ? instanceDataManagerConfig.getConsumerClientIdSuffix() : "";
+        instanceDataManagerConfig != null ? instanceDataManagerConfig.getConsumerClientIdSuffix() : null;
     if (StringUtils.isNotBlank(clientIdSuffix)) {
-      clientIdSuffix = "-" + clientIdSuffix;
+      _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId + "-" + clientIdSuffix;
+    } else {
+      _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId;
     }
-    _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId + clientIdSuffix;
     _segmentLogger = LoggerFactory.getLogger(RealtimeSegmentDataManager.class.getName() + "_" + _segmentNameStr);
     _tableStreamName = _tableNameWithType + "_" + streamTopic;
     if (_indexLoadingConfig.isRealtimeOffHeapAllocation() && !_indexLoadingConfig.isDirectRealtimeOffHeapAllocation()) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -209,7 +209,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   @Override
   public String getConsumerClientIdSuffix() {
-    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX, "");
+    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -209,7 +209,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   @Override
   public String getConsumerClientIdSuffix() {
-    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX);
+    return _serverConfig.getProperty(CONFIG_OF_REALTIME_SEGMENT_CONSUMER_CLIENT_ID_SUFFIX, "");
   }
 
   @Override


### PR DESCRIPTION
label:
`bugfix`

A small follow-up fix to #13168. I recently deployed this patch to one of our clusters and found `null` getting appending to client id. This patch fixes that issue.

```
String clientIdSuffix =
        instanceDataManagerConfig != null ? instanceDataManagerConfig.getConsumerClientIdSuffix() : "";
    if (StringUtils.isNotBlank(clientIdSuffix)) {
      clientIdSuffix = "-" + clientIdSuffix;
    }
    _clientId = _tableNameWithType + "-" + streamTopic + "-" + _partitionGroupId + clientIdSuffix;
```
Above if ciientIdSuffix is null, we were not substituting it with `""`.

cc @Jackie-Jiang 