### PR TITLE
Making Pinot point to itself if it's nested inside another Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>32</version>
+    <relativePath></relativePath>
   </parent>
 
   <groupId>org.apache.pinot</groupId>


### PR DESCRIPTION
Before this change, if this repository was nested inside another Maven project, it would point to the Maven project it was nested in instead of itself when calling `mvn install` inside this repository. We can fix this by adding an empty `<relativePath>` tag to `<parent>`, as described on [StackOverflow](https://stackoverflow.com/questions/6003831/parent-relativepath-points-at-my-com-mycompanymyproject-instead-of-org-apache) and the [Maven docs](https://maven.apache.org/ref/3.8.1/maven-model/maven.html#class_parent).