### PR TITLE
Add retry policy to wait for job id to persist during rebalancing

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -707,11 +707,10 @@ public class PinotTableRestletResource {
       try {
           // This retry policy waits at most for 3.5 to 7s in total. This is chosen to cover
           // typical delays for tables with many segments and avoid excessive HTTP request timeouts.
-          RetryPolicies.exponentialBackoffRetryPolicy(4, 500L, 2.0)
+          RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0)
                   .attempt(() -> {
             Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
             if (controllerJobZKMetadata == null) {
-              LOGGER.warn("jobId not persisted yet while rebalancing table: {}", tableNameWithType);
               return false;
             }
             return true;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -684,6 +684,7 @@ public class PinotTableRestletResource {
               LOGGER.error("Caught exception/error while rebalancing table: {}", tableNameWithType, t);
             }
           });
+          waitForJobIdToPersist(dryRunResult.getJobId(), tableNameWithType);
           return new RebalanceResult(dryRunResult.getJobId(), RebalanceResult.Status.IN_PROGRESS,
               "In progress, check controller logs for updates", dryRunResult.getInstanceAssignment(),
               dryRunResult.getTierInstanceAssignment(), dryRunResult.getSegmentAssignment());
@@ -695,6 +696,31 @@ public class PinotTableRestletResource {
     } catch (TableNotFoundException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.NOT_FOUND);
     }
+  }
+
+  /** Waits for jobId to be persisted using a retry policy. Tables with 100k+ segments
+    * take up to a few seconds for the jobId to persist. This ensures the jobId is present
+    * before returning the jobId to the caller, so they can correctly poll the jobId. **/
+  public void waitForJobIdToPersist(String jobId, String tableNameWithType) {
+      try {
+          // This retry policy waits at most for 3.5 to 7s in total. This is chosen to cover
+          // typical delays for tables with many segments and avoid excessive HTTP request timeouts.
+          RetryPolicies.exponentialBackoffRetryPolicy(4, 500L, 2.0)
+                  .attempt(() -> {
+            Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
+            if (controllerJobZKMetadata == null) {
+              LOGGER.warn("jobId not persisted yet while rebalancing table: {}", tableNameWithType);
+              return false;
+            }
+            return true;
+          });
+      } catch (Exception e) {
+        LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
+      }
+  }
+
+  public Map<String, String> getControllerJobMetadata(String jobId) {
+    return _pinotHelixResourceManager.getControllerJobZKMetadata(jobId, ControllerJobType.TABLE_REBALANCE);
   }
 
   @DELETE
@@ -745,8 +771,7 @@ public class PinotTableRestletResource {
   public ServerRebalanceJobStatusResponse rebalanceStatus(
       @ApiParam(value = "Rebalance Job Id", required = true) @PathParam("jobId") String jobId)
       throws JsonProcessingException {
-    Map<String, String> controllerJobZKMetadata =
-        _pinotHelixResourceManager.getControllerJobZKMetadata(jobId, ControllerJobType.TABLE_REBALANCE);
+    Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
 
     if (controllerJobZKMetadata == null) {
       throw new ControllerApplicationException(LOGGER, "Failed to find controller job id: " + jobId,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -707,13 +707,7 @@ public class PinotTableRestletResource {
     try {
       // This retry policy waits at most for 7.5s to 15s in total. This is chosen to cover typical delays for tables
       // with many segments and avoid excessive HTTP request timeouts.
-      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0).attempt(() -> {
-        Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
-        if (controllerJobZKMetadata == null) {
-          return false;
-        }
-        return true;
-      });
+      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0).attempt(() -> getControllerJobMetadata(jobId) != null);
     } catch (Exception e) {
       LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -698,9 +698,11 @@ public class PinotTableRestletResource {
     }
   }
 
-  /** Waits for jobId to be persisted using a retry policy. Tables with 100k+ segments
-    * take up to a few seconds for the jobId to persist. This ensures the jobId is present
-    * before returning the jobId to the caller, so they can correctly poll the jobId. **/
+  /**
+   * Waits for jobId to be persisted using a retry policy.
+   * Tables with 100k+ segments take up to a few seconds for the jobId to persist. This ensures the jobId is present
+   * before returning the jobId to the caller, so they can correctly poll the jobId.
+   **/
   public void waitForJobIdToPersist(String jobId, String tableNameWithType) {
       try {
           // This retry policy waits at most for 3.5 to 7s in total. This is chosen to cover

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -702,22 +702,21 @@ public class PinotTableRestletResource {
    * Waits for jobId to be persisted using a retry policy.
    * Tables with 100k+ segments take up to a few seconds for the jobId to persist. This ensures the jobId is present
    * before returning the jobId to the caller, so they can correctly poll the jobId.
-   **/
+   */
   public void waitForJobIdToPersist(String jobId, String tableNameWithType) {
-      try {
-          // This retry policy waits at most for 3.5 to 7s in total. This is chosen to cover
-          // typical delays for tables with many segments and avoid excessive HTTP request timeouts.
-          RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0)
-                  .attempt(() -> {
-            Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
-            if (controllerJobZKMetadata == null) {
-              return false;
-            }
-            return true;
-          });
-      } catch (Exception e) {
-        LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
-      }
+    try {
+      // This retry policy waits at most for 7.5s to 15s in total. This is chosen to cover typical delays for tables
+      // with many segments and avoid excessive HTTP request timeouts.
+      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0).attempt(() -> {
+        Map<String, String> controllerJobZKMetadata = getControllerJobMetadata(jobId);
+        if (controllerJobZKMetadata == null) {
+          return false;
+        }
+        return true;
+      });
+    } catch (Exception e) {
+      LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
+    }
   }
 
   public Map<String, String> getControllerJobMetadata(String jobId) {


### PR DESCRIPTION
When rebalancing tables with a large number of segments, it takes a while for the jobId to persist in Zookeeper and polling for the jobId results in a ResourceNotFoundException, even though it would become available in a few seconds. This code aims to introduce a specific retry policy in order to counteract this. It forces a retry 3 times in order to check if the jobId has been found. If it still has not then the rebalance will fail.

Label: Bugfix