### PR TITLE
[DO NOT MERGE] Handle legacy query and log error

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1467,27 +1467,6 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "rsvp_count");
 
-    sql = "select secondsSinceEpoch/86400 AS daysSinceEpoch, sum(rsvp_count) as sum_rsvp_count, count(*) as cnt"
-        + " from meetupRsvp where daysSinceEpoch = 18523 group by daysSinceEpoch order by cnt, sum_rsvp_count DESC"
-        + " limit 50";
-    pinotQuery = compileToPinotQuery(sql);
-    Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
-    // Alias should not be applied to filter
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "daysSinceEpoch");
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 18523);
-    Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "divide");
-    Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "secondsSinceEpoch");
-    Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 86400);
-    Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
-
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).
     try {
       sql = "select sum(rsvp_count), count(*) as cnt from meetupRsvp group by group_country, cnt limit 50";
@@ -1533,15 +1512,6 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "C2");
-  }
-
-  @Test
-  public void testAliasInFilter() {
-    // Alias should not be applied
-    String sql = "SELECT C1 AS ALIAS_CI FROM Foo WHERE ALIAS_CI > 10";
-    PinotQuery pinotQuery = compileToPinotQuery(sql);
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ALIAS_CI");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -145,39 +145,6 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
     }
   }
 
-  @DataProvider
-  public static String[] illegalExpressions() {
-    //@formatter:off
-    return new String[] {
-        // '10.0' cannot be parsed as INT/LONG/TIMESTAMP/BYTES
-        String.format("CASE WHEN true THEN %s ELSE '10.0' END", INT_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE '10.0' END", LONG_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE '10.0' END", TIMESTAMP_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE '10.0' END", BYTES_SV_COLUMN),
-        // 'abc' cannot be parsed as any type other than STRING
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", INT_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", LONG_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", FLOAT_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", DOUBLE_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", BIG_DECIMAL_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", TIMESTAMP_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE 'abc' END", BYTES_SV_COLUMN),
-        // Cannot mix 2 types that are not both numeric
-        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, TIMESTAMP_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, STRING_SV_COLUMN),
-        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, BYTES_SV_COLUMN),
-        String.format("CASE WHEN true THEN 100 ELSE %s END", TIMESTAMP_COLUMN),
-        String.format("CASE WHEN true THEN 100 ELSE %s END", STRING_SV_COLUMN),
-        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN)
-    };
-    //@formatter:on
-  }
-
-  @Test(dataProvider = "illegalExpressions", expectedExceptions = Exception.class)
-  public void testInvalidCaseTransformFunction(String expression) {
-    TransformFunctionFactory.get(RequestContextUtils.getExpression(expression), _dataSourceMap);
-  }
-
   @Test
   public void testCaseTransformationWithNullColumn() {
     ExpressionContext expression = RequestContextUtils.getExpression(

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2419,13 +2419,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     {
-      String pinotQuery = "SELECT count(*), DaysSinceEpoch as d FROM mytable WHERE d = 16138 GROUP BY d";
-      JsonNode jsonNode = postQuery(pinotQuery);
-      JsonNode exceptions = jsonNode.get("exceptions");
-      assertFalse(exceptions.isEmpty());
-      assertEquals(exceptions.get(0).get("errorCode").asInt(), 710);
-    }
-    {
       //test same alias name with column name
       String query = "SELECT ArrTime AS ArrTime, Carrier AS Carrier, DaysSinceEpoch AS DaysSinceEpoch FROM mytable "
           + "ORDER BY DaysSinceEpoch DESC";
@@ -2449,16 +2442,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
       query = "SELECT count(*) AS cnt, Carrier AS CarrierName FROM mytable GROUP BY CarrierName ORDER BY cnt";
       testQuery(query);
-
-      // Test: 1. Alias should not be applied to filter; 2. Ordinal can be properly applied
-      query =
-          "SELECT DaysSinceEpoch + 100 AS DaysSinceEpoch, COUNT(*) AS cnt FROM mytable WHERE DaysSinceEpoch <= 16312 "
-              + "GROUP BY 1 ORDER BY 1 DESC";
-      // NOTE: H2 does not support ordinal in GROUP BY
-      String h2Query =
-          "SELECT DaysSinceEpoch + 100 AS DaysSinceEpoch, COUNT(*) AS cnt FROM mytable WHERE DaysSinceEpoch <= 16312 "
-              + "GROUP BY DaysSinceEpoch ORDER BY 1 DESC";
-      testQuery(query, h2Query);
     }
     {
       //test multiple alias


### PR DESCRIPTION
This change can be used to bring back the legacy non-sql support removed in #11610 and #11763, and log an error:
- on broker when alias is applied to filter clause
- on server when illegal cast is applied for CASE statement