### PR TITLE
add offloadSegmentUnafe to allow separate threads to manage segment offloading

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -309,6 +309,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected PinotHelixResourceManager createHelixResourceManager() {
     return new PinotHelixResourceManager(_config);
   }
+
   public PinotHelixResourceManager getHelixResourceManager() {
     return _helixResourceManager;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -446,6 +446,22 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
+  @Override
+  public void offloadSegmentUnsafe(String segmentName) {
+    if (_shutDown) {
+      _logger.info("Table data manager is already shut down, skipping offloading segment: {} unsafe", segmentName);
+      return;
+    }
+    _logger.info("Offloading segment: {} unsafe", segmentName);
+    try {
+      doOffloadSegment(segmentName);
+    } catch (Exception e) {
+      addSegmentError(segmentName,
+          new SegmentErrorInfo(System.currentTimeMillis(), "Caught exception while offloading segment unsafe", e));
+      throw e;
+    }
+  }
+
   protected void doOffloadSegment(String segmentName) {
     SegmentDataManager segmentDataManager = unregisterSegment(segmentName);
     if (segmentDataManager != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -152,6 +152,13 @@ public interface TableDataManager {
       throws Exception;
 
   /**
+   * Offloads a segment from table like the method {@link #offloadSegment(String)}, but this method doesn't take
+   * segment lock internally to allow separate threads to manage segment offloading w/o the risk of deadlocks.
+   */
+  void offloadSegmentUnsafe(String segmentName)
+      throws Exception;
+
+  /**
    * Reloads an existing immutable segment for the table, which can be an OFFLINE or REALTIME table.
    * A new segment may be downloaded if the local one has a different CRC; or can be forced to download
    * if forceDownload flag is true. This operation is conducted within a failure handling framework

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -309,8 +309,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         }
       }
     }
-    _logger.info("Preloaded segments from partition: {} of table: {} for fast upsert metadata recovery", _partitionId,
-        _tableNameWithType);
+    _logger.info("Preloaded {} segments from partition: {} of table: {} for fast upsert metadata recovery",
+        futures.size(), _partitionId, _tableNameWithType);
   }
 
   private String getInstanceId(TableDataManager tableDataManager) {


### PR DESCRIPTION
Add offloadSegmentUnafe which offload segments w/o taking the segment locks internally, to allow separate threads to offload segment w/o subject to potential deadlocks on segmentLocks