### PR TITLE
ControllerRequestClient accepts headers. Useful for authN tests

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UrlAuthRealtimeIntegrationTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import groovy.lang.IntRange;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -33,13 +31,11 @@ import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.JsonAsyncHttpPinotClientTransportFactory;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.auth.UrlAuthProvider;
-import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.controller.helix.ControllerRequestClient;
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
-import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -144,18 +140,12 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  public void addSchema(Schema schema)
-      throws IOException {
-    SimpleHttpResponse response =
-        sendMultipartPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schema.toSingleLineJsonString(),
-            AUTH_HEADER);
-    Assert.assertEquals(response.getStatusCode(), 200);
-  }
-
-  @Override
-  public void addTableConfig(TableConfig tableConfig)
-      throws IOException {
-    sendPostRequest(_controllerRequestURLBuilder.forTableCreate(), tableConfig.toJsonString(), AUTH_HEADER);
+  public ControllerRequestClient getControllerRequestClient() {
+    if (_controllerRequestClient == null) {
+      _controllerRequestClient =
+          new ControllerRequestClient(_controllerRequestURLBuilder, getHttpClient(), AUTH_HEADER);
+    }
+    return _controllerRequestClient;
   }
 
   @Override
@@ -168,14 +158,6 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
           ConnectionFactory.fromZookeeper(getZkUrl() + "/" + getHelixClusterName(), factory.buildTransport());
     }
     return _pinotConnection;
-  }
-
-  @Override
-  public void dropRealtimeTable(String tableName)
-      throws IOException {
-    sendDeleteRequest(
-        _controllerRequestURLBuilder.forTableDelete(TableNameBuilder.REALTIME.tableNameWithType(tableName)),
-        AUTH_HEADER);
   }
 
   @Test(expectedExceptions = IOException.class)
@@ -197,12 +179,9 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleAllTasksForAllTables(null));
 
     // wait for offline segments
-    JsonNode offlineSegments = TestUtils.waitForResult(() -> {
-      JsonNode segmentSets = JsonUtils.stringToJsonNode(
-          sendGetRequest(_controllerRequestURLBuilder.forSegmentListAPI(getTableName()), AUTH_HEADER));
-      JsonNode currentOfflineSegments =
-          new IntRange(0, segmentSets.size()).stream().map(segmentSets::get).filter(s -> s.has("OFFLINE"))
-              .map(s -> s.get("OFFLINE")).findFirst().get();
+    List<String> offlineSegments = TestUtils.waitForResult(() -> {
+      List<String> currentOfflineSegments =
+          getControllerRequestClient().listSegments(getTableName(), TableType.OFFLINE.name(), false);
       Assert.assertFalse(currentOfflineSegments.isEmpty());
       return currentOfflineSegments;
     }, 30000);
@@ -212,8 +191,7 @@ public class UrlAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertEquals(resultBeforeOffline.getResultSet(0).getLong(0), resultAfterOffline.getResultSet(0).getLong(0));
 
     // download and sanity-check size of offline segment(s)
-    for (int i = 0; i < offlineSegments.size(); i++) {
-      String segment = offlineSegments.get(i).asText();
+    for (String segment : offlineSegments) {
       Assert.assertTrue(
           sendGetRequest(_controllerRequestURLBuilder.forSegmentDownload(getTableName(), segment), AUTH_HEADER).length()
               > 200000); // download segment


### PR DESCRIPTION
authN tests can pass authentication parameters using headers. Allow initialization of ControllerRequestClient with headers so that it can be used in authN tests as well. As an example, UrlAuthRealtimeIntegrationTest has been modified to use ControllerRequestClient initialized with headers. The implementation is now simpler than before.

tags: `refactor`