### PR TITLE
Add support for raw JSON filter predicates

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -80,6 +80,7 @@ public class EqualsPredicateEvaluatorFactory {
       case TIMESTAMP:
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case STRING:
+      case JSON:
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedEqPredicateEvaluator(eqPredicate, BytesUtils.toBytes(value));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -128,7 +128,8 @@ public class InPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
       }
-      case STRING: {
+      case STRING:
+      case JSON: {
         List<String> stringValues = inPredicate.getValues();
         Set<String> matchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(stringValues.size()));
         // NOTE: Add value-by-value to avoid overhead

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -76,6 +76,7 @@ public class NotEqualsPredicateEvaluatorFactory {
       case TIMESTAMP:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case STRING:
+      case JSON:
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedNeqPredicateEvaluator(notEqPredicate, BytesUtils.toBytes(value));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -128,7 +128,8 @@ public class NotInPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
       }
-      case STRING: {
+      case STRING:
+      case JSON: {
         List<String> stringValues = notInPredicate.getValues();
         Set<String> nonMatchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(stringValues.size()));
         // NOTE: Add value-by-value to avoid overhead

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorTestUtils.java
@@ -70,4 +70,15 @@ public class PredicateEvaluatorTestUtils {
       randomValues[i] = RandomStringUtils.random(maxStringLength).getBytes();
     }
   }
+
+  public static void fillRandomJson(String[] randomValues, String jsonStringTemplate, int numPlaceholders,
+      int maxStringLength) {
+    for (int i = 0; i < randomValues.length; i++) {
+      Object[] randomPlaceholderValues = new String[numPlaceholders];
+      for (int j = 0; j < numPlaceholders; j++) {
+        randomPlaceholderValues[j] = RandomStringUtils.randomAlphanumeric(maxStringLength);
+      }
+      randomValues[i] = String.format(jsonStringTemplate, randomPlaceholderValues);
+    }
+  }
 }


### PR DESCRIPTION
- Currently, raw JSON values (non dictionary encoded) can't be queried directly via predicates like `=`, `!=`, `IN`, `NOT IN` and JSON columns are typically queried using the `JSON_MATCH` filter predicate that uses the JSON index.
- Attempting to do so results in errors like:
```
QueryExecutionError:
org.apache.pinot.spi.exception.BadQueryRequestException: java.lang.IllegalStateException: Unsupported data type: JSON
	at org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider.getPredicateEvaluator(PredicateEvaluatorProvider.java:94)
	at org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider.getPredicateEvaluator(PredicateEvaluatorProvider.java:100)
	at org.apache.pinot.core.plan.FilterPlanNode.constructPhysicalOperator(FilterPlanNode.java:310)
	at org.apache.pinot.core.plan.FilterPlanNode.run(FilterPlanNode.java:93)
...
Caused by: java.lang.IllegalStateException: Unsupported data type: JSON
	at org.apache.pinot.core.operator.filter.predicate.EqualsPredicateEvaluatorFactory.newRawValueBasedEvaluator(EqualsPredicateEvaluatorFactory.java:87)
	at org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider.getPredicateEvaluator(PredicateEvaluatorProvider.java:76)
	... 24 more
```
- However, for certain simple JSON values, it could be useful to allow direct comparison using predicates like `=`, `!=`, `IN`, `NOT IN` via direct string matching like is done for `STRING` columns since the stored type for JSON columns is also `STRING`.
- We'd need to document that things like formatting / spacing and object key order aren't considered (since that would slow things down significantly) and such use cases are better served with the JSON index and `JSON_MATCH` filter predicate.