### PR TITLE
Cleanup: Remove dependency on `nimbus-jose-jwt` from`pinot-adls`

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -69,10 +69,6 @@
         <artifactId>msal4j</artifactId>
         <version>1.16.0</version>
       </dependency>
-      <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>nimbus-jose-jwt</artifactId>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
Cleanup: Remove dependency on `nimbus-jose-jwt` from the `pinot-adls` module.

This is already specified in the top level module. Specifying here leads to `mvn idea:idea` failing with the following error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-idea-plugin:2.2.1:idea (default-cli) on project pinot-adls: Unable to build project dependencies.: For artifact {com.nimbusds:nimbus-jose-jwt:null:jar}: The version cannot be empty. -> [Help 1]
[ERROR]
```
