### PR TITLE
Remove commons-lang from License-binary.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -284,7 +284,6 @@ commons-codec:commons-codec:1.16.0
 commons-collections:commons-collections:3.2.2
 commons-configuration:commons-configuration2:2.9.0
 commons-io:commons-io:2.11.0
-commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 commons-pool:commons-pool:1.6
 info.picocli:picocli:4.6.1


### PR DESCRIPTION
This is a minor PR resulting from the last merged [PR](https://github.com/apache/pinot/pull/13480) related to stopping using legacy commons-lang. In this PR, we are just updating the license binary.