### PR TITLE
Change default value of `pinot.set.instance.id.to.hostname` to true.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -151,8 +151,8 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _hostname = brokerConf.getProperty(Broker.CONFIG_OF_BROKER_HOSTNAME);
     if (_hostname == null) {
       _hostname =
-          _brokerConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
-              : NetUtils.getHostAddress();
+          _brokerConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY)
+              ? NetUtils.getHostnameOrAddress() : NetUtils.getHostAddress();
     }
     // Override multi-stage query runner hostname if not set explicitly
     if (!_brokerConf.containsKey(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -261,7 +261,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
   private void inferHostnameIfNeeded(ControllerConf config) {
     if (config.getControllerHost() == null) {
-      if (config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)) {
+      if (config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY,
+          CommonConstants.Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY)) {
         final String inferredHostname = NetUtils.getHostnameOrAddress();
         if (inferredHostname != null) {
           config.setControllerHost(inferredHostname);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -72,7 +72,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testDefaultServerConf()
       throws Exception {
-    String expectedHost = NetUtils.getHostAddress();
+    String expectedHost = NetUtils.getHostnameOrAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
     verifyInstanceConfig(new PinotConfiguration(), expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
   }
@@ -84,7 +84,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
 
     Map<String, Object> properties = new HashMap<>();
-    properties.put(SET_INSTANCE_ID_TO_HOSTNAME_KEY, true);
+    properties.put(SET_INSTANCE_ID_TO_HOSTNAME_KEY, DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY);
 
     verifyInstanceConfig(new PinotConfiguration(properties), expectedInstanceId, expectedHost,
         DEFAULT_SERVER_NETTY_PORT);
@@ -97,7 +97,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     String customInstanceId = CUSTOM_INSTANCE_ID + "_" + System.currentTimeMillis();
     properties.put(CONFIG_OF_INSTANCE_ID, customInstanceId);
 
-    verifyInstanceConfig(new PinotConfiguration(properties), customInstanceId, NetUtils.getHostAddress(),
+    verifyInstanceConfig(new PinotConfiguration(properties), customInstanceId, NetUtils.getHostnameOrAddress(),
         DEFAULT_SERVER_NETTY_PORT);
   }
 
@@ -116,7 +116,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testCustomPort()
       throws Exception {
-    String expectedHost = NetUtils.getHostAddress();
+    String expectedHost = NetUtils.getHostnameOrAddress();
     int customPort = NetUtils.findOpenPort(CUSTOM_PORT);
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + customPort;
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -49,8 +49,9 @@ public class MinionConf extends PinotConfiguration {
   public String getHostName()
       throws Exception {
     return getProperty(CommonConstants.Helix.KEY_OF_MINION_HOST,
-        getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils
-            .getHostnameOrAddress() : NetUtils.getHostAddress());
+        getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY,
+            CommonConstants.Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY) ? NetUtils.getHostnameOrAddress()
+            : NetUtils.getHostAddress());
   }
 
   public int getPort() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -163,8 +163,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
     setupHelixSystemProperties();
     _listenerConfigs = ListenerConfigUtil.buildServerAdminConfigs(_serverConf);
     _hostname = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_HOST,
-        _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
-            : NetUtils.getHostAddress());
+        _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY)
+            ? NetUtils.getHostnameOrAddress() : NetUtils.getHostAddress());
     // Override multi-stage query runner hostname if not set explicitly
     if (!_serverConf.containsKey(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME)) {
       _serverConf.setProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _hostname);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -78,8 +78,9 @@ public class AccessControlTest {
 
     PinotConfiguration serverConf = new PinotConfiguration();
     String hostname = serverConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,
-        serverConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)
-            ? NetUtils.getHostnameOrAddress() : NetUtils.getHostAddress());
+        serverConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY,
+            CommonConstants.Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY) ? NetUtils.getHostnameOrAddress()
+            : NetUtils.getHostAddress());
     int port = serverConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT,
         CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT);
     serverConf.setProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID,

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -134,8 +134,9 @@ public abstract class BaseResourceTest {
 
     PinotConfiguration serverConf = new PinotConfiguration();
     String hostname = serverConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,
-        serverConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)
-            ? NetUtils.getHostnameOrAddress() : NetUtils.getHostAddress());
+        serverConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY,
+            CommonConstants.Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY) ? NetUtils.getHostnameOrAddress()
+            : NetUtils.getHostAddress());
     int port = serverConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT,
         CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT);
     _instanceId = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + hostname + "_" + port;

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
@@ -47,8 +47,9 @@ public class PinotServerAppConfigsTest extends BaseResourceTest {
       throws JsonProcessingException, SocketException, UnknownHostException {
     PinotConfiguration expectedServerConf = new PinotConfiguration();
     String hostname = expectedServerConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,
-        expectedServerConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)
-            ? NetUtils.getHostnameOrAddress() : NetUtils.getHostAddress());
+        expectedServerConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY,
+            CommonConstants.Helix.DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY) ? NetUtils.getHostnameOrAddress()
+            : NetUtils.getHostAddress());
     int port = expectedServerConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT,
         CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT);
     expectedServerConf.setProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -179,6 +179,7 @@ public class CommonConstants {
     }
 
     public static final String SET_INSTANCE_ID_TO_HOSTNAME_KEY = "pinot.set.instance.id.to.hostname";
+    public static final boolean DEFAULT_SET_INSTANCE_ID_TO_HOSTNAME_KEY = true;
 
     public static final String KEY_OF_SERVER_NETTY_PORT = "pinot.server.netty.port";
     public static final int DEFAULT_SERVER_NETTY_PORT = 8098;


### PR DESCRIPTION
By default, the instance names chosen is the IP address of the node (host + port). However, with cloud deployments becoming more mainstream using hostname is more desirable. This PR changes the default behavior to use hostname instead of IP address.

Although, most deployments should not be impacted by this change, still marking this as backward incompatible to err on the side of being cautious.

## Release Notes
The default behavior of `pinot.set.instance.id.to.hostname` is being changed from `false` to `true`. With this change, the hostname would be used for pinot component instance names as opposed to the host IP address by default. The behavior can be reverted by setting this config to `false`.