### PR TITLE
Enable null handling by default for leaf stages in the multi-stage query engine

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -812,6 +812,34 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asInt(), 15482);
   }
 
+  @Test
+  public void testAggregationDefaultValueNull() throws Exception {
+    String sqlQuery = "SELECT MIN(AirTime), MAX(AirTime), SUM(AirTime), AVG(AirTime) "
+        + "FROM mytable WHERE DestCityName = 'INVALID'";
+    JsonNode jsonNode = postQuery(sqlQuery);
+    assertNoError(jsonNode);
+    assertEquals(jsonNode.get("resultTable").get("rows").size(), 1);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).size(), 4);
+
+    for (int i = 0; i < 4; i++) {
+      assertTrue(jsonNode.get("resultTable").get("rows").get(0).get(i).isNull());
+    }
+  }
+
+  @Test
+  public void testAggregationDefaultValueNullHandlingDisabled() throws Exception {
+    // Ensure that null handling can be overridden to false if desired
+    String sqlQuery = "SET enableNullHandling=false; SELECT MIN(AirTime), MAX(AirTime)"
+        + "FROM mytable WHERE DestCityName = 'INVALID'";
+    JsonNode jsonNode = postQuery(sqlQuery);
+    assertNoError(jsonNode);
+    assertEquals(jsonNode.get("resultTable").get("rows").size(), 1);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).size(), 2);
+
+    assertFalse(jsonNode.get("resultTable").get("rows").get(0).get(0).isNull());
+    assertFalse(jsonNode.get("resultTable").get("rows").get(0).get(1).isNull());
+  }
+
   @Override
   protected String getTableName() {
     return _tableName;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -216,6 +216,12 @@ public class ServerPlanRequestUtils {
     Map<String, String> queryOptions = new HashMap<>(executionContext.getOpChainMetadata());
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
+
+    // Null handling is enabled by default only for the multi-stage query engine
+    queryOptions.putIfAbsent(
+        CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING,
+        Boolean.toString(true)
+    );
     pinotQuery.setQueryOptions(queryOptions);
   }
 


### PR DESCRIPTION
- Without null handling enabled in the leaf stages, we get results that don't adhere to the SQL standard for various aggregations. For instance, the `MAX` aggregate function uses `Double.NEGATIVE_INFINITY` as its default value when null handling is not enabled. The SQL standard states that if no row qualifies, the result of any aggregate function (other than `COUNT`) is the `null` value.
- With null handling enabled, the various aggregation operators do return `null` if no doc is matched. This is due to the use of an object based aggregation result holder rather than a primitive based one, for instance here - https://github.com/apache/pinot/blob/efa43007adc1dd7736580d882f33956e359b0678/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java#L57-L60
- This patch enables null handling by default for leaf stages in the multi-stage query engine. Note that users can still explicitly override this to disable null handling if desired.