### PR TITLE
Allow PintoHelixResourceManager subclasses to be used in the controller starter by providing an overridable PinotHelixResouceManager object creator function

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -243,7 +243,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       _adminApp = createControllerAdminApp();
       // Do not use this before the invocation of {@link PinotHelixResourceManager::start()}, which happens in {@link
       // ControllerStarter::start()}
-      _helixResourceManager = new PinotHelixResourceManager(_config);
+      _helixResourceManager = createPinotHelixResourceManager();
       // This executor service is used to do async tasks from multiget util or table rebalancing.
       _executorService =
           Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
@@ -297,6 +297,18 @@ public abstract class BaseControllerStarter implements ServiceStartable {
             MAX_STATE_TRANSITIONS_PER_INSTANCE, constraintItem);
   }
 
+  /**
+   * Creates an instance of PinotHelixResourceManager.
+   * <p>
+   * This method can be overridden by subclasses to instantiate the object
+   * with subclasses of PinotHelixResourceManager.
+   * By default, it returns a new PinotHelixResourceManager using the current configuration.
+   *
+   * @return A new instance of PinotHelixResourceManager.
+   */
+  protected PinotHelixResourceManager createPinotHelixResourceManager() {
+    return new PinotHelixResourceManager(_config);
+  }
   public PinotHelixResourceManager getHelixResourceManager() {
     return _helixResourceManager;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -306,7 +306,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
    *
    * @return A new instance of PinotHelixResourceManager.
    */
-  protected PinotHelixResourceManager createPinotHelixResourceManager() {
+  protected PinotHelixResourceManager createHelixResourceManager() {
     return new PinotHelixResourceManager(_config);
   }
   public PinotHelixResourceManager getHelixResourceManager() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -243,7 +243,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       _adminApp = createControllerAdminApp();
       // Do not use this before the invocation of {@link PinotHelixResourceManager::start()}, which happens in {@link
       // ControllerStarter::start()}
-      _helixResourceManager = createPinotHelixResourceManager();
+      _helixResourceManager = createHelixResourceManager();
       // This executor service is used to do async tasks from multiget util or table rebalancing.
       _executorService =
           Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -355,6 +355,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get the data directory path.
+   *
+   * @return Data directory path
+   */
+  public String getDataDir() {
+    return _dataDir;
+  }
+
+  /**
    * Get the segment deletion manager.
    *
    * @return Segment deletion manager

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -215,7 +215,7 @@ public class PinotHelixResourceManager {
 
   private final String _helixZkURL;
   private final String _helixClusterName;
-  private final String _dataDir;
+  protected final String _dataDir;
   private final boolean _isSingleTenantCluster;
   private final boolean _enableBatchMessageMode;
   private final int _deletedSegmentsRetentionInDays;
@@ -223,7 +223,7 @@ public class PinotHelixResourceManager {
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
-  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private HelixDataAccessor _helixDataAccessor;
   private Builder _keyBuilder;
   private ControllerMetrics _controllerMetrics;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -215,7 +215,7 @@ public class PinotHelixResourceManager {
 
   private final String _helixZkURL;
   private final String _helixClusterName;
-  protected final String _dataDir;
+  private final String _dataDir;
   private final boolean _isSingleTenantCluster;
   private final boolean _enableBatchMessageMode;
   private final int _deletedSegmentsRetentionInDays;
@@ -223,7 +223,7 @@ public class PinotHelixResourceManager {
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
-  protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private HelixDataAccessor _helixDataAccessor;
   private Builder _keyBuilder;
   private ControllerMetrics _controllerMetrics;


### PR DESCRIPTION
### Current Scenario
In `BaseControllerStarter`, the `PinotHelixResourceManager _helixResourceManager` initialization is hard coded to the PinotHelixResourceManager object.

This reduces the flexibility of using **subclasses** of PinotHelixResourceManager in any subclass of the `BaseControllerStarter`. 

### Changes in the PR
Introduce an overridable function for initialization of PinotHelixResourceManager **_helixResourceManager**. Thus, any **subclass** of PinotHelixResourceManager can be used for initialization in the subclass of `BaseControllerStarter`.