### PR TITLE
Handle unsupported exception gracefully

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -195,6 +195,10 @@ public class IngestionDelayTracker {
     StreamPartitionMsgOffset currentOffset = offset._offset;
     StreamPartitionMsgOffset latestOffset = offset._latestOffset;
 
+    if (currentOffset == null || latestOffset == null) {
+      return 0;
+    }
+
     // Compute aged delay for current partition
     // TODO: Support other types of offsets
     if (!(currentOffset instanceof LongMsgOffset && latestOffset instanceof LongMsgOffset)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1810,8 +1810,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private void updateIngestionMetrics(RowMetadata metadata) {
     if (metadata != null) {
       try {
-        StreamPartitionMsgOffset latestOffset =
-            _partitionMetadataProvider.fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, 5000);
+        StreamPartitionMsgOffset latestOffset = fetchLatestStreamOffset(5000);
         _realtimeTableDataManager.updateIngestionMetrics(metadata.getRecordIngestionTimeMs(),
             metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(), latestOffset, _partitionGroupId);
       } catch (Exception e) {


### PR DESCRIPTION
Currently, when an UnsupportedOperationException is thrown when fetching latest offsets (e.g. in case of Kinesis/Pulsar), we do not update the ingestion delay in ms as well, which we should tbh

