### PR TITLE
Add pinot-core dependency back to JDBC client

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -76,6 +76,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
PR #11620 removed `pinot-core` dependency from the `pinot-jdbc-client` since it was not needed for Auth anymore

However, there are a lot of other deps such as sl4j which jdbc client needs from pinot-core that went missing after this PR

This is causing a lot of class not found issues when JDBC driver 1.1.0 shaded jar is used which don't happen when we use 1.0.0