### PR TITLE
Add list of collaborators to asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,3 +29,14 @@ github:
     squash: true
     merge: false
     rebase: false
+  collaborators:
+    - sullis
+    - shenyu0127
+    - tibrewalpratik17
+    - abhioncbr
+    - zhtaoxiang
+    - shounakmk219
+    - itschrispeck
+    - soumitra-st
+    - swaminathanmanish
+    - yashmayya


### PR DESCRIPTION
- ASF Infra allows Apache projects to assign the GitHub "triage" role (see permissions for each role [here](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)) to up to 10 "[collaborators](https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#triage)" (non-committers) per repository.
- This allows for things like assigning, editing, and closing issues / PRs (without giving write-access to the code) and also adding / removing labels, requesting PR reviewers etc.
- This has been adopted by various other Apache projects and is pretty useful as it allows non-committers to contribute additionally towards project maintenance activities.
- In the Apache Kafka project, a policy was adopted to add the top 10 non-committer contributors from the past year (as per git shortlog) as collaborators and has been fairly successful. This PR is a proposal to adopt the same policy for the Apache Pinot project.
- The collaborator list will be updated periodically to account for changes in contribution levels as well as collaborators potentially becoming committers.

```
> git shortlog --numbered --summary --since="1 year ago"

   256  dependabot[bot]
   206  Xiaotian (Jackie) Jiang
   154  Xiang Fu
    65  Rong Rong
    59  Gonzalo Ortiz Jaureguizar
    58  sullis
    49  Shen Yu
    46  Pratik Tibrewal
    44  Abhishek Sharma
    40  Saurabh Dubey
    35  Xiaobing
    30  Haitao Zhang
    30  Shounak kulkarni
    24  Christopher Peck
    20  soumitra-st
    19  Kartik Khare
    19  swaminathanmanish
    18  Yash Mayya
    17  Jayesh Choudhary
    16  Seunghyun Lee
    16  Vivek Iyer Vaidyanathan
    14  Johan Adami
    11  Prashant Pandey
    10  Tim Veil
     9  Aishik
     9  Ankit Sultana
     9  David Cromberge
     9  Ragesh Rajagopalan
     9  Xuanyi Li
```