### PR TITLE
Handle errors gracefully during multi-stage stats collection in the broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.requesthandler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,7 @@ import org.slf4j.LoggerFactory;
 
 public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiStageBrokerRequestHandler.class);
+
   private static final int NUM_UNAVAILABLE_SEGMENTS_TO_LOG = 10;
 
   private final WorkerManager _workerManager;
@@ -270,17 +272,25 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
   private void fillOldBrokerResponseStats(BrokerResponseNativeV2 brokerResponse,
       List<MultiStageQueryStats.StageStats.Closed> queryStats, DispatchableSubPlan dispatchableSubPlan) {
-    List<DispatchablePlanFragment> stagePlans = dispatchableSubPlan.getQueryStageList();
-    List<PlanNode> planNodes = new ArrayList<>(stagePlans.size());
-    for (DispatchablePlanFragment stagePlan : stagePlans) {
-      planNodes.add(stagePlan.getPlanFragment().getFragmentRoot());
-    }
-    MultiStageStatsTreeBuilder treeBuilder = new MultiStageStatsTreeBuilder(planNodes, queryStats);
-    brokerResponse.setStageStats(treeBuilder.jsonStatsByStage(0));
-    for (MultiStageQueryStats.StageStats.Closed stageStats : queryStats) {
-      if (stageStats != null) { // for example pipeline breaker may not have stats
-        stageStats.forEach((type, stats) -> type.mergeInto(brokerResponse, stats));
+    try {
+      List<DispatchablePlanFragment> stagePlans = dispatchableSubPlan.getQueryStageList();
+      List<PlanNode> planNodes = new ArrayList<>(stagePlans.size());
+      for (DispatchablePlanFragment stagePlan : stagePlans) {
+        planNodes.add(stagePlan.getPlanFragment().getFragmentRoot());
       }
+      MultiStageStatsTreeBuilder treeBuilder = new MultiStageStatsTreeBuilder(planNodes, queryStats);
+      brokerResponse.setStageStats(treeBuilder.jsonStatsByStage(0));
+      for (MultiStageQueryStats.StageStats.Closed stageStats : queryStats) {
+        if (stageStats != null) { // for example pipeline breaker may not have stats
+          stageStats.forEach((type, stats) -> type.mergeInto(brokerResponse, stats));
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error encountered while collecting multi-stage stats", e);
+      brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode().put(
+          "error",
+          "Error encountered while collecting multi-stage stats - " + e.getClass().getName() + ": " + e.getMessage())
+      );
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -289,7 +289,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       LOGGER.warn("Error encountered while collecting multi-stage stats", e);
       brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode().put(
           "error",
-          "Error encountered while collecting multi-stage stats - " + e.getClass().getName() + ": " + e.getMessage())
+          "Error encountered while collecting multi-stage stats - " + e)
       );
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -286,7 +286,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Error encountered while collecting multi-stage stats", e);
+      LOGGER.warn("Error encountered while collecting multi-stage stats", e);
       brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode().put(
           "error",
           "Error encountered while collecting multi-stage stats - " + e.getClass().getName() + ": " + e.getMessage())


### PR DESCRIPTION
- There exist certain edge cases during multi-stage stats collection at the broker that can result in exceptions because the stats are generated by the physical operators but the info available to construct the tree is the logical operators.
- Currently, any such exceptions will propagate all the way up to [here](https://github.com/apache/pinot/blob/55f6a6f6d46ca92d2e7ca65a6c1e67de5738cfe7/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java#L323) and will result in the query failing.
- Instead, we should log the error and indicate it in the stats response while still returning the actual query results.