### PR TITLE
Handle Agg Functions with Literal Args When Used with a Union

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.rules.AggregateExtractProjectRule;
@@ -220,7 +221,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
       PinotLogicalExchange exchange, AggType aggType) {
     Aggregate aggRel = call.rel(0);
     RelNode input = PinotRuleUtils.unboxRel(aggRel.getInput());
-    List<RexNode> projects = (input instanceof Project) ? ((Project) input).getProjects() : null;
+    List<RexNode> projects = findImmediateProjects(input);
 
     // Create new AggregateCalls from exchange input. Exchange produces results with group keys followed by intermediate
     // aggregate results.
@@ -259,7 +260,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
 
   private static List<AggregateCall> buildAggCalls(Aggregate aggRel, AggType aggType) {
     RelNode input = PinotRuleUtils.unboxRel(aggRel.getInput());
-    List<RexNode> projects = (input instanceof Project) ? ((Project) input).getProjects() : null;
+    List<RexNode> projects = findImmediateProjects(input);
     List<AggregateCall> orgAggCalls = aggRel.getAggCallList();
     List<AggregateCall> aggCalls = new ArrayList<>(orgAggCalls.size());
     for (AggregateCall orgAggCall : orgAggCalls) {
@@ -329,5 +330,16 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
     return AggregateCall.create(sqlAggFunction, false, orgAggCall.isApproximate(), orgAggCall.ignoreNulls(), rexList,
         ImmutableList.of(), aggType.isInputIntermediateFormat() ? -1 : orgAggCall.filterArg, orgAggCall.distinctKeys,
         orgAggCall.collation, numGroups, input, null, null);
+  }
+
+  @Nullable
+  private static List<RexNode> findImmediateProjects(RelNode relNode) {
+    relNode = PinotRuleUtils.unboxRel(relNode);
+    if (relNode instanceof Project) {
+      return ((Project) relNode).getProjects();
+    } else if (relNode instanceof Union) {
+      return findImmediateProjects(relNode.getInput(0));
+    }
+    return null;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -220,7 +220,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
   private static PinotLogicalAggregate convertAggFromIntermediateInput(RelOptRuleCall call,
       PinotLogicalExchange exchange, AggType aggType) {
     Aggregate aggRel = call.rel(0);
-    RelNode input = PinotRuleUtils.unboxRel(aggRel.getInput());
+    RelNode input = aggRel.getInput();
     List<RexNode> projects = findImmediateProjects(input);
 
     // Create new AggregateCalls from exchange input. Exchange produces results with group keys followed by intermediate
@@ -259,7 +259,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
   }
 
   private static List<AggregateCall> buildAggCalls(Aggregate aggRel, AggType aggType) {
-    RelNode input = PinotRuleUtils.unboxRel(aggRel.getInput());
+    RelNode input = aggRel.getInput();
     List<RexNode> projects = findImmediateProjects(input);
     List<AggregateCall> orgAggCalls = aggRel.getAggCallList();
     List<AggregateCall> aggCalls = new ArrayList<>(orgAggCalls.size());

--- a/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
@@ -133,6 +133,30 @@
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]
+      },
+      {
+        "description": "Select aggregates with literals on top of a union",
+        "sql": "EXPLAIN PLAN FOR with teamOne as (select /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ col2, percentile(col3, 50) as sum_of_runs from a group by col2), teamTwo as (select /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ col2, percentile(col3, 50) as sum_of_runs from a group by col2), all as (select col2, sum_of_runs from teamOne union all select col2, sum_of_runs from teamTwo) select /*+ aggOption(is_skip_leaf_stage_group_by='true') */ col2, percentile(sum_of_runs, 50) from all group by col2",
+        "output": [
+          "Execution Plan",
+          "\nPinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)])",
+          "\n  PinotLogicalExchange(distribution=[hash[0]])",
+          "\n    PinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)])",
+          "\n      LogicalUnion(all=[true])",
+          "\n        PinotLogicalExchange(distribution=[hash[0, 1, 2]])",
+          "\n          LogicalProject(col2=[$0], sum_of_runs=[$1], $f2=[50])",
+          "\n            PinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)])",
+          "\n              PinotLogicalExchange(distribution=[hash[0]])",
+          "\n                LogicalProject(col2=[$1], col3=[$2], $f2=[50])",
+          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalExchange(distribution=[hash[0, 1, 2]])",
+          "\n          LogicalProject(col2=[$0], sum_of_runs=[$1], $f2=[50])",
+          "\n            PinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)])",
+          "\n              PinotLogicalExchange(distribution=[hash[0]])",
+          "\n                LogicalProject(col2=[$1], col3=[$2], $f2=[50])",
+          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Attempts to fix #13305.

This is definitely not the most scientific fix (it's more like an empirical approach).

The issue was that aggregate node may not necessarily be on top of a project node. In our case, it was on top of a Union node, so this PR extends the aggregate exchange rule to handle that.

**Test Plan**

This query was failing before with the error below, but it works now:

```
SET useMultistageEngine=true;

with
  teamOne as (
  	select playerName, teamID, percentile(runs, 50) as sum_of_runs from baseballStats where teamID = 'SFN' group by playerName, teamID
  ),
  teamTwo as (
	select playerName, teamID, percentile(runs, 50) as sum_of_runs from baseballStats where teamID = 'CHN' group by playerName, teamID
  ),
  all as (
	select playerName, teamID, sum_of_runs from teamOne union all select playerName, teamID, sum_of_runs from teamTwo
  )
  select 
    /*+ aggOptions(is_skip_leaf_stage_group_by='true') */
    teamID, 
	-- sum(sum_of_runs) 
	percentile(sum_of_runs, 50) 
  from all
  group by teamID
```

Error:

```
Caused by: org.apache.pinot.spi.exception.BadQueryRequestException: Invalid aggregation function: percentile($1,$2); Reason: null
	at org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory.getAggregationFunction(AggregationFunctionFactory.java:487)
	at org.apache.pinot.query.runtime.operator.AggregateOperator.getAggFunction(AggregateOperator.java:224)
	at org.apache.pinot.query.runtime.operator.AggregateOperator.getAggFunctions(AggregateOperator.java:199)
	at org.apache.pinot.query.runtime.operator.AggregateOperator.<init>(AggregateOperator.java:79)
org.apache.pinot.query.service.dispatch.QueryDispatcher.submit(QueryDispatcher.java:198)
org.apache.pinot.query.service.dispatch.QueryDispatcher.submitAndReduce(QueryDispatcher.java:95)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:217)
org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:133)
```