### PR TITLE
track segments for snapshotting even if they lost all comparisons

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -160,10 +160,13 @@ public class MinionTaskUtils {
         return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
             validDocIdsType, 60_000);
       } catch (Exception e) {
-        LOGGER.info("Unable to retrieve validDocIdsBitmap for {} from {}", segmentName, endpoint);
+        LOGGER.warn(
+            String.format("Unable to retrieve validDocIds bitmap for segment: %s from endpoint: %s", segmentName,
+                endpoint), e);
       }
     }
-    throw new IllegalStateException("Unable to retrieve validDocIds for segment: " + segmentName);
+    throw new IllegalStateException(
+        String.format("Unable to retrieve validDocIds bitmap for segment: %s from servers: %s", segmentName, servers));
   }
 
   public static List<String> getServers(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -624,9 +624,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     try {
       boolean addRecord = doAddRecord(segment, recordInfo);
       _trackedSegments.add(segment);
-      if (_enableSnapshot) {
-        _updatedSegmentsSinceLastSnapshot.add(segment);
-      }
       return addRecord;
     } finally {
       finishOperation();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -209,7 +209,7 @@ public class BasePartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl seg01 = createImmutableSegment("seg01", segDir01, segmentsTakenSnapshot);
     seg01.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3), null);
     upsertMetadataManager.trackSegment(seg01);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg01);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg01);
     // seg01 has a tmp snapshot file, but no snapshot file
     FileUtils.touch(new File(segDir01, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME + "_tmp"));
 
@@ -217,7 +217,7 @@ public class BasePartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl seg02 = createImmutableSegment("seg02", segDir02, segmentsTakenSnapshot);
     seg02.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3, 4, 5), null);
     upsertMetadataManager.trackSegment(seg02);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg02);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg02);
     // seg02 has snapshot file, so its snapshot is taken first.
     FileUtils.touch(new File(segDir02, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
 
@@ -225,12 +225,12 @@ public class BasePartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl seg03 = createImmutableSegment("seg03", segDir03, segmentsTakenSnapshot);
     seg03.enableUpsert(upsertMetadataManager, createValidDocIds(3, 4, 7), null);
     upsertMetadataManager.trackSegment(seg03);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg03);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg03);
 
     // The mutable segments will be skipped.
     MutableSegmentImpl seg04 = mock(MutableSegmentImpl.class);
     upsertMetadataManager.trackSegment(seg04);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg04);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg04);
 
     upsertMetadataManager.doTakeSnapshot();
     assertEquals(segmentsTakenSnapshot.size(), 3);
@@ -261,7 +261,7 @@ public class BasePartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl seg01 = createImmutableSegment("seg01", segDir01, segmentsTakenSnapshot);
     seg01.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3), null);
     upsertMetadataManager.trackSegment(seg01);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg01);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg01);
     // seg01 has a tmp snapshot file, but no snapshot file
     FileUtils.touch(new File(segDir01, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME + "_tmp"));
 
@@ -269,7 +269,7 @@ public class BasePartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl seg02 = createImmutableSegment("seg02", segDir02, segmentsTakenSnapshot);
     seg02.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3, 4, 5), null);
     upsertMetadataManager.trackSegment(seg02);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg02);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg02);
     // seg02 has snapshot file, so its snapshot is taken first.
     FileUtils.touch(new File(segDir02, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
 
@@ -281,7 +281,7 @@ public class BasePartitionUpsertMetadataManagerTest {
     // The mutable segments will be skipped.
     MutableSegmentImpl seg04 = mock(MutableSegmentImpl.class);
     upsertMetadataManager.trackSegment(seg04);
-    upsertMetadataManager.updatedSegmentForSnapshotting(seg04);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg04);
 
     upsertMetadataManager.doTakeSnapshot();
     assertEquals(segmentsTakenSnapshot.size(), 2);
@@ -298,6 +298,60 @@ public class BasePartitionUpsertMetadataManagerTest {
     assertEquals(seg02.loadValidDocIdsFromSnapshot().getCardinality(), 6);
     assertTrue(segDir03.exists());
     assertNull(seg03.loadValidDocIdsFromSnapshot());
+  }
+
+  // Losing segment is the one that lost all comparisons with docs from other segments, thus becomes empty of valid
+  // docs. Previously such segment was not tracked for snapshotting, but we should take snapshot of its empty bitmap.
+  @Test
+  public void testTakeSnapshotWithLosingSegment()
+      throws IOException {
+    UpsertContext upsertContext = mock(UpsertContext.class);
+    when(upsertContext.isSnapshotEnabled()).thenReturn(true);
+    DummyPartitionUpsertMetadataManager upsertMetadataManager =
+        new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
+
+    List<String> segmentsTakenSnapshot = new ArrayList<>();
+
+    File segDir01 = new File(TEMP_DIR, "seg01");
+    ImmutableSegmentImpl seg01 = createImmutableSegment("seg01", segDir01, segmentsTakenSnapshot);
+    seg01.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3), null);
+    // addSegment() would track seg, and mark it as updated for snapshotting.
+    upsertMetadataManager.addSegment(seg01);
+    // seg01 has a tmp snapshot file, but no snapshot file
+    FileUtils.touch(new File(segDir01, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME + "_tmp"));
+
+    File segDir02 = new File(TEMP_DIR, "seg02");
+    ImmutableSegmentImpl seg02 = createImmutableSegment("seg02", segDir02, segmentsTakenSnapshot);
+    seg02.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3, 4, 5), null);
+    upsertMetadataManager.addSegment(seg02);
+    // seg02 has snapshot file, so its snapshot is taken first.
+    FileUtils.touch(new File(segDir02, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
+
+    File segDir03 = new File(TEMP_DIR, "seg03");
+    ImmutableSegmentImpl seg03 = createImmutableSegment("seg03", segDir03, segmentsTakenSnapshot);
+    seg03.enableUpsert(upsertMetadataManager, createValidDocIds(3, 4, 7), null);
+    upsertMetadataManager.addSegment(seg03);
+
+    // The mutable segments will be skipped.
+    MutableSegmentImpl seg04 = mock(MutableSegmentImpl.class);
+    upsertMetadataManager.trackSegment(seg04);
+    upsertMetadataManager.trackSegmentAsUpdatedForSnapshotting(seg04);
+
+    upsertMetadataManager.doTakeSnapshot();
+    assertEquals(segmentsTakenSnapshot.size(), 3);
+    // The snapshot of seg02 was taken firstly, as it's the only segment with existing snapshot.
+    assertEquals(segmentsTakenSnapshot.get(0), "seg02");
+    // Set is used to track segments internally, so we can't assert the order of the other segments deterministically,
+    // but all 3 segments should have taken their snapshots.
+    assertTrue(segmentsTakenSnapshot.containsAll(Arrays.asList("seg01", "seg02", "seg03")));
+
+    assertEquals(TEMP_DIR.list().length, 3);
+    assertTrue(segDir01.exists());
+    assertEquals(seg01.loadValidDocIdsFromSnapshot().getCardinality(), 4);
+    assertTrue(segDir02.exists());
+    assertEquals(seg02.loadValidDocIdsFromSnapshot().getCardinality(), 6);
+    assertTrue(segDir03.exists());
+    assertEquals(seg03.loadValidDocIdsFromSnapshot().getCardinality(), 3);
   }
 
   @Test
@@ -565,7 +619,7 @@ public class BasePartitionUpsertMetadataManagerTest {
       _trackedSegments.add(seg);
     }
 
-    public void updatedSegmentForSnapshotting(IndexSegment seg) {
+    public void trackSegmentAsUpdatedForSnapshotting(IndexSegment seg) {
       _updatedSegmentsSinceLastSnapshot.add(seg);
     }
 


### PR DESCRIPTION
It's possible that docs from a segment lost all comparison with docs from other segments, thus not going to call any of those methods addDocId/replaceDocId where we track segments for snapshotting. So in this PR, we track segments for snapshotting in addSegment/replaceSegment high level entry methods, beside replaceDocId/removeDocId where the existing segments may be updated. This should keep a complete set of segments being updated since last snapshotting.

Also made a fix for another minor bug that some segments were not removed from the track Set after taking snapshot for them. 

The batch mode of consistent view feature is also subject to this issue, i.e missing segment that lost all comparison. Will address that in separate RP so that changes can be reverted separately in case. 