### PR TITLE
pinot-compatibility-verifier module cleanup

### DIFF
--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/BaseOp.java
@@ -36,7 +36,6 @@ public abstract class BaseOp {
     TABLE_OP, SEGMENT_OP, QUERY_OP, STREAM_OP,
   }
 
-  private String _name;
   private final OpType _opType;
   private String _description = "No description provided";
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseOp.class);
@@ -48,20 +47,8 @@ public abstract class BaseOp {
     _opType = opType;
   }
 
-  public String getName() {
-    return _name;
-  }
-
-  public void setName(String name) {
-    _name = name;
-  }
-
   public void setDescription(String description) {
     _description = description;
-  }
-
-  public String getDescription() {
-    return _description;
   }
 
   public String getParentDir() {
@@ -77,7 +64,7 @@ public abstract class BaseOp {
   }
 
   public boolean run(int generationNumber) {
-    LOGGER.info("Running OpType {} : {}", _opType.toString(), getDescription());
+    LOGGER.info("Running OpType {} : {}", _opType.toString(), _description);
     return runOp(generationNumber);
   }
 

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/QueryOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/QueryOp.java
@@ -56,24 +56,12 @@ public class QueryOp extends BaseOp {
     return trimmedLine.isEmpty() || trimmedLine.startsWith(COMMENT_DELIMITER);
   }
 
-  public String getQueryFileName() {
-    return _queryFileName;
-  }
-
   public void setQueryFileName(String queryFileName) {
     _queryFileName = queryFileName;
   }
 
-  public String getExpectedResultsFileName() {
-    return _expectedResultsFileName;
-  }
-
   public void setExpectedResultsFileName(String expectedResultsFileName) {
     _expectedResultsFileName = expectedResultsFileName;
-  }
-
-  public boolean getUseMultiStageQueryEngine() {
-    return _useMultiStageQueryEngine;
   }
 
   public void setUseMultiStageQueryEngine(boolean useMultiStageQueryEngine) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/SegmentOp.java
@@ -85,25 +85,12 @@ public class SegmentOp extends BaseOp {
     super(OpType.SEGMENT_OP);
   }
 
-
-  public Op getOp() {
-    return _op;
-  }
-
   public void setOp(Op op) {
     _op = op;
   }
 
-  public String getInputDataFileName() {
-    return _inputDataFileName;
-  }
-
   public void setInputDataFileName(String inputDataFileName) {
     _inputDataFileName = inputDataFileName;
-  }
-
-  public String getTableConfigFileName() {
-    return _tableConfigFileName;
   }
 
   public void setTableConfigFileName(String tableConfigFileName) {
@@ -114,16 +101,8 @@ public class SegmentOp extends BaseOp {
     _schemaFileName = schemaFileName;
   }
 
-  public String getSchemaFileName() {
-    return _schemaFileName;
-  }
-
   public void setRecordReaderConfigFileName(String recordReaderConfigFileName) {
     _recordReaderConfigFileName = recordReaderConfigFileName;
-  }
-
-  public String getRecordReaderConfigFileName() {
-    return _recordReaderConfigFileName;
   }
 
   public void setSegmentName(String segmentName) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -98,48 +98,24 @@ public class StreamOp extends BaseOp {
     super(OpType.STREAM_OP);
   }
 
-  public Op getOp() {
-    return _op;
-  }
-
   public void setOp(Op op) {
     _op = op;
-  }
-
-  public String getStreamConfigFileName() {
-    return _streamConfigFileName;
   }
 
   public void setStreamConfigFileName(String streamConfigFileName) {
     _streamConfigFileName = streamConfigFileName;
   }
 
-  public int getNumRows() {
-    return _numRows;
-  }
-
   public void setNumRows(int numRows) {
     _numRows = numRows;
-  }
-
-  public String getInputDataFileName() {
-    return _inputDataFileName;
   }
 
   public void setInputDataFileName(String inputDataFileName) {
     _inputDataFileName = inputDataFileName;
   }
 
-  public String getTableConfigFileName() {
-    return _tableConfigFileName;
-  }
-
   public void setTableConfigFileName(String tableConfigFileName) {
     _tableConfigFileName = tableConfigFileName;
-  }
-
-  public String getRecordReaderConfigFileName() {
-    return _recordReaderConfigFileName;
   }
 
   public void setRecordReaderConfigFileName(String recordReaderConfigFileName) {

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/TableOp.java
@@ -61,24 +61,12 @@ public class TableOp extends BaseOp {
     super(OpType.TABLE_OP);
   }
 
-  public String getSchemaFileName() {
-    return _schemaFileName;
-  }
-
   public void setSchemaFileName(String schemaFileName) {
     _schemaFileName = schemaFileName;
   }
 
-  public Op getOp() {
-    return _op;
-  }
-
   public void setOp(Op op) {
     _op = op;
-  }
-
-  public String getTableConfigFileName() {
-    return _tableConfigFileName;
   }
 
   public void setTableConfigFileName(String tableConfigFileName) {


### PR DESCRIPTION
**Labels**
- `cleanup`

This PR continues the last [PR](https://github.com/apache/pinot/pull/13359), which refactored and cleaned up the `pinot-compatibility-verifier`. 

We are deleting the unnecessary `getter` methods for the private fields in the Ops classes. The snakeYaml library requires the `setter` methods for the fields to set the values provided in the compatibility-verifier Yaml files, but there is no need for `getter` methods.