### PR TITLE
Optimize snapshot flow to only snapshot segments which have updates

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -705,8 +705,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         if (_partitionUpsertMetadataManager != null) {
           if (_tableConfig.getUpsertMetadataTTL() > 0) {
             // If upsertMetadataTTL is enabled, we will remove expired primary keys from upsertMetadata
-            // AFTER taking a snapshot. Taking the snapshot first is crucial to ensure we capture the final
-            // state of a particular key before it exits the TTL window.
+            // AFTER taking a snapshot. Taking the snapshot first is crucial to capture the final
+            // state of each key before it exits the TTL window. Out-of-TTL segments are skipped in
+            // the doAddSegment flow, and the snapshot is used to enableUpsert on the immutable out-of-TTL segment.
+            // If no snapshot is found, the entire segment is marked as valid and queryable.
             _partitionUpsertMetadataManager.takeSnapshot();
             _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
           } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -703,9 +703,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         //   persisted.
         // Take upsert snapshot before starting consuming events
         if (_partitionUpsertMetadataManager != null) {
-          _partitionUpsertMetadataManager.takeSnapshot();
-          // If upsertTTL is enabled, we will remove expired primary keys from upsertMetadata after taking snapshot.
+          // we should remove keys first and then take snapshot, this is because deletedKeysTTL flow removes keys from
+          // map and also updates removes valid doc ids. If we take snapshot just after that, this way we save one
+          // commit cycle for the deleted valid doc ids to reflect in snapshot
           _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
+          _partitionUpsertMetadataManager.takeSnapshot();
         }
 
         while (!_state.isFinal()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -48,6 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -895,6 +896,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         numPrimaryKeysInSnapshot += immutableSegment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
       } catch (Exception e) {
         _logger.warn("Caught exception while taking snapshot for segment: {}, skipping", segment.getSegmentName(), e);
+        Utils.rethrowException(e);
       }
     }
     for (ImmutableSegmentImpl segment : segmentsWithoutSnapshot) {
@@ -904,6 +906,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         numPrimaryKeysInSnapshot += segment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
       } catch (Exception e) {
         _logger.warn("Caught exception while taking snapshot for segment: {}, skipping", segment.getSegmentName(), e);
+        Utils.rethrowException(e);
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -390,6 +390,11 @@ public class TableConfig extends BaseJsonConfig {
   }
 
   @JsonIgnore
+  public double getUpsertMetadataTTL() {
+    return _upsertConfig == null ? 0 : _upsertConfig.getMetadataTTL();
+  }
+
+  @JsonIgnore
   @Nullable
   public String getUpsertDeleteRecordColumn() {
     return _upsertConfig == null ? null : _upsertConfig.getDeleteRecordColumn();


### PR DESCRIPTION
label:
`optimization`
`enhancement`
`upsert` 

### Change 1
Inspired from @klsince's work #12976.
This patch enhances the `doTakeSnapshot` flow to not snapshot all segments in a given partition but only the ones which have been updated since last-snapshot taken. This particularly improves scenarios where the number of segments per partition is high. `doTakeSnapshot` workflow runs before a new consuming segment starts consumption and directly introduces ingestion lag before starting consumption. 

### Change 2
This patch also reorders the `takeSnapshot` and `removeDeletedPrimaryKeys` flow putting the latter before the first in case of `deletedKeysTTL` set. This way all the keys and validDocIDs that got removed in `removeDeletedPrimaryKeys` will be snapshotted immediately rather than one commit cycle later.

We were seeing scenerios where the snapshot flow time taken went upto 30s in case of some tables.
<img width="1309" alt="Screenshot 2024-06-06 at 6 21 45 PM" src="https://github.com/apache/pinot/assets/23629228/9b0eb2be-4a6e-402b-8ebd-db9ad4ec3dd0">

### Change 3
We enable snapshotting during server restart for partial-upsert tables before the first consuming segment. This was not done before with the assumption that not all segments are loaded but in case of partial-upsert tables we don't start consumption unless all data is loaded. This saves one segment commit cycle for snapshotting in case of enabling snapshots for tables or after server restart.
The below screenshot shows a dip after server restart and it takes one commit cyle to recover snapshots again.
<img width="1306" alt="Screenshot 2024-06-07 at 7 48 58 PM" src="https://github.com/apache/pinot/assets/23629228/5ef81b6d-9795-483b-be6d-106c365f61fb">

