### PR TITLE
Make 'valueIn' MV transform function work with the multi-stage query engine

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
@@ -196,7 +197,8 @@ public enum TransformFunctionType {
   ARRAY_SUM_INT("arraySumInt", ReturnTypes.INTEGER, OperandTypes.family(SqlTypeFamily.ARRAY), "array_sum_int"),
   ARRAY_SUM_LONG("arraySumLong", ReturnTypes.BIGINT, OperandTypes.family(SqlTypeFamily.ARRAY), "array_sum_long"),
 
-  VALUE_IN("valueIn", "value_in"),
+  VALUE_IN("valueIn", ReturnTypes.ARG0_FORCE_NULLABLE, OperandTypes.variadic(SqlOperandCountRanges.from(2)),
+      "value_in"),
   MAP_VALUE("mapValue", ReturnTypes.cascade(opBinding ->
       opBinding.getOperandType(2).getComponentType(), SqlTypeTransforms.FORCE_NULLABLE),
       OperandTypes.family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY)),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -47,6 +47,11 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
+/**
+ * This class implements the valueIn function for multi-valued columns. It takes at least 2 arguments, where the first
+ * argument is a multi-valued column, and the following arguments are constant values. The transform function will
+ * filter the values from the multi-valued column with the given constant values.
+ */
 public class ValueInTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "valueIn";
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -694,6 +694,17 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
+  public void testVariadicFunction() throws Exception {
+    String sqlQuery = "SELECT ARRAY_TO_MV(VALUE_IN(RandomAirports, 'MFR', 'SUN', 'GTR')) as airport, count(*) "
+        + "FROM mytable WHERE ARRAY_TO_MV(RandomAirports) IN ('MFR', 'SUN', 'GTR') GROUP BY airport";
+    JsonNode jsonNode = postQuery(sqlQuery);
+    assertNoError(jsonNode);
+    assertEquals(jsonNode.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "STRING");
+    assertEquals(jsonNode.get("resultTable").get("dataSchema").get("columnDataTypes").get(1).asText(), "LONG");
+    assertEquals(jsonNode.get("numRowsResultSet").asInt(), 3);
+  }
+
+  @Test
   public void testMultiValueColumnGroupByOrderBy()
       throws Exception {
     String pinotQuery =


### PR DESCRIPTION
- The `valueIn` / `VALUE_IN` transform function didn't work with the multi-stage query engine and resulted in errors like `No match found for function signature valueIn(<VARCHAR ARRAY>, <CHARACTER>, <CHARACTER>)`.
- It didn't have operand type checkers and return type inferences defined in `TransformFunctionType` which are used while registering the Pinot transform functions in Calcite's operator table.
- The `VALUE_IN` function takes a multi-value column as its first input, followed by any number of constant value arguments. Hence, we're using Calcite's [variadic operand type checker](https://github.com/apache/calcite/blob/c0a53f6b17daaca9d057e70d7fae0a0e9c2cd02a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java#L368) in this patch.
- While there exist more powerful type checkers that could ensure things like the first argument is an array and the second argument is the type of the array's elements and so on, these don't seem to be combinable with the variadic type checker. However, this shouldn't be an issue because the transform function itself ensures that the first argument is a multi-value column and even in the v1 query engine, the subsequent arguments are allowed to be of any type.
- Alternatively, we could use the family operand type checker with an arbitrarily large number of subsequent arguments (after the first one being a `SqlTypeFamily.ARRAY`) with all but the first two being optional. This would however introduce an artificial limitation on the number of operands that the `VALUE_IN` function can take (also it would look fairly ugly - both in code, as well as Calcite's generated function signature).