### PR TITLE
Return relevant error message when a v2 / multi-stage query is run on the v1 query engine

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotQueryResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotQueryResourceTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.spi.data.Schema;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+public class PinotQueryResourceTest {
+
+  @Mock
+  PinotHelixResourceManager _resourceManager;
+  @Mock
+  TableCache _tableCache;
+  @Mock
+  Schema _schema;
+  @Mock
+  AccessControlFactory _accessControlFactory;
+  @Mock
+  ControllerConf _controllerConf;
+  @InjectMocks
+  PinotQueryResource _pinotQueryResource;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(_tableCache.getActualTableName(any())).then(AdditionalAnswers.returnsFirstArg());
+    when(_resourceManager.getTableCache()).thenReturn(_tableCache);
+    when(_tableCache.getSchema(any())).thenReturn(_schema);
+  }
+
+  @Test
+  public void testV2QueryOnV1() {
+    String response =
+        _pinotQueryResource.handleGetSql("WITH tmp AS (SELECT * FROM a) SELECT * FROM tmp", null, null, null);
+    Assert.assertTrue(response.contains(String.valueOf(QueryException.SQL_PARSING_ERROR_CODE)));
+    Assert.assertTrue(response.contains("retry the query using the multi-stage query engine"));
+  }
+
+  @Test
+  public void testInvalidQuery() {
+    String response = _pinotQueryResource.handleGetSql("INVALID QUERY", null, null, null);
+    Assert.assertTrue(response.contains(String.valueOf(QueryException.SQL_PARSING_ERROR_CODE)));
+    Assert.assertFalse(response.contains("retry the query using the multi-stage query engine"));
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.parser.utils;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.query.type.TypeSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ParserUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ParserUtils.class);
+
+  private ParserUtils() {
+  }
+
+  /**
+   * @param query the query string to be parsed and compiled
+   * @param calciteSchema the Calcite schema to be used for compilation
+   * @return true if the query can be parsed and compiled using the v2 multi-stage query engine
+   */
+  public static boolean canCompileQueryUsingV2Engine(String query, CalciteSchema calciteSchema) {
+    // try to parse and compile the query with the Calcite planner used by the multi-stage query engine
+    try {
+      LOGGER.info("Trying to compile query `{}` using the multi-stage query engine", query);
+      QueryEnvironment queryEnvironment =
+          new QueryEnvironment(new TypeFactory(new TypeSystem()), calciteSchema, null, null);
+      queryEnvironment.getTableNamesForQuery(query);
+      LOGGER.info("Successfully compiled query using the multi-stage query engine: `{}`", query);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Encountered an error while compiling query `{}` using the multi-stage query engine", query, e);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
- Currently, if a user tries to run a v2 query using the broker query API, the error returned is not very clear and new users won't really know what to do next. For instance, executing a query with a CTE returns an error like:
```
SQLParsingError: java.lang.ClassCastException: class org.apache.calcite.sql.SqlWith cannot be cast to class org.apache.calcite.sql.SqlSelect (org.apache.calcite.sql.SqlWith and org.apache.calcite.sql.SqlSelect are in unnamed module of loader 'app') at org.apache.pinot.sql.parsers.CalciteSqlParser.compileSqlNodeToPinotQuery(CalciteSqlParser.java:434) at org.apache.pinot.sql.parsers.CalciteSqlParser.compileToPinotQuery(CalciteSqlParser.java:166) at org.apache.pinot.broker.requesthandler.BaseSingleStageBrokerRequestHandler.handleRequest(BaseSingleStageBrokerRequestHandler.java:256) at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:133)
```
- Earlier, an improvement was made to return a more helpful error message in such scenarios but only for the controller SQL API - https://github.com/apache/pinot/pull/11451.
- This patch does some refactoring so that we also return a helpful error message in such scenarios with the broker query API. The error message has also been tweaked slightly since even the controller SQL API can technically be called via any REST client and not necessarily only the web based query console.