### PR TITLE
add support to differentiate null and emptyLists for multi-value columns in avro decoder

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -48,6 +48,7 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
     AvroRecordExtractorConfig config = (AvroRecordExtractorConfig) recordExtractorConfig;
     if (config != null) {
       _applyLogicalTypes = config.isEnableLogicalTypes();
+      _differentiateNullAndEmptyForMV = config.isDifferentiateNullAndEmptyForMV();
     }
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
@@ -27,17 +27,27 @@ import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
  */
 public class AvroRecordExtractorConfig implements RecordExtractorConfig {
   private boolean _enableLogicalTypes = false;
+  private boolean _differentiateNullAndEmptyForMV = false;
 
   @Override
   public void init(Map<String, String> props) {
     _enableLogicalTypes = Boolean.parseBoolean(props.get("enableLogicalTypes"));
+    _differentiateNullAndEmptyForMV = Boolean.parseBoolean(props.get("differentiateNullAndEmptyForMV"));
   }
 
   public boolean isEnableLogicalTypes() {
     return _enableLogicalTypes;
   }
 
+  public boolean isDifferentiateNullAndEmptyForMV() {
+    return _differentiateNullAndEmptyForMV;
+  }
+
   public void setEnableLogicalTypes(boolean enableLogicalTypes) {
     _enableLogicalTypes = enableLogicalTypes;
+  }
+
+  public void setDifferentiateNullAndEmptyForMV(boolean differentiateNullAndEmptyForMV) {
+    _differentiateNullAndEmptyForMV = differentiateNullAndEmptyForMV;
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
@@ -39,12 +39,12 @@ public class AvroRecordExtractorConfig implements RecordExtractorConfig {
     return _enableLogicalTypes;
   }
 
-  public boolean isDifferentiateNullAndEmptyForMV() {
-    return _differentiateNullAndEmptyForMV;
-  }
-
   public void setEnableLogicalTypes(boolean enableLogicalTypes) {
     _enableLogicalTypes = enableLogicalTypes;
+  }
+
+  public boolean isDifferentiateNullAndEmptyForMV() {
+    return _differentiateNullAndEmptyForMV;
   }
 
   public void setDifferentiateNullAndEmptyForMV(boolean differentiateNullAndEmptyForMV) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -108,10 +108,8 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
   @Nullable
   protected Object convertMultiValue(Object value) {
     Collection collection = (Collection) value;
-    if (_differentiateNullAndEmptyForMV && collection.isEmpty()) {
-      return new Object[0];
-    } else if (collection.isEmpty()) {
-      return null;
+    if (collection.isEmpty()) {
+      return _differentiateNullAndEmptyForMV ? new Object[0] : null;
     }
 
     int numValues = collection.size();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
  */
 public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
 
+  protected boolean _differentiateNullAndEmptyForMV = false;
+
   /**
    * Converts the field value to either a single value (string, number, byte[]), multi value (Object[]) or a Map.
    * Returns {@code null} if the value is an empty array/collection/map.
@@ -106,7 +108,9 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
   @Nullable
   protected Object convertMultiValue(Object value) {
     Collection collection = (Collection) value;
-    if (collection.isEmpty()) {
+    if (_differentiateNullAndEmptyForMV && collection.isEmpty()) {
+      return new Object[0];
+    } else if (collection.isEmpty()) {
       return null;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordExtractorConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordExtractorConfig.java
@@ -25,5 +25,6 @@ import java.util.Map;
  * Interface for configs of {@link RecordExtractor}
  */
 public interface RecordExtractorConfig {
-  default void init(Map<String, String> props) { }
+  default void init(Map<String, String> props) {
+  }
 }


### PR DESCRIPTION
`bugfix`
`release-notes`

Context:

Customer reached to out to differentiate the multi-value column values: "null value" and "empty list".
Currently both of "null value" and "empty list" are recognized as null and populated with the default null value of the empty list. For example, 

```
{
            "type": [
                "null",
                {
                    "items": "string",
                    "type": "array"
                }
            ],
            "name": "multiple_ids",
            "default": null,
            "doc": "multi-value testing field"
        }, 
```
the decoder it treats null & empty -> ["null"]

In this PR, we introduced a config called "differentiateNullAndEmptyForMV" in `AvroRecordExtractorConfig` to differentiate these two values.
 