### PR TITLE
Add configs to specify keepAlive and shutdownTimeout for GrpcQueryClient

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/GrpcConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/GrpcConfig.java
@@ -28,6 +28,20 @@ public class GrpcConfig {
   public static final String GRPC_TLS_PREFIX = "tls";
   public static final String CONFIG_USE_PLAIN_TEXT = "usePlainText";
   public static final String CONFIG_MAX_INBOUND_MESSAGE_BYTES_SIZE = "maxInboundMessageSizeBytes";
+
+  private static final String CONFIG_CHANNEL_SHUTDOWN_TIMEOUT_SECONDS = "channelShutdownTimeoutSeconds";
+  private static final int DEFAULT_CHANNEL_SHUTDOWN_TIMEOUT_SECONDS = 10;
+
+  // KeepAlive configs
+  private static final String CONFIG_CHANNEL_KEEP_ALIVE_TIME_SECONDS = "channelKeepAliveTimeSeconds";
+  private static final int DEFAULT_CHANNEL_KEEP_ALIVE_TIME_SECONDS = -1; // Set value > 0 to enable keep alive
+
+  private static final String CONFIG_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = "channelKeepAliveTimeoutSeconds";
+  private static final int DEFAULT_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 20; // 20 seconds
+
+  private static final String CONFIG_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS = "channelKeepAliveWithoutCalls";
+  private static final boolean DEFAULT_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS = true;
+
   // Default max message size to 128MB
   public static final int DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE = 128 * 1024 * 1024;
   // Default use plain text for transport
@@ -67,6 +81,23 @@ public class GrpcConfig {
 
   public boolean isUsePlainText() {
     return Boolean.parseBoolean(_pinotConfig.getProperty(CONFIG_USE_PLAIN_TEXT, DEFAULT_IS_USE_PLAIN_TEXT));
+  }
+
+  public int getChannelShutdownTimeoutSecond() {
+    return _pinotConfig.getProperty(CONFIG_CHANNEL_SHUTDOWN_TIMEOUT_SECONDS, DEFAULT_CHANNEL_SHUTDOWN_TIMEOUT_SECONDS);
+  }
+
+  public int getChannelKeepAliveTimeSeconds() {
+    return _pinotConfig.getProperty(CONFIG_CHANNEL_KEEP_ALIVE_TIME_SECONDS, DEFAULT_CHANNEL_KEEP_ALIVE_TIME_SECONDS);
+  }
+
+  public int getChannelKeepAliveTimeoutSeconds() {
+    return _pinotConfig.getProperty(CONFIG_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS,
+        DEFAULT_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS);
+  }
+
+  public boolean isChannelKeepAliveWithoutCalls() {
+    return _pinotConfig.getProperty(CONFIG_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS, DEFAULT_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS);
   }
 
   public TlsConfig getTlsConfig() {


### PR DESCRIPTION
Added configs to specify keepAlive and shutdownTimeout for `GrpcQueryClient`.

- Added `channelShutdownTimeoutSecond` config for `GrpcQueryClient` with default of 10s.
- Added configs for keep-alive:
  - `channelKeepAliveEnabled` to enable/disable the feature, default false.
  - `channelKeepAliveTimeSeconds` to configures the interval for sending keep-alive pings, default 300 seconds (5 minutes).
  - `channelKeepAliveTimeoutSeconds` configures the timeout for waiting for a ping acknowledgment, default 300 seconds (5 minutes).
  - `channelKeepAliveWithoutCalls` ensures pings are sent even when there are no active calls, keeping the connection alive during idle period, default true.

