### PR TITLE
In ClusterTest, make start port higher to avoid potential conflict with Kafka

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -114,10 +114,10 @@ public class ControllerTest {
   protected final String _clusterName = getClass().getSimpleName();
   protected final List<HelixManager> _fakeInstanceHelixManagers = new ArrayList<>();
 
-  protected int _nextControllerPort = 16000;
-  protected int _nextBrokerPort = 17000;
-  protected int _nextServerPort = 18000;
-  protected int _nextMinionPort = 19000;
+  protected int _nextControllerPort = 20000;
+  protected int _nextBrokerPort = _nextControllerPort + 1000;
+  protected int _nextServerPort = _nextBrokerPort + 1000;
+  protected int _nextMinionPort = _nextServerPort + 1000;
 
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
 
@@ -294,6 +294,14 @@ public class ControllerTest {
     _controllerPort = 0;
     _controllerRequestClient = null;
     FileUtils.deleteQuietly(new File(_controllerDataDir));
+  }
+
+  public void restartController()
+      throws Exception {
+    assertNotNull(_controllerStarter, "Controller hasn't been started");
+    _controllerStarter.stop();
+    _controllerStarter = null;
+    startController(_controllerConfig.toMap());
   }
 
   public int getFakeBrokerInstanceCount() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -203,12 +203,8 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
         "JobGroupNames should have SegmentGenerationAndPushTask only");
     validateJob(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE, "0 */10 * ? * * *");
 
-    // Restart controller. We need to set the port after stopping the controller because we are reusing the same config.
-    int controllerPort = _controllerPort;
-    stopController();
-    _controllerPort = controllerPort;
-    startController(properties);
-    // wait for controller to start correctly.
+    // Restart controller.
+    restartController();
     TestUtils.waitForCondition((aVoid) -> {
       try {
         long tableSize = getTableSize(OFFLINE_TABLE_NAME);


### PR DESCRIPTION
- Kafka's default port is 19092
- To be future proof, make pinot components start from port 20000
- Add method to restart controller