### PR TITLE
[Minor] Handle 403 response to send the message as HTTP response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/BrokerCommonExceptionMapper.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/BrokerCommonExceptionMapper.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api.resources;
+
+import javax.inject.Singleton;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.apache.pinot.common.utils.SimpleHttpErrorInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Provider
+@Singleton
+public class BrokerCommonExceptionMapper implements ExceptionMapper<Throwable> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerCommonExceptionMapper.class);
+  private static final int DEFAULT_STATUS = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+
+  @Override
+  public Response toResponse(Throwable t) {
+    int status = DEFAULT_STATUS;
+    if (t instanceof WebApplicationException) {
+      status = ((WebApplicationException) t).getResponse().getStatus();
+    }
+    SimpleHttpErrorInfo errorInfo = new SimpleHttpErrorInfo(status, t.getMessage());
+    return Response.status(status).entity(errorInfo).type(MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/BrokerCommonExceptionMapperTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/BrokerCommonExceptionMapperTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api.resources;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.SimpleHttpErrorInfo;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+public class BrokerCommonExceptionMapperTest {
+
+  private BrokerCommonExceptionMapper _exceptionMapper;
+
+  @Mock
+  private WebApplicationException _webApplicationException;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    _exceptionMapper = new BrokerCommonExceptionMapper();
+  }
+
+  @Test
+  public void testToResponseWithWebApplicationException() {
+    // Arrange
+    int status = 404;
+    when(_webApplicationException.getResponse()).thenReturn(Response.status(status).build());
+    when(_webApplicationException.getMessage()).thenReturn("Not Found");
+
+    // Act
+    Response response = _exceptionMapper.toResponse(_webApplicationException);
+
+    // Assert
+    assertEquals(response.getStatus(), status);
+    SimpleHttpErrorInfo errorInfo = (SimpleHttpErrorInfo) response.getEntity();
+    assertEquals(errorInfo.getCode(), status);
+    assertEquals(errorInfo.getError(), "Not Found");
+  }
+
+  @Test
+  public void testToResponseWithGenericException() {
+    // Arrange
+    Throwable throwable = new RuntimeException("Internal Server Error");
+
+    // Act
+    Response response = _exceptionMapper.toResponse(throwable);
+
+    // Assert
+    assertEquals(response.getStatus(), 500);
+    SimpleHttpErrorInfo errorInfo = (SimpleHttpErrorInfo) response.getEntity();
+    assertEquals(errorInfo.getCode(), 500);
+    assertEquals(errorInfo.getError(), "Internal Server Error");
+  }
+}


### PR DESCRIPTION
The message from WebApplicationException Permission Denied is not sent back as HTTP response from broker. This minor patch fixes that. 

**Existing**
```
$ curl -X POST "http://<host:port>/query/sql"      -H "Content-Type: application/json"      -d '{"sql":"<QUERY>", "queryOptions": "useMultistageEngine=true"}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying <IP>...
* TCP_NODELAY set
* Connected to <HOST> (<IP>) port <port> (#0)
> POST /query/sql HTTP/1.1
> Host: <host:port>
> User-Agent: curl/7.64.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 158
> 
* upload completely sent off: 158 out of 158 bytes
< HTTP/1.1 403 Forbidden
< Content-Length: 0
< 
* Connection #0 to host <host> left intact
```

**With this Change**
```
$ curl -X POST "http://<host:port>/query/sql"      -H "Content-Type: application/json"      -d '{"sql":"<QUERY>", "queryOptions": "useMultistageEngine=true"}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying <IP>...
* TCP_NODELAY set
* Connected to <HOST> (<IP>) port <port> (#0)
> POST /query/sql HTTP/1.1
> Host: <host:port>
> User-Agent: curl/7.64.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 158
> 
* upload completely sent off: 158 out of 158 bytes
< HTTP/1.1 403 Forbidden
< Content-Type: application/json
< Content-Length: <50>
< 
* Connection #0 to host <HOST> left intact
{"code":403,"error":"Permission denied"}
```

This would be useful when the failed table names are returned as from the change made in https://github.com/apache/pinot/pull/13195