### PR TITLE
Fix bug when evaluating resource status during service startup check

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -468,7 +468,8 @@ public class ServiceStatus {
       // some reason)
       Map<String, String> partitionStateMap = getPartitionStateMap(helixState);
       for (String partitionName : partitionSet) {
-        String idealStateStatus = partitionToIdealStateStatusMap.get(partitionName);
+        String idealStateStatus = partitionToIdealStateStatusMap.getOrDefault(partitionName,
+            idealState.getInstanceStateMap(partitionName).get(_instanceName));
 
         // Skip this partition if it is not assigned to this instance or if the instance should be offline
         if (idealStateStatus == null || "OFFLINE".equals(idealStateStatus)) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
@@ -129,11 +129,11 @@ public class ServiceStatusTest {
   @Test
   public void testIdealStateMatch() {
     TestIdealStateAndExternalViewMatchServiceStatusCallback callback;
-//
-//    // No ideal state = GOOD
-//    callback = buildTestISEVCallback();
-//    callback.setExternalView(new ExternalView(TABLE_NAME));
-//    assertEquals(callback.getServiceStatus(), ServiceStatus.Status.GOOD);
+
+    // No ideal state = GOOD
+    callback = buildTestISEVCallback();
+    callback.setExternalView(new ExternalView(TABLE_NAME));
+    assertEquals(callback.getServiceStatus(), ServiceStatus.Status.GOOD);
 
     // No external view, and ideal state shows this instance is assigned a segment of the resource = STARTING
     callback = buildTestISEVCallback();

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
@@ -129,11 +129,11 @@ public class ServiceStatusTest {
   @Test
   public void testIdealStateMatch() {
     TestIdealStateAndExternalViewMatchServiceStatusCallback callback;
-
-    // No ideal state = GOOD
-    callback = buildTestISEVCallback();
-    callback.setExternalView(new ExternalView(TABLE_NAME));
-    assertEquals(callback.getServiceStatus(), ServiceStatus.Status.GOOD);
+//
+//    // No ideal state = GOOD
+//    callback = buildTestISEVCallback();
+//    callback.setExternalView(new ExternalView(TABLE_NAME));
+//    assertEquals(callback.getServiceStatus(), ServiceStatus.Status.GOOD);
 
     // No external view, and ideal state shows this instance is assigned a segment of the resource = STARTING
     callback = buildTestISEVCallback();

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStatusTest.java
@@ -151,7 +151,7 @@ public class ServiceStatusTest {
     callback.setIdealState(new IdealState(znRecord));
     assertEquals(callback.getServiceStatus(), ServiceStatus.Status.GOOD);
 
-    // No external view, and ideal state shows second segment is still offline = STARTING
+    // Online ideal state, and external view shows second segment is still offline = STARTING
     callback = buildTestISEVCallback();
     znRecord = new ZNRecord(TABLE_NAME);
     znRecord.setSimpleField("REBALANCE_MODE", "CUSTOMIZED");


### PR DESCRIPTION
We have seen servers sometimes fail to pass the service status checker until the timeout is reached, even after all segments are online/in the expected state. Logs show:

```
Sleep for 10000ms as service status has not turned GOOD: MultipleCallbackServiceStatusCallback:IdealStateAndCurrentStateMatchServiceStatusCallback:Helix state does not exist, waitingFor=CurrentStateMatch, resource=table_REALTIME, numResourcesLeft=2, numTotalResources=802, minStartCount=802,;IdealStateAndExternalViewMatchServiceStatusCallback:Init;;
```

This is due to [this check](https://github.com/apache/pinot/blob/cf1a0f6b9b44fdb567452b63a34e76ac5c635429/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java#L437-L440), which considers the table resource to have `STARTING` status if the external view/current state is `null` and ideal state is not. However, this isn't a valid assumption since the current state can be null if the last segment on the server is removed and the ideal state still exists. We primary see this behavior with completed segment redistribution turned on, on small tables. 

The change here is meant to allow the resource status to return `GOOD` if the instance is no longer assigned any segment (when the server first started and collected all resources to monitor it was assigned). 