### PR TITLE
Fix time stats in SegmentIndexCreationDriverImpl

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
@@ -435,9 +434,9 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     // Persist creation metadata to disk
     persistCreationMeta(segmentOutputDir, crc, creationTime);
 
-    LOGGER.info("Driver, record read time : {}", TimeUnit.NANOSECONDS.toMillis(_totalRecordReadTimeNs));
-    LOGGER.info("Driver, stats collector time : {}", _totalStatsCollectorTimeNs);
-    LOGGER.info("Driver, indexing time : {}", _totalIndexTimeNs);
+    LOGGER.info("Driver, record read time (in ns) : {}", _totalRecordReadTimeNs);
+    LOGGER.info("Driver, stats collector time (in ns) : {}", _totalStatsCollectorTimeNs);
+    LOGGER.info("Driver, indexing time (in ns) : {}", _totalIndexTimeNs);
   }
 
   private void updatePostSegmentCreationIndexes(File indexDir)


### PR DESCRIPTION
- The record read start / stop times in `SegmentIndexCreationDriverImpl` were in nanoseconds whereas the index stop time was in milliseconds. The total indexing time was being calculated by subtracting the two stats which obviously leads to a garbage result since they're in different units.
- The total stats collection time was being logged but not computed.
- This patch fixes both the above issues along with some other minor cleanups.