### PR TITLE
Do not expand large SEARCH(input, Sarg)

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -48,7 +48,7 @@ public class PinotRuleUtils {
 
   public static final SqlToRelConverter.Config PINOT_SQL_TO_REL_CONFIG =
       SqlToRelConverter.config().withHintStrategyTable(PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE)
-          .withTrimUnusedFields(true).withExpand(true).withInSubQueryThreshold(Integer.MAX_VALUE)
+          .withTrimUnusedFields(true).withExpand(true)
           .withRelBuilderFactory(PINOT_REL_FACTORY);
 
   public static RelNode unboxRel(RelNode rel) {

--- a/pinot-tools/src/main/resources/log4j2.xml
+++ b/pinot-tools/src/main/resources/log4j2.xml
@@ -68,5 +68,12 @@
       <AppenderRef ref="console"/>
     </Logger>
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
+    <!-- Change level to debug to see the full plan before and after each rule that modifies the plan is applied -->
+    <Logger name="org.apache.calcite.plan.RelOptPlanner" level="info" additivity="false">
+      <!--      Change FULL_PLAN marker from onMatch="ACCEPT" to onMatch='DENY" to not see the full plan before and
+                after each rule that modifies the plan is applied -->
+      <MarkerFilter marker="FULL_PLAN" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <AppenderRef ref="console"/>
+    </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
We have recently upgrade our Calcite dependency from 1.31 to 1.37, which impacted some queries negatively.

Specifically multi-stage queries using `IN` with a very large set are spending too much time on broker trying to optimize the query. When using close to 500 entries in the IN set my personal computer was spending close to 6 seconds just to optimize the query.

That was due to some new optimizations added in Calcite 1.32 but mainly due to the way we were using Calcite. Specifically, we were expanding all SEARCH expressions into ORs. That may have been needed in the past when PIPELINE_BREAKER was not implemented in Pinot, but right now it doesn't seem to be needed. But even if we need it sometimes, it is not acceptable to spent so much time on optimization phase.

Given it doesn't look like Calcite optimizations can be turned off, this PR changes Pinot to:
1. Use Calcite default `inSubQueryThreshold`, which is 20.
2. Modify `PinotFilterExpandSearchRule` so SEARCH expressions are not expanded when they are not range based and the number of elements is larger than 20.

We may add in the future a way to configure that threshold with some config parameter.