### PR TITLE
Move BrokerSelector and implementations to pinot-common

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerData.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerData.java
@@ -20,13 +20,15 @@ package org.apache.pinot.client;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.broker.BrokerInfo;
 
 
 public class BrokerData {
-  private final Map<String, List<String>> _tableToBrokerMap;
+  private final Map<String, Set<BrokerInfo>> _tableToBrokerMap;
   private final List<String> _brokers;
 
-  public Map<String, List<String>> getTableToBrokerMap() {
+  public Map<String, Set<BrokerInfo>> getTableToBrokerMap() {
     return _tableToBrokerMap;
   }
 
@@ -34,7 +36,7 @@ public class BrokerData {
     return _brokers;
   }
 
-  public BrokerData(Map<String, List<String>> tableToBrokerMap, List<String> brokers) {
+  public BrokerData(Map<String, Set<BrokerInfo>> tableToBrokerMap, List<String> brokers) {
     _tableToBrokerMap = tableToBrokerMap;
     _brokers = brokers;
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerData.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerData.java
@@ -20,15 +20,14 @@ package org.apache.pinot.client;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.common.broker.BrokerInfo;
 
 
 public class BrokerData {
-  private final Map<String, Set<BrokerInfo>> _tableToBrokerMap;
+  private final Map<String, List<BrokerInfo>> _tableToBrokerMap;
   private final List<String> _brokers;
 
-  public Map<String, Set<BrokerInfo>> getTableToBrokerMap() {
+  public Map<String, List<BrokerInfo>> getTableToBrokerMap() {
     return _tableToBrokerMap;
   }
 
@@ -36,7 +35,7 @@ public class BrokerData {
     return _brokers;
   }
 
-  public BrokerData(Map<String, Set<BrokerInfo>> tableToBrokerMap, List<String> brokers) {
+  public BrokerData(Map<String, List<BrokerInfo>> tableToBrokerMap, List<String> brokers) {
     _tableToBrokerMap = tableToBrokerMap;
     _brokers = brokers;
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.broker.BrokerSelector;
+import org.apache.pinot.common.broker.SimpleBrokerSelector;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -24,7 +24,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.broker.BrokerSelector;
-import org.apache.pinot.common.broker.SimpleBrokerSelector;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import org.apache.pinot.common.broker.DynamicBrokerSelector;
 
 
 /**

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ControllerBasedBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ControllerBasedBrokerSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.client;
 
 import java.util.List;
 import java.util.Properties;
+import org.apache.pinot.common.broker.BrokerSelector;
 
 
 /**
@@ -31,11 +32,6 @@ public class ControllerBasedBrokerSelector implements BrokerSelector {
 
   private final UpdatableBrokerCache _brokerCache;
   private final Properties _properties;
-
-  public ControllerBasedBrokerSelector(String scheme, String controllerHost, int controllerPort)
-      throws Exception {
-    this(scheme, controllerHost, controllerPort, new Properties());
-  }
 
   public ControllerBasedBrokerSelector(String scheme, String controllerHost, int controllerPort, Properties properties)
       throws Exception {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SimpleBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SimpleBrokerSelector.java
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.broker;
+package org.apache.pinot.client;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Random;
+import org.apache.pinot.common.broker.BrokerSelector;
 
 
 /**

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
@@ -54,7 +54,9 @@ public class ConnectionFactoryTest {
       }
 
       @Override
-      public List<BrokerInfo> getBrokerInfoList() {return ImmutableList.of(givenBrokerInfo);}
+      public List<BrokerInfo> getBrokerInfoList() {
+        return ImmutableList.of(givenBrokerInfo);
+      }
     });
 
     PinotClientTransport pinotClientTransport = Mockito.mock(PinotClientTransport.class);

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
@@ -67,7 +67,7 @@ public class ConnectionFactoryTest {
             pinotClientTransport);
 
     // Check that the broker list has the right length and has the same servers
-    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of("localhost:2345"));
+    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of(givenBrokerInfo.getHostPort(false)));
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.I0Itec.zkclient.ZkClient;
+import org.apache.pinot.common.broker.BrokerInfo;
 import org.apache.pinot.common.broker.DynamicBrokerSelector;
 import org.apache.pinot.common.broker.ExternalViewReader;
 import org.mockito.Mockito;
@@ -39,6 +40,8 @@ public class ConnectionFactoryTest {
   public void testZkConnection() {
     // Create a dummy Helix structure
     final String givenZkServers = "127.0.0.1:1234";
+    final BrokerInfo givenBrokerInfo = new BrokerInfo("localhost", 2345);
+
     DynamicBrokerSelector dynamicBrokerSelector = Mockito.spy(new DynamicBrokerSelector(givenZkServers) {
       @Override
       protected ZkClient getZkClient(String zkServers) {
@@ -49,6 +52,9 @@ public class ConnectionFactoryTest {
       protected ExternalViewReader getEvReader(ZkClient zkClient) {
         return Mockito.mock(ExternalViewReader.class);
       }
+
+      @Override
+      public List<BrokerInfo> getBrokerInfoList() {return ImmutableList.of(givenBrokerInfo);}
     });
 
     PinotClientTransport pinotClientTransport = Mockito.mock(PinotClientTransport.class);
@@ -59,7 +65,7 @@ public class ConnectionFactoryTest {
             pinotClientTransport);
 
     // Check that the broker list has the right length and has the same servers
-    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of(givenZkServers));
+    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of("localhost:2345"));
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.I0Itec.zkclient.ZkClient;
+import org.apache.pinot.common.broker.DynamicBrokerSelector;
+import org.apache.pinot.common.broker.ExternalViewReader;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/PreparedStatementTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.client;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pinot.common.broker.BrokerSelector;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -346,6 +346,10 @@
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.101tec</groupId>
+      <artifactId>zkclient</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
@@ -21,6 +21,9 @@ package org.apache.pinot.common.broker;
 import java.util.Objects;
 
 
+/**
+ * Store ID and network information about Brokers required by components that have to select a broker.
+ */
 public class BrokerInfo {
   private final String _instanceId;
   private final String _hostname;
@@ -35,6 +38,7 @@ public class BrokerInfo {
   }
 
   public BrokerInfo(String hostname, int port) {
+    // If an instance ID is not specified, then use host:port as the identifier.
     _instanceId = hostname + ":" + port;
     _hostname = hostname;
     _port = port;
@@ -61,6 +65,7 @@ public class BrokerInfo {
     return String.format("%s:%s", _hostname, preferTlsPort && _tlsPort > 0 ? _tlsPort : _port);
   }
 
+  // equals only uses Instance ID to check for equality.
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,6 +78,7 @@ public class BrokerInfo {
     return Objects.equals(getInstanceId(), that.getInstanceId());
   }
 
+  // hashCode only uses Instance ID to generate the hash.
   @Override
   public int hashCode() {
     return Objects.hash(getInstanceId());

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
@@ -37,6 +37,13 @@ public class BrokerInfo {
     _tlsPort = tlsPort;
   }
 
+  public BrokerInfo(String instanceId, String hostname, int port) {
+    _instanceId = instanceId;
+    _hostname = hostname;
+    _port = port;
+    _tlsPort = -1;
+  }
+
   public BrokerInfo(String hostname, int port) {
     // If an instance ID is not specified, then use host:port as the identifier.
     _instanceId = hostname + ":" + port;

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.broker;
+
+import java.util.Objects;
+
+
+public class BrokerInfo {
+  private final String _instanceId;
+  private final String _hostname;
+  private final int _port;
+  private final int _tlsPort;
+
+  public BrokerInfo(String instanceId, String hostname, int port, int tlsPort) {
+    _instanceId = instanceId;
+    _hostname = hostname;
+    _port = port;
+    _tlsPort = tlsPort;
+  }
+
+  public BrokerInfo(String hostname, int port) {
+    _instanceId = hostname + ":" + port;
+    _hostname = hostname;
+    _port = port;
+    _tlsPort = -1;
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public int getPort() {
+    return _port;
+  }
+
+  public int getTlsPort() {
+    return _tlsPort;
+  }
+
+  public String getHostPort(boolean preferTlsPort) {
+    return String.format("%s:%s", _hostname, preferTlsPort && _tlsPort > 0 ? _tlsPort : _port);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BrokerInfo that = (BrokerInfo) o;
+    return Objects.equals(getInstanceId(), that.getInstanceId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getInstanceId());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfo.java
@@ -72,7 +72,6 @@ public class BrokerInfo {
     return String.format("%s:%s", _hostname, preferTlsPort && _tlsPort > 0 ? _tlsPort : _port);
   }
 
-  // equals only uses Instance ID to check for equality.
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -82,12 +81,12 @@ public class BrokerInfo {
       return false;
     }
     BrokerInfo that = (BrokerInfo) o;
-    return Objects.equals(getInstanceId(), that.getInstanceId());
+    return getPort() == that.getPort() && getTlsPort() == that.getTlsPort() && Objects.equals(getInstanceId(),
+        that.getInstanceId()) && Objects.equals(getHostname(), that.getHostname());
   }
 
-  // hashCode only uses Instance ID to generate the hash.
   @Override
   public int hashCode() {
-    return Objects.hash(getInstanceId());
+    return Objects.hash(getInstanceId(), getHostname(), getPort(), getTlsPort());
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfoSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfoSelector.java
@@ -1,0 +1,44 @@
+package org.apache.pinot.common.broker;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+
+public abstract class BrokerInfoSelector implements BrokerSelector {
+
+  protected final boolean _preferTlsPort;
+
+  public BrokerInfoSelector(boolean preferTlsPort) {
+    _preferTlsPort = preferTlsPort;
+  }
+
+  @Nullable
+  @Override
+  public String selectBroker(String... tableNames) {
+    BrokerInfo brokerInfo = selectBrokerInfo(tableNames);
+    if (brokerInfo != null) {
+      return brokerInfo.getHostPort(_preferTlsPort);
+    }
+    return null;
+  }
+
+
+  @Override
+  public List<String> getBrokers() {
+    return getBrokerInfoList().stream().map(b -> b.getHostPort(_preferTlsPort)).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a BrokerInfo object with network information about the broker.
+   * @param tableNames List of tables that the broker has to process.
+   * @return A BrokerInfo object or null if none found.
+   */
+  public abstract BrokerInfo selectBrokerInfo(String... tableNames);
+
+  /**
+   * Get a list of BrokerInfo objects.
+   * @return A list of BrokerInfo objects
+   */
+  public abstract List<BrokerInfo> getBrokerInfoList();
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfoSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerInfoSelector.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.broker;
 
 import java.util.List;

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.common.broker;
 
 import java.util.List;
-import org.apache.commons.lang.NotImplementedException;
 
 
 public interface BrokerSelector {
@@ -31,7 +30,7 @@ public interface BrokerSelector {
   String selectBroker(String... tableNames);
 
   default BrokerInfo selectBrokerInfo(String... tableName) {
-   throw new NotImplementedException();
+   throw new UnsupportedOperationException("selectBrokerInfo has not been implemented.");
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
@@ -20,7 +20,6 @@ package org.apache.pinot.common.broker;
 
 import java.util.List;
 
-
 public interface BrokerSelector {
   /**
    * Returns the broker address in the form host:port

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
@@ -29,10 +29,6 @@ public interface BrokerSelector {
    */
   String selectBroker(String... tableNames);
 
-  default BrokerInfo selectBrokerInfo(String... tableName) {
-   throw new UnsupportedOperationException("selectBrokerInfo has not been implemented.");
-  }
-
   /**
    * Returns list of all brokers.
    */

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelector.java
@@ -16,37 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.client;
+package org.apache.pinot.common.broker;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Random;
+import org.apache.commons.lang.NotImplementedException;
 
 
-/**
- * Picks a broker randomly from list of brokers provided. This assumes that all the provided brokers
- * are healthy. There is no health check done on the brokers
- */
-public class SimpleBrokerSelector implements BrokerSelector {
+public interface BrokerSelector {
+  /**
+   * Returns the broker address in the form host:port
+   * @param tableNames
+   * @return
+   */
+  String selectBroker(String... tableNames);
 
-  private final List<String> _brokerList;
-  private final Random _random = new Random();
-
-  public SimpleBrokerSelector(List<String> brokerList) {
-    _brokerList = ImmutableList.copyOf(brokerList);
+  default BrokerInfo selectBrokerInfo(String... tableName) {
+   throw new NotImplementedException();
   }
 
-  @Override
-  public String selectBroker(String... tableNames) {
-    return _brokerList.get(_random.nextInt(_brokerList.size()));
-  }
+  /**
+   * Returns list of all brokers.
+   */
+  List<String> getBrokers();
 
-  @Override
-  public List<String> getBrokers() {
-    return ImmutableList.copyOf(_brokerList);
-  }
-
-  @Override
-  public void close() {
-  }
+  /**
+   * Close any resources
+   */
+  void close();
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelectorUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelectorUtils.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 
 public class BrokerSelectorUtils {
@@ -34,11 +33,11 @@ public class BrokerSelectorUtils {
    *
    * @param tableNames: List of table names.
    * @param brokerData: map holding data for table hosting on brokers.
-   * @return set of common brokers hosting all the tables.
+   * @return list of common brokers hosting all the tables.
    */
-  public static Set<BrokerInfo> getTablesCommonBrokers(List<String> tableNames,
-      Map<String, Set<BrokerInfo>> brokerData) {
-    List<Set<BrokerInfo>> tablesBrokersList = new ArrayList<>();
+  public static List<BrokerInfo> getTablesCommonBrokers(List<String> tableNames,
+      Map<String, List<BrokerInfo>> brokerData) {
+    List<List<BrokerInfo>> tablesBrokersList = new ArrayList<>();
     for (String name: tableNames) {
       String tableName = getTableNameWithoutSuffix(name);
       int idx = tableName.indexOf('.');
@@ -58,7 +57,7 @@ public class BrokerSelectorUtils {
       return null;
     }
 
-    Set<BrokerInfo> commonBrokers = tablesBrokersList.get(0);
+    List<BrokerInfo> commonBrokers = tablesBrokersList.get(0);
     for (int i = 1; i < tablesBrokersList.size(); i++) {
       commonBrokers.retainAll(tablesBrokersList.get(i));
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelectorUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/BrokerSelectorUtils.java
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.client.utils;
+package org.apache.pinot.common.broker;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.pinot.client.ExternalViewReader;
+import java.util.Set;
 
 
 public class BrokerSelectorUtils {
@@ -34,10 +34,11 @@ public class BrokerSelectorUtils {
    *
    * @param tableNames: List of table names.
    * @param brokerData: map holding data for table hosting on brokers.
-   * @return list of common brokers hosting all the tables.
+   * @return set of common brokers hosting all the tables.
    */
-  public static List<String> getTablesCommonBrokers(List<String> tableNames, Map<String, List<String>> brokerData) {
-    List<List<String>> tablesBrokersList = new ArrayList<>();
+  public static Set<BrokerInfo> getTablesCommonBrokers(List<String> tableNames,
+      Map<String, Set<BrokerInfo>> brokerData) {
+    List<Set<BrokerInfo>> tablesBrokersList = new ArrayList<>();
     for (String name: tableNames) {
       String tableName = getTableNameWithoutSuffix(name);
       int idx = tableName.indexOf('.');
@@ -57,7 +58,7 @@ public class BrokerSelectorUtils {
       return null;
     }
 
-    List<String> commonBrokers = tablesBrokersList.get(0);
+    Set<BrokerInfo> commonBrokers = tablesBrokersList.get(0);
     for (int i = 1; i < tablesBrokersList.size(); i++) {
       commonBrokers.retainAll(tablesBrokersList.get(i));
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/CommonTenantBroker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/CommonTenantBroker.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.broker;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+public class CommonTenantBroker extends DynamicBrokerSelector {
+
+  public CommonTenantBroker(String zkServers, boolean preferTlsPort) {
+    super(zkServers, preferTlsPort);
+  }
+
+  public CommonTenantBroker(String zkServers) {
+    super(zkServers);
+  }
+
+  @Nullable
+  @Override
+  public BrokerInfo selectBrokerInfo(String... tableNames) {
+    if (!(tableNames == null || tableNames.length == 0 || tableNames[0] == null)) {
+      // getting list of brokers hosting all the tables.
+      Set<BrokerInfo> commonBrokers = BrokerSelectorUtils.getTablesCommonBrokers(Arrays.asList(tableNames),
+          _tableToBrokerListMapRef.get());
+      if (commonBrokers != null && !commonBrokers.isEmpty()) {
+        // Return a broker randomly if table is null or no broker is found for the specified table.
+        List<BrokerInfo> list = new ArrayList<>(commonBrokers);
+        if (!list.isEmpty()) {
+          return list.get(RANDOM.nextInt(list.size()));
+        }
+      }
+    } else {
+      List<BrokerInfo> list = new ArrayList<>(_allBrokerListRef.get());
+      if (!list.isEmpty()) {
+        return list.get(RANDOM.nextInt(list.size()));
+      }
+    }
+
+    return null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/DynamicBrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/DynamicBrokerSelector.java
@@ -21,9 +21,11 @@ package org.apache.pinot.common.broker;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -75,11 +77,11 @@ public class DynamicBrokerSelector extends BrokerInfoSelector implements IZkData
   private void refresh() {
     Map<String, List<BrokerInfo>> tableToBrokerListMap = _evReader.getTableToBrokerInfosMap();
     _tableToBrokerListMapRef.set(tableToBrokerListMap);
-    List<BrokerInfo> brokerList = new ArrayList<>();
-    for (List<BrokerInfo> brokerInfoSet : tableToBrokerListMap.values()) {
-      brokerList.addAll(brokerInfoSet);
+    Set<BrokerInfo> brokerInfoSet = new HashSet<>();
+    for (List<BrokerInfo> brokerInfoList : tableToBrokerListMap.values()) {
+      brokerInfoSet.addAll(brokerInfoList);
     }
-    _allBrokerListRef.set(brokerList);
+    _allBrokerListRef.set(new ArrayList<>(brokerInfoSet));
   }
 
   @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/ExternalViewReader.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/ExternalViewReader.java
@@ -152,8 +152,8 @@ public class ExternalViewReader {
     return new ByteArrayInputStream(brokerResourceNodeData);
   }
 
-  public Map<String, Set<BrokerInfo>> getTableToBrokerInfosMap() {
-    Map<String, Set<BrokerInfo>> brokerInfosMap = new HashMap<>();
+  public Map<String, List<BrokerInfo>> getTableToBrokerInfosMap() {
+    Map<String, List<BrokerInfo>> brokerInfosMap = new HashMap<>();
     try {
       byte[] brokerResourceNodeData = _zkClient.readData(BROKER_EXTERNAL_VIEW_PATH, true);
       brokerResourceNodeData = unpackZnodeIfNecessary(brokerResourceNodeData);
@@ -165,7 +165,7 @@ public class ExternalViewReader {
         Entry<String, JsonNode> resourceEntry = resourceEntries.next();
         String resourceName = resourceEntry.getKey();
         String tableName = resourceName.replace(OFFLINE_SUFFIX, "").replace(REALTIME_SUFFIX, "");
-        Set<BrokerInfo> brokerUrls = brokerInfosMap.computeIfAbsent(tableName, k -> new HashSet<>());
+        Set<BrokerInfo> brokerUrls = new HashSet<>();
         JsonNode resource = resourceEntry.getValue();
         Iterator<Entry<String, JsonNode>> brokerEntries = resource.fields();
         while (brokerEntries.hasNext()) {
@@ -175,6 +175,7 @@ public class ExternalViewReader {
             brokerUrls.add(getBrokerInfo(brokerName));
           }
         }
+        brokerInfosMap.put(tableName, new ArrayList<>(brokerUrls));
       }
     } catch (Exception e) {
       LOGGER.warn("Exception while reading External view from zookeeper", e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/ExternalViewReader.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/ExternalViewReader.java
@@ -187,8 +187,8 @@ public class ExternalViewReader {
 
   public Map<String, List<String>> getTableToBrokersMap() {
     Map<String, List<String>> tableToBrokersMap = new HashMap<>();
-    Map<String, Set<BrokerInfo>> tableToBrokerInfosMap = getTableToBrokerInfosMap();
-    for (Entry<String, Set<BrokerInfo>> entry : tableToBrokerInfosMap.entrySet()) {
+    Map<String, List<BrokerInfo>> tableToBrokerInfosMap = getTableToBrokerInfosMap();
+    for (Entry<String, List<BrokerInfo>> entry : tableToBrokerInfosMap.entrySet()) {
       tableToBrokersMap.put(entry.getKey(),
           entry.getValue().stream().map(b -> b.getHostPort(_preferTlsPort)).collect(Collectors.toList()));
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/broker/SimpleBrokerSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/broker/SimpleBrokerSelector.java
@@ -16,25 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.client;
+package org.apache.pinot.common.broker;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Random;
 
-public interface BrokerSelector {
-  /**
-   * Returns the broker address in the form host:port
-   * @param tableNames
-   * @return
-   */
-  String selectBroker(String... tableNames);
 
-  /**
-   * Returns list of all brokers.
-   */
-  List<String> getBrokers();
+/**
+ * Picks a broker randomly from list of brokers provided. This assumes that all the provided brokers
+ * are healthy. There is no health check done on the brokers
+ */
+public class SimpleBrokerSelector implements BrokerSelector {
 
-  /**
-   * Close any resources
-   */
-  void close();
+  private final List<String> _brokerList;
+  private final Random _random = new Random();
+
+  public SimpleBrokerSelector(List<String> brokerList) {
+    _brokerList = ImmutableList.copyOf(brokerList);
+  }
+
+  @Override
+  public String selectBroker(String... tableNames) {
+    return _brokerList.get(_random.nextInt(_brokerList.size()));
+  }
+
+  @Override
+  public List<String> getBrokers() {
+    return ImmutableList.copyOf(_brokerList);
+  }
+
+  @Override
+  public void close() {
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/broker/DynamicBrokerSelectorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/broker/DynamicBrokerSelectorTest.java
@@ -143,7 +143,7 @@ public class DynamicBrokerSelectorTest {
 
   @Test
   public void testGetBrokers() {
-    assertEquals(_dynamicBrokerSelectorUnderTest.getBrokers(), ImmutableList.of(ZK_SERVER));
+    assertEquals(_dynamicBrokerSelectorUnderTest.getBrokers(), ImmutableList.of("broker1:8080"));
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/broker/DynamicBrokerSelectorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/broker/DynamicBrokerSelectorTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.client;
+package org.apache.pinot.common.broker;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;

--- a/pinot-common/src/test/java/org/apache/pinot/common/broker/ExternalViewReaderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/broker/ExternalViewReaderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.client;
+package org.apache.pinot.common.broker;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;

--- a/pinot-common/src/test/java/org/apache/pinot/common/broker/ExternalViewReaderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/broker/ExternalViewReaderTest.java
@@ -92,8 +92,7 @@ public class ExternalViewReaderTest {
   }
 
   @Test
-  public void testGetLiveBrokers()
-      throws IOException {
+  public void testGetLiveBrokers() {
     // Setup
     final List<String> expectedResult = Arrays.asList("12.34.56.78:1234");
     when(_mockZkClient.readData(Mockito.anyString(), Mockito.anyBoolean())).thenReturn("json".getBytes());
@@ -130,7 +129,7 @@ public class ExternalViewReaderTest {
     final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
 
     // Verify the results
-    assertEquals(expectedResult, result);
+    assertEquals(result, expectedResult);
   }
 
   @Test

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -260,7 +260,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
 
-    LOGGER.info("Using DynamicBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL, _helixClusterName);
+    LOGGER.info("Using CommonTenantBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL, _helixClusterName);
     _brokerSelector = new CommonTenantBrokerSelector(String.format("%s/%s", _helixZkURL, _helixClusterName));
 
     // Initialize the table config tuner registry.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -260,7 +260,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
 
-    LOGGER.info("Using CommonTenantBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL, _helixClusterName);
+    LOGGER.info("Using CommonTenantBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL,
+        _helixClusterName);
     _brokerSelector = new CommonTenantBrokerSelector(String.format("%s/%s", _helixZkURL, _helixClusterName));
 
     // Initialize the table config tuner registry.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -60,7 +60,7 @@ import org.apache.helix.task.TaskDriver;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.broker.BrokerSelector;
-import org.apache.pinot.common.broker.CommonTenantBroker;
+import org.apache.pinot.common.broker.CommonTenantBrokerSelector;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -261,7 +261,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     }
 
     LOGGER.info("Using DynamicBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL, _helixClusterName);
-    _brokerSelector = new CommonTenantBroker(String.format("%s/%s", _helixZkURL, _helixClusterName));
+    _brokerSelector = new CommonTenantBrokerSelector(String.format("%s/%s", _helixZkURL, _helixClusterName));
 
     // Initialize the table config tuner registry.
     TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -59,7 +59,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.Utils;
-import org.apache.pinot.common.broker.BrokerSelector;
+import org.apache.pinot.common.broker.BrokerInfoSelector;
 import org.apache.pinot.common.broker.CommonTenantBrokerSelector;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
@@ -200,7 +200,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected ExecutorService _tenantRebalanceExecutorService;
   protected TableSizeReader _tableSizeReader;
   protected StorageQuotaChecker _storageQuotaChecker;
-  protected BrokerSelector _brokerSelector;
+  protected BrokerInfoSelector _brokerInfoSelector;
 
   @Override
   public void init(PinotConfiguration pinotConfiguration)
@@ -262,7 +262,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
     LOGGER.info("Using CommonTenantBrokerSelector with Zookeeper: {} and cluster name: {}", _helixZkURL,
         _helixClusterName);
-    _brokerSelector = new CommonTenantBrokerSelector(String.format("%s/%s", _helixZkURL, _helixClusterName));
+    _brokerInfoSelector = new CommonTenantBrokerSelector(String.format("%s/%s", _helixZkURL, _helixClusterName));
 
     // Initialize the table config tuner registry.
     TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());
@@ -552,7 +552,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_tableSizeReader).to(TableSizeReader.class);
         bind(_storageQuotaChecker).to(StorageQuotaChecker.class);
         bind(controllerStartTime).named(ControllerAdminApiApplication.START_TIME);
-        bind(_brokerSelector).to(BrokerSelector.class);
+        bind(_brokerInfoSelector).to(BrokerInfoSelector.class);
         String loggerRootDir = _config.getProperty(CommonConstants.Controller.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
           bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -49,7 +49,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.broker.BrokerInfo;
-import org.apache.pinot.common.broker.BrokerSelector;
+import org.apache.pinot.common.broker.BrokerInfoSelector;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -96,7 +96,7 @@ public class PinotQueryResource {
   ControllerConf _controllerConf;
 
   @Inject
-  BrokerSelector _brokerSelector;
+  BrokerInfoSelector _brokerInfoSelector;
 
   @POST
   @Path("sql")
@@ -218,7 +218,7 @@ public class PinotQueryResource {
     }
     BrokerInfo brokerInfo;
     if (!tableNames.isEmpty()) {
-      brokerInfo = _brokerSelector.selectBrokerInfo(tableNames.toArray(new String[0]));
+      brokerInfo = _brokerInfoSelector.selectBrokerInfo(tableNames.toArray(new String[0]));
       if (brokerInfo == null) {
         // No common broker found for table tenants
         LOGGER.error("Unable to find a common broker instance for table tenants. Tables: {}", tableNames);
@@ -227,7 +227,7 @@ public class PinotQueryResource {
       }
     } else {
       // TODO fail these queries going forward. Added this logic to take care of tautologies like BETWEEN 0 and -1.
-      brokerInfo = _brokerSelector.selectBrokerInfo();
+      brokerInfo = _brokerInfoSelector.selectBrokerInfo();
       LOGGER.error("Unable to find table name from SQL {} thus dispatching to random broker.", query);
     }
     //TODO: Check if broker is online. Or is ExternalView up to date on liveness of the broker?
@@ -276,7 +276,7 @@ public class PinotQueryResource {
     }
 
     // Get brokers for the resource table.
-    BrokerInfo brokerInfo = _brokerSelector.selectBrokerInfo(rawTableName);
+    BrokerInfo brokerInfo = _brokerInfoSelector.selectBrokerInfo(rawTableName);
     return sendRequestToBroker(query, brokerInfo, traceEnabled, queryOptions, httpHeaders);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -230,7 +230,6 @@ public class PinotQueryResource {
       brokerInfo = _brokerInfoSelector.selectBrokerInfo();
       LOGGER.error("Unable to find table name from SQL {} thus dispatching to random broker.", query);
     }
-    //TODO: Check if broker is online. Or is ExternalView up to date on liveness of the broker?
     return sendRequestToBroker(query, brokerInfo, traceEnabled, queryOptions, httpHeaders);
   }
 


### PR DESCRIPTION
BrokerSelector is useful in other components when an appropriate broker has to be selected. For example,
the controller has to choose a broker that can process all tables in a V2 query. 

Move BrokerSelector to `pinot-common` so that other components can have access to the interface and implementations.
Also add `CommonTenantBrokerSelector` which will error out if a broker that can process all the tables in a query cannot
be found.

Remove similar code in the controller that chose the right tenant and replace it with a broker selector.

Tags:
multi-stage
cleanup