### PR TITLE
Add table level metric for segment upload error

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -47,6 +47,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_STREAM_DATA_LOSS("dataLoss", false),
   CONTROLLER_PERIODIC_TASK_RUN("periodicTaskRun", false),
   CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
+  CONTROLLER_TABLE_SEGMENT_UPLOAD_ERROR("TableSegmentUploadError", false),
   PERIODIC_TASK_ERROR("periodicTaskError", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -401,6 +401,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       throw e;
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
+      _controllerMetrics.addMeteredTableValue(tableName, ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER, "Exception while uploading segment: " + e.getMessage(),
           Response.Status.INTERNAL_SERVER_ERROR, e);
     } finally {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -401,7 +401,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       throw e;
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
-      _controllerMetrics.addMeteredTableValue(tableName, ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
+      _controllerMetrics.addMeteredTableValue(tableName, ControllerMeter.CONTROLLER_TABLE_SEGMENT_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER, "Exception while uploading segment: " + e.getMessage(),
           Response.Status.INTERNAL_SERVER_ERROR, e);
     } finally {


### PR DESCRIPTION
label:
`observability` 

Adding a table-level metric to track number of segment upload errors. Right now, the metric is only emitted at controller level.

cc @ankitsultana @Jackie-Jiang 