### PR TITLE
Upgrade hadoop version to 3.4.0

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -74,5 +74,9 @@
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
 
     <!-- Solve conflict across dependencies -->
     <kotlin.stdlib.version>1.9.24</kotlin.stdlib.version>
+    <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
     <jetbrains.annotations.version>13.0</jetbrains.annotations.version>
     <kotlin.stdlib.version>2.0.0</kotlin.stdlib.version>
     <okio.version>3.9.0</okio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <javassist.version>3.30.2-GA</javassist.version>
     <swagger.version>1.6.14</swagger.version>
     <swagger-ui.version>5.17.14</swagger-ui.version>
-    <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.version>3.4.0</hadoop.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.1</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>
@@ -233,6 +233,8 @@
     <scala.compat.version>2.12</scala.compat.version>
 
     <!-- Solve conflict across dependencies -->
+    <kotlin.stdlib.version>1.9.24</kotlin.stdlib.version>
+    <jetbrains.annotations.version>13.0</jetbrains.annotations.version>
     <kotlin.stdlib.version>2.0.0</kotlin.stdlib.version>
     <okio.version>3.9.0</okio.version>
     <kerby.version>2.0.3</kerby.version>
@@ -1489,6 +1491,11 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib-common</artifactId>
         <version>${kotlin.stdlib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrains.annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,6 @@
     <!-- Solve conflict across dependencies -->
     <kotlin.stdlib.version>1.9.24</kotlin.stdlib.version>
     <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
-    <jetbrains.annotations.version>13.0</jetbrains.annotations.version>
     <kotlin.stdlib.version>2.0.0</kotlin.stdlib.version>
     <okio.version>3.9.0</okio.version>
     <kerby.version>2.0.3</kerby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
     <scala.compat.version>2.12</scala.compat.version>
 
     <!-- Solve conflict across dependencies -->
-    <kotlin.stdlib.version>1.9.24</kotlin.stdlib.version>
     <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
     <kotlin.stdlib.version>2.0.0</kotlin.stdlib.version>
     <okio.version>3.9.0</okio.version>


### PR DESCRIPTION
**Labels**
- `dependencies`

**Description**
As per the [issue](https://github.com/apache/pinot/issues/13571), This PR upgrades the Hadoop version to 3.4.0. There was the `jetbrains.annotations` dependency convergence issue, and to fix it, we are explicitly importing the dependency in the parent pom file.
