### PR TITLE
Support more formats in TimestampUtils

### DIFF
--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TimestampUtilsTest {
+  @Test
+  public void testToTimestamp() {
+    Assert.assertEquals(
+        TimestampUtils.toTimestamp("2024-07-12 15:32:36.111"),
+        Timestamp.valueOf("2024-07-12 15:32:36.111")
+    );
+    Assert.assertEquals(
+        TimestampUtils.toTimestamp("2024-07-12 15:32:36"),
+        Timestamp.valueOf(LocalDateTime.of(2024, 7, 12, 15, 32, 36))
+    );
+    Assert.assertEquals(
+        TimestampUtils.toTimestamp("2024-07-12 15:32"),
+        Timestamp.valueOf(LocalDateTime.of(2024, 7, 12, 15, 32))
+    );
+    Assert.assertEquals(
+        TimestampUtils.toTimestamp("2024-07-12"),
+        Timestamp.valueOf(LocalDate.of(2024, 7, 12).atStartOfDay())
+    );
+    Assert.assertEquals(TimestampUtils.toTimestamp("1720798356111"), new Timestamp(1720798356111L));
+    Assert.assertThrows(IllegalArgumentException.class, () -> TimestampUtils.toTimestamp("July 12, 2024"));
+  }
+
+  @Test
+  public void testToMillisSinceEpoch() {
+    Assert.assertEquals(
+        TimestampUtils.toMillisSinceEpoch("2024-07-12 15:32:36.111"),
+        Timestamp.valueOf("2024-07-12 15:32:36.111").getTime()
+    );
+    Assert.assertEquals(
+        TimestampUtils.toMillisSinceEpoch("2024-07-12 15:32:36"),
+        Timestamp.valueOf(LocalDateTime.of(2024, 7, 12, 15, 32, 36)).getTime()
+    );
+    Assert.assertEquals(
+        TimestampUtils.toMillisSinceEpoch("2024-07-12 15:32"),
+        Timestamp.valueOf(LocalDateTime.of(2024, 7, 12, 15, 32)).getTime()
+    );
+    Assert.assertEquals(
+        TimestampUtils.toMillisSinceEpoch("2024-07-12"),
+        Timestamp.valueOf(LocalDate.of(2024, 7, 12).atStartOfDay()).getTime()
+    );
+    Assert.assertEquals(TimestampUtils.toMillisSinceEpoch("1720798356111"), 1720798356111L);
+    Assert.assertThrows(IllegalArgumentException.class, () -> TimestampUtils.toMillisSinceEpoch("July 12, 2024"));
+  }
+}


### PR DESCRIPTION
Motivation: https://github.com/apache/pinot/issues/13610

Changes:
- Refactor existing try catch blocks in TimestampUtils
- Add 1 more try catch block after to try parsing string with java.time.* classes
  - Add after because catching exceptions can be expensive. If there is existing code making many calls to this function with e.g. format "yyyy-MM-dd HH:mm:ss.fff" then adding the new try catch beforehand can significantly slow down the code since it'll always be catching an exception
  - Use java.time.* classes as the recommended way to parse (compared to e.g. SimpleDateFormat). java.time.LocalDateTime also is supported by java.sql.Timestamp which TimestampUtils is based on
- Add TimestampUtilsTest

Tested: Saw working locally 

<img width="2555" alt="image" src="https://github.com/user-attachments/assets/14e3862d-70a2-4e7a-92f8-bd0624a6349d">

The following error is what was showing previously for `ts >= '2024-07-07'. Here is it expectedly showing for a badly formatted timestamp

<img width="2554" alt="image" src="https://github.com/user-attachments/assets/8464a197-5c70-43f4-affd-eec25e61a00e">