### PR TITLE
Refactored compatibility-verifier module

### DIFF
--- a/pinot-compatibility-verifier/pom.xml
+++ b/pinot-compatibility-verifier/pom.xml
@@ -48,11 +48,17 @@
             <program>
               <mainClass>org.apache.pinot.compat.CompatibilityOpsRunner</mainClass>
               <name>pinot-compat-test-runner</name>
+              <jvmSettings>
+                <initialMemorySize>2G</initialMemorySize>
+                <maxMemorySize>2G</maxMemorySize>
+                <extraArguments>
+                  <extraArgument>-Dlog4j2.configurationFile=pinot-compatibility-verifier-log4j2.xml</extraArgument>
+                </extraArguments>
+              </jvmSettings>
             </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>
-          <extraJvmArguments>-Xms2G -Xmx2G -Dlog4j2.configurationFile=log4j2.xml</extraJvmArguments>
         </configuration>
       </plugin>
     </plugins>

--- a/pinot-compatibility-verifier/pom.xml
+++ b/pinot-compatibility-verifier/pom.xml
@@ -48,14 +48,11 @@
             <program>
               <mainClass>org.apache.pinot.compat.CompatibilityOpsRunner</mainClass>
               <name>pinot-compat-test-runner</name>
-              <jvmSettings>
-                <initialMemorySize>2G</initialMemorySize>
-                <maxMemorySize>2G</maxMemorySize>
-              </jvmSettings>
             </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>
+          <extraJvmArguments>-Xms2G -Xmx2G -Dlog4j2.configurationFile=log4j2.xml</extraJvmArguments>
         </configuration>
       </plugin>
     </plugins>

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
@@ -20,6 +20,8 @@ package org.apache.pinot.compat;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -37,6 +39,7 @@ public abstract class BaseOp {
   private String _name;
   private final OpType _opType;
   private String _description = "No description provided";
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseOp.class);
   protected static final String GENERATION_NUMBER_PLACEHOLDER = "__GENERATION_NUMBER__";
   protected static final String CONFIG_PLACEHOLDER = "/config/";
   private String _parentDir;
@@ -74,7 +77,7 @@ public abstract class BaseOp {
   }
 
   public boolean run(int generationNumber) {
-    System.out.println("Running OpType " + _opType.toString() + ": " + getDescription());
+    LOGGER.info("Running OpType " + _opType.toString() + ": " + getDescription());
     return runOp(generationNumber);
   }
 

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
@@ -77,7 +77,7 @@ public abstract class BaseOp {
   }
 
   public boolean run(int generationNumber) {
-    LOGGER.info("Running OpType " + _opType.toString() + ": " + getDescription());
+    LOGGER.info("Running OpType {} : {}", _opType.toString(), getDescription());
     return runOp(generationNumber);
   }
 

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = SegmentOp.class, name = "segmentOp"),
     @JsonSubTypes.Type(value = TableOp.class, name = "tableOp"),

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/ClusterDescriptor.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/ClusterDescriptor.java
@@ -22,10 +22,7 @@ package org.apache.pinot.compat;
 public class ClusterDescriptor {
 
   private static final String DEFAULT_HOST = "localhost";
-  private static final String ZOOKEEPER_PORT = "2181";
   private static final String KAFKA_PORT = "19092";
-  private static final String ZOOKEEPER_URL = String.format("http://%s:%s", DEFAULT_HOST, ZOOKEEPER_PORT);
-  private static final String KAFKA_URL = String.format("http://%s:%s", DEFAULT_HOST, KAFKA_PORT);
   private static final ClusterDescriptor INSTANCE = new ClusterDescriptor();
 
   private String _controllerPort = "9000";
@@ -62,15 +59,7 @@ public class ClusterDescriptor {
     return String.format("http://%s:%s", DEFAULT_HOST, _brokerQueryPort);
   }
 
-  public String getDefaultHost() {
-    return DEFAULT_HOST;
-  }
-
-  public String getKafkaPort() {
-    return KAFKA_PORT;
-  }
-
-  public String getServerAdminUrl() {
-    return String.format("http://%s:%s", DEFAULT_HOST, _serverAdminPort);
+  public String getKafkaServerUrl() {
+    return String.format("%s:%s", DEFAULT_HOST, KAFKA_PORT);
   }
 }

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/CompatibilityOpsRunner.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/CompatibilityOpsRunner.java
@@ -38,9 +38,8 @@ import org.yaml.snakeyaml.representer.Representer;
 public class CompatibilityOpsRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(CompatibilityOpsRunner.class);
 
-  private String _parentDir;
   private final String _configFileName;
-  private int _generationNumber;
+  private final int _generationNumber;
 
   private CompatibilityOpsRunner(String configFileName, int generationNumber) {
     _configFileName = configFileName;
@@ -50,7 +49,7 @@ public class CompatibilityOpsRunner {
   private boolean runOps()
       throws Exception {
     Path path = Paths.get(_configFileName);
-    _parentDir = path.getParent().toString();
+    String parentDir = path.getParent().toString();
     InputStream inputStream = Files.newInputStream(path);
 
     Representer representer = new Representer(new DumperOptions());
@@ -62,7 +61,7 @@ public class CompatibilityOpsRunner {
 
     boolean passed = true;
     for (BaseOp op : operation.getOperations()) {
-      op.setParentDir(_parentDir);
+      op.setParentDir(parentDir);
       if (!op.run(_generationNumber)) {
         passed = false;
         System.out.println("Failure");
@@ -82,7 +81,7 @@ public class CompatibilityOpsRunner {
     clusterDescriptor.setBrokerQueryPort(System.getProperty("BrokerQueryPort"));
     clusterDescriptor.setServerAdminPort(System.getProperty("ServerAdminPort"));
 
-    CompatibilityOpsRunner runner = new CompatibilityOpsRunner(args[0], Integer.valueOf(args[1]));
+    CompatibilityOpsRunner runner = new CompatibilityOpsRunner(args[0], Integer.parseInt(args[1]));
     int exitStatus = 1;
     if (runner.runOps()) {
       exitStatus = 0;

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/CompatibilityOpsRunner.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/CompatibilityOpsRunner.java
@@ -57,14 +57,14 @@ public class CompatibilityOpsRunner {
     Yaml yaml = new Yaml(new CustomConstructor(new LoaderOptions()), representer);
 
     CompatTestOperation operation = yaml.loadAs(inputStream, CompatTestOperation.class);
-    LOGGER.info("Running compat verifications from file:{} ({})", path.toString(), operation.getDescription());
+    LOGGER.info("Running compat verifications from file:{} ({})", path, operation.getDescription());
 
     boolean passed = true;
     for (BaseOp op : operation.getOperations()) {
       op.setParentDir(parentDir);
       if (!op.run(_generationNumber)) {
         passed = false;
-        System.out.println("Failure");
+        LOGGER.error("Failure");
         break;
       }
     }

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/QueryOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/QueryOp.java
@@ -42,8 +42,6 @@ import org.slf4j.LoggerFactory;
 public class QueryOp extends BaseOp {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryOp.class);
 
-  private static final String NUM_DOCS_SCANNED_KEY = "numDocsScanned";
-  private static final String TIME_USED_MS_KEY = "timeUsedMs";
   private static final String COMMENT_DELIMITER = "#";
   private String _queryFileName;
   private String _expectedResultsFileName;
@@ -84,7 +82,7 @@ public class QueryOp extends BaseOp {
 
   @Override
   boolean runOp(int generationNumber) {
-    System.out.println("Verifying queries in " + _queryFileName + " against results in " + _expectedResultsFileName);
+    LOGGER.info("Verifying queries in {} against results in {}", _queryFileName, _expectedResultsFileName);
     try {
       for (int i = 1; i <= generationNumber; i++) {
         if (!verifyQueries(i)) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
@@ -85,6 +85,7 @@ public class SegmentOp extends BaseOp {
     super(OpType.SEGMENT_OP);
   }
 
+
   public Op getOp() {
     return _op;
   }

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
@@ -233,8 +233,8 @@ public class SegmentOp extends BaseOp {
    * Verify given table and segment name in the controller are in the state matching the parameter.
    * @param state of the segment to be verified in the controller.
    * @return true if segment is in the state provided in the parameter, else false.
-   * @throws IOException
-   * @throws InterruptedException
+   * @throws IOException when unable to get the external view for the table.
+   * @throws InterruptedException when thread sleep is interrupted.
    */
   private boolean verifySegmentInState(String state)
       throws IOException, InterruptedException {
@@ -308,8 +308,8 @@ public class SegmentOp extends BaseOp {
   /**
    * Verify given table name and segment name deleted from the controller.
    * @return true if no segment found, else false.
-   * @throws IOException
-   * @throws InterruptedException
+   * @throws IOException when unable to get the external view for the table.
+   * @throws InterruptedException when thread sleep is interrupted.
    */
   private boolean verifySegmentDeleted()
       throws IOException, InterruptedException {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -57,7 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-
 
 /**
  * PRODUCE
@@ -226,7 +226,8 @@ public class StreamOp extends BaseOp {
           .sendGetRequest(ControllerRequestURLBuilder.baseUrl(ClusterDescriptor.getInstance().getControllerUrl())
               .forSchemaGet(schemaName));
       Schema schema = JsonUtils.stringToObject(schemaString, Schema.class);
-      DateTimeFormatSpec dateTimeFormatSpec = schema.getSpecForTimeColumn(timeColumn).getFormatSpec();
+      DateTimeFormatSpec dateTimeFormatSpec = Objects.requireNonNull(
+          schema.getSpecForTimeColumn(timeColumn)).getFormatSpec();
 
       try (RecordReader csvRecordReader = RecordReaderFactory
           .getRecordReader(FileFormat.CSV, localReplacedCSVFile, columnNames, recordReaderConfig)) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -167,9 +167,8 @@ public class StreamOp extends BaseOp {
       int partitions = Integer.parseInt(streamConfigMap.getProperty(NUM_PARTITIONS));
 
       final Map<String, Object> config = new HashMap<>();
-      config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-          ClusterDescriptor.getInstance().getDefaultHost() + ":" + ClusterDescriptor.getInstance().getKafkaPort());
-      config.put(AdminClientConfig.CLIENT_ID_CONFIG, "Kafka2AdminClient-" + UUID.randomUUID().toString());
+      config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, ClusterDescriptor.getInstance().getKafkaServerUrl());
+      config.put(AdminClientConfig.CLIENT_ID_CONFIG, "Kafka2AdminClient-" + UUID.randomUUID());
       config.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 15000);
       AdminClient adminClient = KafkaAdminClient.create(config);
       NewTopic topic = new NewTopic(topicName, partitions, KAFKA_REPLICATION_FACTOR);

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
@@ -21,6 +21,7 @@ package org.apache.pinot.compat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,7 +89,9 @@ public class TableOp extends BaseOp {
   boolean runOp(int generationNumber) {
     switch (_op) {
       case CREATE:
-        createSchema();
+        if (!createSchema()) {
+          return false;
+        }
         return createTable();
       case DELETE:
         return deleteTable();
@@ -111,7 +114,8 @@ public class TableOp extends BaseOp {
       }};
       ControllerTest.sendPostRequestRaw(
           ControllerRequestURLBuilder.baseUrl(ClusterDescriptor.getInstance().getControllerUrl()).forSchemaCreate(),
-          FileUtils.readFileToString(new File(getAbsoluteFileName(_schemaFileName))), headers);
+          FileUtils.readFileToString(new File(getAbsoluteFileName(_schemaFileName)), Charset.defaultCharset()),
+          headers);
       return true;
     } catch (IOException e) {
       LOGGER.error("Failed to create schema with file: {}", _schemaFileName, e);
@@ -123,7 +127,8 @@ public class TableOp extends BaseOp {
     try {
       ControllerTest.sendPostRequestRaw(
           ControllerRequestURLBuilder.baseUrl(ClusterDescriptor.getInstance().getControllerUrl()).forTableCreate(),
-          FileUtils.readFileToString(new File(getAbsoluteFileName(_tableConfigFileName))), Collections.emptyMap());
+          FileUtils.readFileToString(new File(getAbsoluteFileName(_tableConfigFileName)), Charset.defaultCharset()),
+          Collections.emptyMap());
       return true;
     } catch (IOException e) {
       LOGGER.error("Failed to create table with file: {}", _tableConfigFileName, e);

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
@@ -96,10 +96,10 @@ public class TableOp extends BaseOp {
       case DELETE:
         return deleteTable();
       case UPDATE_CONFIG:
-        System.out.println("Updating table config to " + _tableConfigFileName);
+        LOGGER.info("Updating table config to {}", _tableConfigFileName);
         break;
       case UPDATE_SCHEMA:
-        System.out.println("Updating schema to " + _schemaFileName);
+        LOGGER.info("Updating schema to {}", _schemaFileName);
         break;
       default:
         break;
@@ -109,7 +109,7 @@ public class TableOp extends BaseOp {
 
   private boolean createSchema() {
     try {
-      Map<String, String> headers = new HashMap<String, String>() {{
+      Map<String, String> headers = new HashMap<>() {{
         put("Content-type", "application/json");
       }};
       ControllerTest.sendPostRequestRaw(

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/Utils.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/Utils.java
@@ -36,11 +36,11 @@ public class Utils {
 
   /**
    * Replace all occurrence of a string in originalDataFile and write the replaced content to replacedDataFile.
-   * @param originalDataFile
-   * @param replacedDataFile
-   * @param original
-   * @param replaced
-   * @throws IOException
+   * @param originalDataFile original data file
+   * @param replacedDataFile replaced data file
+   * @param original original string
+   * @param replaced replaced string
+   * @throws IOException if an I/O error occurs
    */
   public static void replaceContent(File originalDataFile, File replacedDataFile, String original, String replaced)
       throws IOException {

--- a/pinot-compatibility-verifier/src/main/resources/pinot-compatibility-verifier-log4j2.xml
+++ b/pinot-compatibility-verifier/src/main/resources/pinot-compatibility-verifier-log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.apache.pinot" level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="info">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
**Labels:**
- `refactor`
- `cleanup`

**Description:**
In this PR, the focus is mainly on the cleanliness of the code in the `pinot-compatibility-verifier` module. Here is the summary
- Writing logs using logger instead of using the `system.out`
- leveraging the `createSchema` return value in table creation operation.
- Set the default character for the file objects.
- addressing particular minor warning issues.
