### PR TITLE
Fix 'WEEK' transform function in multi-stage query engine

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -36,7 +36,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   protected Chronology _chronology = ISOChronology.getInstanceUTC();
 
   private enum Field {
-    YEAR, QUARTER, MONTH, DAY, DOY, DOW, HOUR, MINUTE, SECOND
+    YEAR, QUARTER, MONTH, WEEK, DAY, DOY, DOW, HOUR, MINUTE, SECOND
   }
 
   @Override
@@ -83,6 +83,10 @@ public class ExtractTransformFunction extends BaseTransformFunction {
           break;
         case MONTH:
           accessor = _chronology.monthOfYear();
+          output[i] = accessor.get(timestamps[i]);
+          break;
+        case WEEK:
+          accessor = _chronology.weekOfWeekyear();
           output[i] = accessor.get(timestamps[i]);
           break;
         case DAY:

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunctionTest.java
@@ -39,6 +39,7 @@ public class ExtractTransformFunctionTest extends BaseTransformFunctionTest {
         //@formatter:off
         {"year", (LongToIntFunction) DateTimeFunctions::year},
         {"month", (LongToIntFunction) DateTimeFunctions::monthOfYear},
+        {"week", (LongToIntFunction) DateTimeFunctions::weekOfYear},
         {"day", (LongToIntFunction) DateTimeFunctions::dayOfMonth},
         {"hour", (LongToIntFunction) DateTimeFunctions::hour},
         {"minute", (LongToIntFunction) DateTimeFunctions::minute},

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
@@ -190,6 +190,7 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
         + "YEAR_OF_WEEK(tsBase), YEAR_OF_WEEK(tsHalfDayAfter),\n"
         + "MONTH_OF_YEAR(tsBase), MONTH_OF_YEAR(tsHalfDayAfter),\n"
         + "WEEK_OF_YEAR(tsBase), WEEK_OF_YEAR(tsHalfDayAfter),\n"
+        + "WEEK(tsBase), WEEK(tsHalfDayAfter),\n"
         + "DAY_OF_YEAR(tsBase), DAY_OF_YEAR(tsHalfDayAfter),\n"
         + "DAY_OF_MONTH(tsBase), DAY_OF_MONTH(tsHalfDayAfter),\n"
         + "DAY_OF_WEEK(tsBase), DAY_OF_WEEK(tsHalfDayAfter),\n"
@@ -228,6 +229,8 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
           jsonNode.get("resultTable").get("rows").get(i).get(25).asInt());
       assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(26).asInt(),
           jsonNode.get("resultTable").get("rows").get(i).get(27).asInt());
+      assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(28).asInt(),
+          jsonNode.get("resultTable").get("rows").get(i).get(29).asInt());
     }
   }
 


### PR DESCRIPTION
- In the v2 multi-stage query engine, [numerous date time functions](https://github.com/apache/calcite/blob/444a8cea4389b5db515f4356bf810f03d8efed28/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java#L2006-L2094) are [rewritten to a call to EXTRACT](https://github.com/apache/calcite/blob/444a8cea4389b5db515f4356bf810f03d8efed28/core/src/main/java/org/apache/calcite/sql/fun/SqlDatePartFunction.java#L67) by Calcite.
- Of all the functions that get re-written to an `EXTRACT` call, the only one that is not supported by Pinot's extract transformation function is `WEEK`. This leads to simple queries like `SELECT WEEK(ts) FROM airlineStats` failing with:
```
Received error query execution result block: {200=QueryExecutionError:
org.apache.pinot.spi.exception.BadQueryRequestException: Caught exception while initializing transform function: extract
	at org.apache.pinot.core.operator.transform.function.TransformFunctionFactory.get(TransformFunctionFactory.java:332)
	at org.apache.pinot.core.operator.transform.TransformOperator.<init>(TransformOperator.java:56)
	at org.apache.pinot.core.plan.ProjectPlanNode.run(ProjectPlanNode.java:85)
	at org.apache.pinot.core.plan.StreamingSelectionPlanNode.run(StreamingSelectionPlanNode.java:54)
...
Caused by: java.lang.IllegalArgumentException: No enum constant org.apache.pinot.core.operator.transform.function.ExtractTransformFunction.Field.WEEK
	at java.base/java.lang.Enum.valueOf(Enum.java:273)
	at org.apache.pinot.core.operator.transform.function.ExtractTransformFunction$Field.valueOf(ExtractTransformFunction.java:38)
	at org.apache.pinot.core.operator.transform.function.ExtractTransformFunction.init(ExtractTransformFunction.java:54)
	at org.apache.pinot.core.operator.transform.function.BaseTransformFunction.init(BaseTransformFunction.java:120)}
org.apache.pinot.query.service.dispatch.QueryDispatcher.runReducer(QueryDispatcher.java:306)
org.apache.pinot.query.service.dispatch.QueryDispatcher.submitAndReduce(QueryDispatcher.java:96)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:217)
org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:133)
```
- This patch fixes the above issue by adding support for `WEEK` in the existing extract transform function (and updating the tests added in https://github.com/apache/pinot/pull/9184 and https://github.com/apache/pinot/pull/11350).
- This isn't an issue in the v1 query engine, where there's a separate transform function for `WEEK` - https://github.com/apache/pinot/blob/f52e651c3184bbe3229061224194674a8ceaa1c7/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java#L130
- Also note that this doesn't fix the issue with extract or its associated date time functions when used in a scalar context in the multi-stage query engine (i.e., with literals or in intermediate stages). There's a separate [issue](https://github.com/apache/pinot/issues/13462) and [fix](https://github.com/apache/pinot/pull/13463) for that.