### PR TITLE
allow to set segment when use SegmentProcessorFramework

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -265,6 +265,7 @@ public class SegmentProcessorFramework {
       // SegmentNameGenerator will be inferred by the SegmentGeneratorConfig.
       generatorConfig.setSegmentNamePrefix(segmentNamePrefix);
       generatorConfig.setSegmentNamePostfix(segmentNamePostfix);
+      generatorConfig.setSegmentName(fixedSegmentName);
     }
 
     for (Map.Entry<String, GenericRowFileManager> entry : partitionToFileManagerMap.entrySet()) {


### PR DESCRIPTION
set `fixedSegmentName` for generatorConfig so that one can set segment name when generating segments with SegmentProcessorFramework, and no side effect if the value is null