### PR TITLE
Fix v1 query engine behavior for aggregations without group by where the limit is zero

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -68,7 +68,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
 
   @Override
   public int getNumRows() {
-    return 1;
+    return _queryContext.getLimit() == 0 ? 0 : 1;
   }
 
   @Override
@@ -108,6 +108,12 @@ public class AggregationResultsBlock extends BaseResultsBlock {
     ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
     int numColumns = columnDataTypes.length;
     DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(dataSchema);
+
+    // For LIMIT 0 queries
+    if (_results.isEmpty()) {
+      return dataTableBuilder.build();
+    }
+
     boolean returnFinalResult = _queryContext.isServerReturnFinalResult();
     if (_queryContext.isNullHandlingEnabled()) {
       RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/AggregationResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/AggregationResultsBlockMerger.java
@@ -37,6 +37,11 @@ public class AggregationResultsBlockMerger implements ResultsBlockMerger<Aggrega
     List<Object> resultsToMerge = blockToMerge.getResults();
     assert aggregationFunctions != null && mergedResults != null && resultsToMerge != null;
 
+    // Skip merging empty results (LIMIT 0 queries)
+    if (mergedBlock.getNumRows() == 0 && blockToMerge.getNumRows() == 0) {
+      return;
+    }
+
     int numAggregationFunctions = aggregationFunctions.length;
     for (int i = 0; i < numAggregationFunctions; i++) {
       mergedResults.set(i, aggregationFunctions[i].merge(mergedResults.get(i), resultsToMerge.get(i)));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptyAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptyAggregationOperator.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+/**
+ * The <code>EmptyAggregationOperator</code> provides a way to short circuit aggregation only queries (no group by)
+ * with a LIMIT of zero.
+ */
+public class EmptyAggregationOperator extends BaseOperator<AggregationResultsBlock> {
+
+  private static final String EXPLAIN_NAME = "AGGREGATE_EMPTY";
+  private final QueryContext _queryContext;
+  private final ExecutionStatistics _executionStatistics;
+
+  public EmptyAggregationOperator(QueryContext queryContext, int numTotalDocs) {
+    _queryContext = queryContext;
+    _executionStatistics = new ExecutionStatistics(0, 0, 0, numTotalDocs);
+  }
+
+  @Override
+  protected AggregationResultsBlock getNextBlock() {
+    return new AggregationResultsBlock(_queryContext.getAggregationFunctions(), Collections.emptyList(), _queryContext);
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    return _executionStatistics;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -25,6 +25,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.operator.query.EmptyAggregationOperator;
 import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.FilteredAggregationOperator;
 import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
@@ -69,6 +70,11 @@ public class AggregationPlanNode implements PlanNode {
   @Override
   public Operator<AggregationResultsBlock> run() {
     assert _queryContext.getAggregationFunctions() != null;
+
+    if (_queryContext.getLimit() == 0) {
+      return new EmptyAggregationOperator(_queryContext, _indexSegment.getSegmentMetadata().getTotalDocs());
+    }
+
     return _queryContext.hasFilteredAggregations() ? buildFilteredAggOperator() : buildNonFilteredAggOperator();
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3476,7 +3476,34 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testGroupByAggregationWithLimitZero(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    testQuery("SELECT Origin, SUM(ArrDelay) FROM mytable GROUP BY Origin LIMIT 0");
+
+    String sqlQuery = "SELECT Origin, SUM(ArrDelay) FROM mytable GROUP BY Origin LIMIT 0";
+    JsonNode response = postQuery(sqlQuery);
+    assertTrue(response.get("exceptions").isEmpty());
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), 0);
+
+    // Ensure data schema returned is accurate even if there are no rows returned
+    JsonNode columnDataTypes = response.get("resultTable").get("dataSchema").get("columnDataTypes");
+    assertEquals(columnDataTypes.size(), 2);
+    assertEquals(columnDataTypes.get(1).asText(), "DOUBLE");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testAggregationWithLimitZero(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    String sqlQuery = "SELECT AVG(ArrDelay) FROM mytable LIMIT 0";
+    JsonNode response = postQuery(sqlQuery);
+    assertTrue(response.get("exceptions").isEmpty());
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), 0);
+
+    // Ensure data schema returned is accurate even if there are no rows returned
+    JsonNode columnDataTypes = response.get("resultTable").get("dataSchema").get("columnDataTypes");
+    assertEquals(columnDataTypes.size(), 1);
+    assertEquals(columnDataTypes.get(0).asText(), "DOUBLE");
   }
 
   private String buildSkipIndexesOption(String columnsAndIndexes) {


### PR DESCRIPTION
- Aggregation queries without `GROUP BY` clauses typically aren't used with a `LIMIT` clause since it semantically doesn't make sense.
- However, it isn't considered invalid, and most databases (including Postgres and MySQL) return the same aggregation results (i.e., over the entire table) regardless of what the `LIMIT` is - except if the `LIMIT` is 0, in which case an empty result set is returned.
- The v1 query engine in Pinot follows the former but not the latter - i.e., it returns the same aggregation results (i.e., over the entire table) regardless of what the `LIMIT` is (even if it is 0).
- This patch standardizes the Pinot behavior in this case by introducing an `EmptyAggregationOperator` (somewhat similar to the [EmptySelectionOperator](https://github.com/apache/pinot/blob/efa43007adc1dd7736580d882f33956e359b0678/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java#L39)):

```
> EXPLAIN PLAN FOR SELECT SUM(ArrDelay) FROM airlineStats LIMIT 0;

PLAN_START(numSegmentsForThisPlan:31)
BROKER_REDUCE(limit:0)
COMBINE_AGGREGATE
AGGREGATE_EMPTY
```

```
> SELECT SUM(ArrDelay) FROM airlineStats LIMIT 0;

{"resultTable":{"dataSchema":{"columnNames":["sum(ArrDelay)"],"columnDataTypes":["DOUBLE"]},"rows":[]},"numRowsResultSet":0,"partialResult":false,"exceptions":[],"numGroupsLimitReached":false,"timeUsedMs":3,"requestId":"11345490000000018","brokerId":"Broker_192.168.29.25_8000","numDocsScanned":0,"totalDocs":9746,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":0,"numServersQueried":1,"numServersResponded":1,"numSegmentsQueried":31,"numSegmentsProcessed":31,"numSegmentsMatched":0,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"brokerReduceTimeMs":0,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0,"traceInfo":{}}
```

- This patch fixes one of the cases described in https://github.com/apache/pinot/issues/13563.
- Note that this isn't an issue in the v2 multi-stage query engine because the Calcite planner is smart enough to prune sections of query plans that are known to never produce any rows.
```
> SET useMultiStageEngine = true; EXPLAIN PLAN FOR SELECT SUM(ArrDelay) FROM airlineStats LIMIT 0;

Execution Plan
LogicalValues(tuples=[[]])
```
- The existing test `testGroupByAggregationWithLimitZero` recently added in https://github.com/apache/pinot/pull/13555 is updated because the integration test actually doesn't do any comparison for aggregation group by queries without an order by clause (also in this case we just want to verify that 0 rows are returned and that the data schema is still returned)   - https://github.com/apache/pinot/blob/efa43007adc1dd7736580d882f33956e359b0678/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java#L812-L817