### PR TITLE
Update getValidDocIdsMetadataFromServer to make call in batches to servers and other bug fixes

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -972,7 +972,10 @@ public class PinotTableRestletResource {
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
       @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType")
-      @DefaultValue("SNAPSHOT") ValidDocIdsType validDocIdsType, @Context HttpHeaders headers) {
+      @DefaultValue("SNAPSHOT") ValidDocIdsType validDocIdsType,
+      @ApiParam(value = "Number of segments in a batch per server request")
+      @QueryParam("numSegmentsBatchPerServerRequest") @DefaultValue("500") int numSegmentsBatchPerServerRequest,
+      @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch aggregate validDocIds metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
@@ -990,7 +993,8 @@ public class PinotTableRestletResource {
       validDocIdsType = (validDocIdsType == null) ? ValidDocIdsType.SNAPSHOT : validDocIdsType;
       JsonNode segmentsMetadataJson =
           tableMetadataReader.getAggregateValidDocIdsMetadata(tableNameWithType, segmentNames,
-              validDocIdsType.toString(), _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+              validDocIdsType.toString(), _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000,
+              numSegmentsBatchPerServerRequest);
       validDocIdsMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
     } catch (InvalidConfigException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -974,7 +974,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType")
       @DefaultValue("SNAPSHOT") ValidDocIdsType validDocIdsType,
       @ApiParam(value = "Number of segments in a batch per server request")
-      @QueryParam("numSegmentsBatchPerServerRequest") @DefaultValue("500") int numSegmentsBatchPerServerRequest,
+      @QueryParam("serverRequestBatchSize") @DefaultValue("500") int serverRequestBatchSize,
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch aggregate validDocIds metadata for a table {}", tableName);
@@ -994,7 +994,7 @@ public class PinotTableRestletResource {
       JsonNode segmentsMetadataJson =
           tableMetadataReader.getAggregateValidDocIdsMetadata(tableNameWithType, segmentNames,
               validDocIdsType.toString(), _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000,
-              numSegmentsBatchPerServerRequest);
+              serverRequestBatchSize);
       validDocIdsMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
     } catch (InvalidConfigException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
@@ -139,8 +139,7 @@ public class CompletionServiceHelper {
         // we append a count value to the key to ensure each response is uniquely identified.
         // Otherwise, the map will store only the last response, overwriting previous ones.
         if (multiRequestPerServer) {
-          int count = completionServiceResponse._instanceToRequestCount.getOrDefault(key, 0) + 1;
-          completionServiceResponse._instanceToRequestCount.put(key, count);
+          int count = completionServiceResponse._instanceToRequestCount.compute(key, (k, v) -> v == null ? 1 : v + 1);
           key = key + "__" + count;
         }
         completionServiceResponse._httpResponses.put(key, responseString);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
@@ -136,6 +136,9 @@ public class CompletionServiceHelper {
         }
         String responseString = EntityUtils.toString(multiHttpRequestResponse.getResponse().getEntity());
         String key = multiRequestPerServer ? uri.toString() : instance;
+        // there can be a scenario where all the requests to a particular server had the same uri but the
+        // payload might be different. In that scenario, we should append a random string to the key so that
+        // we send all the responses back to the caller otherwise in the map, the last response will overwrite
         if (multiRequestPerServer && completionServiceResponse._httpResponses.containsKey(key)) {
           LOGGER.warn("Appending random string to http response key name: {}", key);
           key = key + "__" + RandomStringUtils.randomAlphanumeric(10);
@@ -156,10 +159,10 @@ public class CompletionServiceHelper {
       }
     }
 
-    int numServerRequestssResponded = completionServiceResponse._httpResponses.size();
-    if (numServerRequestssResponded != size) {
+    int numServerRequestsResponded = completionServiceResponse._httpResponses.size();
+    if (numServerRequestsResponded != size) {
       LOGGER.warn("Finished reading information for table: {} with {}/{} server-request responses", tableNameWithType,
-          numServerRequestssResponded, size);
+          numServerRequestsResponded, size);
     } else {
       LOGGER.info("Finished reading information for table: {}", tableNameWithType);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -159,7 +159,7 @@ public class TableMetadataReader {
    * @return a list of ValidDocIdsMetadataInfo
    */
   public JsonNode getAggregateValidDocIdsMetadata(String tableNameWithType, List<String> segmentNames,
-      String validDocIdsType, int timeoutMs)
+      String validDocIdsType, int timeoutMs, int numSegmentsBatchPerServerRequest)
       throws InvalidConfigException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -170,7 +170,7 @@ public class TableMetadataReader {
 
     List<ValidDocIdsMetadataInfo> aggregateTableMetadataInfo =
         serverSegmentMetadataReader.getValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments, endpoints,
-            segmentNames, timeoutMs, validDocIdsType);
+            segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest);
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -169,5 +169,10 @@ public class MinionConstants {
      * Valid doc ids type
      */
     public static final String VALID_DOC_IDS_TYPE = "validDocIdsType";
+
+    /**
+     * number of segments to query in one batch to fetch valid doc id metadata, by default 500
+     */
+    public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -137,9 +137,6 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
           new ServerSegmentMetadataReader(_clusterInfoAccessor.getExecutor(),
               _clusterInfoAccessor.getConnectionManager());
 
-      // TODO: currently, we put segmentNames=null to get metadata for all segments. We can change this to get
-      // valid doc id metadata in batches with the loop.
-
       // By default, we use 'snapshot' for validDocIdsType. This means that we will use the validDocIds bitmap from
       // the snapshot from Pinot segment. This will require 'enableSnapshot' from UpsertConfig to be set to true.
       String validDocIdsTypeStr =

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -58,7 +58,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   private static final String DEFAULT_BUFFER_PERIOD = "7d";
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
   private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 0;
-  private static final int DEFAULT_SEGMENT_BATCH_SIZE_FOR_QUERYING_SERVER = 500;
+  private static final int DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = 500;
 
   public static class SegmentSelectionResult {
 
@@ -148,7 +148,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
       int numSegmentsBatchPerServerRequest =
           Integer.parseInt(taskConfigs.getOrDefault(UpsertCompactionTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
-              String.valueOf(DEFAULT_SEGMENT_BATCH_SIZE_FOR_QUERYING_SERVER)));
+              String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
 
       // Validate that the snapshot is enabled if validDocIdsType is validDocIdsSnapshot
       if (validDocIdsType == ValidDocIdsType.SNAPSHOT) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -657,9 +657,7 @@ public class TablesResource {
     }
     try {
       if (!missingSegments.isEmpty()) {
-        throw new WebApplicationException(
-            String.format("Table %s has missing segments: %s)", tableNameWithType, segments),
-            Response.Status.NOT_FOUND);
+        LOGGER.warn("Table {} has missing segments {}", tableNameWithType, missingSegments);
       }
       List<Map<String, Object>> allValidDocIdsMetadata = new ArrayList<>(segmentDataManagers.size());
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -657,6 +657,10 @@ public class TablesResource {
     }
     try {
       if (!missingSegments.isEmpty()) {
+        // we need not abort here or throw exception as we can still process the segments that are available
+        // During UpsertCompactionTaskGenerator, controller sends a lot of segments to server to fetch validDocIds
+        // and it may happen that a segment is deleted concurrently. In such cases, we should log a warning and
+        // process the remaining available segments.
         LOGGER.warn("Table {} has missing segments {}", tableNameWithType, missingSegments);
       }
       List<Map<String, Object>> allValidDocIdsMetadata = new ArrayList<>(segmentDataManagers.size());


### PR DESCRIPTION
label:
`bugfix`
`upsert`

This patch addresses multiple things:

1. We saw issue with upsert-compaction not working for few servers of a table but working for others. This was primarily because we send all segment names from controller to server in payload and even if one is missing (which can be due to concurrent deletion) it results in `NOT_FOUND` error. We are moving the failure behaviour of API in this scenario to a warn log instead and continue proceeding to return valid doc ids for whatever segments are available. 
2. We send high number of segments in the payload from controller to server. Sending requests in batches so that request-body is nominal in size and if there is issue with one segment, then entire host data is not missed but only batch's data.
3. For CompletionServiceHelper code, if we enabled `multiRequestsPerServer` flag and the uri is same for the requests to a server, then only last response will be returned back to the caller. We add a count value to the uri key in this scenario to honour all responses from a single host.

cc @klsince @snleee 