### PR TITLE
add feature flag for recent TextIndex optimizations

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -113,9 +113,6 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
     _textColumn = column;
     _commitOnClose = commit;
 
-    // to reuse the mutable index, it must be (1) not the realtime index, i.e. commit is set to false
-    // and (2) happens during realtime segment conversion
-    _reuseMutableIndex = commit && realtimeConversion;
     String luceneAnalyzerClass = config.getLuceneAnalyzerClass();
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
@@ -135,22 +132,25 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
       indexWriterConfig.setCommitOnClose(commit);
       indexWriterConfig.setUseCompoundFile(config.isLuceneUseCompoundFile());
 
-      // For the realtime segment, prevent background merging. The realtime segment will call .commit()
-      // on the IndexWriter when segment conversion occurs. By default, Lucene will sometimes choose to
-      // merge segments in the background, which is problematic because the lucene index directory's
-      // contents is copied to create the immutable segment. If a background merge occurs during this
-      // copy, a FileNotFoundException will be triggered and segment build will fail.
-      //
-      // Also, for the realtime segment, we set the OpenMode to CREATE to ensure that any existing artifacts
-      // will be overwritten. This is necessary because the realtime segment can be created multiple times
-      // during a server crash and restart scenario. If the existing artifacts are appended to, the realtime
-      // query results will be accurate, but after segment conversion the mapping file generated will be loaded
-      // for only the first numDocs lucene docIds, which can cause IndexOutOfBounds errors.
-      if (!_commitOnClose) {
+      if (!_commitOnClose && config.isReuseMutableIndex()) {
+        // For the realtime segment, to reuse mutable index, we should set the two write configs below.
+        // The realtime segment will call .commit() on the IndexWriter when segment conversion occurs.
+        // By default, Lucene will sometimes choose to merge segments in the background, which is problematic because
+        // the lucene index directory's contents is copied to create the immutable segment. If a background merge
+        // occurs during this copy, a FileNotFoundException will be triggered and segment build will fail.
+        //
+        // Also, for the realtime segment, we set the OpenMode to CREATE to ensure that any existing artifacts
+        // will be overwritten. This is necessary because the realtime segment can be created multiple times
+        // during a server crash and restart scenario. If the existing artifacts are appended to, the realtime
+        // query results will be accurate, but after segment conversion the mapping file generated will be loaded
+        // for only the first numDocs lucene docIds, which can cause IndexOutOfBounds errors.
         indexWriterConfig.setMergeScheduler(NoMergeScheduler.INSTANCE);
         indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
       }
 
+      // to reuse the mutable index, it must be (1) not the realtime index, i.e. commit is set to true
+      // and (2) happens during realtime segment conversion
+      _reuseMutableIndex = config.isReuseMutableIndex() && commit && realtimeConversion;
       if (_reuseMutableIndex) {
         LOGGER.info("Reusing the realtime lucene index for segment {} and column {}", segmentIndexDir, column);
         indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
@@ -158,15 +158,15 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
         return;
       }
 
-      if (_commitOnClose) {
-        _indexDirectory = FSDirectory.open(_indexFile.toPath());
-      } else {
+      if (!_commitOnClose && config.isEnableNRTCachingDirectory()) {
         // For realtime index, use NRTCachingDirectory to reduce the number of open files. This buffers the
         // flushes triggered by the near real-time refresh and writes them to disk when the buffer is full,
         // reducing the number of small writes.
         _indexDirectory =
             new NRTCachingDirectory(FSDirectory.open(_indexFile.toPath()), config.getLuceneMaxBufferSizeMB(),
                 config.getLuceneMaxBufferSizeMB());
+      } else {
+        _indexDirectory = FSDirectory.open(_indexFile.toPath());
       }
       _indexWriter = new IndexWriter(_indexDirectory, indexWriterConfig);
     } catch (ReflectiveOperationException e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -162,8 +162,11 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
         // For realtime index, use NRTCachingDirectory to reduce the number of open files. This buffers the
         // flushes triggered by the near real-time refresh and writes them to disk when the buffer is full,
         // reducing the number of small writes.
-        _indexDirectory = new NRTCachingDirectory(FSDirectory.open(_indexFile.toPath()),
-            config.getLuceneNRTCachingDirectoryMaxBufferSizeMB(), config.getLuceneNRTCachingDirectoryMaxBufferSizeMB());
+        int bufSize = config.getLuceneNRTCachingDirectoryMaxBufferSizeMB();
+        LOGGER.info(
+            "Using NRTCachingDirectory for realtime lucene index for segment {} and column {} with buffer size: {}MB",
+            segmentIndexDir, column, bufSize);
+        _indexDirectory = new NRTCachingDirectory(FSDirectory.open(_indexFile.toPath()), bufSize, bufSize);
       } else {
         _indexDirectory = FSDirectory.open(_indexFile.toPath());
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -158,13 +158,12 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
         return;
       }
 
-      if (!_commitOnClose && config.isEnableNRTCachingDirectory()) {
+      if (!_commitOnClose && config.getLuceneNRTCachingDirectoryMaxBufferSizeMB() > 0) {
         // For realtime index, use NRTCachingDirectory to reduce the number of open files. This buffers the
         // flushes triggered by the near real-time refresh and writes them to disk when the buffer is full,
         // reducing the number of small writes.
-        _indexDirectory =
-            new NRTCachingDirectory(FSDirectory.open(_indexFile.toPath()), config.getLuceneMaxBufferSizeMB(),
-                config.getLuceneMaxBufferSizeMB());
+        _indexDirectory = new NRTCachingDirectory(FSDirectory.open(_indexFile.toPath()),
+            config.getLuceneNRTCachingDirectoryMaxBufferSizeMB(), config.getLuceneNRTCachingDirectoryMaxBufferSizeMB());
       } else {
         _indexDirectory = FSDirectory.open(_indexFile.toPath());
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -477,7 +477,7 @@ public class RealtimeSegmentConverterTest {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     TextIndexConfig textIndexConfig =
         new TextIndexConfig(false, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-            500, null, false);
+            500, null, false, true, true);
 
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
         new RealtimeSegmentConfig.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -448,16 +448,18 @@ public class RealtimeSegmentConverterTest {
   public static Object[][] reuseParams() {
     List<Boolean> enabledColumnMajorSegmentBuildParams = Arrays.asList(false, true);
     String[] sortedColumnParams = new String[]{null, STRING_COLUMN1};
+    List<Boolean> reuseMutableIndex = Arrays.asList(true, false);
+    List<Boolean> enableNRTCachingDirectory = Arrays.asList(true, false);
 
-    return enabledColumnMajorSegmentBuildParams.stream().flatMap(
-            columnMajor -> Arrays.stream(sortedColumnParams).map(sortedColumn -> new Object[]{columnMajor,
-                sortedColumn}))
-        .toArray(Object[][]::new);
+    return enabledColumnMajorSegmentBuildParams.stream().flatMap(columnMajor -> Arrays.stream(sortedColumnParams)
+        .flatMap(sortedColumn -> reuseMutableIndex.stream().flatMap(reuse -> enableNRTCachingDirectory.stream()
+            .map(cache -> new Object[]{columnMajor, sortedColumn, reuse, cache})))).toArray(Object[][]::new);
   }
 
   // Test the realtime segment conversion of a table with an index that reuses mutable index artifacts during conversion
   @Test(dataProvider = "reuseParams")
-  public void testSegmentBuilderWithReuse(boolean columnMajorSegmentBuilder, String sortedColumn)
+  public void testSegmentBuilderWithReuse(boolean columnMajorSegmentBuilder, String sortedColumn,
+      boolean reuseMutableIndex, boolean enableNRTCachingDirectory)
       throws Exception {
     File tmpDir = new File(TMP_DIR, "tmp_" + System.currentTimeMillis());
     FieldConfig textIndexFieldConfig =
@@ -477,7 +479,7 @@ public class RealtimeSegmentConverterTest {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     TextIndexConfig textIndexConfig =
         new TextIndexConfig(false, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-            500, null, false, true, true);
+            500, null, false, reuseMutableIndex, enableNRTCachingDirectory);
 
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
         new RealtimeSegmentConfig.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -447,19 +447,21 @@ public class RealtimeSegmentConverterTest {
   @DataProvider
   public static Object[][] reuseParams() {
     List<Boolean> enabledColumnMajorSegmentBuildParams = Arrays.asList(false, true);
-    String[] sortedColumnParams = new String[]{null, STRING_COLUMN1};
+    List<String> sortedColumnParams = Arrays.asList(null, STRING_COLUMN1);
     List<Boolean> reuseMutableIndex = Arrays.asList(true, false);
-    List<Boolean> enableNRTCachingDirectory = Arrays.asList(true, false);
+    List<Integer> luceneNRTCachingDirectoryMaxBufferSizeMB = Arrays.asList(0, 5);
 
-    return enabledColumnMajorSegmentBuildParams.stream().flatMap(columnMajor -> Arrays.stream(sortedColumnParams)
-        .flatMap(sortedColumn -> reuseMutableIndex.stream().flatMap(reuse -> enableNRTCachingDirectory.stream()
-            .map(cache -> new Object[]{columnMajor, sortedColumn, reuse, cache})))).toArray(Object[][]::new);
+    return enabledColumnMajorSegmentBuildParams.stream().flatMap(columnMajor -> sortedColumnParams.stream().flatMap(
+            sortedColumn -> reuseMutableIndex.stream().flatMap(
+                reuseIndex -> luceneNRTCachingDirectoryMaxBufferSizeMB.stream()
+                    .map(cacheSize -> new Object[]{columnMajor, sortedColumn, reuseIndex, cacheSize}))))
+        .toArray(Object[][]::new);
   }
 
   // Test the realtime segment conversion of a table with an index that reuses mutable index artifacts during conversion
   @Test(dataProvider = "reuseParams")
   public void testSegmentBuilderWithReuse(boolean columnMajorSegmentBuilder, String sortedColumn,
-      boolean reuseMutableIndex, boolean enableNRTCachingDirectory)
+      boolean reuseMutableIndex, int luceneNRTCachingDirectoryMaxBufferSizeMB)
       throws Exception {
     File tmpDir = new File(TMP_DIR, "tmp_" + System.currentTimeMillis());
     FieldConfig textIndexFieldConfig =
@@ -479,7 +481,7 @@ public class RealtimeSegmentConverterTest {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     TextIndexConfig textIndexConfig =
         new TextIndexConfig(false, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-            500, null, false, reuseMutableIndex, enableNRTCachingDirectory);
+            500, null, false, reuseMutableIndex, luceneNRTCachingDirectoryMaxBufferSizeMB);
 
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
         new RealtimeSegmentConfig.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -65,7 +65,7 @@ public class LuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "table__0__1__20240602T0014Z", config);
     String[][] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -65,7 +65,7 @@ public class LuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "table__0__1__20240602T0014Z", config);
     String[][] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -75,7 +75,7 @@ public class NativeAndLuceneMutableTextIndexTest {
       throws Exception {
     ServerMetrics.register(mock(ServerMetrics.class));
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "table__0__1__20240602T0014Z", config);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -75,7 +75,7 @@ public class NativeAndLuceneMutableTextIndexTest {
       throws Exception {
     ServerMetrics.register(mock(ServerMetrics.class));
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "table__0__1__20240602T0014Z", config);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -202,7 +202,7 @@ public class FilePerIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);
@@ -266,7 +266,7 @@ public class FilePerIndexDirectoryTest {
   public void testGetColumnIndices()
       throws IOException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
@@ -293,17 +293,15 @@ public class FilePerIndexDirectoryTest {
     }
 
     // Need segmentMetadata to tell the full set of columns in this segment.
-    when(_segmentMetadata.getAllColumns())
-        .thenReturn(new TreeSet<>(Arrays.asList("col1", "col2", "col3", "col4", "col5", "foo", "bar")));
+    when(_segmentMetadata.getAllColumns()).thenReturn(
+        new TreeSet<>(Arrays.asList("col1", "col2", "col3", "col4", "col5", "foo", "bar")));
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap)) {
-      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.forward()),
-          new HashSet<>(Arrays.asList("col1", "col3")));
+      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.forward()), new HashSet<>(Arrays.asList("col1", "col3")));
       assertEquals(fpi.getColumnsWithIndex(StandardIndexes.dictionary()),
           new HashSet<>(Collections.singletonList("col2")));
       assertEquals(fpi.getColumnsWithIndex(StandardIndexes.inverted()),
           new HashSet<>(Collections.singletonList("col4")));
-      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.h3()),
-          new HashSet<>(Collections.singletonList("col5")));
+      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.h3()), new HashSet<>(Collections.singletonList("col5")));
       assertEquals(fpi.getColumnsWithIndex(StandardIndexes.text()), new HashSet<>(Arrays.asList("foo", "bar")));
 
       fpi.removeIndex("col1", StandardIndexes.forward());
@@ -318,8 +316,7 @@ public class FilePerIndexDirectoryTest {
       assertEquals(fpi.getColumnsWithIndex(StandardIndexes.inverted()),
           new HashSet<>(Collections.singletonList("col4")));
       assertEquals(fpi.getColumnsWithIndex(StandardIndexes.h3()), new HashSet<>(Collections.emptySet()));
-      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.text()),
-          new HashSet<>(Collections.singletonList("bar")));
+      assertEquals(fpi.getColumnsWithIndex(StandardIndexes.text()), new HashSet<>(Collections.singletonList("bar")));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -202,7 +202,7 @@ public class FilePerIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);
@@ -266,7 +266,7 @@ public class FilePerIndexDirectoryTest {
   public void testGetColumnIndices()
       throws IOException {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -235,7 +235,7 @@ public class SingleFileIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException, ConfigurationException {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);
@@ -343,7 +343,7 @@ public class SingleFileIndexDirectoryTest {
   public void testGetColumnIndices()
       throws Exception {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, 0);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -235,7 +235,7 @@ public class SingleFileIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException, ConfigurationException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);
@@ -343,7 +343,7 @@ public class SingleFileIndexDirectoryTest {
   public void testGetColumnIndices()
       throws Exception {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false, false, false);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, false, null, null,
             config);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -35,10 +35,12 @@ import org.apache.pinot.spi.config.table.IndexConfig;
 public class TextIndexConfig extends IndexConfig {
   private static final int LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB = 500;
   private static final boolean LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE = true;
+  private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
+  private static final boolean LUCENE_INDEX_REUSE_MUTABLE_INDEX = false;
+  private static final boolean LUCENE_INDEX_ENABLE_NRT_CACHING_DIRECTORY = false;
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, false);
-  private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
+          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, false, false, false);
   private final FSTType _fstType;
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -50,6 +52,8 @@ public class TextIndexConfig extends IndexConfig {
   private final int _luceneMaxBufferSizeMB;
   private final String _luceneAnalyzerClass;
   private final boolean _enablePrefixSuffixMatchingInPhraseQueries;
+  private final boolean _reuseMutableIndex;
+  private final boolean _enableNRTCachingDirectory;
 
   @JsonCreator
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("fst") FSTType fstType,
@@ -61,7 +65,9 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
       @JsonProperty("luceneMaxBufferSizeMB") Integer luceneMaxBufferSizeMB,
       @JsonProperty("luceneAnalyzerClass") String luceneAnalyzerClass,
-      @JsonProperty("enablePrefixSuffixMatchingInPhraseQueries") Boolean enablePrefixSuffixMatchingInPhraseQueries) {
+      @JsonProperty("enablePrefixSuffixMatchingInPhraseQueries") Boolean enablePrefixSuffixMatchingInPhraseQueries,
+      @JsonProperty("reuseMutableIndex") Boolean reuseMutableIndex,
+      @JsonProperty("enableNRTCachingDirectory") Boolean enableNRTCachingDirectory) {
     super(disabled);
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
@@ -78,6 +84,9 @@ public class TextIndexConfig extends IndexConfig {
     _enablePrefixSuffixMatchingInPhraseQueries =
         enablePrefixSuffixMatchingInPhraseQueries == null ? LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH
             : enablePrefixSuffixMatchingInPhraseQueries;
+    _reuseMutableIndex = reuseMutableIndex == null ? LUCENE_INDEX_REUSE_MUTABLE_INDEX : reuseMutableIndex;
+    _enableNRTCachingDirectory =
+        enableNRTCachingDirectory == null ? LUCENE_INDEX_ENABLE_NRT_CACHING_DIRECTORY : enableNRTCachingDirectory;
   }
 
   public FSTType getFstType() {
@@ -141,6 +150,14 @@ public class TextIndexConfig extends IndexConfig {
     return _enablePrefixSuffixMatchingInPhraseQueries;
   }
 
+  public boolean isReuseMutableIndex() {
+    return _reuseMutableIndex;
+  }
+
+  public boolean isEnableNRTCachingDirectory() {
+    return _enableNRTCachingDirectory;
+  }
+
   public static abstract class AbstractBuilder {
     @Nullable
     protected FSTType _fstType;
@@ -154,6 +171,8 @@ public class TextIndexConfig extends IndexConfig {
     protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
     protected String _luceneAnalyzerClass = FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS;
     protected boolean _enablePrefixSuffixMatchingInPhraseQueries = false;
+    protected boolean _reuseMutableIndex = false;
+    protected boolean _enableNRTCachingDirectory = false;
 
     public AbstractBuilder(@Nullable FSTType fstType) {
       _fstType = fstType;
@@ -169,12 +188,14 @@ public class TextIndexConfig extends IndexConfig {
       _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
       _luceneAnalyzerClass = other._luceneAnalyzerClass;
       _enablePrefixSuffixMatchingInPhraseQueries = other._enablePrefixSuffixMatchingInPhraseQueries;
+      _reuseMutableIndex = other._reuseMutableIndex;
+      _enableNRTCachingDirectory = other._enableNRTCachingDirectory;
     }
 
     public TextIndexConfig build() {
       return new TextIndexConfig(false, _fstType, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
           _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerClass,
-          _enablePrefixSuffixMatchingInPhraseQueries);
+          _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex, _enableNRTCachingDirectory);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -214,6 +235,16 @@ public class TextIndexConfig extends IndexConfig {
       _enablePrefixSuffixMatchingInPhraseQueries = enablePrefixSuffixMatchingInPhraseQueries;
       return this;
     }
+
+    public AbstractBuilder withReuseMutableIndex(boolean reuseMutableIndex) {
+      _reuseMutableIndex = reuseMutableIndex;
+      return this;
+    }
+
+    public AbstractBuilder withEnableNRTCachingDirectory(boolean enableNRTCachingDirectory) {
+      _enableNRTCachingDirectory = enableNRTCachingDirectory;
+      return this;
+    }
   }
 
   @Override
@@ -229,16 +260,21 @@ public class TextIndexConfig extends IndexConfig {
     }
     TextIndexConfig that = (TextIndexConfig) o;
     return _enableQueryCache == that._enableQueryCache && _useANDForMultiTermQueries == that._useANDForMultiTermQueries
-        && _fstType == that._fstType && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
-        && Objects.equals(_stopWordsInclude, that._stopWordsInclude) && Objects.equals(_stopWordsExclude,
-        that._stopWordsExclude) && _luceneUseCompoundFile == that._luceneUseCompoundFile
-        && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB && _luceneAnalyzerClass == that._luceneAnalyzerClass;
+        && _luceneUseCompoundFile == that._luceneUseCompoundFile
+        && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB
+        && _enablePrefixSuffixMatchingInPhraseQueries == that._enablePrefixSuffixMatchingInPhraseQueries
+        && _reuseMutableIndex == that._reuseMutableIndex
+        && _enableNRTCachingDirectory == that._enableNRTCachingDirectory && _fstType == that._fstType && Objects.equals(
+        _rawValueForTextIndex, that._rawValueForTextIndex) && Objects.equals(_stopWordsInclude, that._stopWordsInclude)
+        && Objects.equals(_stopWordsExclude, that._stopWordsExclude) && Objects.equals(_luceneAnalyzerClass,
+        that._luceneAnalyzerClass);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _fstType, _rawValueForTextIndex, _enableQueryCache,
         _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile,
-        _luceneMaxBufferSizeMB, _luceneAnalyzerClass);
+        _luceneMaxBufferSizeMB, _luceneAnalyzerClass, _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex,
+        _enableNRTCachingDirectory);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -37,10 +37,10 @@ public class TextIndexConfig extends IndexConfig {
   private static final boolean LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE = true;
   private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
   private static final boolean LUCENE_INDEX_REUSE_MUTABLE_INDEX = false;
-  private static final boolean LUCENE_INDEX_ENABLE_NRT_CACHING_DIRECTORY = false;
+  private static final int LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB = 0;
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, false, false, false);
+          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, false, false, 0);
   private final FSTType _fstType;
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -53,7 +53,7 @@ public class TextIndexConfig extends IndexConfig {
   private final String _luceneAnalyzerClass;
   private final boolean _enablePrefixSuffixMatchingInPhraseQueries;
   private final boolean _reuseMutableIndex;
-  private final boolean _enableNRTCachingDirectory;
+  private final int _luceneNRTCachingDirectoryMaxBufferSizeMB;
 
   @JsonCreator
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("fst") FSTType fstType,
@@ -67,7 +67,7 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("luceneAnalyzerClass") String luceneAnalyzerClass,
       @JsonProperty("enablePrefixSuffixMatchingInPhraseQueries") Boolean enablePrefixSuffixMatchingInPhraseQueries,
       @JsonProperty("reuseMutableIndex") Boolean reuseMutableIndex,
-      @JsonProperty("enableNRTCachingDirectory") Boolean enableNRTCachingDirectory) {
+      @JsonProperty("luceneNRTCachingDirectoryMaxBufferSizeMB") Integer luceneNRTCachingDirectoryMaxBufferSizeMB) {
     super(disabled);
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
@@ -85,8 +85,9 @@ public class TextIndexConfig extends IndexConfig {
         enablePrefixSuffixMatchingInPhraseQueries == null ? LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH
             : enablePrefixSuffixMatchingInPhraseQueries;
     _reuseMutableIndex = reuseMutableIndex == null ? LUCENE_INDEX_REUSE_MUTABLE_INDEX : reuseMutableIndex;
-    _enableNRTCachingDirectory =
-        enableNRTCachingDirectory == null ? LUCENE_INDEX_ENABLE_NRT_CACHING_DIRECTORY : enableNRTCachingDirectory;
+    _luceneNRTCachingDirectoryMaxBufferSizeMB =
+        luceneNRTCachingDirectoryMaxBufferSizeMB == null ? LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB
+            : luceneNRTCachingDirectoryMaxBufferSizeMB;
   }
 
   public FSTType getFstType() {
@@ -154,8 +155,8 @@ public class TextIndexConfig extends IndexConfig {
     return _reuseMutableIndex;
   }
 
-  public boolean isEnableNRTCachingDirectory() {
-    return _enableNRTCachingDirectory;
+  public int getLuceneNRTCachingDirectoryMaxBufferSizeMB() {
+    return _luceneNRTCachingDirectoryMaxBufferSizeMB;
   }
 
   public static abstract class AbstractBuilder {
@@ -170,9 +171,10 @@ public class TextIndexConfig extends IndexConfig {
     protected boolean _luceneUseCompoundFile = LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
     protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
     protected String _luceneAnalyzerClass = FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS;
-    protected boolean _enablePrefixSuffixMatchingInPhraseQueries = false;
-    protected boolean _reuseMutableIndex = false;
-    protected boolean _enableNRTCachingDirectory = false;
+    protected boolean _enablePrefixSuffixMatchingInPhraseQueries =
+        LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH;
+    protected boolean _reuseMutableIndex = LUCENE_INDEX_REUSE_MUTABLE_INDEX;
+    protected int _luceneNRTCachingDirectoryMaxBufferSizeMB = LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB;
 
     public AbstractBuilder(@Nullable FSTType fstType) {
       _fstType = fstType;
@@ -189,13 +191,13 @@ public class TextIndexConfig extends IndexConfig {
       _luceneAnalyzerClass = other._luceneAnalyzerClass;
       _enablePrefixSuffixMatchingInPhraseQueries = other._enablePrefixSuffixMatchingInPhraseQueries;
       _reuseMutableIndex = other._reuseMutableIndex;
-      _enableNRTCachingDirectory = other._enableNRTCachingDirectory;
+      _luceneNRTCachingDirectoryMaxBufferSizeMB = other._luceneNRTCachingDirectoryMaxBufferSizeMB;
     }
 
     public TextIndexConfig build() {
       return new TextIndexConfig(false, _fstType, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
           _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerClass,
-          _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex, _enableNRTCachingDirectory);
+          _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex, _luceneNRTCachingDirectoryMaxBufferSizeMB);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -241,8 +243,8 @@ public class TextIndexConfig extends IndexConfig {
       return this;
     }
 
-    public AbstractBuilder withEnableNRTCachingDirectory(boolean enableNRTCachingDirectory) {
-      _enableNRTCachingDirectory = enableNRTCachingDirectory;
+    public AbstractBuilder withLuceneNRTCachingDirectoryMaxBufferSizeMB(int luceneNRTCachingDirectoryMaxBufferSizeMB) {
+      _luceneNRTCachingDirectoryMaxBufferSizeMB = luceneNRTCachingDirectoryMaxBufferSizeMB;
       return this;
     }
   }
@@ -264,10 +266,10 @@ public class TextIndexConfig extends IndexConfig {
         && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB
         && _enablePrefixSuffixMatchingInPhraseQueries == that._enablePrefixSuffixMatchingInPhraseQueries
         && _reuseMutableIndex == that._reuseMutableIndex
-        && _enableNRTCachingDirectory == that._enableNRTCachingDirectory && _fstType == that._fstType && Objects.equals(
-        _rawValueForTextIndex, that._rawValueForTextIndex) && Objects.equals(_stopWordsInclude, that._stopWordsInclude)
-        && Objects.equals(_stopWordsExclude, that._stopWordsExclude) && Objects.equals(_luceneAnalyzerClass,
-        that._luceneAnalyzerClass);
+        && _luceneNRTCachingDirectoryMaxBufferSizeMB == that._luceneNRTCachingDirectoryMaxBufferSizeMB
+        && _fstType == that._fstType && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
+        && Objects.equals(_stopWordsInclude, that._stopWordsInclude) && Objects.equals(_stopWordsExclude,
+        that._stopWordsExclude) && Objects.equals(_luceneAnalyzerClass, that._luceneAnalyzerClass);
   }
 
   @Override
@@ -275,6 +277,6 @@ public class TextIndexConfig extends IndexConfig {
     return Objects.hash(super.hashCode(), _fstType, _rawValueForTextIndex, _enableQueryCache,
         _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile,
         _luceneMaxBufferSizeMB, _luceneAnalyzerClass, _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex,
-        _enableNRTCachingDirectory);
+        _luceneNRTCachingDirectoryMaxBufferSizeMB);
   }
 }


### PR DESCRIPTION
Add feature flag for two optimizations for TextIndex recently: 1) reuse mutable index when converting mutable segment to immutable segment; 2) use NRT caching for mutable segment. 

The feature flags are added to TextIndex config, as listed below
- reuseMutableIndex
- luceneNRTCachingDirectoryMaxBufferSizeMB

I set them to false by default so one can enable them incrementally. As those are validated more widely and we can set them to true by default to keep them on by default. 