### PR TITLE
Added API to check if 2 tables are co-located

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -1255,6 +1255,14 @@ public class PinotTableRestletResource {
       throw new IllegalArgumentException("Table '" + table2 + "' cannot be found in the Pinot cluster.");
     }
 
+    Set<String> table1Partitions = table1IdealState.getPartitionSet();
+    Set<String> table2Partitions = table2IdealState.getPartitionSet();
+
+    // If table1 has 0 partitions, check if table2 also has 0 partitions
+    if (table1Partitions.isEmpty()) {
+      return table2Partitions.isEmpty();
+    }
+
     for (String partition : table1IdealState.getPartitionSet()) {
       if (table2IdealState.getPartitionSet().contains(partition)) {
         Set<String> table1Servers = new HashSet<>(table1IdealState.getInstanceStateMap(partition).keySet());


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Added API to validate table co\-location by comparing partition server sets\.

```mermaid
flowchart TD
  N0["validateColocation resource method #40;F1#41;"]:::stAdded
  N1["checkColocation method #40;F1#41;"]:::stAdded
  N2["retrieve IdealState for both tables #40;F1#41;"]:::stAdded
  N3["null checks for IdealState #40;F1#41;"]:::stAdded
  N4["get partition sets and handle empty case #40;F1#41;"]:::stAdded
  N5["iterate partitions and compare server sets #40;F1#41;"]:::stAdded
  N6["return boolean colocation result #40;F1#41;"]:::stAdded
  N7["map boolean to #39;true#39;#47;#39;false#39; string #40;F1#41;"]:::stAdded
  N8["return StringResultResponse #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"invokes"| N2
  N2 -->|"feeds"| N3
  N3 -->|"proceeds"| N4
  N4 -->|"continues"| N5
  N5 -->|"produces"| N6
  N6 -->|"maps"| N7
  N7 -->|"returns"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource\.java — [before](https://github.com/apache/pinot/blob/57d6486e9b1c984d9c33db0dca6e0dc58341ca8e/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java) · [after](https://github.com/apache/pinot/blob/ccbd8be520c58c492e2b8d0a6d4f17357c6d8d19/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU3ZDY0ODZlOWIxYzk4NGQ5YzMzZGIwZGNhNmUwZGM1ODM0MWNhOGUiLCJjb250ZXh0X2hhc2giOiI0MWE0N2Q4MzVjMjVlNWQ3NmZiZDY0YTk3NGRmZDRhNWZhNDRlNWUwNzVmODBiMjY1MTM3MThhNjIyYjk4ZGJhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDM5NzQ2LCJoZWFkX3NoYSI6ImNjYmQ4YmU1MjBjNThjNDkyZTJiOGQwYTZkNGYxNzM1N2M2ZDhkMTkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1N2Q2NDg2ZTliMWM5ODRkOWMzM2RiMGRjYTZlMGRjNTgzNDFjYThlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3857fb54b1744d47ec71e0b96906477a9d6e20bcf436254de7fa2cacd3521c48 -->
<!-- pinot-pr-flow:end -->

Addresses #11788.

Approach: For each partition get the set of servers on which the partition resides for each table and verify that the 2 server sets are equal

Edge case: Consider table0 (with replication factor: 2) and table1 (replication factor: 1)
server0: segment0_table0_replica_0, segment0_table1_replica_0
server1: segment0_table0_replia_1

In the above case the API will return false i.e tables aren't co-located (because the server sets must match exactly). 

Notes:
The reason I am returning a string response ("true" or "false") is so that we can decide in the UI how to display it to the user

Testing:
Tested both positive and negative scenarios

![testing-colocated-api](https://github.com/apache/pinot/assets/20127725/51beb96a-3cc0-402f-b260-431db7c9d184)
![testing-negative](https://github.com/apache/pinot/assets/20127725/555140fa-4261-4f78-9596-c84922654b5a)
 