### PR TITLE
Add nonLeaderCleanUp with tables parameters in PinotTaskGenerator

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.helix.AccessOption;
 import org.apache.helix.task.TaskState;
@@ -699,6 +700,18 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     LOGGER.info("Cleaning up all task generators");
     for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
       _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
+    }
+  }
+
+  @Override
+  protected void nonLeaderCleanup(List<String> tableNamesWithType) {
+    LOGGER.info(
+        "Cleaning up all task generators for tables that the controller is not the leader for. Number of tables to be"
+            + " cleaned up: {}. Printing at most first 10 table names to be cleaned up: [{}].",
+        tableNamesWithType.size(),
+        StringUtils.join(tableNamesWithType.stream().limit(10).map(t -> "\"" + t + "\"").toArray(), ", "));
+    for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
+      _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp(tableNamesWithType);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -87,6 +87,13 @@ public interface PinotTaskGenerator {
   }
 
   /**
+   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes,
+   * given a list of tables that the current controller isn't the leader for.
+   */
+  default void nonLeaderCleanUp(List<String> tableNamesWithType) {
+  }
+
+  /**
    * Gets the minionInstanceTag for the tableConfig
    */
   default String getMinionInstanceTag(TableConfig tableConfig) {


### PR DESCRIPTION
This PR adds the nonLeaderCleanUp method with the list of table names as the parameter in the PinotTaskGenerator interface.

When the tasks are scheduled, the current controller may not always be the lead controller for the tables that were assigned to this controller (e.g. due to hardware uplift, downlift, maintenance), so there might be stale information like metrics that are left in this controller. Adding the `nonLeaderCleanup` override method in `PinotTaskGenerator` helps clean up the stale information.
