### PR TITLE
Fix TextMatchFilterOptimizer `or not` behavior

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.optimizer.filter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,10 +141,8 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
 
             // Lucene special case: if `OR NOT`, skip optimizing as NOT cannot be used with just one term
             if (operator.equals(FilterKind.OR.name())) {
-              Expression textMatchExpression = RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name());
-              textMatchExpression.getFunctionCall().setOperands(
-                  Arrays.asList(operand.getFunctionCall().getOperands().get(0),
-                      operand.getFunctionCall().getOperands().get(1)));
+              Expression textMatchExpression = RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name(),
+                  operand.getFunctionCall().getOperands().get(0), operand.getFunctionCall().getOperands().get(1));
               newChildren.add(RequestUtils.getFunctionExpression(FilterKind.NOT.name(), textMatchExpression));
               continue;
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.optimizer.filter;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.optimizer.filter;
 
-import java.util.Collections;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
@@ -293,6 +293,11 @@ public class QueryOptimizerTest {
             + "AND TEXT_MATCH(string2, 'foo2') AND TEXT_MATCH(string2, 'bar2')",
         "SELECT * FROM testTable WHERE TEXT_MATCH(string1, '(foo1 AND bar1)') AND TEXT_MATCH(string2, '(foo2 AND "
             + "bar2)')");
+    testQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string, 'foo') OR NOT TEXT_MATCH(string, 'bar')",
+        "SELECT * FROM testTable WHERE NOT TEXT_MATCH(string, 'bar') OR TEXT_MATCH(string, 'foo')");
+    testQuery(
+        "select * from testTable where intCol > 1 AND (text_match(string, 'foo') OR NOT text_match(string, 'bar'))",
+        "select * from testTable where intCol > 1 AND (NOT text_match(string, 'bar') OR text_match(string, 'foo'))");
     testCannotOptimizeQuery("SELECT * FROM testTable WHERE TEXT_MATCH(string1, 'foo') OR TEXT_MATCH(string2, 'bar')");
     testCannotOptimizeQuery(
         "SELECT * FROM testTable WHERE int = 1 AND TEXT_MATCH(string, 'foo') OR TEXT_MATCH(string, 'bar')");


### PR DESCRIPTION
Lucene's query language has a constraint where `NOT` operator cannot be used with just one term, since it relies on the difference of sets. Therefore, the pinot query `x OR NOT y` and the lucene query `x OR NOT y` are not equivalent. Rather, `x OR NOT y` in Lucene is equivalent to simply `x`. 

This patch skips optimizing these cases to ensure query correctness. 

From the [Lucene docs](https://lucene.apache.org/core/9_8_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description): 
```
Note: The NOT operator cannot be used with just one term. For example, the following search will return no results:
NOT "jakarta apache"
```