### PR TITLE
Make upsert compaction task more robust to crc mismatch

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -257,10 +257,9 @@ public class ServerSegmentMetadataReader {
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
-      Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(
-          segmentsToQueryBatch -> serverURLsAndBodies.add(
-              generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch, validDocIdsType,
-                  serverToEndpoints.get(serverToSegments.getKey()))));
+      Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(segmentsToQueryBatch ->
+          serverURLsAndBodies.add(generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch,
+              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()))));
     }
 
     BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
@@ -215,11 +216,29 @@ public class ServerSegmentMetadataReader {
 
   /**
    * This method is called when the API request is to fetch validDocId metadata for a list segments of the given table.
-   * This method will pick a server that hosts the target segment and fetch the segment metadata result.
+   * This method will pick one server randomly that hosts the target segment and fetch the segment metadata result.
    *
-   * @return segment metadata as a JSON string
+   * @return list of valid doc id metadata, one per segment processed.
    */
   public List<ValidDocIdsMetadataInfo> getValidDocIdsMetadataFromServer(String tableNameWithType,
+      Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
+      @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
+      int numSegmentsBatchPerServerRequest) {
+    return getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegmentsMap, serverToEndpoints,
+        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest)
+        .values().stream().filter(list -> list != null && !list.isEmpty())
+        .map(list -> list.get(0))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * This method is called when the API request is to fetch validDocId metadata for a list segments of the given table.
+   * This method will pick all servers that hosts the target segment and fetch the segment metadata result and
+   * return as a list.
+   *
+   * @return map of segment name to list of valid doc id metadata where each element is every server's metadata.
+   */
+  public Map<String, List<ValidDocIdsMetadataInfo>> getSegmentToValidDocIdsMetadataFromServer(String tableNameWithType,
       Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
@@ -256,7 +275,7 @@ public class ServerSegmentMetadataReader {
         completionServiceHelper.doMultiPostRequest(serverURLsAndBodies, tableNameWithType, true, requestHeaders,
             timeoutMs, null);
 
-    Map<String, ValidDocIdsMetadataInfo> validDocIdsMetadataInfos = new HashMap<>();
+    Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfos = new HashMap<>();
     int failedParses = 0;
     int returnedServerRequestsCount = 0;
     for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
@@ -265,8 +284,12 @@ public class ServerSegmentMetadataReader {
         List<ValidDocIdsMetadataInfo> validDocIdsMetadataInfoList =
             JsonUtils.stringToObject(validDocIdsMetadataList, new TypeReference<ArrayList<ValidDocIdsMetadataInfo>>() {
             });
-        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo : validDocIdsMetadataInfoList) {
-          validDocIdsMetadataInfos.put(validDocIdsMetadataInfo.getSegmentName(), validDocIdsMetadataInfo);
+        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo: validDocIdsMetadataInfoList) {
+          String segmentName = validDocIdsMetadataInfo.getSegmentName();
+          List<ValidDocIdsMetadataInfo> presentValidDocIdsMetadataInfo =
+              validDocIdsMetadataInfos.computeIfAbsent(segmentName, k -> new ArrayList<>());
+          presentValidDocIdsMetadataInfo.add(validDocIdsMetadataInfo);
+          validDocIdsMetadataInfos.put(segmentName, presentValidDocIdsMetadataInfo);
         }
         returnedServerRequestsCount++;
       } catch (Exception e) {
@@ -292,7 +315,7 @@ public class ServerSegmentMetadataReader {
 
     LOGGER.info("Retrieved validDocIds metadata for {} segments from {} server requests.",
         validDocIdsMetadataInfos.size(), returnedServerRequestsCount);
-    return new ArrayList<>(validDocIdsMetadataInfos.values());
+    return validDocIdsMetadataInfos;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -225,10 +225,8 @@ public class ServerSegmentMetadataReader {
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
     return getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegmentsMap, serverToEndpoints,
-        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest)
-        .values().stream().filter(list -> list != null && !list.isEmpty())
-        .map(list -> list.get(0))
-        .collect(Collectors.toList());
+        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest).values().stream()
+        .filter(list -> list != null && !list.isEmpty()).map(list -> list.get(0)).collect(Collectors.toList());
   }
 
   /**
@@ -259,9 +257,10 @@ public class ServerSegmentMetadataReader {
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
-      Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(segmentsToQueryBatch ->
-          serverURLsAndBodies.add(generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch,
-              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()))));
+      Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(
+          segmentsToQueryBatch -> serverURLsAndBodies.add(
+              generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch, validDocIdsType,
+                  serverToEndpoints.get(serverToSegments.getKey()))));
     }
 
     BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();
@@ -284,12 +283,9 @@ public class ServerSegmentMetadataReader {
         List<ValidDocIdsMetadataInfo> validDocIdsMetadataInfoList =
             JsonUtils.stringToObject(validDocIdsMetadataList, new TypeReference<ArrayList<ValidDocIdsMetadataInfo>>() {
             });
-        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo: validDocIdsMetadataInfoList) {
-          String segmentName = validDocIdsMetadataInfo.getSegmentName();
-          List<ValidDocIdsMetadataInfo> presentValidDocIdsMetadataInfo =
-              validDocIdsMetadataInfos.computeIfAbsent(segmentName, k -> new ArrayList<>());
-          presentValidDocIdsMetadataInfo.add(validDocIdsMetadataInfo);
-          validDocIdsMetadataInfos.put(segmentName, presentValidDocIdsMetadataInfo);
+        for (ValidDocIdsMetadataInfo validDocIdsMetadataInfo : validDocIdsMetadataInfoList) {
+          validDocIdsMetadataInfos.computeIfAbsent(validDocIdsMetadataInfo.getSegmentName(), k -> new ArrayList<>())
+              .add(validDocIdsMetadataInfo);
         }
         returnedServerRequestsCount++;
       } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -174,5 +174,11 @@ public class MinionConstants {
      * number of segments to query in one batch to fetch valid doc id metadata, by default 500
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
+
+    /**
+     * skip crc mismatch as deepstore copies are not updated during schema / index changes
+     * so it's natural for crc to mismatch.
+     */
+    public static final String SKIP_CRC_MISMATCH = "skipCrcMismatch";
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -174,11 +174,5 @@ public class MinionConstants {
      * number of segments to query in one batch to fetch valid doc id metadata, by default 500
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
-
-    /**
-     * skip crc mismatch as deepstore copies are not updated during schema / index changes
-     * so it's natural for crc to mismatch.
-     */
-    public static final String SKIP_CRC_MISMATCH = "skipCrcMismatch";
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -194,7 +194,7 @@ public class MinionTaskUtils {
     String clusterName = minionContext.getHelixManager().getClusterName();
     HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
     RoaringBitmap validDocIds = null;
-    List<String> servers = MinionTaskUtils.getServers(segmentName, tableNameWithType, helixAdmin, clusterName);
+    List<String> servers = getServers(segmentName, tableNameWithType, helixAdmin, clusterName);
     for (String server : servers) {
       InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, server);
       String endpoint = InstanceUtils.getServerAdminEndpoint(instanceConfig);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -231,6 +231,7 @@ public class MinionTaskUtils {
         continue;
       }
       validDocIds = RoaringBitmapUtils.deserialize(validDocIdsBitmapResponse.getBitmap());
+      break;
     }
     return validDocIds;
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -23,9 +23,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
+import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
+import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -37,6 +44,7 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,5 +182,67 @@ public class MinionTaskUtils {
       }
     }
     return defaultValue;
+  }
+
+  /**
+   * Returns the validDocID bitmap from the server whose local segment crc matches both crc of ZK metadata and
+   * deepstore copy.
+   */
+  @Nullable
+  public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
+      String validDocIdsType, MinionContext minionContext, String originalSegmentCrcFromTaskGenerator,
+      String crcFromDeepStorageSegment) {
+    String clusterName = minionContext.getHelixManager().getClusterName();
+    HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
+    RoaringBitmap validDocIds = null;
+    List<String> servers = MinionTaskUtils.getServers(segmentName, tableNameWithType, helixAdmin, clusterName);
+    for (String server : servers) {
+      InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, server);
+      String endpoint = InstanceUtils.getServerAdminEndpoint(instanceConfig);
+
+      // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
+      // passing an empty list.
+      ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
+      ValidDocIdsBitmapResponse validDocIdsBitmapResponse;
+      try {
+        validDocIdsBitmapResponse =
+            serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
+                validDocIdsType, 60_000);
+      } catch (Exception e) {
+        LOGGER.warn(
+            String.format("Unable to retrieve validDocIds bitmap for segment: %s from endpoint: %s", segmentName,
+                endpoint), e);
+        continue;
+      }
+
+      // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
+      // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been
+      // uploaded successfully while the server is still reloading the segment. Reloading can take a while when the
+      // offheap upsert is used because we will need to delete & add all primary keys.
+      // `BaseSingleSegmentConversionExecutor.executeTask()` already checks for the crc from the task generator
+      // against the crc from the current segment zk metadata, so we don't need to check that here.
+      String crcFromValidDocIdsBitmap = validDocIdsBitmapResponse.getSegmentCrc();
+      if (!originalSegmentCrcFromTaskGenerator.equals(crcFromValidDocIdsBitmap)) {
+        // In this scenario, we are hitting the other replica of the segment which did not commit to ZK or deepstore.
+        // We will skip processing this bitmap to query other server to confirm if there is a valid matching CRC.
+        String message = String.format("CRC mismatch for segment: %s, expected value based on task generator: %s, "
+                + "actual crc from validDocIdsBitmapResponse from endpoint %s: %s", segmentName,
+            originalSegmentCrcFromTaskGenerator, endpoint, crcFromValidDocIdsBitmap);
+        LOGGER.warn(message);
+        continue;
+      }
+      if (!crcFromValidDocIdsBitmap.equals(crcFromDeepStorageSegment)) {
+        // Deepstore copies might not always have the same CRC as that from the server we queried for ValidDocIdsBitmap
+        // It can happen due to CRC mismatch issues due to replicas diverging, lucene index issues.
+        String message = String.format(
+            "CRC mismatch for segment: %s, " + "expected crc from validDocIdsBitmapResponse from endpoint %s: %s, "
+                + "actual crc based on deepstore / server metadata copy: %s", segmentName, endpoint,
+            crcFromValidDocIdsBitmap, crcFromDeepStorageSegment);
+        LOGGER.warn(message);
+        continue;
+      }
+      validDocIds = RoaringBitmapUtils.deserialize(validDocIdsBitmapResponse.getBitmap());
+    }
+    return validDocIds;
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -20,17 +20,10 @@ package org.apache.pinot.plugin.minion.tasks.upsertcompaction;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
-import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
-import org.apache.pinot.common.utils.config.InstanceUtils;
-import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor;
@@ -50,6 +43,27 @@ import org.slf4j.LoggerFactory;
 public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskExecutor.class);
 
+  private static SegmentGeneratorConfig getSegmentGeneratorConfig(File workingDir, TableConfig tableConfig,
+      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema) {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(workingDir.getPath());
+    config.setSegmentName(segmentName);
+    // Keep index creation time the same as original segment because both segments use the same raw data.
+    // This way, for REFRESH case, when new segment gets pushed to controller, we can use index creation time to
+    // identify if the new pushed segment has newer data than the existing one.
+    config.setCreationTime(String.valueOf(segmentMetadata.getIndexCreationTime()));
+
+    // The time column type info is not stored in the segment metadata.
+    // Keep segment start/end time to properly handle time column type other than EPOCH (e.g.SIMPLE_FORMAT).
+    if (segmentMetadata.getTimeInterval() != null) {
+      config.setTimeColumnName(tableConfig.getValidationConfig().getTimeColumnName());
+      config.setStartTime(Long.toString(segmentMetadata.getStartTime()));
+      config.setEndTime(Long.toString(segmentMetadata.getEndTime()));
+      config.setSegmentTimeUnit(segmentMetadata.getTimeUnit());
+    }
+    return config;
+  }
+
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
       throws Exception {
@@ -65,60 +79,12 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
 
     String validDocIdsTypeStr =
         configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.name());
-    ValidDocIdsType validDocIdsType = ValidDocIdsType.valueOf(validDocIdsTypeStr.toUpperCase());
-    String clusterName = MINION_CONTEXT.getHelixManager().getClusterName();
-    HelixAdmin helixAdmin = MINION_CONTEXT.getHelixManager().getClusterManagmentTool();
-    List<String> servers = MinionTaskUtils.getServers(segmentName, tableNameWithType, helixAdmin, clusterName);
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
     String originalSegmentCrcFromTaskGenerator = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
     String crcFromDeepStorageSegment = segmentMetadata.getCrc();
-    RoaringBitmap validDocIds = null;
-    for (String server : servers) {
-      InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, server);
-      String endpoint = InstanceUtils.getServerAdminEndpoint(instanceConfig);
-
-      // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
-      // passing an empty list.
-      ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
-      ValidDocIdsBitmapResponse validDocIdsBitmapResponse;
-      try {
-        validDocIdsBitmapResponse = serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType,
-            segmentName, endpoint, validDocIdsType.toString(), 60_000);
-      } catch (Exception e) {
-        LOGGER.warn(
-            String.format("Unable to retrieve validDocIds bitmap for segment: %s from endpoint: %s", segmentName,
-                endpoint), e);
-        continue;
-      }
-
-      // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
-      // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been
-      // uploaded successfully while the server is still reloading the segment. Reloading can take a while when the
-      // offheap upsert is used because we will need to delete & add all primary keys.
-      // `BaseSingleSegmentConversionExecutor.executeTask()` already checks for the crc from the task generator
-      // against the crc from the current segment zk metadata, so we don't need to check that here.
-      String crcFromValidDocIdsBitmap = validDocIdsBitmapResponse.getSegmentCrc();
-      if (!originalSegmentCrcFromTaskGenerator.equals(crcFromValidDocIdsBitmap)) {
-        // In this scenario, we are hitting the other replica of the segment which did not commit to ZK or deepstore.
-        // We will skip processing this bitmap to query other server to confirm if there is a valid matching CRC.
-        String message = String.format("CRC mismatch for segment: %s, expected value based on task generator: %s, "
-                + "actual crc from validDocIdsBitmapResponse from endpoint %s: %s", segmentName,
-            originalSegmentCrcFromTaskGenerator, endpoint, crcFromValidDocIdsBitmap);
-        LOGGER.warn(message);
-        continue;
-      }
-      if (!crcFromValidDocIdsBitmap.equals(crcFromDeepStorageSegment)) {
-        // Deepstore copies might not always have the same CRC as that from the server we queried for ValidDocIdsBitmap
-        // It can happen due to CRC mismatch issues due to replicas diverging, lucene index issues.
-        String message = String.format("CRC mismatch for segment: %s, "
-                + "expected crc from validDocIdsBitmapResponse from endpoint %s: %s, "
-                + "actual crc based on deepstore / server metadata copy: %s", segmentName, endpoint,
-            crcFromValidDocIdsBitmap, crcFromDeepStorageSegment);
-        LOGGER.warn(message);
-        continue;
-      }
-      validDocIds = RoaringBitmapUtils.deserialize(validDocIdsBitmapResponse.getBitmap());
-    }
+    RoaringBitmap validDocIds =
+        MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, segmentName, validDocIdsTypeStr,
+            MINION_CONTEXT, originalSegmentCrcFromTaskGenerator, crcFromDeepStorageSegment);
     if (validDocIds == null) {
       // no valid crc match found or no validDocIds obtained from all servers
       // error out the task instead of silently failing so that we can track it via task-error metrics
@@ -157,27 +123,6 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
 
     return result;
-  }
-
-  private static SegmentGeneratorConfig getSegmentGeneratorConfig(File workingDir, TableConfig tableConfig,
-      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema) {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
-    config.setOutDir(workingDir.getPath());
-    config.setSegmentName(segmentName);
-    // Keep index creation time the same as original segment because both segments use the same raw data.
-    // This way, for REFRESH case, when new segment gets pushed to controller, we can use index creation time to
-    // identify if the new pushed segment has newer data than the existing one.
-    config.setCreationTime(String.valueOf(segmentMetadata.getIndexCreationTime()));
-
-    // The time column type info is not stored in the segment metadata.
-    // Keep segment start/end time to properly handle time column type other than EPOCH (e.g.SIMPLE_FORMAT).
-    if (segmentMetadata.getTimeInterval() != null) {
-      config.setTimeColumnName(tableConfig.getValidationConfig().getTimeColumnName());
-      config.setStartTime(Long.toString(segmentMetadata.getStartTime()));
-      config.setEndTime(Long.toString(segmentMetadata.getEndTime()));
-      config.setSegmentTimeUnit(segmentMetadata.getTimeUnit());
-    }
-    return config;
   }
 
   @Override

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -59,7 +59,6 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
   private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 1;
   private static final int DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = 500;
-  private static final String DEFAULT_SKIP_CRC_MISMATCH = "false";
 
   public static class SegmentSelectionResult {
 
@@ -165,8 +164,6 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
             String.format("deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdsType = %s",
                 validDocIdsType));
       }
-      String skipCrcMismatch = taskConfigs.getOrDefault(UpsertCompactionTask.SKIP_CRC_MISMATCH,
-          DEFAULT_SKIP_CRC_MISMATCH);
 
       List<ValidDocIdsMetadataInfo> validDocIdsMetadataList =
           serverSegmentMetadataReader.getValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
@@ -202,7 +199,6 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoAccessor.getVipUrl() + "/segments");
         configs.put(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY, String.valueOf(segment.getCrc()));
         configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType.toString());
-        configs.put(UpsertCompactionTask.SKIP_CRC_MISMATCH, String.valueOf(skipCrcMismatch));
         pinotTaskConfigs.add(new PinotTaskConfig(UpsertCompactionTask.TASK_TYPE, configs));
         numTasks++;
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -59,6 +59,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
   private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 1;
   private static final int DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = 500;
+  private static final String DEFAULT_SKIP_CRC_MISMATCH = "false";
 
   public static class SegmentSelectionResult {
 
@@ -164,6 +165,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
             String.format("deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdsType = %s",
                 validDocIdsType));
       }
+      String skipCrcMismatch = taskConfigs.getOrDefault(UpsertCompactionTask.SKIP_CRC_MISMATCH,
+          DEFAULT_SKIP_CRC_MISMATCH);
 
       List<ValidDocIdsMetadataInfo> validDocIdsMetadataList =
           serverSegmentMetadataReader.getValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
@@ -199,6 +202,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoAccessor.getVipUrl() + "/segments");
         configs.put(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY, String.valueOf(segment.getCrc()));
         configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType.toString());
+        configs.put(UpsertCompactionTask.SKIP_CRC_MISMATCH, String.valueOf(skipCrcMismatch));
         pinotTaskConfigs.add(new PinotTaskConfig(UpsertCompactionTask.TASK_TYPE, configs));
         numTasks++;
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -76,7 +76,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // check if segment is part of completed segments
       if (!completedSegmentsMap.containsKey(segmentName)) {
         LOGGER.warn("Segment {} is not found in the completed segments list, skipping it for compaction", segmentName);
-        break;
+        continue;
       }
       SegmentZKMetadata segment = completedSegmentsMap.get(segmentName);
       for (ValidDocIdsMetadataInfo validDocIdsMetadata : validDocIdsMetadataInfoMap.get(segmentName)) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -165,8 +165,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
                 validDocIdsType));
       }
 
-      List<ValidDocIdsMetadataInfo> validDocIdsMetadataList =
-          serverSegmentMetadataReader.getValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
+      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
+          serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
               serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest);
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
@@ -209,7 +209,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
 
   @VisibleForTesting
   public static SegmentSelectionResult processValidDocIdsMetadata(Map<String, String> taskConfigs,
-      Map<String, SegmentZKMetadata> completedSegmentsMap, List<ValidDocIdsMetadataInfo> validDocIdsMetadataInfoList) {
+      Map<String, SegmentZKMetadata> completedSegmentsMap,
+      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfoMap) {
     double invalidRecordsThresholdPercent = Double.parseDouble(
         taskConfigs.getOrDefault(UpsertCompactionTask.INVALID_RECORDS_THRESHOLD_PERCENT,
             String.valueOf(DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT)));
@@ -218,30 +219,33 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
             String.valueOf(DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT)));
     List<Pair<SegmentZKMetadata, Long>> segmentsForCompaction = new ArrayList<>();
     List<String> segmentsForDeletion = new ArrayList<>();
-    for (ValidDocIdsMetadataInfo validDocIdsMetadata : validDocIdsMetadataInfoList) {
-      long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
-      String segmentName = validDocIdsMetadata.getSegmentName();
+    for (String segmentName: validDocIdsMetadataInfoMap.keySet()) {
+      for (ValidDocIdsMetadataInfo validDocIdsMetadata : validDocIdsMetadataInfoMap.get(segmentName)) {
+        long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
 
-      // Skip segments if the crc from zk metadata and server does not match. They may be being reloaded.
-      SegmentZKMetadata segment = completedSegmentsMap.get(segmentName);
-      if (segment == null) {
-        LOGGER.warn("Segment {} is not found in the completed segments list, skipping it for compaction", segmentName);
-        continue;
-      }
+        // Skip segments if the crc from zk metadata and server does not match. They may be being reloaded.
+        SegmentZKMetadata segment = completedSegmentsMap.get(segmentName);
+        if (segment == null) {
+          LOGGER.warn("Segment {} is not found in the completed segments list, skipping it for compaction",
+              segmentName);
+          break;
+        }
 
-      if (segment.getCrc() != Long.parseLong(validDocIdsMetadata.getSegmentCrc())) {
-        LOGGER.warn(
-            "CRC mismatch for segment: {}, skipping it for compaction (segmentZKMetadata={}, validDocIdsMetadata={})",
-            segmentName, segment.getCrc(), validDocIdsMetadata.getSegmentCrc());
-        continue;
-      }
-      long totalDocs = validDocIdsMetadata.getTotalDocs();
-      double invalidRecordPercent = ((double) totalInvalidDocs / totalDocs) * 100;
-      if (totalInvalidDocs == totalDocs) {
-        segmentsForDeletion.add(segment.getSegmentName());
-      } else if (invalidRecordPercent >= invalidRecordsThresholdPercent
-          && totalInvalidDocs >= invalidRecordsThresholdCount) {
-        segmentsForCompaction.add(Pair.of(segment, totalInvalidDocs));
+        if (segment.getCrc() != Long.parseLong(validDocIdsMetadata.getSegmentCrc())) {
+          LOGGER.warn(
+              "CRC mismatch for segment: {}, (segmentZKMetadata={}, validDocIdsMetadata={})",
+              segmentName, segment.getCrc(), validDocIdsMetadata.getSegmentCrc());
+          continue;
+        }
+        long totalDocs = validDocIdsMetadata.getTotalDocs();
+        double invalidRecordPercent = ((double) totalInvalidDocs / totalDocs) * 100;
+        if (totalInvalidDocs == totalDocs) {
+          segmentsForDeletion.add(segment.getSegmentName());
+        } else if (invalidRecordPercent >= invalidRecordsThresholdPercent
+            && totalInvalidDocs >= invalidRecordsThresholdCount) {
+          segmentsForCompaction.add(Pair.of(segment, totalInvalidDocs));
+        }
+        break;
       }
     }
     segmentsForCompaction.sort((o1, o2) -> {


### PR DESCRIPTION
Pushing multiple fixes / enhancements in this patch together for faster reviews.

**Enhancement 1**

Solves Scenario 1 of https://github.com/apache/pinot/issues/13491 where Segment ZK Metadata CRC = Segment CRC deepstore != ValidDocID Bitmap CRC was happening.

The change here is to iterate through all peer servers and see if we can find atleast 1 host with matching CRCs and proceed with the task execution. Assumption is that we have one host which was the leader in updating ZK and uploading to deepstore as well.

We also fail the task-execution if we don't find any such host instead of silently skipping and succeeding the task which we were doing previously.

I tried this fix out for one of our tables and the tasks which were blocked initially due to this issue, it successfully executed compaction after this change and we saw a drop in the row-count and size.
<img width="1300" alt="Screenshot 2024-06-27 at 4 20 57 PM" src="https://github.com/apache/pinot/assets/23629228/9ca54ad3-9dbe-4ab2-b8e4-12fd090a5d6b">

**Enhancement 2**

Solves https://github.com/apache/pinot/issues/13492. The controller fetches validDocIDBitmap from one of the replica servers and compares the CRC in the response against the segment ZK metadata CRC. If they don't match, the segment is not considered for compaction.

The fix is similar to the previous solution. We already retrieve all the bitmaps from all servers. Instead of randomly considering just one, we now iterate through all the bitmaps for each segment. If any of them match the ZK CRC, the segment is then considered for compaction.

I deployed this fix for one of our tables, which unblocked many segments for compaction. Attached is a screenshot showing the drop in rows.
<img width="1289" alt="Screenshot 2024-06-29 at 1 00 00 AM" src="https://github.com/apache/pinot/assets/23629228/4d8cf0dd-d262-44f7-884e-513dac7da75a">

