### PR TITLE
Fix segment size check in OfflineClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -288,7 +288,7 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
 
   // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
   @Test(enabled = false)
-  public void testStarTreeTriggering(boolean useMultiStageQueryEngine) {
+  public void testStarTreeTriggering() {
     // Ignored
   }
 


### PR DESCRIPTION
Segment size is platform dependent because of the native library used by the chunk compressor.
Do not use the hard-coded segment size. Cache the segment size of the generated segments.