### PR TITLE
Improve upsert compaction threshold validations

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -57,7 +57,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskGenerator.class);
   private static final String DEFAULT_BUFFER_PERIOD = "7d";
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
-  private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 0;
+  private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 1;
   private static final int DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = 500;
 
   public static class SegmentSelectionResult {
@@ -239,8 +239,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       double invalidRecordPercent = ((double) totalInvalidDocs / totalDocs) * 100;
       if (totalInvalidDocs == totalDocs) {
         segmentsForDeletion.add(segment.getSegmentName());
-      } else if (invalidRecordPercent > invalidRecordsThresholdPercent
-          && totalInvalidDocs > invalidRecordsThresholdCount) {
+      } else if (invalidRecordPercent >= invalidRecordsThresholdPercent
+          && totalInvalidDocs >= invalidRecordsThresholdCount) {
         segmentsForCompaction.add(Pair.of(segment, totalInvalidDocs));
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -747,14 +747,14 @@ public final class TableConfigUtils {
           }
           // check invalidRecordsThresholdPercent
           if (taskTypeConfig.containsKey("invalidRecordsThresholdPercent")) {
-            Preconditions.checkState(Double.parseDouble(taskTypeConfig.get("invalidRecordsThresholdPercent")) > 0
+            Preconditions.checkState(Double.parseDouble(taskTypeConfig.get("invalidRecordsThresholdPercent")) >= 0
                     && Double.parseDouble(taskTypeConfig.get("invalidRecordsThresholdPercent")) <= 100,
-                "invalidRecordsThresholdPercent must be > 0 and <= 100");
+                "invalidRecordsThresholdPercent must be >= 0 and <= 100");
           }
           // check invalidRecordsThresholdCount
           if (taskTypeConfig.containsKey("invalidRecordsThresholdCount")) {
-            Preconditions.checkState(Long.parseLong(taskTypeConfig.get("invalidRecordsThresholdCount")) >= 0,
-                "invalidRecordsThresholdCount must be >= 0");
+            Preconditions.checkState(Long.parseLong(taskTypeConfig.get("invalidRecordsThresholdCount")) >= 1,
+                "invalidRecordsThresholdCount must be >= 1");
           }
           // check that either invalidRecordsThresholdPercent or invalidRecordsThresholdCount was provided
           Preconditions.checkState(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -745,7 +745,7 @@ public final class TableConfigUtils {
           if (taskTypeConfig.containsKey("bufferTimePeriod")) {
             TimeUtils.convertPeriodToMillis(taskTypeConfig.get("bufferTimePeriod"));
           }
-          // check maxNumRecordsPerSegment
+          // check invalidRecordsThresholdPercent
           if (taskTypeConfig.containsKey("invalidRecordsThresholdPercent")) {
             Preconditions.checkState(Double.parseDouble(taskTypeConfig.get("invalidRecordsThresholdPercent")) > 0
                     && Double.parseDouble(taskTypeConfig.get("invalidRecordsThresholdPercent")) <= 100,
@@ -753,8 +753,8 @@ public final class TableConfigUtils {
           }
           // check invalidRecordsThresholdCount
           if (taskTypeConfig.containsKey("invalidRecordsThresholdCount")) {
-            Preconditions.checkState(Long.parseLong(taskTypeConfig.get("invalidRecordsThresholdCount")) >= 1,
-                "invalidRecordsThresholdCount must be >= 1");
+            Preconditions.checkState(Long.parseLong(taskTypeConfig.get("invalidRecordsThresholdCount")) >= 0,
+                "invalidRecordsThresholdCount must be >= 0");
           }
           // check that either invalidRecordsThresholdPercent or invalidRecordsThresholdCount was provided
           Preconditions.checkState(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2355,14 +2355,22 @@ public class TableConfigUtilsTest {
 
     TableConfigUtils.validateTaskConfigs(tableConfig, schema);
 
-    // test with invalid invalidRecordsThresholdPercents
-    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "-1");
+    // test with invalidRecordsThresholdPercents as 0
+    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "0");
     TableConfig zeroPercentTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(upsertConfig)
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
         .build();
+    TableConfigUtils.validateTaskConfigs(zeroPercentTableConfig, schema);
+
+    // test with invalid invalidRecordsThresholdPercents as -1 and 110
+    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "-1");
+    TableConfig negativePercentTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setUpsertConfig(upsertConfig)
+        .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
+        .build();
     Assert.assertThrows(IllegalStateException.class,
-        () -> TableConfigUtils.validateTaskConfigs(zeroPercentTableConfig, schema));
+        () -> TableConfigUtils.validateTaskConfigs(negativePercentTableConfig, schema));
     upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "110");
     TableConfig hundredTenPercentTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2356,7 +2356,7 @@ public class TableConfigUtilsTest {
     TableConfigUtils.validateTaskConfigs(tableConfig, schema);
 
     // test with invalid invalidRecordsThresholdPercents
-    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "0");
+    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "-1");
     TableConfig zeroPercentTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(upsertConfig)
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
@@ -2372,7 +2372,7 @@ public class TableConfigUtilsTest {
         () -> TableConfigUtils.validateTaskConfigs(hundredTenPercentTableConfig, schema));
 
     // test with invalid invalidRecordsThresholdCount
-    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdCount", "-1");
+    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdCount", "0");
     TableConfig invalidCountTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2372,7 +2372,7 @@ public class TableConfigUtilsTest {
         () -> TableConfigUtils.validateTaskConfigs(hundredTenPercentTableConfig, schema));
 
     // test with invalid invalidRecordsThresholdCount
-    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdCount", "0");
+    upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdCount", "-1");
     TableConfig invalidCountTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))


### PR DESCRIPTION
Currently, there is no method to schedule an UpsertCompaction task for a segment that has only one invalid record. We have prevented the invalidRecordsThresholdCount from being set to 0 in the tableConfig, although it defaults to 0 in the generator flow. Additionally, during the taskGenerator process, we perform a strict increment check of the invalid threshold count.
https://github.com/apache/pinot/blob/99f6934166633308547d37cacc634e03c723ab17/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java#L242-L244

Therefore, we either need to set a very low decimal value for invalidRecordsThresholdPercent, which may require precision to several decimal places based on the invalid-to-total-docs ratio of a segment, or we can allow the value to be set to 0, enabling users to perform compaction for segments with just one invalid record.