### PR TITLE
Support more arguments for LEAD/LAG window functions

### DIFF
--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -191,6 +191,10 @@ public class QueryEnvironmentTestBase {
         new Object[]{"SELECT RANK() OVER(PARTITION BY a.col2 ORDER BY a.col1) FROM a"},
         new Object[]{"SELECT a.col1, LEAD(a.col3) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
         new Object[]{"SELECT a.col1, LAG(a.col3) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
+        new Object[]{"SELECT a.col1, LEAD(a.col3, 5) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
+        new Object[]{"SELECT a.col1, LAG(a.col3, 5) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
+        new Object[]{"SELECT a.col1, LEAD(a.col3, 5, -1) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
+        new Object[]{"SELECT a.col1, LAG(a.col3, 5, -1) OVER (PARTITION BY a.col2 ORDER BY a.col3) FROM a"},
         new Object[]{"SELECT DENSE_RANK() OVER(ORDER BY a.col1) FROM a"},
         new Object[]{"SELECT a.col1, SUM(a.col3) OVER (ORDER BY a.col2), MIN(a.col3) OVER (ORDER BY a.col2) FROM a"},
         new Object[]{

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AggregationUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AggregationUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator.utils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
@@ -223,8 +222,7 @@ public class AggregationUtils {
     private RexExpression toAggregationFunctionOperand(RexExpression.FunctionCall aggCall) {
       List<RexExpression> functionOperands = aggCall.getFunctionOperands();
       int numOperands = functionOperands.size();
-      Preconditions.checkState(numOperands < 2, "Aggregate functions cannot have more than one operand");
-      return numOperands == 1 ? functionOperands.get(0) : new RexExpression.Literal(ColumnDataType.INT, 1);
+      return numOperands == 0 ? new RexExpression.Literal(ColumnDataType.INT, 1) : functionOperands.get(0);
     }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
@@ -18,32 +18,66 @@
  */
 package org.apache.pinot.query.runtime.operator.window.value;
 
-import java.util.ArrayList;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 
 
 public class LagValueWindowFunction extends ValueWindowFunction {
+  private final int _offset;
+  private final Object _defaultValue;
 
   public LagValueWindowFunction(RexExpression.FunctionCall aggCall, DataSchema inputSchema,
       List<RelFieldCollation> collations, boolean partitionByOnly) {
     super(aggCall, inputSchema, collations, partitionByOnly);
+    int offset = 1;
+    Object defaultValue = null;
+    List<RexExpression> operands = aggCall.getFunctionOperands();
+    int numOperands = operands.size();
+    if (numOperands > 1) {
+      RexExpression secondOperand = operands.get(1);
+      Preconditions.checkArgument(secondOperand instanceof RexExpression.Literal,
+          "Second operand (offset) of LAG function must be a literal");
+      Object offsetValue = ((RexExpression.Literal) secondOperand).getValue();
+      if (offsetValue instanceof Number) {
+        offset = ((Number) offsetValue).intValue();
+      }
+    }
+    if (numOperands == 3) {
+      RexExpression thirdOperand = operands.get(2);
+      Preconditions.checkArgument(thirdOperand instanceof RexExpression.Literal,
+          "Third operand (default value) of LAG function must be a literal");
+      RexExpression.Literal defaultValueLiteral = (RexExpression.Literal) thirdOperand;
+      defaultValue = defaultValueLiteral.getValue();
+      if (defaultValue != null) {
+        DataSchema.ColumnDataType srcDataType = defaultValueLiteral.getDataType();
+        DataSchema.ColumnDataType destDataType = inputSchema.getColumnDataType(0);
+        if (srcDataType != destDataType) {
+          // Convert the default value to the same data type as the input column
+          // (e.g. convert INT to LONG, FLOAT to DOUBLE, etc.
+          defaultValue = PinotDataType.getPinotDataTypeForExecution(destDataType)
+              .convert(defaultValue, PinotDataType.getPinotDataTypeForExecution(srcDataType));
+        }
+      }
+    }
+    _offset = offset;
+    _defaultValue = defaultValue;
   }
 
   @Override
   public List<Object> processRows(List<Object[]> rows) {
-    List<Object> result = new ArrayList<>(rows.size());
-    Object[] prevRow = null;
-    for (Object[] row : rows) {
-      if (prevRow == null) {
-        result.add(null);
-      } else {
-        result.add(extractValueFromRow(prevRow));
-      }
-      prevRow = row;
+    int numRows = rows.size();
+    Object[] result = new Object[numRows];
+    if (_defaultValue != null) {
+      Arrays.fill(result, 0, _offset, _defaultValue);
     }
-    return result;
+    for (int i = _offset; i < numRows; i++) {
+      result[i] = extractValueFromRow(rows.get(i - _offset));
+    }
+    return Arrays.asList(result);
   }
 }


### PR DESCRIPTION
Fix the LEAD/LAG window function implementation to match the SQL syntax.
Syntax:
```sql
LEAD(column_name, offset, default_value) OVER (PARTITION BY partition_column ORDER BY order_column)
LAG(column_name, offset, default_value) OVER (PARTITION BY partition_column ORDER BY order_column)
```

- column_name: The column from which to retrieve the value.
- offset: The number of rows forward from the current row to access. Default is 1 if not specified.
- default_value: The value to return if the offset goes beyond the number of rows.


Example:
```
SELECT 
    employee_id, 
    salary, 
    LAG(salary, 1) OVER (ORDER BY employee_id) AS previous_salary
FROM employees;
```