### PR TITLE
Prevent 500 error for non-existent tasktype in /tasks/{taskType}/tasks API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -192,7 +192,12 @@ public class PinotTaskRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation("List all tasks for the given task type")
   public Set<String> getTasks(@ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
-    return _pinotHelixTaskResourceManager.getTasks(taskType);
+    Set<String> tasks = _pinotHelixTaskResourceManager.getTasks(taskType);
+    if (tasks == null) {
+      throw new NotFoundException("No tasks found for task type: " + taskType);
+    }
+
+    return tasks;
   }
 
   @GET

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -317,8 +317,10 @@ public class PinotHelixTaskResourceManager {
   public synchronized Set<String> getTasks(String taskType) {
     String helixJobQueueName = getHelixJobQueueName(taskType);
     WorkflowConfig workflowConfig = _taskDriver.getWorkflowConfig(helixJobQueueName);
-    Preconditions.checkArgument(workflowConfig != null, "Task queue: %s for task type: %s does not exist",
-        helixJobQueueName, taskType);
+    if (workflowConfig == null) {
+      LOGGER.error("Task queue: {} for task type: {} does not exist", helixJobQueueName, taskType);
+      return Collections.emptySet();
+    }
     Set<String> helixJobs = workflowConfig.getJobDag().getAllNodes();
     Set<String> tasks = new HashSet<>(helixJobs.size());
     for (String helixJobName : helixJobs) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -318,8 +318,8 @@ public class PinotHelixTaskResourceManager {
     String helixJobQueueName = getHelixJobQueueName(taskType);
     WorkflowConfig workflowConfig = _taskDriver.getWorkflowConfig(helixJobQueueName);
     if (workflowConfig == null) {
-      LOGGER.error("Task queue: {} for task type: {} does not exist", helixJobQueueName, taskType);
-      return Collections.emptySet();
+      LOGGER.info("Task queue: {} for task type: {} does not exist", helixJobQueueName, taskType);
+      return null;
     }
     Set<String> helixJobs = workflowConfig.getJobDag().getAllNodes();
     Set<String> tasks = new HashSet<>(helixJobs.size());
@@ -753,6 +753,9 @@ public class PinotHelixTaskResourceManager {
    */
   public synchronized Map<String, TaskCount> getTaskCounts(String taskType) {
     Set<String> tasks = getTasks(taskType);
+    if (tasks == null) {
+      return Collections.emptyMap();
+    }
     Map<String, TaskCount> taskCounts = new TreeMap<>();
     for (String taskName : tasks) {
       taskCounts.put(taskName, getTaskCount(taskName));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -312,13 +312,13 @@ public class PinotHelixTaskResourceManager {
    * Get all tasks for the given task type.
    *
    * @param taskType Task type
-   * @return Set of task names
+   * @return Set of task names. Null for invalid task type.
    */
+  @Nullable
   public synchronized Set<String> getTasks(String taskType) {
     String helixJobQueueName = getHelixJobQueueName(taskType);
     WorkflowConfig workflowConfig = _taskDriver.getWorkflowConfig(helixJobQueueName);
     if (workflowConfig == null) {
-      LOGGER.info("Task queue: {} for task type: {} does not exist", helixJobQueueName, taskType);
       return null;
     }
     Set<String> helixJobs = workflowConfig.getJobDag().getAllNodes();


### PR DESCRIPTION
# Before fix
## Curl output
```
% curl -k "http://localhost:9000/tasks/REFRESH/tasks" -w "\n%{http_code}\n"
{"code":500,"error":"Task queue: TaskQueue_REFRESH for task type: REFRESH does not exist"}
500
```

## Log in the controller
```
2024/07/03 21:07:02.350 ERROR [WebApplicationExceptionMapper] [grizzly-http-server-0] Server error:
java.lang.IllegalArgumentException: Task queue: TaskQueue_REFRESH for task type: REFRESH does not exist
	at org.apache.pinot.shaded.com.google.common.base.Preconditions.checkArgument(Preconditions.java:448)
	at org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager.getTasks(PinotHelixTaskResourceManager.java:320)
	at org.apache.pinot.controller.api.resources.PinotTaskRestletResource.getTasks(PinotTaskRestletResource.java:194)
```

# After fix
## Curl output
```
% curl -k "http://localhost:9000/tasks/REFRESH/tasks" -w "\n%{http_code}\n"
{"code":404,"error":"No tasks found for task type: REFRESH"}
404
```