### PR TITLE
Fix bug preventing numeric casts for MV columns in filters using the multi-stage query engine

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.optimizer.filter;
 import java.math.BigDecimal;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
@@ -399,6 +400,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
         dataType = DataType.INT;
       } else if ("VARCHAR".equals(targetTypeLiteral)) {
         dataType = DataType.STRING;
+      } else if (targetTypeLiteral.endsWith("_ARRAY")) {
+        dataType = DataType.valueOf(StringUtils.removeEnd(targetTypeLiteral, "_ARRAY").trim());
       } else {
         dataType = DataType.valueOf(targetTypeLiteral);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.optimizer.filter;
 import java.math.BigDecimal;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
@@ -396,12 +395,17 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
       String targetTypeLiteral =
           expression.getFunctionCall().getOperands().get(1).getLiteral().getStringValue().toUpperCase();
       DataType dataType;
+
+      // Strip out _ARRAY suffix that can be used to represent an MV field type since the semantics here will be the
+      // same as that for the equivalent SV field of the same type
+      if (targetTypeLiteral.endsWith("_ARRAY")) {
+        targetTypeLiteral = targetTypeLiteral.substring(0, targetTypeLiteral.length() - 6);
+      }
+
       if ("INTEGER".equals(targetTypeLiteral)) {
         dataType = DataType.INT;
       } else if ("VARCHAR".equals(targetTypeLiteral)) {
         dataType = DataType.STRING;
-      } else if (targetTypeLiteral.endsWith("_ARRAY")) {
-        dataType = DataType.valueOf(StringUtils.removeEnd(targetTypeLiteral, "_ARRAY").trim());
       } else {
         dataType = DataType.valueOf(targetTypeLiteral);
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -793,6 +793,14 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertNoError(jsonNode);
   }
 
+  @Test
+  public void testMVNumericCastInFilter() throws Exception {
+    String sqlQuery = "SELECT COUNT(*) FROM mytable WHERE arrayToMV(CAST(DivAirportIDs AS BIGINT ARRAY)) > 0";
+    JsonNode jsonNode = postQuery(sqlQuery);
+    assertNoError(jsonNode);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asInt(), 15482);
+  }
+
   @Override
   protected String getTableName() {
     return _tableName;


### PR DESCRIPTION
- Queries like `SELECT * FROM mytable WHERE ARRAY_TO_MV(CAST(mv_col AS BIGINT ARRAY)) = 0;` fail when run with the multi-stage query engine with an error like:
```
Unable to execute query plan for request: 11345490000000000 on server: 192.168.29.25@{61393,61394}, ERROR: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Caught exception while submitting request: 11345490000000000, stage: 1
...
...
Caused by: java.lang.RuntimeException: Caught exception while submitting request: 11345490000000000, stage: 1
...
...
Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No enum constant org.apache.pinot.spi.data.FieldSpec.DataType.LONG_ARRAY
...
	at org.apache.pinot.query.service.server.QueryServer.lambda$submit$1(QueryServer.java:141)
...

Caused by: java.lang.IllegalArgumentException: No enum constant org.apache.pinot.spi.data.FieldSpec.DataType.LONG_ARRAY
	at java.base/java.lang.Enum.valueOf(Enum.java:273)
	at org.apache.pinot.spi.data.FieldSpec$DataType.valueOf(FieldSpec.java:474)
	at org.apache.pinot.core.query.optimizer.filter.NumericalFilterOptimizer.getDataType(NumericalFilterOptimizer.java:403)
	at org.apache.pinot.core.query.optimizer.filter.NumericalFilterOptimizer.optimizeChild(NumericalFilterOptimizer.java:88)
org.apache.pinot.query.service.dispatch.QueryDispatcher.submit(QueryDispatcher.java:198)
org.apache.pinot.query.service.dispatch.QueryDispatcher.submitAndReduce(QueryDispatcher.java:95)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:216)
org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:133)
```
- That's because the [NumericalFilterOptimizer](https://github.com/apache/pinot/blob/99f6934166633308547d37cacc634e03c723ab17/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java#L385) wasn't handling the `ARRAY` Calcite types that represent MV fields in the v2 query engine.
- Since MV columns aren't actual arrays and can be queried directly just like SV columns (where rows are matched if any value in the MV field matches the predicate) of the corresponding type, this bug can be fixed by simply stripping the `_ARRAY` suffix from the target type.