### PR TITLE
fixing the single quoted literal in window function

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotWindowExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotWindowExchangeNodeInsertRule.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
@@ -172,6 +173,17 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
             newRexNode = window.constants.get(inputRefIndex - windowInputSize);
             changed = true;
             aggCallChanged = true;
+          } else {
+            RelNode windowInputRelNode = ((HepRelVertex) window.getInput()).getCurrentRel();
+            if (windowInputRelNode instanceof LogicalProject) {
+              RexNode inputRefRexNode = ((LogicalProject) windowInputRelNode).getProjects().get(inputRefIndex);
+              if (inputRefRexNode instanceof RexLiteral) {
+                // If the input reference is a literal, replace it with the literal value
+                newRexNode = inputRefRexNode;
+                changed = true;
+                aggCallChanged = true;
+              }
+            }
           }
         }
         rexList.add(newRexNode);


### PR DESCRIPTION
When literal arguments are singled quoted, it's parsed to WindowNode inputs, as a literal, not constants.

Sample query:
```
WITH tmp AS (
  select count(*) as num_trips,
    DaysSinceEpoch
  from airlineStats
  GROUP BY DaysSinceEpoch
)

SELECT DaysSinceEpoch,
  num_trips,
  LAG(num_trips, '2') OVER (
    ORDER BY DaysSinceEpoch
  ) AS previous_num_trips,
  num_trips - LAG(num_trips, '2') OVER (
    ORDER BY DaysSinceEpoch
  ) AS difference
FROM tmp;
```

Before:
![image](https://github.com/apache/pinot/assets/1202120/d9dec9a6-d7ed-48f8-b3b7-7eb15a0a1de4)
```
Caused by: java.lang.IllegalArgumentException: Second operand (offset) of LAG function must be a literal
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
	at org.apache.pinot.query.runtime.operator.window.value.LagValueWindowFunction.<init>(LagValueWindowFunction.java:43)
	... 24 more
```

After:
![image](https://github.com/apache/pinot/assets/1202120/fdc670bf-e709-4e70-b3c1-a597869b2c88)
