### PR TITLE
bugfix: json_extract_index out of bounds case

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -150,7 +150,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
         getValueToMatchingDocsMap(), false);
     for (int i = 0; i < numDocs; i++) {
-      String value = valuesFromIndex[inputDocIds[i]];
+      String value = valuesFromIndex[i];
       if (value == null) {
         if (_defaultValue != null) {
           _intValuesSV[i] = (int) _defaultValue;


### PR DESCRIPTION
`json_extract_index(col, '$.key', 'INT', 0)` fails with `java.lang.ArrayIndexOutOfBoundsException: Index 10000 out of bounds for length 10000` - there's a typo in one of the functions for converting to `INT`. This PR fixes this logic.

Unit testing this case looks like a larger change, requiring refactoring most of the transform function test cases since they are currently only tested w/ a single `ValueBlock`. The functionality is covered w/ the existing single `ValueBlock` test