### PR TITLE
[Bug fix] Fix URI construction so that AddSchema command line tool works

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -177,7 +177,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       URI schemaURI = FileUploadDownloadClient
           .getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort));
-      schemaURI = new URI(schemaURI + "?override=" + _override + "?force=" + _force);
+      schemaURI = new URI(schemaURI + "?override=" + _override + "&force=" + _force);
       fileUploadDownloadClient.addSchema(schemaURI,
           schema.getSchemaName(), schemaFile, AuthProviderUtils.makeAuthHeaders(
               AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken,


### PR DESCRIPTION
Addresses #13312. Fix URI construction so that AddSchema command line tool works when override flag is set to true
 
 Verified that when the override flag is set to true the schema is overridden successfully
 
  $ bin/pinot-admin.sh AddSchema \
  -schemaFile /Users/suyash/Desktop/work/open-source/workspace/testData/transcript_schema.json \
  -controllerHost localhost \
  -controllerPort 9000 \
  -override=true \
  -exec

2024/06/05 23:22:22.613 INFO [AddSchemaCommand] [main] Executing command: AddSchema -controllerProtocol http -controllerHost localhost -controllerPort 9000 -schemaFile /Users/suyash/Desktop/work/open-source/workspace/testData/transcript_schema.json -override true _force false -user null -password [hidden] -exec