### PR TITLE
Fix array literal handling

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.request.context;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -51,6 +52,7 @@ public class ExpressionContext {
     return forLiteral(new LiteralContext(literal));
   }
 
+  @VisibleForTesting
   public static ExpressionContext forLiteral(DataType type, @Nullable Object value) {
     return forLiteral(new LiteralContext(type, value));
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -170,48 +170,48 @@ public class RequestUtils {
       return getNullLiteral();
     }
     if (object instanceof Boolean) {
-      return RequestUtils.getLiteral((boolean) object);
+      return getLiteral((boolean) object);
     }
     if (object instanceof Integer) {
-      return RequestUtils.getLiteral((int) object);
+      return getLiteral((int) object);
     }
     if (object instanceof Long) {
-      return RequestUtils.getLiteral((long) object);
+      return getLiteral((long) object);
     }
     if (object instanceof Float) {
-      return RequestUtils.getLiteral((float) object);
+      return getLiteral((float) object);
     }
     if (object instanceof Double) {
-      return RequestUtils.getLiteral((double) object);
+      return getLiteral((double) object);
     }
     if (object instanceof BigDecimal) {
-      return RequestUtils.getLiteral((BigDecimal) object);
+      return getLiteral((BigDecimal) object);
     }
     if (object instanceof Timestamp) {
-      return RequestUtils.getLiteral(((Timestamp) object).getTime());
+      return getLiteral(((Timestamp) object).getTime());
     }
     if (object instanceof String) {
-      return RequestUtils.getLiteral((String) object);
+      return getLiteral((String) object);
     }
     if (object instanceof byte[]) {
-      return RequestUtils.getLiteral((byte[]) object);
+      return getLiteral((byte[]) object);
     }
     if (object instanceof int[]) {
-      return RequestUtils.getLiteral((int[]) object);
+      return getLiteral((int[]) object);
     }
     if (object instanceof long[]) {
-      return RequestUtils.getLiteral((long[]) object);
+      return getLiteral((long[]) object);
     }
     if (object instanceof float[]) {
-      return RequestUtils.getLiteral((float[]) object);
+      return getLiteral((float[]) object);
     }
     if (object instanceof double[]) {
-      return RequestUtils.getLiteral((double[]) object);
+      return getLiteral((double[]) object);
     }
     if (object instanceof String[]) {
-      return RequestUtils.getLiteral((String[]) object);
+      return getLiteral((String[]) object);
     }
-    return RequestUtils.getLiteral(object.toString());
+    return getLiteral(object.toString());
   }
 
   public static Literal getLiteral(SqlLiteral node) {

--- a/pinot-common/src/main/proto/expressions.proto
+++ b/pinot-common/src/main/proto/expressions.proto
@@ -58,7 +58,32 @@ message Literal {
     double double = 6;
     string string = 7;
     bytes bytes = 8;
+    IntArray intArray = 9;
+    LongArray longArray = 10;
+    FloatArray floatArray = 11;
+    DoubleArray doubleArray = 12;
+    StringArray stringArray = 13;
   }
+}
+
+message IntArray {
+  repeated int32 values = 1;
+}
+
+message LongArray {
+  repeated int64 values = 1;
+}
+
+message FloatArray {
+  repeated float values = 1;
+}
+
+message DoubleArray {
+  repeated double values = 1;
+}
+
+message StringArray {
+  repeated string values = 1;
 }
 
 message FunctionCall {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
@@ -56,10 +56,9 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
   private String[][] _stringArrayResult;
 
   public ArrayLiteralTransformFunction(LiteralContext literalContext) {
-    List literalArray = (List) literalContext.getValue();
-    Preconditions.checkNotNull(literalArray);
-    if (literalArray.isEmpty()) {
-      _dataType = DataType.UNKNOWN;
+    _dataType = literalContext.getType();
+    Object value = literalContext.getValue();
+    if (value == null) {
       _intArrayLiteral = new int[0];
       _longArrayLiteral = new long[0];
       _floatArrayLiteral = new float[0];
@@ -67,53 +66,37 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
       _stringArrayLiteral = new String[0];
       return;
     }
-    _dataType = literalContext.getType();
     switch (_dataType) {
       case INT:
-        _intArrayLiteral = new int[literalArray.size()];
-        for (int i = 0; i < _intArrayLiteral.length; i++) {
-          _intArrayLiteral[i] = (int) literalArray.get(i);
-        }
+        _intArrayLiteral = (int[]) value;
         _longArrayLiteral = null;
         _floatArrayLiteral = null;
         _doubleArrayLiteral = null;
         _stringArrayLiteral = null;
         break;
       case LONG:
-        _longArrayLiteral = new long[literalArray.size()];
-        for (int i = 0; i < _longArrayLiteral.length; i++) {
-          _longArrayLiteral[i] = (long) literalArray.get(i);
-        }
+        _longArrayLiteral = (long[]) value;
         _intArrayLiteral = null;
         _floatArrayLiteral = null;
         _doubleArrayLiteral = null;
         _stringArrayLiteral = null;
         break;
       case FLOAT:
-        _floatArrayLiteral = new float[literalArray.size()];
-        for (int i = 0; i < _floatArrayLiteral.length; i++) {
-          _floatArrayLiteral[i] = (float) literalArray.get(i);
-        }
+        _floatArrayLiteral = (float[]) value;
         _intArrayLiteral = null;
         _longArrayLiteral = null;
         _doubleArrayLiteral = null;
         _stringArrayLiteral = null;
         break;
       case DOUBLE:
-        _doubleArrayLiteral = new double[literalArray.size()];
-        for (int i = 0; i < _doubleArrayLiteral.length; i++) {
-          _doubleArrayLiteral[i] = (double) literalArray.get(i);
-        }
+        _doubleArrayLiteral = (double[]) value;
         _intArrayLiteral = null;
         _longArrayLiteral = null;
         _floatArrayLiteral = null;
         _stringArrayLiteral = null;
         break;
       case STRING:
-        _stringArrayLiteral = new String[literalArray.size()];
-        for (int i = 0; i < _stringArrayLiteral.length; i++) {
-          _stringArrayLiteral[i] = (String) literalArray.get(i);
-        }
+        _stringArrayLiteral = (String[]) value;
         _intArrayLiteral = null;
         _longArrayLiteral = null;
         _floatArrayLiteral = null;
@@ -121,8 +104,8 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
         break;
       default:
         throw new IllegalStateException(
-            "Illegal data type for ArrayLiteralTransformFunction: " + _dataType + ", literal contexts: "
-                + Arrays.toString(literalArray.toArray()));
+            "Illegal data type for ArrayLiteralTransformFunction: " + _dataType + ", literal context: "
+                + literalContext);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -338,12 +338,13 @@ public class TransformFunctionFactory {
         return new IdentifierTransformFunction(columnName, columnContextMap.get(columnName));
       case LITERAL:
         LiteralContext literal = expression.getLiteral();
-        if (literal.getValue() != null && literal.getValue() instanceof ArrayList) {
+        if (literal.isSingleValue()) {
+          return queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, literal,
+              LiteralTransformFunction::new);
+        } else {
           return queryContext.getOrComputeSharedValue(ArrayLiteralTransformFunction.class, literal,
               ArrayLiteralTransformFunction::new);
         }
-        return queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, literal,
-            LiteralTransformFunction::new);
       default:
         throw new IllegalStateException();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -41,6 +41,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.common.ExplainPlanRowData;
 import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
@@ -72,7 +73,6 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.QueryCancelledException;
@@ -236,8 +236,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           if (indexTimeMs > 0) {
             minIndexTimeMs = Math.min(minIndexTimeMs, indexTimeMs);
           }
-          long ingestionTimeMs = ((RealtimeTableDataManager)
-              tableDataManager).getPartitionIngestionTimeMs(indexSegment.getSegmentName());
+          long ingestionTimeMs =
+              ((RealtimeTableDataManager) tableDataManager).getPartitionIngestionTimeMs(indexSegment.getSegmentName());
           if (ingestionTimeMs > 0) {
             minIngestionTimeMs = Math.min(minIngestionTimeMs, ingestionTimeMs);
           }
@@ -602,8 +602,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           result != null ? result.getClass().getSimpleName() : null);
       // Rewrite the expression
       function.setFunctionName(TransformFunctionType.IN_ID_SET.name());
-      arguments.set(1,
-          ExpressionContext.forLiteral(FieldSpec.DataType.STRING, ((IdSet) result).toBase64String()));
+      arguments.set(1, ExpressionContext.forLiteral(RequestUtils.getLiteral(((IdSet) result).toBase64String())));
     } else {
       for (ExpressionContext argument : arguments) {
         handleSubquery(argument, tableDataManager, indexSegments, timerContext, executorService, endTimeMs);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpression.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.logical;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.apache.calcite.rex.RexNode;
@@ -92,12 +93,12 @@ public interface RexExpression {
         return false;
       }
       Literal literal = (Literal) o;
-      return _dataType == literal._dataType && Objects.equals(_value, literal._value);
+      return _dataType == literal._dataType && Objects.deepEquals(_value, literal._value);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(_dataType, _value);
+      return Arrays.deepHashCode(new Object[]{_dataType, _value});
     }
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.pinot.common.proto.Expressions;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
@@ -74,10 +75,67 @@ public class ProtoExpressionToRexExpression {
         return new RexExpression.Literal(dataType, literal.getFloat());
       case DOUBLE:
         return new RexExpression.Literal(dataType, literal.getDouble());
+      case BIG_DECIMAL:
+        return new RexExpression.Literal(dataType, BigDecimalUtils.deserialize(literal.getBytes().toByteArray()));
       case STRING:
         return new RexExpression.Literal(dataType, literal.getString());
       case BYTES:
         return new RexExpression.Literal(dataType, new ByteArray(literal.getBytes().toByteArray()));
+      case INT_ARRAY: {
+        Expressions.IntArray intArray = literal.getIntArray();
+        int numValues = intArray.getValuesCount();
+        int[] values = new int[numValues];
+        {
+          for (int i = 0; i < numValues; i++) {
+            values[i] = intArray.getValues(i);
+          }
+        }
+        return new RexExpression.Literal(dataType, values);
+      }
+      case LONG_ARRAY: {
+        Expressions.LongArray longArray = literal.getLongArray();
+        int numValues = longArray.getValuesCount();
+        long[] values = new long[numValues];
+        {
+          for (int i = 0; i < numValues; i++) {
+            values[i] = longArray.getValues(i);
+          }
+        }
+        return new RexExpression.Literal(dataType, values);
+      }
+      case FLOAT_ARRAY: {
+        Expressions.FloatArray floatArray = literal.getFloatArray();
+        int numValues = floatArray.getValuesCount();
+        float[] values = new float[numValues];
+        {
+          for (int i = 0; i < numValues; i++) {
+            values[i] = floatArray.getValues(i);
+          }
+        }
+        return new RexExpression.Literal(dataType, values);
+      }
+      case DOUBLE_ARRAY: {
+        Expressions.DoubleArray doubleArray = literal.getDoubleArray();
+        int numValues = doubleArray.getValuesCount();
+        double[] values = new double[numValues];
+        {
+          for (int i = 0; i < numValues; i++) {
+            values[i] = doubleArray.getValues(i);
+          }
+        }
+        return new RexExpression.Literal(dataType, values);
+      }
+      case STRING_ARRAY: {
+        Expressions.StringArray stringArray = literal.getStringArray();
+        int numValues = stringArray.getValuesCount();
+        String[] values = new String[numValues];
+        {
+          for (int i = 0; i < numValues; i++) {
+            values[i] = stringArray.getValues(i);
+          }
+        }
+        return new RexExpression.Literal(dataType, values);
+      }
       default:
         throw new IllegalStateException("Unsupported ColumnDataType: " + dataType);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
@@ -19,8 +19,13 @@
 package org.apache.pinot.query.planner.serde;
 
 import com.google.protobuf.ByteString;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.common.proto.Expressions;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -93,6 +98,26 @@ public class RexExpressionToProtoExpression {
           break;
         case BYTES:
           literalBuilder.setBytes(ByteString.copyFrom(((ByteArray) value).getBytes()));
+          break;
+        case INT_ARRAY:
+          literalBuilder.setIntArray(
+              Expressions.IntArray.newBuilder().addAllValues(IntArrayList.wrap((int[]) value)).build());
+          break;
+        case LONG_ARRAY:
+          literalBuilder.setLongArray(
+              Expressions.LongArray.newBuilder().addAllValues(LongArrayList.wrap((long[]) value)).build());
+          break;
+        case FLOAT_ARRAY:
+          literalBuilder.setFloatArray(
+              Expressions.FloatArray.newBuilder().addAllValues(FloatArrayList.wrap((float[]) value)).build());
+          break;
+        case DOUBLE_ARRAY:
+          literalBuilder.setDoubleArray(
+              Expressions.DoubleArray.newBuilder().addAllValues(DoubleArrayList.wrap((double[]) value)).build());
+          break;
+        case STRING_ARRAY:
+          literalBuilder.setStringArray(
+              Expressions.StringArray.newBuilder().addAllValues(Arrays.asList((String[]) value)).build());
           break;
         default:
           throw new IllegalStateException("Unsupported ColumnDataType: " + dataType);

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.serde;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class RexExpressionSerDeTest {
+  private static final List<ColumnDataType> SUPPORTED_DATE_TYPES =
+      List.of(ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.FLOAT, ColumnDataType.DOUBLE,
+          ColumnDataType.BIG_DECIMAL, ColumnDataType.BOOLEAN, ColumnDataType.TIMESTAMP, ColumnDataType.STRING,
+          ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY, ColumnDataType.FLOAT_ARRAY,
+          ColumnDataType.DOUBLE_ARRAY, ColumnDataType.BOOLEAN_ARRAY, ColumnDataType.TIMESTAMP_ARRAY,
+          ColumnDataType.STRING_ARRAY, ColumnDataType.UNKNOWN);
+  private static final Random RANDOM = new Random();
+
+  @Test
+  public void testNullLiteral() {
+    for (ColumnDataType dataType : SUPPORTED_DATE_TYPES) {
+      verifyLiteralSerDe(new RexExpression.Literal(dataType, null));
+    }
+  }
+
+  @Test
+  public void testIntLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.INT, RANDOM.nextInt()));
+  }
+
+  @Test
+  public void testLongLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.LONG, RANDOM.nextLong()));
+  }
+
+  @Test
+  public void testFloatLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.FLOAT, RANDOM.nextFloat()));
+  }
+
+  @Test
+  public void testDoubleLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.DOUBLE, RANDOM.nextDouble()));
+  }
+
+  @Test
+  public void testBigDecimalLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BIG_DECIMAL,
+        RANDOM.nextBoolean() ? BigDecimal.valueOf(RANDOM.nextLong()) : BigDecimal.valueOf(RANDOM.nextDouble())));
+  }
+
+  @Test
+  public void testBooleanLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BOOLEAN, BooleanUtils.toInt(RANDOM.nextBoolean())));
+  }
+
+  @Test
+  public void testTimestampLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.TIMESTAMP, RANDOM.nextLong()));
+  }
+
+  @Test
+  public void testStringLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.STRING, RandomStringUtils.random(RANDOM.nextInt(10))));
+  }
+
+  @Test
+  public void testBytesLiteral() {
+    byte[] bytes = new byte[RANDOM.nextInt(10)];
+    RANDOM.nextBytes(bytes);
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BYTES, new ByteArray(bytes)));
+  }
+
+  @Test
+  public void testIntArrayLiteral() {
+    int[] values = new int[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RANDOM.nextInt();
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.INT_ARRAY, values));
+  }
+
+  @Test
+  public void testLongArrayLiteral() {
+    long[] values = new long[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RANDOM.nextLong();
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.LONG_ARRAY, values));
+  }
+
+  @Test
+  public void testFloatArrayLiteral() {
+    float[] values = new float[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RANDOM.nextFloat();
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.FLOAT_ARRAY, values));
+  }
+
+  @Test
+  public void testDoubleArrayLiteral() {
+    double[] values = new double[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RANDOM.nextDouble();
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.DOUBLE_ARRAY, values));
+  }
+
+  @Test
+  public void testBooleanArrayLiteral() {
+    int[] values = new int[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = BooleanUtils.toInt(RANDOM.nextBoolean());
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BOOLEAN_ARRAY, values));
+  }
+
+  @Test
+  public void testTimestampArrayLiteral() {
+    long[] values = new long[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RANDOM.nextLong();
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.TIMESTAMP_ARRAY, values));
+  }
+
+  @Test
+  public void testStringArrayLiteral() {
+    String[] values = new String[RANDOM.nextInt(10)];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = RandomStringUtils.random(RANDOM.nextInt(10));
+    }
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.STRING_ARRAY, values));
+  }
+
+  private void verifyLiteralSerDe(RexExpression.Literal literal) {
+    assertEquals(literal,
+        ProtoExpressionToRexExpression.convertLiteral(RexExpressionToProtoExpression.convertLiteral(literal)));
+  }
+}


### PR DESCRIPTION
- Store array (primitive array if possible) instead of `List` in `LiteralContext` because it is the internal representation of array
- Fix the missing int bits conversion for `FLOAT_ARRAY`
- Add array support in `RexExpression.Literal` for future proof