### PR TITLE
Use a two server setup for multi-stage query engine backward compatibility regression test suite

### DIFF
--- a/compatibility-verifier/compCheck.sh
+++ b/compatibility-verifier/compCheck.sh
@@ -46,20 +46,32 @@ cmdName=`basename $0`
 source `dirname $0`/utils.inc
 
 function cleanupControllerDirs() {
-  local dirName=$(grep -F controller.data.dir ${CONTROLLER_CONF} | awk '{print $3}')
-  if [ ! -z "$dirName" ]; then
-    ${RM} -rf ${dirName}
+  local dirName=$(grep -F controller.data.dir "${CONTROLLER_CONF}" | awk '{print $3}')
+  if [ -n "$dirName" ]; then
+    ${RM} -rf "${dirName}"
   fi
 }
 
 function cleanupServerDirs() {
-  local dirName=$(grep -F pinot.server.instance.dataDir ${SERVER_CONF} | awk '{print $3}')
-  if [ ! -z "$dirName" ]; then
-    ${RM} -rf ${dirName}
+  local dirName=$(grep -F pinot.server.instance.dataDir "${SERVER_CONF}" | awk '{print $3}')
+  if [ -n "$dirName" ]; then
+    ${RM} -rf "${dirName}"
   fi
-  dirName=$(grep -F pinot.server.instance.segmentTarDir ${SERVER_CONF} | awk '{print $3}')
-  if [ ! -z "$dirName" ]; then
-    ${RM} -rf ${dirName}
+  dirName=$(grep -F pinot.server.instance.segmentTarDir "${SERVER_CONF}" | awk '{print $3}')
+  if [ -n "$dirName" ]; then
+    ${RM} -rf "${dirName}"
+  fi
+
+  # Cleanup directories for server 2 if a second server is configured
+  if [ -f "${SERVER_CONF_2}" ]; then
+    local dirName=$(grep -F pinot.server.instance.dataDir "${SERVER_CONF_2}" | awk '{print $3}')
+      if [ -n "$dirName" ]; then
+        ${RM} -rf "${dirName}"
+      fi
+      dirName=$(grep -F pinot.server.instance.segmentTarDir "${SERVER_CONF_2}" | awk '{print $3}')
+      if [ -n "$dirName" ]; then
+        ${RM} -rf "${dirName}"
+      fi
   fi
 }
 
@@ -78,9 +90,9 @@ function waitForZkReady() {
   status=1
   while [ $status -ne 0 ]; do
     sleep 1
-    echo Checking port ${ZK_PORT} for zk ready
+    echo "Checking port ${ZK_PORT} for zk ready"
     echo x | nc localhost ${ZK_PORT} 1>/dev/null 2>&1
-    status=$(echo $?)
+    status=$?
   done
 }
 
@@ -88,9 +100,9 @@ function waitForControllerReady() {
   status=1
   while [ $status -ne 0 ]; do
     sleep 1
-    echo Checking port ${CONTROLLER_PORT} for controller ready
+    echo "Checking port ${CONTROLLER_PORT} for controller ready"
     curl localhost:${CONTROLLER_PORT}/health 1>/dev/null 2>&1
-    status=$(echo $?)
+    status=$?
   done
 }
 
@@ -98,9 +110,9 @@ function waitForKafkaReady() {
   status=1
   while [ $status -ne 0 ]; do
     sleep 1
-    echo Checking port 19092 for kafka ready
+    echo "Checking port 19092 for kafka ready"
     echo x | nc localhost 19092 1>/dev/null 2>&1
-    status=$(echo $?)
+    status=$?
   done
 }
 
@@ -108,9 +120,9 @@ function waitForBrokerReady() {
   local status=1
   while [ $status -ne 0 ]; do
     sleep 1
-    echo Checking port ${BROKER_QUERY_PORT} for broker ready
+    echo "Checking port ${BROKER_QUERY_PORT} for broker ready"
     curl localhost:${BROKER_QUERY_PORT}/debug/routingTable 1>/dev/null 2>&1
-    status=$(echo $?)
+    status=$?
   done
 }
 
@@ -118,15 +130,31 @@ function waitForServerReady() {
   local status=1
   while [ $status -ne 0 ]; do
     sleep 1
-    echo Checking port ${SERVER_ADMIN_PORT} for server ready
+    echo "Checking port ${SERVER_ADMIN_PORT} for server ready"
     curl localhost:${SERVER_ADMIN_PORT}/health 1>/dev/null 2>&1
-    status=$(echo $?)
+    status=$?
+  done
+}
+
+function waitForServer2Ready() {
+  local status=1
+  while [ $status -ne 0 ]; do
+    sleep 1
+    echo "Checking port ${SERVER_2_ADMIN_PORT} for server ready"
+    curl localhost:${SERVER_2_ADMIN_PORT}/health 1>/dev/null 2>&1
+    status=$?
   done
 }
 
 function waitForClusterReady() {
   waitForBrokerReady
   waitForServerReady
+
+  # Check second server if configured
+  if [ -f "${SERVER_CONF_2}" ]; then
+      waitForServer2Ready
+  fi
+
   waitForKafkaReady
 }
 
@@ -164,6 +192,9 @@ function startService() {
   elif [ "$serviceName" = "server" ]; then
     ./pinot-admin.sh StartServer ${configFileArg} 1>${LOG_DIR}/server.${logCount}.log 2>&1 &
     echo $! >${PID_DIR}/server.pid
+  elif [ "$serviceName" = "server2" ]; then
+    ./pinot-admin.sh StartServer ${configFileArg} 1>${LOG_DIR}/server2.${logCount}.log 2>&1 &
+        echo $! >${PID_DIR}/server2.pid
   elif [ "$serviceName" = "kafka" ]; then
     ./pinot-admin.sh StartKafka -zkAddress localhost:${ZK_PORT}/kafka 1>${LOG_DIR}/kafka.${logCount}.log 2>&1 &
     echo $! >${PID_DIR}/kafka.pid
@@ -207,6 +238,12 @@ function startServices() {
   waitForControllerReady
   startService broker "$dirName" "$BROKER_CONF"
   startService server "$dirName" "$SERVER_CONF"
+
+  # Start second server if configured
+  if [ -f "${SERVER_CONF_2}" ]; then
+    startService server2 "$dirName" "$SERVER_CONF_2"
+  fi
+
   startService kafka "$dirName" "unused"
   echo "Cluster started."
   waitForClusterReady
@@ -217,6 +254,12 @@ function stopServices() {
   stopService controller
   stopService broker
   stopService server
+
+  # Stop second server if configured
+  if [ -f "${SERVER_CONF_2}" ]; then
+    stopService server2
+  fi
+
   stopService zookeeper
   stopService kafka
   echo "Controller logs:"
@@ -254,23 +297,50 @@ function setupControllerVariables() {
 function setupBrokerVariables() {
   if [ -f ${BROKER_CONF} ]; then
     local port=$(grep -F pinot.broker.client.queryPort ${BROKER_CONF} | awk '{print $3}')
-    if [ ! -z "$port" ]; then
+    if [ -n "$port" ]; then
       BROKER_QUERY_PORT=$port
     fi
   fi
 }
 
 function setupServerVariables() {
-  if [ -f ${SERVER_CONF} ]; then
+  if [ -f "${SERVER_CONF}" ]; then
     local port
-    port=$(grep -F pinot.server.adminapi.port ${SERVER_CONF} | awk '{print $3}')
-    if [ ! -z "$port" ]; then
+    port=$(grep -F pinot.server.adminapi.port "${SERVER_CONF}" | awk '{print $3}')
+    if [ -n "$port" ]; then
       SERVER_ADMIN_PORT=$port
     fi
-    port=$(grep -F pinot.server.netty.port ${SERVER_CONF} | awk '{print $3}')
-    if [ ! -z "$port" ]; then
+    port=$(grep -F pinot.server.netty.port "${SERVER_CONF}" | awk '{print $3}')
+    if [ -n "$port" ]; then
       SERVER_NETTY_PORT=$port
     fi
+    port=$(grep -F pinot.server.grpc.port "${SERVER_CONF}" | awk '{print $3}')
+    if [ -n "$port" ]; then
+      SERVER_GRPC_PORT=$port
+    fi
+  fi
+
+  if [ -f "${SERVER_CONF_2}" ]; then
+    local port
+    port=$(grep -F pinot.server.adminapi.port "${SERVER_CONF_2}" | awk '{print $3}')
+    if [ -n "$port" ]; then
+      SERVER_2_ADMIN_PORT=$port
+    fi
+    port=$(grep -F pinot.server.netty.port "${SERVER_CONF_2}" | awk '{print $3}')
+    if [ -n "$port" ]; then
+      SERVER_2_NETTY_PORT=$port
+    fi
+    port=$(grep -F pinot.server.grpc.port "${SERVER_CONF_2}" | awk '{print $3}')
+    if [ -n "$port" ]; then
+      SERVER_2_GRPC_PORT=$port
+    fi
+  fi
+}
+
+function checkPortAvailable() {
+  if lsof -t -i:"$1" -s TCP:LISTEN; then
+    echo "Port number $1 not available. Check any existing process that may be using this port."
+    return 1
   fi
 }
 
@@ -320,6 +390,7 @@ COMPAT_TESTER_PATH="pinot-compatibility-verifier/target/pinot-compatibility-veri
 BROKER_CONF=${testSuiteDir}/config/BrokerConfig.properties
 CONTROLLER_CONF=${testSuiteDir}/config/ControllerConfig.properties
 SERVER_CONF=${testSuiteDir}/config/ServerConfig.properties
+SERVER_CONF_2=${testSuiteDir}/config/ServerConfig2.properties
 
 cleanupControllerDirs
 cleanupServerDirs
@@ -328,7 +399,11 @@ BROKER_QUERY_PORT=8099
 ZK_PORT=2181
 CONTROLLER_PORT=9000
 SERVER_ADMIN_PORT=8097
+SERVER_2_ADMIN_PORT=9097
 SERVER_NETTY_PORT=8098
+SERVER_2_NETTY_PORT=9098
+SERVER_GRPC_PORT=8090
+SERVER_2_GRPC_PORT=9090
 
 PID_DIR=${workingDir}/pids
 LOG_DIR=${workingDir}/logs
@@ -350,9 +425,9 @@ newTargetDir="$workingDir"/newTargetDir
 setupCompatTester
 
 # check that the default ports are open
-if [ "$(lsof -t -i:${SERVER_ADMIN_PORT} -s TCP:LISTEN)" ] || [ "$(lsof -t -i:${SERVER_NETTY_PORT} -sTCP:LISTEN)" ] || [ "$(lsof -t -i:${BROKER_QUERY_PORT} -sTCP:LISTEN)" ] ||
-  [ "$(lsof -t -i:${CONTROLLER_PORT} -sTCP:LISTEN)" ] || [ "$(lsof -t -i:${ZK_PORT} -sTCP:LISTEN)" ]; then
-  echo "Cannot start the components since the default ports are not open. Check any existing process that may be using the default ports."
+if ! checkPortAvailable ${SERVER_ADMIN_PORT} || ! checkPortAvailable ${SERVER_NETTY_PORT} || ! checkPortAvailable ${SERVER_GRPC_PORT} ||
+  ! checkPortAvailable ${BROKER_QUERY_PORT} || ! checkPortAvailable ${CONTROLLER_PORT} || ! checkPortAvailable ${ZK_PORT} ||
+  { [ -f "${SERVER_CONF_2}" ] && { ! checkPortAvailable ${SERVER_2_ADMIN_PORT} || ! checkPortAvailable ${SERVER_2_NETTY_PORT} || ! checkPortAvailable ${SERVER_2_GRPC_PORT}; } ; }; then
   exit 1
 fi
 
@@ -369,10 +444,11 @@ if [ -f $testSuiteDir/pre-controller-upgrade.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed before controller upgrade
+    echo "Failed before controller upgrade"
     exit 1
   fi
 fi
+
 echo "Upgrading controller"
 stopService controller
 startService controller "$newTargetDir" "$CONTROLLER_CONF"
@@ -386,14 +462,16 @@ if [ -f $testSuiteDir/pre-broker-upgrade.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed before broker upgrade
+    echo "Failed before broker upgrade"
     exit 1
   fi
 fi
+
 echo "Upgrading broker"
 stopService broker
 startService broker "$newTargetDir" "$BROKER_CONF"
 waitForBrokerReady
+
 if [ -f $testSuiteDir/pre-server-upgrade.yaml ]; then
   echo "Running tests after broker upgrade"
   genNum=$((genNum+1))
@@ -402,14 +480,16 @@ if [ -f $testSuiteDir/pre-server-upgrade.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed before server upgrade
+    echo "Failed before server upgrade"
     exit 1
   fi
 fi
+
 echo "Upgrading server"
 stopService server
 startService server "$newTargetDir" "$SERVER_CONF"
 waitForServerReady
+
 if [ -f $testSuiteDir/post-server-upgrade.yaml ]; then
   echo "Running tests after server upgrade"
   genNum=$((genNum+1))
@@ -418,8 +498,47 @@ if [ -f $testSuiteDir/post-server-upgrade.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed after server upgrade
+    echo "Failed after server upgrade"
     exit 1
+  fi
+fi
+
+if [ -f "${SERVER_CONF_2}" ]; then
+  echo "Upgrading server 2"
+  stopService server2
+  startService server2 "$newTargetDir" "$SERVER_CONF_2"
+  waitForServer2Ready
+
+  if [ -f $testSuiteDir/post-server-2-upgrade.yaml ]; then
+    echo "Running tests after server 2 upgrade"
+    genNum=$((genNum+1))
+    $COMPAT_TESTER $testSuiteDir/post-server-2-upgrade.yaml $genNum
+    if [ $? -ne 0 ]; then
+      if [ $keepClusterOnFailure == "false" ]; then
+        stopServices
+      fi
+      echo "Failed after server 2 upgrade"
+      exit 1
+    fi
+  fi
+
+  echo "Downgrading server 2"
+  # Upgrade completed, now do a rollback
+  stopService server2
+  startService server2 "$oldTargetDir" "$SERVER_CONF_2"
+  waitForServer2Ready
+
+  if [ -f $testSuiteDir/post-server-2-rollback.yaml ]; then
+    echo "Running tests after server 2 downgrade"
+    genNum=$((genNum+1))
+    $COMPAT_TESTER $testSuiteDir/post-server-2-rollback.yaml $genNum
+    if [ $? -ne 0 ]; then
+      if [ $keepClusterOnFailure == "false" ]; then
+        stopServices
+      fi
+      echo "Failed after server 2 downgrade"
+      exit 1
+    fi
   fi
 fi
 
@@ -428,6 +547,7 @@ echo "Downgrading server"
 stopService server
 startService server "$oldTargetDir" "$SERVER_CONF"
 waitForServerReady
+
 if [ -f $testSuiteDir/post-server-rollback.yaml ]; then
   echo "Running tests after server downgrade"
   genNum=$((genNum+1))
@@ -436,14 +556,16 @@ if [ -f $testSuiteDir/post-server-rollback.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed after server downgrade
+    echo "Failed after server downgrade"
     exit 1
   fi
 fi
+
 echo "Downgrading broker"
 stopService broker
 startService broker "$oldTargetDir" "$BROKER_CONF"
 waitForBrokerReady
+
 if [ -f $testSuiteDir/post-broker-rollback.yaml ]; then
   echo "Running tests after broker downgrade"
   genNum=$((genNum+1))
@@ -452,15 +574,17 @@ if [ -f $testSuiteDir/post-broker-rollback.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed after broker downgrade
+    echo "Failed after broker downgrade"
     exit 1
   fi
 fi
+
 echo "Downgrading controller"
 stopService controller
 startService controller "$oldTargetDir" "$CONTROLLER_CONF"
 waitForControllerReady
 waitForControllerReady
+
 if [ -f $testSuiteDir/post-controller-rollback.yaml ]; then
   echo "Running tests after controller downgrade"
   genNum=$((genNum+1))
@@ -469,10 +593,11 @@ if [ -f $testSuiteDir/post-controller-rollback.yaml ]; then
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
-    echo Failed after controller downgrade
+    echo "Failed after controller downgrade"
     exit 1
   fi
 fi
+
 stopServices
 
 echo "All tests passed"

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/ServerConfig2.properties
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/ServerConfig2.properties
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pinot.server.adminapi.port = 9097
+pinot.server.netty.port = 9098
+pinot.server.grpc.port = 9090
+pinot.zk.server = localhost:2181
+pinot.cluster.name = PinotCluster
+pinot.server.instance.dataDir = /tmp/PinotServer2/data
+pinot.server.instance.segmentTarDir = /tmp/PinotServer2/segments

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/post-broker-rollback.yaml
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/post-broker-rollback.yaml
@@ -21,13 +21,13 @@
 description: Operations to be run after broker rollback
 operations:
   - type: segmentOp
-    description: Add segment FeatureTest1_Segment6 to table FeatureTest1
+    description: Add segment FeatureTest1_Segment8 to table FeatureTest1
     op: UPLOAD
     inputDataFileName: data/FeatureTest1-data-00.csv
     schemaFileName: FeatureTest1-schema.json
     tableConfigFileName: feature-test-1.json
     recordReaderConfigFileName: data/recordReaderConfig.json
-    segmentName: FeatureTest1_Segment6
+    segmentName: FeatureTest1_Segment8
   - type: streamOp
     description: publish rows to PinotRealtimeFeatureTest2Event
     op: PRODUCE

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-2-rollback.yaml
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-2-rollback.yaml
@@ -18,16 +18,16 @@
 #
 
 # Operations to be done.
-description: Operations to be run after controller rollback
+description: Operations to be run after server rollback
 operations:
   - type: segmentOp
-    description: Add segment FeatureTest1_Segment9 to table FeatureTest1
+    description: Add segment FeatureTest1_Segment6 to table FeatureTest1
     op: UPLOAD
     inputDataFileName: data/FeatureTest1-data-00.csv
     schemaFileName: FeatureTest1-schema.json
     tableConfigFileName: feature-test-1.json
     recordReaderConfigFileName: data/recordReaderConfig.json
-    segmentName: FeatureTest1_Segment9
+    segmentName: FeatureTest1_Segment6
   - type: streamOp
     description: publish rows to PinotRealtimeFeatureTest2Event
     op: PRODUCE
@@ -41,13 +41,3 @@ operations:
     useMultiStageQueryEngine: true
     queryFileName: queries/feature-test-multi-stage.queries
     expectedResultsFileName: query-results/feature-test-multi-stage.results
-  - type: segmentOp
-    description: Delete segment FeatureTest1_Segment
-    op: DELETE
-    tableConfigFileName: feature-test-1.json
-    segmentName: FeatureTest1_Segment
-  - type: tableOp
-    description: Delete table feature-test-1.json
-    op: DELETE
-    schemaFileName: FeatureTest1-schema.json
-    tableConfigFileName: feature-test-1.json

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-2-upgrade.yaml
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-2-upgrade.yaml
@@ -18,16 +18,16 @@
 #
 
 # Operations to be done.
-description: Operations to be run after controller rollback
+description: Operations to be run after server upgrade
 operations:
   - type: segmentOp
-    description: Add segment FeatureTest1_Segment9 to table FeatureTest1
+    description: Add segment FeatureTest1_Segment5 to table FeatureTest1
     op: UPLOAD
     inputDataFileName: data/FeatureTest1-data-00.csv
     schemaFileName: FeatureTest1-schema.json
     tableConfigFileName: feature-test-1.json
     recordReaderConfigFileName: data/recordReaderConfig.json
-    segmentName: FeatureTest1_Segment9
+    segmentName: FeatureTest1_Segment5
   - type: streamOp
     description: publish rows to PinotRealtimeFeatureTest2Event
     op: PRODUCE
@@ -41,13 +41,3 @@ operations:
     useMultiStageQueryEngine: true
     queryFileName: queries/feature-test-multi-stage.queries
     expectedResultsFileName: query-results/feature-test-multi-stage.results
-  - type: segmentOp
-    description: Delete segment FeatureTest1_Segment
-    op: DELETE
-    tableConfigFileName: feature-test-1.json
-    segmentName: FeatureTest1_Segment
-  - type: tableOp
-    description: Delete table feature-test-1.json
-    op: DELETE
-    schemaFileName: FeatureTest1-schema.json
-    tableConfigFileName: feature-test-1.json

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-rollback.yaml
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/post-server-rollback.yaml
@@ -21,13 +21,13 @@
 description: Operations to be run after server rollback
 operations:
   - type: segmentOp
-    description: Add segment FeatureTest1_Segment5 to table FeatureTest1
+    description: Add segment FeatureTest1_Segment7 to table FeatureTest1
     op: UPLOAD
     inputDataFileName: data/FeatureTest1-data-00.csv
     schemaFileName: FeatureTest1-schema.json
     tableConfigFileName: feature-test-1.json
     recordReaderConfigFileName: data/recordReaderConfig.json
-    segmentName: FeatureTest1_Segment5
+    segmentName: FeatureTest1_Segment7
   - type: streamOp
     description: publish rows to PinotRealtimeFeatureTest2Event
     op: PRODUCE


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/13193 added a backward compatibility regression test suite for the multi-stage query engine, leveraging the framework added in https://github.com/apache/pinot/pull/6129, https://github.com/apache/pinot/pull/6650, https://github.com/apache/pinot/issues/4001.
- However, there was one major element missing - the framework relies on a single controller, broker and server setup for Pinot. While this was fine for the v1 query engine backward compatibility tests, using a multi server setup for the multi-stage query engine backward compatibility tests is much more important. Since v2 queries typically involve data shuffling between servers, we also need to test scenarios where one server is running on an older version and another is on a newer version.
- This patch adds an optional second server to the generic framework which is leveraged by the multi-stage query engine backward compatibility regression test suite. Since the segments are added sequentially in the test framework, and the default balanced segment assignment strategy is used (https://docs.pinot.apache.org/operators/operating-pinot/segment-assignment), we know that the queries involving joins between the two tables will result in some data shuffling.
- This isn't easily extensible for adding more controllers / brokers / servers which could've been done via some form of parameterized configuration; however, doing so would likely break existing config file support (https://github.com/apache/pinot/pull/6901) and currently it seems sufficient to have a 1 controller / 1 broker / 2 server setup for testing backward compatibility.