### PR TITLE
fixing TLS configuration for http clients

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -34,6 +34,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
+import org.apache.pinot.common.http.PoolingHttpClientConnectionManagerHelper;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.swagger.SwaggerApiListingResource;
 import org.apache.pinot.common.swagger.SwaggerSetupUtils;
@@ -87,7 +88,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     }
     _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
-    PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
+    PoolingHttpClientConnectionManager connMgr = PoolingHttpClientConnectionManagerHelper.createWithSocketFactory();
     int timeoutMs = (int) brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
         CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
     connMgr.setDefaultSocketConfig(

--- a/pinot-common/src/main/java/org/apache/pinot/common/http/PoolingHttpClientConnectionManagerHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/PoolingHttpClientConnectionManagerHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.http;
+
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.pinot.common.utils.tls.TlsUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class PoolingHttpClientConnectionManagerHelper {
+
+  private PoolingHttpClientConnectionManagerHelper() {
+  }
+
+  public static Registry<ConnectionSocketFactory> getSocketFactoryRegistry() {
+    return RegistryBuilder.<ConnectionSocketFactory>create()
+        .register(CommonConstants.HTTP_PROTOCOL, PlainConnectionSocketFactory.getSocketFactory())
+        .register(CommonConstants.HTTPS_PROTOCOL, TlsUtils.buildConnectionSocketFactory()).build();
+  }
+
+  public static PoolingHttpClientConnectionManager createWithSocketFactory() {
+    return new PoolingHttpClientConnectionManager(getSocketFactoryRegistry());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/TlsUtils.java
@@ -39,6 +39,7 @@ import javax.net.ssl.TrustManagerFactory;
 import nl.altindag.ssl.SSLFactory;
 import nl.altindag.ssl.exception.GenericSSLContextException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -338,6 +339,10 @@ public final class TlsUtils {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static SSLConnectionSocketFactory buildConnectionSocketFactory() {
+    return new SSLConnectionSocketFactory(getSslContext());
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/http/PoolingHttpClientConnectionManagerHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/http/PoolingHttpClientConnectionManagerHelperTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.http;
+
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class PoolingHttpClientConnectionManagerHelperTest {
+
+  @Test
+  public void itBuildsCorrectRegistry() {
+    Registry<ConnectionSocketFactory> socketFactoryRegistry =
+        PoolingHttpClientConnectionManagerHelper.getSocketFactoryRegistry();
+
+    assertNotNull(socketFactoryRegistry.lookup(CommonConstants.HTTP_PROTOCOL));
+    assertNotNull(socketFactoryRegistry.lookup(CommonConstants.HTTPS_PROTOCOL));
+    assertTrue(socketFactoryRegistry.lookup(CommonConstants.HTTP_PROTOCOL) instanceof PlainConnectionSocketFactory);
+    assertTrue(socketFactoryRegistry.lookup(CommonConstants.HTTPS_PROTOCOL) instanceof SSLConnectionSocketFactory);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -61,6 +61,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.http.PoolingHttpClientConnectionManagerHelper;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -482,7 +483,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
     _sqlQueryExecutor = new SqlQueryExecutor(_config.generateVipUrl());
 
-    _connectionManager = new PoolingHttpClientConnectionManager();
+    _connectionManager = PoolingHttpClientConnectionManagerHelper.createWithSocketFactory();
     _connectionManager.setDefaultSocketConfig(
         SocketConfig.custom()
             .setSoTimeout(Timeout.of(_config.getServerAdminRequestTimeoutSeconds() * 1000, TimeUnit.MILLISECONDS))


### PR DESCRIPTION
As reported in [this issue](https://github.com/apache/pinot/issues/13431) there is an issue where the created HttpClients do not respect the TLS configuration. This fixes that bug.