### PR TITLE
Fix issue with group by combine operator when limit is zero

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -71,9 +71,9 @@ public abstract class IndexedTable extends BaseTable {
       int trimSize, int trimThreshold, Map<Key, Record> lookupMap) {
     super(dataSchema);
 
-    Preconditions.checkArgument(resultSize > 0, "Result size should be a non-zero positive integer");
-    Preconditions.checkArgument(trimSize > 0, "Trim size should be a non-zero positive integer");
-    Preconditions.checkArgument(trimThreshold > 0, "Trim threshold should be a non-zero positive integer");
+    Preconditions.checkArgument(resultSize >= 0, "Result size can't be negative");
+    Preconditions.checkArgument(trimSize >= 0, "Trim size can't be negative");
+    Preconditions.checkArgument(trimThreshold >= 0, "Trim threshold can't be negative");
 
     _lookupMap = lookupMap;
     _hasFinalInput = hasFinalInput;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3472,6 +3472,13 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     testQuery("SELECT BOOL_OR(CAST(Diverted AS BOOLEAN)) FROM mytable");
   }
 
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testGroupByAggregationWithLimitZero(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    testQuery("SELECT Origin, SUM(ArrDelay) FROM mytable GROUP BY Origin LIMIT 0");
+  }
+
   private String buildSkipIndexesOption(String columnsAndIndexes) {
     return "SET " + SKIP_INDEXES + "='" + columnsAndIndexes + "'; ";
   }


### PR DESCRIPTION
- A query like `SELECT Origin, SUM(ArrDelay) FROM mytable GROUP BY Origin LIMIT 0` was resulting in the error:
```
QueryExecutionError:
java.lang.IllegalArgumentException: Result size should be a non-zero positive integer
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
    at org.apache.pinot.core.data.table.IndexedTable.<init>(IndexedTable.java:74)
    at org.apache.pinot.core.data.table.ConcurrentIndexedTable.<init>(ConcurrentIndexedTable.java:42)
    at org.apache.pinot.core.data.table.ConcurrentIndexedTable.<init>(ConcurrentIndexedTable.java:37)
```
- This check was added recently in https://github.com/apache/pinot/pull/13514 to ensure that an integer overflow check doesn't become error prone due to negative values (also the negative values don't make sense for result size / trim size / trim threshold).
- However, one thing that was missed is that the result size / trim size can be 0 for aggregation queries using group by when the limit is zero - https://github.com/apache/pinot/blob/cf1a0f6b9b44fdb567452b63a34e76ac5c635429/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java#L94
- This was surfaced by the [testGeneratedQueries](https://github.com/apache/pinot/blob/cf1a0f6b9b44fdb567452b63a34e76ac5c635429/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java#L480) becoming a flaky test in recent CI runs (see https://github.com/apache/pinot/actions/runs/9834355954/job/27146034854, https://github.com/apache/pinot/actions/runs/9811276363/job/27093161297 for instance). The test can randomly generate group by aggregation queries with zero limits - https://github.com/apache/pinot/blob/cf1a0f6b9b44fdb567452b63a34e76ac5c635429/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/QueryGenerator.java#L862