### PR TITLE
Enable more integration tests to run on the v2 multi-stage query engine

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -507,8 +507,16 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
   public void testQueryExceptions()
       throws Exception {
     testQueryException("POTATO", QueryException.SQL_PARSING_ERROR_CODE);
-    testQueryException("SELECT COUNT(*) FROM potato", QueryException.TABLE_DOES_NOT_EXIST_ERROR_CODE);
-    testQueryException("SELECT POTATO(ArrTime) FROM mytable", QueryException.QUERY_EXECUTION_ERROR_CODE);
+
+    // Ideally, we should attempt to unify the error codes returned by the two query engines if possible
+    testQueryException("SELECT COUNT(*) FROM potato",
+        useMultiStageQueryEngine()
+            ? QueryException.QUERY_PLANNING_ERROR_CODE : QueryException.TABLE_DOES_NOT_EXIST_ERROR_CODE);
+
+    testQueryException("SELECT POTATO(ArrTime) FROM mytable",
+        useMultiStageQueryEngine()
+            ? QueryException.QUERY_PLANNING_ERROR_CODE : QueryException.QUERY_EXECUTION_ERROR_CODE);
+
     testQueryException("SELECT COUNT(*) FROM mytable where ArrTime = 'potato'",
         QueryException.QUERY_EXECUTION_ERROR_CODE);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
@@ -153,7 +153,6 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
   public void testHardcodedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     super.testHardcodedQueries();
   }
 
@@ -161,6 +160,8 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
   public void testQueriesFromQueryFile(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Some of the hardcoded queries in the query file need to be adapted for v2 (for instance, using the arrayToMV
+    // with multi-value columns in filters / aggregations)
     notSupportedInV2();
     super.testQueriesFromQueryFile();
   }
@@ -169,7 +170,6 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
   public void testGeneratedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     testGeneratedQueries(true, useMultiStageQueryEngine);
   }
 
@@ -177,7 +177,6 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
   public void testQueryExceptions(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     super.testQueryExceptions();
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -278,6 +278,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   public void testQueryTracing(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Tracing is a v1 only concept and the v2 query engine has separate multi-stage stats that are enabled by default
     notSupportedInV2();
     JsonNode jsonNode = postQuery("SET trace = true; SELECT COUNT(*) FROM " + getTableName());
     Assert.assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
@@ -292,6 +293,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   public void testQueryTracingWithLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Tracing is a v1 only concept and the v2 query engine has separate multi-stage stats that are enabled by default
     notSupportedInV2();
     JsonNode jsonNode =
         postQuery("SET trace = true; SELECT 1, \'test\', ArrDelay FROM " + getTableName() + " LIMIT 10");
@@ -330,7 +332,6 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   public void testHardcodedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     super.testHardcodedQueries();
   }
 
@@ -338,6 +339,8 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   public void testQueriesFromQueryFile(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Some of the hardcoded queries in the query file need to be adapted for v2 (for instance, using the arrayToMV
+    // with multi-value columns in filters / aggregations)
     notSupportedInV2();
     super.testQueriesFromQueryFile();
   }
@@ -346,15 +349,13 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   public void testGeneratedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
-    super.testGeneratedQueries();
+    super.testGeneratedQueries(true, useMultiStageQueryEngine);
   }
 
   @Test(dataProvider = "useBothQueryEngines")
   public void testQueryExceptions(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     super.testQueryExceptions();
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
@@ -55,7 +55,9 @@ import org.testng.annotations.Test;
 
 
 /**
- * Integration test for heap size based server query killing, this works only for xmx4G
+ * Integration test for heap size based server query killing, this works only for xmx4G.
+ * <p>
+ * Query killing isn't currently supported in the v2 multi-stage query engine so these tests only run on the v1 engine.
  */
 public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterIntegrationTestSet {
   public static final String STRING_DIM_SV1 = "stringDimSV1";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterServerCPUTimeQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterServerCPUTimeQueryKillingTest.java
@@ -55,6 +55,8 @@ import org.testng.annotations.Test;
 
 /**
  * Integration test for heap size based server query killing, this works only for xmx4G
+ * <p>
+ * Query killing isn't currently supported in the v2 multi-stage query engine so these tests only run on the v1 engine.
  */
 public class OfflineClusterServerCPUTimeQueryKillingTest extends BaseClusterIntegrationTestSet {
   public static final String STRING_DIM_SV1 = "stringDimSV1";


### PR DESCRIPTION
- Last year, many v1 integration tests were configured to also run on the v2 multi-stage query engine in https://github.com/apache/pinot/pull/11404. Many tests were marked to be skipped due to either differences in behavior between v1 and v2 or unsupported features in v2.
- Over time, many gaps have been plugged and most integration tests should now be able to run on both the query engines. While some patches updated ITs as well (https://github.com/apache/pinot/pull/13255), not all did, and this patch enables more v1 integration tests to run on the v2 multi-stage query engine.
- In some cases, we need to add some additional branches to tests in order to make them work with v2. For instance:
    - Use of `arrayToMV` for MV columns in filters / aggregations (see https://github.com/apache/pinot/pull/11117/).
    - Using `X''` for byte literal strings instead of simply `''`.
    - Explicit casts for timestamp fields being treated as a `LONG` / `BIGINT`.
    - Slight differences in error codes returned by the two query engines in different query scenarios.
    - Skip small subsets of tests that use functionality not yet present in v2 like support for `BIG_DECIMAL` and expression overrides (https://github.com/apache/pinot/pull/8319).