### PR TITLE
Add Debug APIs that return Thread and Query Resource Usage

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -289,8 +289,8 @@ public class PinotBrokerDebug {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get current resource usage of queries in this service", notes = "This is a debug endpoint, "
       + "and won't maintain backward compatibility")
-  public Map<String, ? extends QueryResourceTracker> getQueryUsage() {
+  public Collection<? extends QueryResourceTracker> getQueryUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
-    return threadAccountant.getQueryResources();
+    return threadAccountant.getQueryResources().values();
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -27,6 +27,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,10 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 
@@ -267,5 +271,15 @@ public class PinotBrokerDebug {
 
   private long getRequestId() {
     return _requestIdGenerator.getAndIncrement();
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/threads/resourceUsage")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
+  @ApiOperation(value = "Get resource usage of threads")
+  public Collection<? extends ThreadResourceTracker> getThreadResourceUsage() {
+    ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
+    return threadAccountant.getThreadResources();
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -287,6 +287,7 @@ public class PinotBrokerDebug {
   @GET
   @Path("debug/queries/resourceUsage")
   @Produces(MediaType.APPLICATION_JSON)
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get current resource usage of queries in this service", notes = "This is a debug endpoint, "
       + "and won't maintain backward compatibility")
   public Collection<? extends QueryResourceTracker> getQueryUsage() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -58,6 +58,7 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.config.table.TableType;
@@ -281,5 +282,15 @@ public class PinotBrokerDebug {
   public Collection<? extends ThreadResourceTracker> getThreadResourceUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
     return threadAccountant.getThreadResources();
+  }
+
+  @GET
+  @Path("debug/queries/resourceUsage")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get current resource usage of queries in this service", notes = "This is a debug endpoint, "
+      + "and won't maintain backward compatibility")
+  public Map<String, ? extends QueryResourceTracker> getQueryUsage() {
+    ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
+    return threadAccountant.getQueryResources();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
@@ -89,7 +89,7 @@ public class CPUMemThreadLevelAccountingObjects {
       return _currentThreadCPUTimeSampleMS;
     }
 
-    public long getMemoryAllocationBytes() {
+    public long getAllocatedBytes() {
       return _currentThreadMemoryAllocationSampleBytes;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.core.accounting;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -34,7 +36,7 @@ public class CPUMemThreadLevelAccountingObjects {
    * Entry to track the task execution status and usage stats of a Thread
    * (including but not limited to server worker thread, runner thread, broker jetty thread, or broker netty thread)
    */
-  public static class ThreadEntry {
+  public static class ThreadEntry implements ThreadResourceTracker {
     // current query_id, task_id of the thread; this field is accessed by the thread itself and the accountant
     AtomicReference<TaskEntry> _currentThreadTaskStatus = new AtomicReference<>();
     // current sample of thread memory usage/cputime ; this field is accessed by the thread itself and the accountant
@@ -77,9 +79,28 @@ public class CPUMemThreadLevelAccountingObjects {
      *
      * @return the current query id on the thread, {@code null} if idle
      */
+    @JsonIgnore
     @Nullable
     public TaskEntry getCurrentThreadTaskStatus() {
       return _currentThreadTaskStatus.get();
+    }
+
+    public long getCPUTimeMS() {
+      return _currentThreadCPUTimeSampleMS;
+    }
+
+    public long getMemoryAllocationBytes() {
+      return _currentThreadMemoryAllocationSampleBytes;
+    }
+
+    public String getQueryId() {
+      TaskEntry taskEntry = _currentThreadTaskStatus.get();
+      return taskEntry == null ? "" : taskEntry.getQueryId();
+    }
+
+    public int getTaskId() {
+      TaskEntry taskEntry = _currentThreadTaskStatus.get();
+      return taskEntry == null ? -1 : taskEntry.getTaskId();
     }
 
     public void setThreadTaskStatus(@Nonnull String queryId, int taskId, @Nonnull Thread anchorThread) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.accounting;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.Collection;
@@ -509,6 +510,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         return _cpuNS;
       }
 
+      @JsonIgnore
       public Thread getAnchorThread() {
         return _anchorThread;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -170,6 +170,12 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       return _threadEntriesMap.values();
     }
 
+    /**
+     * This function aggregates resource usage from all active threads and groups by queryId.
+     * It is inspired by {@link PerQueryCPUMemResourceUsageAccountant::aggregate}. The major difference is that
+     * it only reads from thread entries and does not update them.
+     * @return A map of query id, QueryResourceTracker.
+     */
     @Override
     public Map<String, ? extends QueryResourceTracker> getQueryResources() {
       HashMap<String, AggregatedStats> ret = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -493,6 +493,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         return _queryId;
       }
 
+      @Override
       public long getAllocatedBytes() {
         return _allocatedBytes;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.accounting;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.config.instance.InstanceType;
@@ -160,6 +162,11 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       _inactiveQuery = new HashSet<>();
 
       _watcherTask = new WatcherTask();
+    }
+
+    @Override
+    public Collection<? extends ThreadResourceTracker> getThreadResources() {
+      return _threadEntriesMap.values();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -34,6 +34,7 @@ public class Actions {
     public static final String CREATE_TENANT = "CreateTenant";
     public static final String CREATE_USER = "CreateUser";
     public static final String DEBUG_TASK = "DebugTask";
+    public static final String DEBUG_RESOURCE_USAGE = "DebugResourceUsage";
     public static final String DELETE_CLUSTER_CONFIG = "DeleteClusterConfig";
     public static final String DELETE_INSTANCE = "DeleteInstance";
     public static final String DELETE_TASK = "DeleteTask";

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,8 +53,11 @@ import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
@@ -120,6 +124,16 @@ public class DebugResource {
         tableDataManager.releaseSegment(segmentDataManager);
       }
     }
+  }
+
+  @GET
+  @Path("threads/resourceUsage")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get current resource usage of threads",
+      notes = "This is a debug endpoint, and won't maintain backward compatibility")
+  public Collection<? extends ThreadResourceTracker> getThreadUsage() {
+    ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
+    return threadAccountant.getThreadResources();
   }
 
   private List<SegmentServerDebugInfo> getSegmentServerDebugInfo(String tableNameWithType, TableType tableType) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -53,6 +53,7 @@ import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.config.table.TableType;
@@ -134,6 +135,17 @@ public class DebugResource {
   public Collection<? extends ThreadResourceTracker> getThreadUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
     return threadAccountant.getThreadResources();
+  }
+
+  @GET
+  @Path("queries/resourceUsage")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get current resource usage of queries in this service",
+      notes = "This is a debug endpoint, and won't maintain backward compatibility")
+  public Collection<? extends QueryResourceTracker> getQueryUsage() {
+    ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
+    Collection<? extends QueryResourceTracker> resources = threadAccountant.getQueryResources().values();
+    return resources;
   }
 
   private List<SegmentServerDebugInfo> getSegmentServerDebugInfo(String tableNameWithType, TableType tableType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/QueryResourceTracker.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/QueryResourceTracker.java
@@ -22,12 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
 @JsonSerialize
-public interface ThreadResourceTracker {
-  long getCPUTimeMS();
-
-  long getMemoryAllocationBytes();
-
+public interface QueryResourceTracker {
   String getQueryId();
-
-  int getTaskId();
+  long getAllocatedBytes();
+  long getCpuTimeNs();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/QueryResourceTracker.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/QueryResourceTracker.java
@@ -21,9 +21,26 @@ package org.apache.pinot.spi.accounting;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
+/**
+ * Tracks allocated bytes and CPU time for a query in a server or a broker.
+ */
 @JsonSerialize
 public interface QueryResourceTracker {
+  /**
+   * QueryId tracked by the implementation.
+   * @return a string containing the query id.
+   */
   String getQueryId();
+
+  /**
+   * Allocated bytes for a query in a server or broker
+   * @return A long containing the number of bytes allocated to execute the query.
+   */
   long getAllocatedBytes();
+
+  /**
+   * Total execution CPU Time(nanoseconds) of a query in a server or broker.
+   * @return A long containing the nanoseconds.
+   */
   long getCpuTimeNs();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceTracker.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceTracker.java
@@ -21,13 +21,32 @@ package org.apache.pinot.spi.accounting;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 
+/**
+ * Tracks allocated bytes and CPU time by a thread when executing a task of a query.
+ */
 @JsonSerialize
 public interface ThreadResourceTracker {
+  /**
+   * Total execution CPU Time(nanoseconds) of a thread when executing a query task in a server or broker.
+   * @return A long containing the nanoseconds.
+   */
   long getCPUTimeMS();
 
-  long getMemoryAllocationBytes();
+  /**
+   * Allocated bytes for a query task in a server or broker
+   * @return A long containing the number of bytes allocated to execute the query task.
+   */
+  long getAllocatedBytes();
 
+  /**
+   * QueryId of the task the thread is executing.
+   * @return a string containing the query id.
+   */
   String getQueryId();
 
+  /**
+   * TaskId of the task the thread is executing.
+   * @return an int containing the task id.
+   */
   int getTaskId();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceTracker.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceTracker.java
@@ -1,0 +1,15 @@
+package org.apache.pinot.spi.accounting;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+
+@JsonSerialize
+public interface ThreadResourceTracker {
+  long getCPUTimeMS();
+
+  long getMemoryAllocationBytes();
+
+  String getQueryId();
+
+  int getTaskId();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.accounting;
 
 import java.util.Collection;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 
@@ -77,4 +78,5 @@ public interface ThreadResourceUsageAccountant {
   Exception getErrorStatus();
 
   Collection<? extends ThreadResourceTracker> getThreadResources();
+  Map<String, ? extends QueryResourceTracker> getQueryResources();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -77,6 +77,15 @@ public interface ThreadResourceUsageAccountant {
    */
   Exception getErrorStatus();
 
+  /**
+   * Get all the ThreadResourceTrackers for all threads executing query tasks
+   * @return A collection of ThreadResourceTracker objects
+   */
   Collection<? extends ThreadResourceTracker> getThreadResources();
+
+  /**
+   * Get all the QueryResourceTrackers for all the queries executing in a broker or server.
+   * @return A Map of String, QueryResourceTracker for all the queries.
+   */
   Map<String, ? extends QueryResourceTracker> getQueryResources();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.accounting;
 
+import java.util.Collection;
 import javax.annotation.Nullable;
 
 
@@ -74,4 +75,6 @@ public interface ThreadResourceUsageAccountant {
    * @return empty string if N/A
    */
   Exception getErrorStatus();
+
+  Collection<? extends ThreadResourceTracker> getThreadResources();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -22,7 +22,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
@@ -233,6 +235,11 @@ public class Tracing {
     @Override
     public Collection<? extends ThreadResourceTracker> getThreadResources() {
       return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, ? extends QueryResourceTracker> getQueryResources() {
+      return Collections.emptyMap();
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -20,9 +20,12 @@ package org.apache.pinot.spi.trace;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -225,6 +228,11 @@ public class Tracing {
     @Override
     public Exception getErrorStatus() {
       return null;
+    }
+
+    @Override
+    public Collection<? extends ThreadResourceTracker> getThreadResources() {
+      return Collections.emptyList();
     }
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultiStageResourceTrackerQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultiStageResourceTrackerQuickStart.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.utils.SampleQueries;
+
+
+public class MultiStageResourceTrackerQuickStart extends SingleStageResourceTrackingQuickStart {
+  @Override
+  protected List<String> getQueries() {
+    return List.of(SampleQueries.COUNT_BASEBALL_STATS, SampleQueries.BASEBALL_STATS_SELF_JOIN,
+        SampleQueries.BASEBALL_JOIN_DIM_BASEBALL_TEAMS);
+  }
+
+  @Override
+  protected Map<String, String> getQueryOptions() {
+    return Collections.singletonMap("queryOptions",
+        CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
+  }
+
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("MULTI_STAGE_RESOURCE_TRACKING");
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "MULTI_STAGE_RESOURCE_TRACKING"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -24,12 +24,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
+import org.apache.pinot.tools.utils.SampleQueries;
 
 
 public class MultistageEngineQuickStart extends Quickstart {
@@ -61,28 +59,23 @@ public class MultistageEngineQuickStart extends Quickstart {
     printStatus(Quickstart.Color.YELLOW, "***** Multi-stage engine quickstart setup complete *****");
     Map<String, String> queryOptions = Collections.singletonMap("queryOptions",
         CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
-    String q1 = "SELECT count(*) FROM baseballStats_OFFLINE LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Total number of documents in the table");
-    printStatus(Quickstart.Color.CYAN, "Query : " + q1);
-    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q1, queryOptions)));
+    printStatus(Quickstart.Color.CYAN, "Query : " + SampleQueries.COUNT_BASEBALL_STATS);
+    printStatus(Quickstart.Color.YELLOW,
+        prettyPrintResponse(runner.runQuery(SampleQueries.COUNT_BASEBALL_STATS, queryOptions)));
     printStatus(Quickstart.Color.GREEN, "***************************************************");
 
-    String q2 = "SELECT a.playerID, a.runs, a.yearID, b.runs, b.yearID"
-        + " FROM baseballStats_OFFLINE AS a JOIN baseballStats_OFFLINE AS b ON a.playerID = b.playerID"
-        + " WHERE a.runs > 160 AND b.runs < 2 LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Correlate the same player(s) with more than 160-run some year(s) and"
         + " with less than 2-run some other year(s)");
-    printStatus(Quickstart.Color.CYAN, "Query : " + q2);
-    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q2, queryOptions)));
+    printStatus(Quickstart.Color.CYAN, "Query : " + SampleQueries.BASEBALL_STATS_SELF_JOIN);
+    printStatus(Quickstart.Color.YELLOW,
+        prettyPrintResponse(runner.runQuery(SampleQueries.BASEBALL_STATS_SELF_JOIN, queryOptions)));
     printStatus(Quickstart.Color.GREEN, "***************************************************");
 
-    String q3 = "SELECT a.playerName, a.teamID, b.teamName \n"
-        + "FROM baseballStats_OFFLINE AS a\n"
-        + "JOIN dimBaseballTeams_OFFLINE AS b\n"
-        + "ON a.teamID = b.teamID LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Baseball Stats with joined team names");
-    printStatus(Quickstart.Color.CYAN, "Query : " + q3);
-    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q3, queryOptions)));
+    printStatus(Quickstart.Color.CYAN, "Query : " + SampleQueries.BASEBALL_JOIN_DIM_BASEBALL_TEAMS);
+    printStatus(Quickstart.Color.YELLOW,
+        prettyPrintResponse(runner.runQuery(SampleQueries.BASEBALL_JOIN_DIM_BASEBALL_TEAMS, queryOptions)));
     printStatus(Quickstart.Color.GREEN, "***************************************************");
 
     String q4 =
@@ -290,23 +283,6 @@ public class MultistageEngineQuickStart extends Quickstart {
     printStatus(Quickstart.Color.GREEN, "***************************************************");
     printStatus(Quickstart.Color.YELLOW, "Example query run completed.");
     printStatus(Quickstart.Color.GREEN, "***************************************************");
-
-    ExecutorService service = Executors.newFixedThreadPool(10);
-    for (int i = 0; i < 10; i++) {
-      service.submit(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            while (true) {
-              runner.runQuery(q3, queryOptions);
-              Thread.sleep(10);
-            }
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
-    }
   }
 
   @Override
@@ -318,22 +294,6 @@ public class MultistageEngineQuickStart extends Quickstart {
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configOverrides = new HashMap<>();
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-
-    configOverrides.put(
-        CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        PerQueryCPUMemAccountantFactory.class.getCanonicalName());
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    configOverrides.put(
-        CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-            + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, false);
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
     return configOverrides;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SingleStageResourceTrackingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SingleStageResourceTrackingQuickStart.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
+import org.apache.pinot.tools.utils.SampleQueries;
+
+public class SingleStageResourceTrackingQuickStart extends Quickstart {
+  @Override
+  protected Map<String, Object> getConfigOverrides() {
+    Map<String, Object> configOverrides = new HashMap<>();
+    // Quickstart.getConfigOverrides may return an ImmutableMap.
+    configOverrides.putAll(super.getConfigOverrides());
+    configOverrides.putAll(PinotConfigUtils.getResourceTrackingConf());
+    return configOverrides;
+  }
+
+  @Override
+  public void runSampleQueries(QuickstartRunner runner)
+      throws Exception {
+    List<String> queries = getQueries();
+    Map<String, String> queryOptions = getQueryOptions();
+
+    printStatus(Color.YELLOW, "***** Running queries for eternity *****");
+    ExecutorService service = Executors.newFixedThreadPool(10);
+
+    for (int i = 0; i < 10; i++) {
+      service.submit(() -> {
+        try {
+          while (true) {
+            for (String query : queries) {
+              runner.runQuery(query, queryOptions);
+            }
+            Thread.sleep(10);
+          }
+        } catch (Exception e) {
+          printStatus(Color.CYAN, e.getMessage());
+        }
+      });
+    }
+  }
+
+  protected List<String> getQueries() {
+    return List.of(SampleQueries.COUNT_BASEBALL_STATS,
+        SampleQueries.BASEBALL_SUM_RUNS_Q1,
+        SampleQueries.BASEBALL_SUM_RUNS_Q2,
+        SampleQueries.BASEBALL_SUM_RUNS_Q3,
+        SampleQueries.BASEBALL_ORDER_BY_YEAR);
+  }
+
+  protected Map<String, String> getQueryOptions() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("SINGLE_STAGE_RESOURCE_TRACKING");
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "SINGLE_STAGE_RESOURCE_TRACKING"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -32,6 +32,7 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerConf.ControllerPeriodicTasksConf;
+import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -213,6 +214,27 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort != 0 ? minionPort : getAvailablePort());
 
     return properties;
+  }
+
+  public static Map<String, Object> getResourceTrackingConf() {
+    Map<String, Object> configOverrides = new HashMap<>();
+    configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
+    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+
+    configOverrides.put(
+        CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
+        PerQueryCPUMemAccountantFactory.class.getCanonicalName());
+    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, false);
+    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+        + CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+    return configOverrides;
   }
 
   public static int getAvailablePort() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/SampleQueries.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/SampleQueries.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.utils;
+
+public class SampleQueries {
+  private SampleQueries() {
+  }
+
+  public final static String COUNT_BASEBALL_STATS = "SELECT count(*) FROM baseballStats_OFFLINE LIMIT 10";
+  public final static String BASEBALL_STATS_SELF_JOIN = "SELECT a.playerID, a.runs, a.yearID, b.runs, b.yearID"
+      + " FROM baseballStats_OFFLINE AS a JOIN baseballStats_OFFLINE AS b ON a.playerID = b.playerID"
+      + " WHERE a.runs > 160 AND b.runs < 2 LIMIT 10";
+  public final static String BASEBALL_JOIN_DIM_BASEBALL_TEAMS =
+      "SELECT a.playerName, a.teamID, b.teamName \n" + "FROM baseballStats_OFFLINE AS a\n"
+          + "JOIN dimBaseballTeams_OFFLINE AS b\n" + "ON a.teamID = b.teamID LIMIT 10";
+  public final static String BASEBALL_SUM_RUNS_Q1 =
+      "select playerName, sum(runs) from baseballStats group by playerName order by sum(runs) desc limit 5";
+  public final static String BASEBALL_SUM_RUNS_Q2 =
+      "select playerName, sum(runs) from baseballStats where yearID=2000 group by playerName order by sum(runs) "
+          + "desc limit 5";
+  public final static String BASEBALL_SUM_RUNS_Q3 =
+      "select playerName, sum(runs) from baseballStats where yearID>=2000 group by playerName order by sum(runs) "
+          + "desc limit 10";
+  public final static String BASEBALL_ORDER_BY_YEAR =
+      "select playerName, runs, homeRuns from baseballStats order by yearID limit 10";
+}


### PR DESCRIPTION
Query cancellation in OOM conditions depends on tracking resource usage by query execution threads. Resource tracking is implemented in `PerQueryCPUMemAccountantFactory.java`. A couple of debug APIs have been added to broker and server to access the internal data structures that track resource usage. These debug APIs will help to understand the behavior of this feature in production systems. 

The following two APIs have been added in brokers and servers

### debug/queries/resourceUsage

Example response
```
[
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000095_O",
    "allocatedBytes": 3239944
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000094_O",
    "allocatedBytes": 3239944
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000093_O",
    "allocatedBytes": 3239944
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000082_O",
    "allocatedBytes": 4520488
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000092_O",
    "allocatedBytes": 2599672
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000087_O",
    "allocatedBytes": 3880216
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000088_O",
    "allocatedBytes": 2599672
  },
  {
    "cpuTimeNs": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000000096_O",
    "allocatedBytes": 1959400
  }
]
```

### /debug/threads/resourceUsage

Example o/p

```
[
  {
    "taskId": -1,
    "queryId": "174733410000001465",
    "cputimeMS": 0,
    "allocatedBytes": 0
  },
  {
    "taskId": -1,
    "queryId": "174733410000001466",
    "cputimeMS": 0,
    "allocatedBytes": 0
  },
  {
    "taskId": -1,
    "queryId": "174733410000001467",
    "cputimeMS": 0,
    "allocatedBytes": 0
  },
  {
    "taskId": -1,
    "queryId": "Broker_192.168.0.107_8000_174733410000001466_O",
    "cputimeMS": 0,
    "allocatedBytes": 0
  },
  {
    "taskId": 0,
    "queryId": "Broker_192.168.0.107_8000_174733410000001466_O",
    "cputimeMS": 0,
    "allocatedBytes": 3239680
  },
]
```
tags: observability