### PR TITLE
add `skipUnavailableServers` query option

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -302,4 +302,8 @@ public class QueryOptionsUtils {
     String windowOverflowModeStr = queryOptions.get(QueryOptionKey.WINDOW_OVERFLOW_MODE);
     return windowOverflowModeStr != null ? WindowOverFlowMode.valueOf(windowOverflowModeStr) : null;
   }
+
+  public static boolean isSkipUnavailableServers(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UNAVAILABLE_SERVERS));
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -183,7 +183,8 @@ public class AsyncQueryResponse implements QueryResponse {
   }
 
   /**
-   * Wait for one less server response
+   * Wait for one less server response. This is used when the server is skipped, as
+   * query submission will have failed we do not want to wait for the response.
    */
   void skipServerResponse() {
     _countDownLatch.countDown();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -181,4 +181,11 @@ public class AsyncQueryResponse implements QueryResponse {
       markQueryFailed(serverRoutingInstance, exception);
     }
   }
+
+  /**
+   * Wait for one less server response
+   */
+  void skipServerResponse() {
+    _countDownLatch.countDown();
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -411,6 +411,9 @@ public class CommonConstants {
         // Indicates the maximum length of serialized response across all servers for a query. This value is equally
         // divided across all servers processing the query.
         public static final String MAX_QUERY_RESPONSE_SIZE_BYTES = "maxQueryResponseSizeBytes";
+
+        // If query submission causes an exception, still continue to submit the query to other servers
+        public static final String SKIP_UNAVAILABLE_SERVERS = "skipUnavailableServers";
       }
 
       public static class QueryOptionValue {


### PR DESCRIPTION
By default, during query submission to servers, if any exception is encountered the request will be failed. The change here adds a query option that so the server will be skipped and we can still return partial results. This is similar to the CH setting [skip_unavailable_shards](https://clickhouse.com/docs/en/operations/settings/settings#skip_unavailable_shards)

For testing, the behavior looks right when blocking the port for one server with:
`echo 'block return in quick on lo0 proto tcp from any to any port 7050' | sudo pfctl -f -`

When the query option is missing/false the query immediately errors out. When the query option is applied the query displays results from the non-blocked server, and an error saying the blocked server did not respond. 

tags: `feature` `documentation` `release-notes`