### PR TITLE
Fix field spec data type for JSON predicate evaluator tests

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryEqualsPredicateEvaluatorsTest.java
@@ -257,11 +257,11 @@ public class NoDictionaryEqualsPredicateEvaluatorsTest {
 
     EqPredicate eqPredicate = new EqPredicate(COLUMN_EXPRESSION, jsonString);
     PredicateEvaluator eqPredicateEvaluator =
-        EqualsPredicateEvaluatorFactory.newRawValueBasedEvaluator(eqPredicate, FieldSpec.DataType.STRING);
+        EqualsPredicateEvaluatorFactory.newRawValueBasedEvaluator(eqPredicate, FieldSpec.DataType.JSON);
 
     NotEqPredicate notEqPredicate = new NotEqPredicate(COLUMN_EXPRESSION, jsonString);
     PredicateEvaluator neqPredicateEvaluator =
-        NotEqualsPredicateEvaluatorFactory.newRawValueBasedEvaluator(notEqPredicate, FieldSpec.DataType.STRING);
+        NotEqualsPredicateEvaluatorFactory.newRawValueBasedEvaluator(notEqPredicate, FieldSpec.DataType.JSON);
 
     Assert.assertTrue(eqPredicateEvaluator.applySV(jsonString));
     Assert.assertFalse(neqPredicateEvaluator.applySV(jsonString));

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -300,11 +300,11 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
     InPredicate inPredicate = new InPredicate(COLUMN_EXPRESSION, jsonValues);
     PredicateEvaluator inPredicateEvaluator =
-        InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.STRING);
+        InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.JSON);
 
     NotInPredicate notInPredicate = new NotInPredicate(COLUMN_EXPRESSION, jsonValues);
     PredicateEvaluator notInPredicateEvaluator =
-        NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.STRING);
+        NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.JSON);
 
     for (String value : jsonValueSet) {
       Assert.assertTrue(inPredicateEvaluator.applySV(value));


### PR DESCRIPTION
- These tests were added in https://github.com/apache/pinot/pull/13283
- The semantics of the tests don't change currently since the predicate evaluators all have a common branch for `STRING` and `JSON` (see [here](https://github.com/apache/pinot/blob/ddce06f9cc557463e79f8a451224b44f3e63ff5d/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java#L82-L84) for instance), although this isn't guaranteed to remain the same in the future.