### PR TITLE
Support 'EXTRACT' as a scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeUtils.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Helper methods and constructs for datetrunc function
+ * Helper methods and constructs for date/time functions
  */
 public class DateTimeUtils {
   private DateTimeUtils() {
@@ -41,6 +41,7 @@ public class DateTimeUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DateTimeUtils.class);
   private static final DateTimeFieldType QUARTER_OF_YEAR = new QuarterOfYearDateTimeField();
+  private static final Chronology CHRONOLOGY_UTC = ISOChronology.getInstanceUTC();
 
   public static DateTimeField getTimestampField(ISOChronology chronology, String unitString) {
     switch (unitString.toLowerCase()) {
@@ -150,6 +151,43 @@ public class DateTimeUtils {
       public DurationField getField(Chronology chronology) {
         return new ScaledDurationField(chronology.months(), QUARTER_OF_YEAR_DURATION_FIELD_TYPE, 3);
       }
+    }
+  }
+
+  /**
+   * The supported field types for the EXTRACT operator
+   */
+  public enum ExtractFieldType {
+    YEAR, QUARTER, MONTH, WEEK, DAY, DOY, DOW, HOUR, MINUTE, SECOND
+  }
+
+  /**
+   * Helper method to implement the SQL <code>EXTRACT</code> operator.
+   */
+  public static int extract(ExtractFieldType extractFieldType, long timestamp) {
+    switch (extractFieldType) {
+      case YEAR:
+        return CHRONOLOGY_UTC.year().get(timestamp);
+      case QUARTER:
+        return (CHRONOLOGY_UTC.monthOfYear().get(timestamp) - 1) / 3 + 1;
+      case MONTH:
+        return CHRONOLOGY_UTC.monthOfYear().get(timestamp);
+      case WEEK:
+        return CHRONOLOGY_UTC.weekOfWeekyear().get(timestamp);
+      case DAY:
+        return CHRONOLOGY_UTC.dayOfMonth().get(timestamp);
+      case DOY:
+        return CHRONOLOGY_UTC.dayOfYear().get(timestamp);
+      case DOW:
+        return CHRONOLOGY_UTC.dayOfWeek().get(timestamp);
+      case HOUR:
+        return CHRONOLOGY_UTC.hourOfDay().get(timestamp);
+      case MINUTE:
+        return CHRONOLOGY_UTC.minuteOfHour().get(timestamp);
+      case SECOND:
+        return CHRONOLOGY_UTC.secondOfMinute().get(timestamp);
+      default:
+        throw new IllegalArgumentException("Unsupported FIELD type");
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -1259,4 +1259,9 @@ public class DateTimeFunctions {
     }
     return results;
   }
+
+  @ScalarFunction
+  public static int extract(String interval, long timestamp) {
+    return DateTimeUtils.extract(DateTimeUtils.ExtractFieldType.valueOf(interval), timestamp);
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -263,32 +263,25 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testExtract() {
     {
-      // Case 1 -- Year and date format ('2017-06-15')
-      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15')");
-      Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
-      Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "YEAR");
-      Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
+      // Case 1 -- Year
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(YEAR FROM 1719573611000)");
+      // The CompileTimeFunctionsInvoker will rewrite the query to replace the function call with the resultant literal
+      // value
+      Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getIntValue(), 2024);
     }
     {
-      // Case 2 -- date format ('2017-06-15 09:34:21')
-      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(YEAR FROM '2017-06-15 09:34:21')");
-      Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
-      Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "YEAR");
-      Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15 09:34:21");
+      // Case 2 -- Month
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(MONTH FROM '1719573611000')");
+      // The CompileTimeFunctionsInvoker will rewrite the query to replace the function call with the resultant literal
+      // value
+      Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getIntValue(), 6);
     }
     {
-      // Case 3 -- Month
-      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(MONTH FROM '2017-06-15')");
-      Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
-      Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "MONTH");
-      Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
-    }
-    {
-      // Case 4 -- Day
-      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(DAY FROM '2017-06-15')");
-      Function function = pinotQuery.getSelectList().get(0).getFunctionCall();
-      Assert.assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), "DAY");
-      Assert.assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "2017-06-15");
+      // Case 3 -- Day
+      PinotQuery pinotQuery = compileToPinotQuery("SELECT EXTRACT(DAY FROM 1719573611000)");
+      // The CompileTimeFunctionsInvoker will rewrite the query to replace the function call with the resultant literal
+      // value
+      Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getIntValue(), 28);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunctionTest.java
@@ -38,9 +38,12 @@ public class ExtractTransformFunctionTest extends BaseTransformFunctionTest {
     return new Object[][]{
         //@formatter:off
         {"year", (LongToIntFunction) DateTimeFunctions::year},
+        {"quarter", (LongToIntFunction) timestamp -> (DateTimeFunctions.monthOfYear(timestamp) - 1) / 3 + 1},
         {"month", (LongToIntFunction) DateTimeFunctions::monthOfYear},
         {"week", (LongToIntFunction) DateTimeFunctions::weekOfYear},
         {"day", (LongToIntFunction) DateTimeFunctions::dayOfMonth},
+        {"doy", (LongToIntFunction) DateTimeFunctions::dayOfYear},
+        {"dow", (LongToIntFunction) DateTimeFunctions::dayOfWeek},
         {"hour", (LongToIntFunction) DateTimeFunctions::hour},
         {"minute", (LongToIntFunction) DateTimeFunctions::minute},
         {"second", (LongToIntFunction) DateTimeFunctions::second},

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotEvaluateLiteralRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotEvaluateLiteralRule.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.logical.LogicalFilter;
@@ -233,6 +234,8 @@ public class PinotEvaluateLiteralRule {
     } else if (value instanceof ByteString) {
       // BYTES
       return ((ByteString) value).getBytes();
+    } else if (value instanceof TimeUnitRange) {
+      return ((TimeUnitRange) value).name();
     } else {
       return value;
     }


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/13462
- The extract transform function was originally added in https://github.com/apache/pinot/pull/9184 but since there's no scalar version of it, it can't be used for literal evaluation or an intermediate stage in the multi-stage query engine (similar to https://github.com/apache/pinot/pull/13457).
- It is critical to support the `EXTRACT` function since in the v2 engine, [numerous functions](https://github.com/apache/calcite/blob/444a8cea4389b5db515f4356bf810f03d8efed28/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java#L2006-L2094) are [rewritten to a call to EXTRACT](https://github.com/apache/calcite/blob/444a8cea4389b5db515f4356bf810f03d8efed28/core/src/main/java/org/apache/calcite/sql/fun/SqlDatePartFunction.java#L67) by Calcite.
- This patch does some minor refactoring so that there is no code duplication but we can still use extract as both a transform and scalar function.
- The existing tests from https://github.com/apache/pinot/pull/9184 and https://github.com/apache/pinot/pull/11350 verify this change's correctness and this patch adds some additional coverage for https://github.com/apache/pinot/pull/11388/.
- The change in `PinotEvaluateLiteralRule` is required to support the use of the new scalar function with literals in intermediate stages with the multi-stage query engine.