### PR TITLE
Add some missing geospatial scalar functions to support use in intermediate stages with the v2 query engine

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -188,4 +188,40 @@ public class ScalarFunctions {
       return firstGeometry.isEmpty() || secondGeometry.isEmpty() ? Double.NaN : firstGeometry.distance(secondGeometry);
     }
   }
+
+  @ScalarFunction(names = {"stContains", "st_contains"})
+  public static int stContains(byte[] first, byte[] second) {
+    Geometry firstGeometry = GeometrySerializer.deserialize(first);
+    Geometry secondGeometry = GeometrySerializer.deserialize(second);
+    if (GeometryUtils.isGeography(firstGeometry) != GeometryUtils.isGeography(secondGeometry)) {
+      throw new RuntimeException("The first and second arguments should either both be geometry or both be geography");
+    }
+    // TODO: to fully support Geography contains operation.
+    return firstGeometry.contains(secondGeometry) ? 1 : 0;
+  }
+
+  @ScalarFunction(names = {"stEquals", "st_equals"})
+  public static int stEquals(byte[] first, byte[] second) {
+    Geometry firstGeometry = GeometrySerializer.deserialize(first);
+    Geometry secondGeometry = GeometrySerializer.deserialize(second);
+
+    return firstGeometry.equals(secondGeometry) ? 1 : 0;
+  }
+
+  @ScalarFunction(names = {"stGeometryType", "st_geometry_type"})
+  public static String stGeometryType(byte[] bytes) {
+    Geometry geometry = GeometrySerializer.deserialize(bytes);
+    return geometry.getGeometryType();
+  }
+
+  @ScalarFunction(names = {"stWithin", "st_within"})
+  public static int stWithin(byte[] first, byte[] second) {
+    Geometry firstGeometry = GeometrySerializer.deserialize(first);
+    Geometry secondGeometry = GeometrySerializer.deserialize(second);
+    if (GeometryUtils.isGeography(firstGeometry) != GeometryUtils.isGeography(secondGeometry)) {
+      throw new RuntimeException("The first and second arguments should either both be geometry or both be geography");
+    }
+    // TODO: to fully support Geography within operation.
+    return firstGeometry.within(secondGeometry) ? 1 : 0;
+  }
 }


### PR DESCRIPTION
- Currently, a query like `Select ST_Contains(ST_GeomFromText('MULTIPOINT (20 20, 25 25)'), ST_GeomFromText('POINT (25 25)')) from GeoSpatialTest LIMIT 5;` will work on both the v1 and v2 query engine.
- However, a query like `Select ST_Contains(ST_GeomFromText('MULTIPOINT (20 20, 25 25)'), ST_GeomFromText('POINT (25 25)')) from GeoSpatialTest a CROSS JOIN GeoSpatialTest b LIMIT 5` results in the following error: `IllegalStateException: Cannot find function with name: ST_CONTAINS`.
- The reason is that the function is executed in the leaf stage in the first query, and is able to make use of the `ST_Contains` [transform function](https://github.com/apache/pinot/blob/74e1a1470a44f3d3b1a3e07e82414698e01426fa/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java#L32). In the second query, however, the function is executed in an intermediate stage where transform functions aren't currently supported (scalar functions are supported though).
- Explain plans for the queries -
    - First: 
       ```
        LogicalSort(offset=[0], fetch=[5])
          PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])
            LogicalSort(fetch=[5])
              LogicalProject(EXPR$0=[1])
                LogicalTableScan(table=[[default, GeoSpatialTest]])
        ```
    - Second:
       ```
        LogicalSort(offset=[0], fetch=[5])
          PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])
            LogicalSort(fetch=[5])
              LogicalProject(EXPR$0=[1])
                LogicalJoin(condition=[true], joinType=[inner])
                  PinotLogicalExchange(distribution=[random])
                    LogicalProject(DUMMY=[0])
                      LogicalTableScan(table=[[default, GeoSpatialTest]])
                  PinotLogicalExchange(distribution=[broadcast])
                    LogicalProject(DUMMY=[0])
                      LogicalTableScan(table=[[default, GeoSpatialTest]])
        ```
- Note that the queries are only representative literal selection queries to demonstrate the issue which can occur in numerous other real queries on the v2 query engine. Also note that the second query type could be optimized in the future to not execute the function in an intermediate stage.
- Most of the geospatial transform functions are also implemented as scalar functions [here](https://github.com/apache/pinot/blob/74e1a1470a44f3d3b1a3e07e82414698e01426fa/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java#L35) and so this issue is limited to only some functions. This patch adds some of the simpler missing functions as a short term fix. However, the long term fix would be to allow the use of transform functions in intermediate stages as well and avoid these sorts of duplicate implementations.