### PR TITLE
extend CompactedPinotSegmentRecordReader so that it can skip deleteRecord

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -265,7 +265,7 @@ public class ServerSegmentMetadataReader {
         List<ValidDocIdsMetadataInfo> validDocIdsMetadataInfoList =
             JsonUtils.stringToObject(validDocIdsMetadataList, new TypeReference<ArrayList<ValidDocIdsMetadataInfo>>() {
             });
-        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo: validDocIdsMetadataInfoList) {
+        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo : validDocIdsMetadataInfoList) {
           validDocIdsMetadataInfos.put(validDocIdsMetadataInfo.getSegmentName(), validDocIdsMetadataInfo);
         }
         returnedServerRequestsCount++;
@@ -286,8 +286,8 @@ public class ServerSegmentMetadataReader {
     }
 
     if (segmentNames != null && !segmentNames.isEmpty() && segmentNames.size() != validDocIdsMetadataInfos.size()) {
-      LOGGER.error("Unable to get validDocIdsMetadata for all segments. Expected: {}, Actual: {}",
-          segmentNames.size(), validDocIdsMetadataInfos.size());
+      LOGGER.error("Unable to get validDocIdsMetadata for all segments. Expected: {}, Actual: {}", segmentNames.size(),
+          validDocIdsMetadataInfos.size());
     }
 
     LOGGER.info("Retrieved validDocIds metadata for {} segments from {} server requests.",

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -94,8 +94,8 @@ public class MinionTaskUtils {
       String pushMode = IngestionConfigUtils.getPushMode(taskConfigs);
 
       Map<String, String> singleFileGenerationTaskConfig = new HashMap<>(taskConfigs);
-      if (pushMode == null
-          || pushMode.toUpperCase().contentEquals(BatchConfigProperties.SegmentPushType.TAR.toString())) {
+      if (pushMode == null || pushMode.toUpperCase()
+          .contentEquals(BatchConfigProperties.SegmentPushType.TAR.toString())) {
         singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_MODE,
             BatchConfigProperties.SegmentPushType.TAR.toString());
       } else {
@@ -158,7 +158,7 @@ public class MinionTaskUtils {
       ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
       try {
         return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
-                validDocIdsType, 60_000);
+            validDocIdsType, 60_000);
       } catch (Exception e) {
         LOGGER.info("Unable to retrieve validDocIdsBitmap for {} from {}", segmentName, endpoint);
       }
@@ -167,7 +167,7 @@ public class MinionTaskUtils {
   }
 
   public static List<String> getServers(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,
-                                        String clusterName) {
+      String clusterName) {
     ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, tableNameWithType);
     if (externalView == null) {
       throw new IllegalStateException("External view does not exist for table: " + tableNameWithType);
@@ -197,8 +197,8 @@ public class MinionTaskUtils {
     if (tableTaskConfig != null) {
       Map<String, String> configs = tableTaskConfig.getConfigsForTaskType(taskType);
       if (configs != null && !configs.isEmpty()) {
-        return Boolean.parseBoolean(configs.getOrDefault(TableTaskConfig.MINION_ALLOW_DOWNLOAD_FROM_SERVER,
-            String.valueOf(defaultValue)));
+        return Boolean.parseBoolean(
+            configs.getOrDefault(TableTaskConfig.MINION_ALLOW_DOWNLOAD_FROM_SERVER, String.valueOf(defaultValue)));
       }
     }
     return defaultValue;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
@@ -74,7 +74,10 @@ public class CompactedPinotSegmentRecordReader implements RecordReader {
       return true;
     }
 
-    // Try to get the next row to return, skip invalid doc and deleted doc.
+    // Try to get the next row to return, skip invalid docs. If _deleteRecordColumn is set, the deleteRecord (i.e.
+    // the tombstone record used to soft-delete old record) is also skipped.
+    // Note that dropping deleteRecord too soon may cause the old soft-deleted record to show up unexpectedly, so one
+    // should be careful when to skip the deleteRecord.
     while (_validDocIdsIterator.hasNext()) {
       int docId = _validDocIdsIterator.next();
       _nextRow.clear();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReaderTest.java
@@ -46,6 +46,7 @@ public class CompactedPinotSegmentRecordReaderTest {
   private static final String M1 = "m1";
   private static final String M2 = "m2";
   private static final String TIME = "t";
+  private static final String DELETE_COLUMN = "del_col";
 
   private String _segmentOutputDir;
   private File _segmentIndexDir;
@@ -60,6 +61,10 @@ public class CompactedPinotSegmentRecordReaderTest {
     String segmentName = "compactedPinotSegmentRecordReaderTest";
     _segmentOutputDir = Files.createTempDir().toString();
     _rows = PinotSegmentUtil.createTestData(schema, NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = _rows.get(i);
+      row.putValue(DELETE_COLUMN, i % 2 == 0 ? "true" : "false");
+    }
     _recordReader = new GenericRowRecordReader(_rows);
     _segmentIndexDir =
         PinotSegmentUtil.createSegment(tableConfig, schema, segmentName, _segmentOutputDir, _recordReader);
@@ -67,6 +72,7 @@ public class CompactedPinotSegmentRecordReaderTest {
 
   private Schema createPinotSchema() {
     return new Schema.SchemaBuilder().setSchemaName("schema").addSingleValueDimension(D_SV_1, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(DELETE_COLUMN, FieldSpec.DataType.STRING)
         .addMultiValueDimension(D_MV_1, FieldSpec.DataType.STRING).addMetric(M1, FieldSpec.DataType.INT)
         .addMetric(M2, FieldSpec.DataType.FLOAT)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, TIME), null).build();
@@ -79,7 +85,6 @@ public class CompactedPinotSegmentRecordReaderTest {
   @Test
   public void testCompactedPinotSegmentRecordReader()
       throws Exception {
-
     RoaringBitmap validDocIds = new RoaringBitmap();
     for (int i = 0; i < NUM_ROWS; i += 2) {
       validDocIds.add(i);
@@ -116,6 +121,46 @@ public class CompactedPinotSegmentRecordReaderTest {
     for (int i = 0; i < rewoundOuputRows.size(); i++) {
       GenericRow outputRow = rewoundOuputRows.get(i);
       GenericRow row = _rows.get(i * 2);
+      Assert.assertEquals(outputRow.getValue(D_SV_1), row.getValue(D_SV_1));
+      Assert.assertTrue(PinotSegmentUtil.compareMultiValueColumn(outputRow.getValue(D_MV_1), row.getValue(D_MV_1)));
+      Assert.assertEquals(outputRow.getValue(M1), row.getValue(M1));
+      Assert.assertEquals(outputRow.getValue(M2), row.getValue(M2));
+      Assert.assertEquals(outputRow.getValue(TIME), row.getValue(TIME));
+    }
+  }
+
+  @Test
+  public void testCompactedPinotSegmentRecordReaderWithDeleteColumn()
+      throws Exception {
+    RoaringBitmap validDocIds = new RoaringBitmap();
+    for (int i = 0; i < NUM_ROWS; i += 2) {
+      validDocIds.add(i);
+    }
+    List<GenericRow> evenOutputRows = new ArrayList<>();
+    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(_segmentIndexDir,
+        validDocIds, DELETE_COLUMN)) {
+      while (compactedReader.hasNext()) {
+        evenOutputRows.add(compactedReader.next());
+      }
+    }
+
+    validDocIds = new RoaringBitmap();
+    for (int i = 1; i < NUM_ROWS; i += 2) {
+      validDocIds.add(i);
+    }
+    List<GenericRow> oddOutputRows = new ArrayList<>();
+    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(_segmentIndexDir,
+        validDocIds, DELETE_COLUMN)) {
+      while (compactedReader.hasNext()) {
+        oddOutputRows.add(compactedReader.next());
+      }
+    }
+
+    Assert.assertEquals(evenOutputRows.size(), 0, "All even rows are deleted");
+    Assert.assertEquals(oddOutputRows.size(), NUM_ROWS / 2, "All odd rows are kept");
+    for (int i = 0; i < oddOutputRows.size(); i++) {
+      GenericRow outputRow = oddOutputRows.get(i);
+      GenericRow row = _rows.get(i * 2 + 1);
       Assert.assertEquals(outputRow.getValue(D_SV_1), row.getValue(D_SV_1));
       Assert.assertTrue(PinotSegmentUtil.compareMultiValueColumn(outputRow.getValue(D_MV_1), row.getValue(D_MV_1)));
       Assert.assertEquals(outputRow.getValue(M1), row.getValue(M1));


### PR DESCRIPTION
Extend CompactedPinotSegmentRecordReader so that it can skip deleteRecord if configured. 

Note that dropping deleteRecord too soon may cause the old soft-deleted record to show up unexpectedly, so one should be careful when to skip the deleteRecord. e.g. tombstones from segments older than certain threshold may be dropped safely.

Plus a few fix on code formats