### PR TITLE
Fix NPE in Minion

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -616,8 +616,10 @@ public class PinotTaskRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Authenticate(AccessType.UPDATE)
   @ApiOperation("Schedule tasks and return a map from task type to task name scheduled")
-  public Map<String, String> scheduleTasks(@ApiParam(value = "Task type") @QueryParam("taskType") String taskType,
-      @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName,
+  @Nullable
+  public Map<String, String> scheduleTasks(
+      @ApiParam(value = "Task type") @QueryParam("taskType") @Nullable String taskType,
+      @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") @Nullable String tableName,
       @ApiParam(value = "Minion Instance tag to schedule the task explicitly on") @QueryParam("minionInstanceTag")
       @Nullable String minionInstanceTag, @Context HttpHeaders headers) {
     String database = headers != null ? headers.getHeaderString(DATABASE) : DEFAULT_DATABASE;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -632,8 +632,9 @@ public class PinotTaskRestletResource {
       Map<String, List<String>> allTaskNames = tableName != null ? _pinotTaskManager.scheduleAllTasksForTable(
           DatabaseUtils.translateTableName(tableName, headers), minionInstanceTag)
           : _pinotTaskManager.scheduleAllTasksForDatabase(database, minionInstanceTag);
-      return allTaskNames.entrySet().stream()
+      Map<String, String> result = allTaskNames.entrySet().stream().filter(entry -> entry.getValue() != null)
           .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.join(",", entry.getValue())));
+      return result.isEmpty() ? null : result;
     }
   }
 


### PR DESCRIPTION
Fix NPE in Minion

## Issue
- Fix a corner case where an NPE is thrown when `tasks/schedule` API is called without any `tableName` and `tasktype`. All the tasks are checked for all the tables. It might so happen that a particular `taskType` does not have any corresponding task to schedule. In that particular case, there can be an NPE while adding to the resultant map.
      
## Solution
 - Put the null check before adding elements to the map.