### PR TITLE
API to expose gauge metric values on minion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -495,6 +495,16 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Get the gauge metric value for the provided gauge name
+   * @param gaugeName gauge name
+   * @return gauge value. If gauge is not present return null.
+   */
+  public Long getGaugeValue(final String gaugeName) {
+    AtomicLong value = _gaugeValues.get(gaugeName);
+    return value != null ? value.get() : null;
+  }
+
+  /**
    * Initializes all global meters (such as exceptions count) to zero.
    */
   public void initializeGlobalMeters() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -495,15 +495,6 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
-   * Get the gauge metric value of the provided gauge
-   * @param gauge gauge
-   * @return gauge value
-   */
-  public long getGaugeValue(final G gauge) {
-    return _gaugeValues.get(gauge.getGaugeName()).get();
-  }
-
-  /**
    * Initializes all global meters (such as exceptions count) to zero.
    */
   public void initializeGlobalMeters() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.spi.metrics.PinotGauge;
 import org.apache.pinot.spi.metrics.PinotMeter;
@@ -499,6 +500,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param gaugeName gauge name
    * @return gauge value. If gauge is not present return null.
    */
+  @Nullable
   public Long getGaugeValue(final String gaugeName) {
     AtomicLong value = _gaugeValues.get(gaugeName);
     return value != null ? value.get() : null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -495,6 +495,15 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Get the gauge metric value of the provided gauge
+   * @param gauge gauge
+   * @return gauge value
+   */
+  public long getGaugeValue(final G gauge) {
+    return _gaugeValues.get(gauge.getGaugeName()).get();
+  }
+
+  /**
    * Initializes all global meters (such as exceptions count) to zero.
    */
   public void initializeGlobalMeters() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionMetricsResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionMetricsResource.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.api.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.common.metrics.MinionMetrics;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+
+@Api(tags = "Metrics", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
+    HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
+@Path("/metrics")
+public class PinotMinionMetricsResource {
+  public static final String METRIC_EXISTS = "metricExists";
+  public static final String GAUGE_VALUE = "gaugeValue";
+  private final MinionMetrics _minionMetrics = MinionMetrics.get();
+
+  @GET
+  @Path("/gauge/{gaugeName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Get gauge value for the provided minion gauge name")
+  public String getMinionGaugeValue(@ApiParam(value = "Gauge name") @PathParam("gaugeName") String gaugeName)
+      throws JsonProcessingException {
+    Long value = _minionMetrics.getGaugeValue(gaugeName);
+    Map<String, Object> response = new HashMap<>();
+    if (value != null) {
+      response.put(GAUGE_VALUE, value);
+      response.put(METRIC_EXISTS, true);
+    } else {
+      response.put(METRIC_EXISTS, false);
+    }
+    return JsonUtils.objectToString(response);
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -42,8 +42,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.common.metrics.MinionGauge;
-import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.event.MinionTaskState;
@@ -64,7 +62,6 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 public class PinotTaskProgressResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotTaskProgressResource.class);
-  private final MinionMetrics _minionMetrics = MinionMetrics.get();
 
   @GET
   @Path("/tasks/subtask/progress")
@@ -147,14 +144,20 @@ public class PinotTaskProgressResource {
   }
 
   @GET
-  @Path("/tasks/active/count")
+  @Path("/tasks/subtask/activeCount")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation("Get active task execution count on the minion instance")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
   })
   public ActiveTasksCountPayload getActiveTasksCount() {
-    return new ActiveTasksCountPayload(_minionMetrics.getGaugeValue(MinionGauge.NUMBER_OF_TASKS));
+    long activeTasks = 0;
+    for (MinionEventObserver observer : MinionEventObservers.getInstance().getMinionEventObservers().values()) {
+      if (observer.getTaskState().equals(MinionTaskState.IN_PROGRESS)) {
+        activeTasks++;
+      }
+    }
+    return new ActiveTasksCountPayload(activeTasks);
   }
 
   private static class ActiveTasksCountPayload {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -142,33 +142,4 @@ public class PinotTaskProgressResource {
           .build());
     }
   }
-
-  @GET
-  @Path("/tasks/subtask/activeCount")
-  @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation("Get active task execution count on the minion instance")
-  @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
-  })
-  public ActiveTasksCountPayload getActiveTasksCount() {
-    long activeTasks = 0;
-    for (MinionEventObserver observer : MinionEventObservers.getInstance().getMinionEventObservers().values()) {
-      if (observer.getTaskState().equals(MinionTaskState.IN_PROGRESS)) {
-        activeTasks++;
-      }
-    }
-    return new ActiveTasksCountPayload(activeTasks);
-  }
-
-  private static class ActiveTasksCountPayload {
-    private final long _activeTasksCount;
-
-    public ActiveTasksCountPayload(long activeTasksCount) {
-      _activeTasksCount = activeTasksCount;
-    }
-
-    public long getActiveTasksCount() {
-      return _activeTasksCount;
-    }
-  }
 }


### PR DESCRIPTION
# Description

Expose an API that provides the gauge metric value on the minion based on the provided gauge name

Path : `/metrics/gauge/<gaugeName>`
Method : `GET`
Sample response:
```
{
  "gaugeValue": 10,
  "metricExists": true
}
```