### PR TITLE
fix race condition in `ScalingThreadPoolExecutor`

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutor.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
  * the pool to create a new thread. The rejection is then handled to queue the task anyway.
  * <p>
  * This differs from the plain ThreadPoolExecutor implementation which does not create new threads if the queue (not
- * thread pool) has capacity. For a more complete explanation, see (note: the orginal version includes a race
+ * thread pool) has capacity. For a more complete explanation, see (note: the original version includes a race
  * condition, and the implementation here differs slightly):
  * https://github.com/kimchy/kimchy.github.com/blob/master/_posts/2008-11-23-juc-executorservice-gotcha.textile
  */

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutor.java
@@ -26,7 +26,7 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 /**
@@ -108,22 +108,26 @@ public class ScalingThreadPoolExecutor extends ThreadPoolExecutor {
     }
 
     @Override
-    @Nonnull
     public E take()
         throws InterruptedException {
       _currentIdleThreadCount.incrementAndGet();
-      E e = super.take();
-      _currentIdleThreadCount.decrementAndGet();
-      return e;
+      try {
+        return super.take();
+      } finally {
+        _currentIdleThreadCount.decrementAndGet();
+      }
     }
 
     @Override
+    @Nullable
     public E poll(long timeout, TimeUnit unit)
         throws InterruptedException {
       _currentIdleThreadCount.incrementAndGet();
-      E e = super.poll(timeout, unit);
-      _currentIdleThreadCount.decrementAndGet();
-      return e;
+      try {
+        return super.poll(timeout, unit);
+      } finally {
+        _currentIdleThreadCount.decrementAndGet();
+      }
     }
 
     /**
@@ -134,7 +138,7 @@ public class ScalingThreadPoolExecutor extends ThreadPoolExecutor {
      * @return true if it was possible to add the element to this queue, else false
      */
     @Override
-    public boolean offer(@Nonnull E e) {
+    public boolean offer(E e) {
       return _currentIdleThreadCount.get() > 0 && super.offer(e);
     }
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ScalingThreadPoolExecutorTest.java
@@ -57,6 +57,21 @@ public class ScalingThreadPoolExecutorTest {
         "Timed out waiting for thread pool to scale down");
   }
 
+  @Test
+  public void testRapidSubmission() {
+    ThreadPoolExecutor executorService = (ThreadPoolExecutor) ScalingThreadPoolExecutor.newScalingThreadPool(0, 4, 0L);
+    Runnable r1 = getSleepingRunnable();
+    Runnable r2 = getSleepingRunnable();
+
+    // When Runnables are submitted rapidly, the pool should scale up to 2 threads. The previous test cases can fail
+    // to catch such a race condition because Runnables are initialized as they are submitted, which introduced enough
+    // delay to avoid the condition
+    executorService.submit(r1);
+    executorService.submit(r2);
+    TestUtils.waitForCondition(aVoid -> executorService.getPoolSize() == 2, 2000,
+        "Timed out waiting for thread pool to scale up");
+  }
+
   private Runnable getSleepingRunnable() {
     return () -> {
       try {


### PR DESCRIPTION
I introduced `ScalingThreadPoolExecutor` previously to provide an autoscaling thread pool, used to prevent interrupts from corrupting the realtime Lucene index. 

There is a race condition as the logic relied on `_executor.getPoolSize()` and `_executor.getActiveCount()`, and using the latter could lag the 'real' count of currently idle threads. In this case, the task would be queued and not executed. This PR changes the implementation slightly to track idle threads via overriding the [two methods that may be used by ThreadPoolExecutor.getTask()](https://github.com/openjdk/jdk21/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java#L1069-L1070), which is always executed by an idle thread to pick up the next task. 

In theory the bug could cause sporadic timeouts for searches against the realtime Lucene index, though it is hard to reproduce. I came across this bug trying to use `ScalingThreadPoolExecutor` for another feature.

For testing, unit tests should cover this logic. The race condition is easily reproducible when the added unit test is used against the old implementation. 

suggested tag: `bugfix`
