### PR TITLE
Exclude dimensions from star-tree index stored type check

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -95,40 +95,43 @@ abstract class BaseStarTreeV2Test<R, A> {
   private static final int MAX_LEAF_RECORDS = RANDOM.nextInt(100) + 1;
   // Using column names with '__' to make sure regular table columns with '__' in the name aren't wrongly interpreted
   // as AggregationFunctionColumnPair
-  private static final String DIMENSION_D1 = "d1__COLUMN_NAME";
-  private static final String DIMENSION_D2 = "__d2";
+  private static final String DIMENSION1 = "d1__COLUMN_NAME";
+  private static final String DIMENSION2 = "DISTINCTCOUNTRAWHLL__d2";
   private static final int DIMENSION_CARDINALITY = 100;
   private static final String METRIC = "m";
 
   // Supported filters
-  private static final String QUERY_FILTER_AND = " WHERE d1__COLUMN_NAME = 0 AND __d2 < 10";
+  private static final String QUERY_FILTER_AND = String.format(" WHERE %1$s = 0 AND %2$s < 10", DIMENSION1, DIMENSION2);
   // StarTree supports OR predicates only on a single dimension
-  private static final String QUERY_FILTER_OR = " WHERE d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50";
-  private static final String QUERY_FILTER_NOT = " WHERE NOT d1__COLUMN_NAME > 10";
-  private static final String QUERY_FILTER_AND_NOT = " WHERE d1__COLUMN_NAME > 10 AND NOT __d2 < 10";
-  private static final String QUERY_FILTER_OR_NOT = " WHERE d1__COLUMN_NAME > 50 OR NOT d1__COLUMN_NAME > 10";
-  private static final String QUERY_NOT_NOT = " WHERE NOT NOT d1__COLUMN_NAME > 10";
+  private static final String QUERY_FILTER_OR = String.format(" WHERE %1$s > 10 OR %1$s < 50", DIMENSION1);
+  private static final String QUERY_FILTER_NOT = String.format(" WHERE NOT %s > 10", DIMENSION1);
+  private static final String QUERY_FILTER_AND_NOT =
+      String.format(" WHERE %1$s > 10 AND NOT %2$s < 10", DIMENSION1, DIMENSION2);
+  private static final String QUERY_FILTER_OR_NOT = String.format(" WHERE %1$s > 50 OR NOT %1$s > 10", DIMENSION1);
+  private static final String QUERY_NOT_NOT = String.format(" WHERE NOT NOT %s > 10", DIMENSION1);
   private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS =
-      " WHERE __d2 < 95 AND (NOT d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME > 50)";
+      String.format(" WHERE %2$s < 95 AND (NOT %1$s > 10 OR %1$s > 50)", DIMENSION1, DIMENSION2);
   private static final String QUERY_FILTER_COMPLEX_AND_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
-      " WHERE __d2 < 95 AND NOT __d2 < 25 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
+      String.format(" WHERE %2$s < 95 AND NOT %2$s < 25 AND (%1$s > 10 OR %1$s < 50)", DIMENSION1, DIMENSION2);
   private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
-      " WHERE (__d2 > 95 OR __d2 < 25) AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
+      String.format(" WHERE (%2$s > 95 OR %2$s < 25) AND (%1$s > 10 OR %1$s < 50)", DIMENSION1, DIMENSION2);
   private static final String QUERY_FILTER_COMPLEX_OR_SINGLE_DIMENSION =
-      " WHERE NOT d1__COLUMN_NAME = 95 AND (d1__COLUMN_NAME > 90 OR d1__COLUMN_NAME < 100)";
+      String.format(" WHERE NOT %1$s = 95 AND (%1$s > 90 OR %1$s < 100)", DIMENSION1);
 
   // Unsupported filters
-  private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS = " WHERE d1__COLUMN_NAME > 10 OR __d2 < 50";
+  private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS =
+      String.format(" WHERE %1$s > 10 OR %2$s < 50", DIMENSION1, DIMENSION2);
   private static final String QUERY_FILTER_OR_ON_AND =
-      " WHERE (d1__COLUMN_NAME > 10 AND d1__COLUMN_NAME < 50) OR d1__COLUMN_NAME < 50";
-  private static final String QUERY_FILTER_NOT_ON_AND = " WHERE NOT (d1__COLUMN_NAME > 10 AND d1__COLUMN_NAME < 50)";
-  private static final String QUERY_FILTER_NOT_ON_OR = " WHERE NOT (d1__COLUMN_NAME < 10 OR d1__COLUMN_NAME > 50)";
+      String.format(" WHERE (%1$s > 10 AND %1$s < 50) OR %1$s < 50", DIMENSION1);
+  private static final String QUERY_FILTER_NOT_ON_AND =
+      String.format(" WHERE NOT (%1$s > 10 AND %1$s < 50)", DIMENSION1);
+  private static final String QUERY_FILTER_NOT_ON_OR = String.format(" WHERE NOT (%1$s < 10 OR %1$s > 50)", DIMENSION1);
   // Always false filters
-  private static final String QUERY_FILTER_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100";
-  private static final String QUERY_FILTER_OR_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100 OR d1__COLUMN_NAME < 0";
+  private static final String QUERY_FILTER_ALWAYS_FALSE = String.format(" WHERE %s > 100", DIMENSION1);
+  private static final String QUERY_FILTER_OR_ALWAYS_FALSE = String.format(" WHERE %1$s > 100 OR %1$s < 0", DIMENSION1);
 
-  private static final String QUERY_GROUP_BY = " GROUP BY __d2";
-  private static final String FILTER_AGG_CLAUSE = " FILTER(WHERE d1__COLUMN_NAME > 10)";
+  private static final String QUERY_GROUP_BY = " GROUP BY " + DIMENSION2;
+  private static final String FILTER_AGG_CLAUSE = String.format(" FILTER(WHERE %s > 10)", DIMENSION1);
 
   private ValueAggregator _valueAggregator;
   private DataType _aggregatedValueType;
@@ -143,8 +146,8 @@ abstract class BaseStarTreeV2Test<R, A> {
     _aggregatedValueType = _valueAggregator.getAggregatedValueType();
     _aggregation = getAggregation(_valueAggregator.getAggregationType());
 
-    Schema.SchemaBuilder schemaBuilder = new Schema.SchemaBuilder().addSingleValueDimension(DIMENSION_D1, DataType.INT)
-        .addSingleValueDimension(DIMENSION_D2, DataType.INT);
+    Schema.SchemaBuilder schemaBuilder = new Schema.SchemaBuilder().addSingleValueDimension(DIMENSION1, DataType.INT)
+        .addSingleValueDimension(DIMENSION2, DataType.INT);
     DataType rawValueType = getRawValueType();
     // Raw value type will be null for COUNT aggregation function
     if (rawValueType != null) {
@@ -156,8 +159,8 @@ abstract class BaseStarTreeV2Test<R, A> {
     List<GenericRow> segmentRecords = new ArrayList<>(NUM_SEGMENT_RECORDS);
     for (int i = 0; i < NUM_SEGMENT_RECORDS; i++) {
       GenericRow segmentRecord = new GenericRow();
-      segmentRecord.putValue(DIMENSION_D1, RANDOM.nextInt(DIMENSION_CARDINALITY));
-      segmentRecord.putValue(DIMENSION_D2, RANDOM.nextInt(DIMENSION_CARDINALITY));
+      segmentRecord.putValue(DIMENSION1, RANDOM.nextInt(DIMENSION_CARDINALITY));
+      segmentRecord.putValue(DIMENSION2, RANDOM.nextInt(DIMENSION_CARDINALITY));
       if (rawValueType != null) {
         segmentRecord.putValue(METRIC, getRandomRawValue(RANDOM));
       }
@@ -171,10 +174,9 @@ abstract class BaseStarTreeV2Test<R, A> {
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(segmentRecords));
     driver.build();
 
-    StarTreeIndexConfig starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList(DIMENSION_D1, DIMENSION_D2), null, null, Collections.singletonList(
-            new StarTreeAggregationConfig(METRIC, _valueAggregator.getAggregationType().getName(),
-                getCompressionCodec(), true, getIndexVersion(), null, null)), MAX_LEAF_RECORDS);
+    StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList(DIMENSION1, DIMENSION2), null, null,
+        Collections.singletonList(new StarTreeAggregationConfig(METRIC, _valueAggregator.getAggregationType().getName(),
+            getCompressionCodec(), true, getIndexVersion(), null, null)), MAX_LEAF_RECORDS);
     File indexDir = new File(TEMP_DIR, SEGMENT_NAME);
     // Randomly build star-tree using on-heap or off-heap mode
     MultipleTreesBuilder.BuildMode buildMode =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -268,7 +267,7 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
       default:
         break;
     }
-    if (CollectionUtils.isNotEmpty(_segmentMetadata.getStarTreeV2MetadataList())) {
+    if (_segmentMetadata.getStarTreeV2MetadataList() != null) {
       try {
         _starTreeIndexReader = new StarTreeIndexReader(_segmentDirectory, _segmentMetadata, _readMode);
       } catch (ConfigurationException e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
@@ -55,6 +55,7 @@ public class StarTreeLoaderUtils {
       SegmentMetadataImpl segmentMetadata, Map<String, ColumnIndexContainer> indexContainerMap)
       throws IOException {
     List<StarTreeV2Metadata> starTreeMetadataList = segmentMetadata.getStarTreeV2MetadataList();
+    assert starTreeMetadataList != null;
     int numStarTrees = starTreeMetadataList.size();
     List<StarTreeV2> starTrees = new ArrayList<>(numStarTrees);
     for (int i = 0; i < numStarTrees; i++) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/ColumnIndexDirectoryTestHelper.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/ColumnIndexDirectoryTestHelper.java
@@ -89,6 +89,7 @@ public class ColumnIndexDirectoryTestHelper {
   static SegmentMetadataImpl writeMetadata(SegmentVersion version) {
     SegmentMetadataImpl segmentMetadata = Mockito.mock(SegmentMetadataImpl.class);
     when(segmentMetadata.getVersion()).thenReturn(version);
+    when(segmentMetadata.getStarTreeV2MetadataList()).thenReturn(null);
     ColumnMetadata columnMetadata = Mockito.mock(ColumnMetadata.class);
     when(columnMetadata.isSingleValue()).thenReturn(true);
     when(columnMetadata.isSorted()).thenReturn(false);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparatorTest.java
@@ -18,85 +18,63 @@
  */
 package org.apache.pinot.segment.local.startree.v2.builder;
 
-import com.google.common.collect.Lists;
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
-import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION;
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION;
 import static org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants.STAR_TREE_INDEX_FILE_NAME;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 
 public class StarTreeIndexSeparatorTest {
-
   private static final String SEGMENT_PATH = "data/startree/segment";
-  private static final String TOTAL_DOCS_KEY = "startree.v2.0.total.docs";
-
-  private StarTreeIndexSeparator _separator;
-  private PropertiesConfiguration _metadataProperties;
-  private final StarTreeV2BuilderConfig _builderConfig = StarTreeV2BuilderConfig.fromIndexConfig(
-      new StarTreeIndexConfig(
-          Lists.newArrayList("AirlineID", "Origin", "Dest"),
-          Lists.newArrayList(),
-          Lists.newArrayList("count__*", "max__ArrDelay"),
-          null,
-          10));
+  private static final StarTreeV2BuilderConfig BUILDER_CONFIG = StarTreeV2BuilderConfig.fromIndexConfig(
+      new StarTreeIndexConfig(List.of("AirlineID", "Origin", "Dest"), List.of(), List.of("count__*", "max__ArrDelay"),
+          null, 10));
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "StarTreeIndexSeparatorTest");
 
   @BeforeClass
-  public void setup()
-      throws IOException, ConfigurationException {
-    ClassLoader classLoader = getClass().getClassLoader();
-    URL segmentUrl = classLoader.getResource(SEGMENT_PATH);
+  public void setUp() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @Test
+  public void testSeparate()
+      throws Exception {
+    URL segmentUrl = getClass().getClassLoader().getResource(SEGMENT_PATH);
+    assertNotNull(segmentUrl);
     File segmentDir = new File(segmentUrl.getFile());
-    _metadataProperties = CommonsConfigurationUtils.fromFile(
-        new File(segmentDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
-    _separator = new StarTreeIndexSeparator(
+    try (StarTreeIndexSeparator separator = new StarTreeIndexSeparator(
         new File(segmentDir, StarTreeV2Constants.INDEX_MAP_FILE_NAME),
         new File(segmentDir, StarTreeV2Constants.INDEX_FILE_NAME),
-        _metadataProperties);
-  }
-
-  @Test
-  public void extractTotalDocsListTest() {
-    assertNotNull(_separator);
-    List<Integer> docsList = _separator.extractTotalDocsList(_metadataProperties);
-    assertNotNull(docsList);
-    assertEquals(docsList, Lists.newArrayList(_metadataProperties.getInt(TOTAL_DOCS_KEY)));
-  }
-
-  @Test
-  public void extractBuilderConfigsTest() {
-    List<StarTreeV2BuilderConfig> builderConfigList = _separator.extractBuilderConfigs(_metadataProperties);
-    assertEquals(builderConfigList, Lists.newArrayList(_builderConfig));
-  }
-
-  @Test
-  public void separateTest()
-      throws IOException {
-    File tempDir = new File(FileUtils.getTempDirectory(), "separateTest");
-    _separator.separate(tempDir, _builderConfig);
-    List<String> files = Arrays.asList(Objects.requireNonNull(tempDir.list()));
-    assertTrue(files.contains(STAR_TREE_INDEX_FILE_NAME));
-    _builderConfig.getDimensionsSplitOrder()
-        .forEach(dimension -> assertTrue(files.contains(dimension + UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION)));
-    _builderConfig.getFunctionColumnPairs()
-        .forEach(dimension -> assertTrue(files.contains(dimension + RAW_SV_FORWARD_INDEX_FILE_EXTENSION)));
-    FileUtils.forceDelete(tempDir);
+        new SegmentMetadataImpl(segmentDir).getStarTreeV2MetadataList())) {
+      separator.separate(TEMP_DIR, BUILDER_CONFIG);
+    }
+    String[] fileNames = TEMP_DIR.list();
+    assertNotNull(fileNames);
+    Set<String> fileNameSet = new HashSet<>(Arrays.asList(fileNames));
+    assertTrue(fileNameSet.contains(STAR_TREE_INDEX_FILE_NAME));
+    BUILDER_CONFIG.getDimensionsSplitOrder()
+        .forEach(dimension -> assertTrue(fileNameSet.contains(dimension + UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION)));
+    BUILDER_CONFIG.getFunctionColumnPairs()
+        .forEach(dimension -> assertTrue(fileNameSet.contains(dimension + RAW_SV_FORWARD_INDEX_FILE_EXTENSION)));
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -92,6 +92,7 @@ public interface SegmentMetadata {
    */
   long getLatestIngestionTimestamp();
 
+  @Nullable
   List<StarTreeV2Metadata> getStarTreeV2MetadataList();
 
   Map<String, String> getCustomMap();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -388,6 +388,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     return Long.MIN_VALUE;
   }
 
+  @Nullable
   @Override
   public List<StarTreeV2Metadata> getStarTreeV2MetadataList() {
     return _starTreeV2MetadataList;


### PR DESCRIPTION
Related to #12164 and #12554

Do not check stored type for dimensions to avoid mismatching columns with '__' in column name