### PR TITLE
Add offset based lag metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -72,7 +72,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   // Needed to track if valid doc id snapshots are present for faster restarts
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),
-  UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false);
+  UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false),
+  REALTIME_INGESTION_DELAY_OFFSET("offsetLag", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -73,7 +73,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   // Needed to track if valid doc id snapshots are present for faster restarts
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),
   UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false),
-  REALTIME_INGESTION_DELAY_OFFSET("offsetLag", false);
+  REALTIME_INGESTION_OFFSET_LAG("offsetLag", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -655,6 +655,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     updateCurrentDocumentCountMetrics();
     if (messageBatch.getUnfilteredMessageCount() > 0) {
       updateIngestionDelay(messageBatch.getLastMessageMetadata());
+      updateIngestionDelayOffset(messageBatch.getLastMessageMetadata());
       _hasMessagesFetched = true;
       if (streamMessageCount > 0 && _segmentLogger.isDebugEnabled()) {
         _segmentLogger.debug("Indexed {} messages ({} messages read from stream) current offset {}",
@@ -1776,6 +1777,19 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     if (metadata != null) {
       _realtimeTableDataManager.updateIngestionDelay(metadata.getRecordIngestionTimeMs(),
           metadata.getFirstStreamRecordIngestionTimeMs(), _partitionGroupId);
+    }
+  }
+
+  private void updateIngestionDelayOffset(RowMetadata metadata) {
+    if (metadata != null) {
+      try {
+        StreamPartitionMsgOffset latestOffset =
+            _partitionMetadataProvider.fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, 5000);
+      _realtimeTableDataManager.updateIngestionDelayOffset(metadata.getOffset(),
+          latestOffset, _partitionGroupId);
+      } catch (Exception e) {
+        _segmentLogger.warn("Failed to fetch latest offset for updating ingestion delay", e);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -266,15 +266,15 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Method used by RealtimeSegmentManagers to update their partition delays
    *
    * @param ingestionTimeMs Ingestion delay being reported.
+   * @param firstStreamIngestionTimeMs Ingestion time of the first message in the stream.
    * @param partitionGroupId Partition ID for which delay is being updated.
+   * @param offset last offset received for the partition.
+   * @param latestOffset latest upstream offset for the partition.
    */
-  public void updateIngestionDelay(long ingestionTimeMs, long firstStreamIngestionTimeMs, int partitionGroupId) {
-    _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, firstStreamIngestionTimeMs, partitionGroupId);
-  }
-
-  public void updateIngestionDelayOffset(StreamPartitionMsgOffset offset, StreamPartitionMsgOffset latestOffset,
-      int partitionGroupId) {
-    _ingestionDelayTracker.updateIngestionDelayOffset(offset, latestOffset, partitionGroupId);
+  public void updateIngestionMetrics(long ingestionTimeMs, long firstStreamIngestionTimeMs,
+      StreamPartitionMsgOffset offset, StreamPartitionMsgOffset latestOffset, int partitionGroupId) {
+    _ingestionDelayTracker.updateIngestionMetrics(ingestionTimeMs, firstStreamIngestionTimeMs, offset, latestOffset,
+        partitionGroupId);
   }
 
   /*

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -74,6 +74,7 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.spi.utils.TimeUtils;
@@ -269,6 +270,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    */
   public void updateIngestionDelay(long ingestionTimeMs, long firstStreamIngestionTimeMs, int partitionGroupId) {
     _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, firstStreamIngestionTimeMs, partitionGroupId);
+  }
+
+  public void updateIngestionDelayOffset(StreamPartitionMsgOffset offset, StreamPartitionMsgOffset latestOffset,
+      int partitionGroupId) {
+    _ingestionDelayTracker.updateIngestionDelayOffset(offset, latestOffset, partitionGroupId);
   }
 
   /*


### PR DESCRIPTION
Adds new methods and metric that reports ingestion delay as difference in offset.

Only works for KafkaConsumer because Kinesis would need methods to get latest offset from upstream which are not present. 