### PR TITLE
Added kafka partition number to metadata.

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -93,6 +93,8 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
   private StreamMessageMetadata extractMessageMetadata(ConsumerRecord<String, Bytes> record) {
     long timestamp = record.timestamp();
     long offset = record.offset();
+    int partition = record.partition();
+
     StreamMessageMetadata.Builder builder = new StreamMessageMetadata.Builder().setRecordIngestionTimeMs(timestamp)
         .setOffset(new LongMsgOffset(offset), new LongMsgOffset(offset + 1));
     if (_config.isPopulateMetadata()) {
@@ -105,7 +107,8 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
         builder.setHeaders(headerGenericRow);
       }
       builder.setMetadata(Map.of(KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(timestamp),
-          KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(offset)));
+          KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(offset),
+          KafkaStreamMessageMetadata.METADATA_PARTITION_KEY, String.valueOf(partition)));
     }
     return builder.build();
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -93,7 +93,6 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
   private StreamMessageMetadata extractMessageMetadata(ConsumerRecord<String, Bytes> record) {
     long timestamp = record.timestamp();
     long offset = record.offset();
-    int partition = record.partition();
 
     StreamMessageMetadata.Builder builder = new StreamMessageMetadata.Builder().setRecordIngestionTimeMs(timestamp)
         .setOffset(new LongMsgOffset(offset), new LongMsgOffset(offset + 1));
@@ -108,7 +107,7 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
       }
       builder.setMetadata(Map.of(KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(timestamp),
           KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(offset),
-          KafkaStreamMessageMetadata.METADATA_PARTITION_KEY, String.valueOf(partition)));
+          KafkaStreamMessageMetadata.METADATA_PARTITION_KEY, String.valueOf(record.partition())));
     }
     return builder.build();
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
@@ -27,6 +27,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 public class KafkaStreamMessageMetadata extends StreamMessageMetadata {
   public static final String METADATA_OFFSET_KEY = "offset";
   public static final String RECORD_TIMESTAMP_KEY = "recordTimestamp";
+  public static final String METADATA_PARTITION_KEY = "partition";
 
   @Deprecated
   public KafkaStreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,


### PR DESCRIPTION
Added Kafka partition number to be available to schema metadata `__metadata$partition` when  `"stream.kafka.metadata.populate": "true"` in table config

Schema snippet:
```
{
"name": "__metadata$offset",
    ...
},
{
"name": "__metadata$partition",
    ...
},
```
 
Related documentation: [PR 353](https://github.com/pinot-contrib/pinot-docs/pull/353) in pinot-docs repo.