### PR TITLE
Fix null handling for window aggregate

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AggregationUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AggregationUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator.utils;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -170,25 +169,18 @@ public class AggregationUtils {
    */
   public static class Accumulator {
     //@formatter:off
-    public static final Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> MERGERS =
-        ImmutableMap.<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>>builder()
-            .put("SUM", cdt -> AggregationUtils::mergeSum)
-            .put("$SUM", cdt -> AggregationUtils::mergeSum)
-            .put("$SUM0", cdt -> AggregationUtils::mergeSum)
-            .put("MIN", cdt -> AggregationUtils::mergeMin)
-            .put("$MIN", cdt -> AggregationUtils::mergeMin)
-            .put("$MIN0", cdt -> AggregationUtils::mergeMin)
-            .put("MAX", cdt -> AggregationUtils::mergeMax)
-            .put("$MAX", cdt -> AggregationUtils::mergeMax)
-            .put("$MAX0", cdt -> AggregationUtils::mergeMax)
-            .put("COUNT", cdt -> new AggregationUtils.MergeCounts())
-            .put("BOOL_AND", cdt -> AggregationUtils::mergeBoolAnd)
-            .put("$BOOL_AND", cdt -> AggregationUtils::mergeBoolAnd)
-            .put("$BOOL_AND0", cdt -> AggregationUtils::mergeBoolAnd)
-            .put("BOOL_OR", cdt -> AggregationUtils::mergeBoolOr)
-            .put("$BOOL_OR", cdt -> AggregationUtils::mergeBoolOr)
-            .put("$BOOL_OR0", cdt -> AggregationUtils::mergeBoolOr)
-            .build();
+    public static final Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> MERGERS = Map.of(
+        "SUM", cdt -> AggregationUtils::mergeSum,
+        // NOTE: Keep both 'SUM0' and '$SUM0' for backward compatibility where 'SUM0' is SqlKind and '$SUM0' is function
+        //       name.
+        "SUM0", cdt -> AggregationUtils::mergeSum,
+        "$SUM0", cdt -> AggregationUtils::mergeSum,
+        "MIN", cdt -> AggregationUtils::mergeMin,
+        "MAX", cdt -> AggregationUtils::mergeMax,
+        "COUNT", cdt -> new AggregationUtils.MergeCounts(),
+        "BOOL_AND", cdt -> AggregationUtils::mergeBoolAnd,
+        "BOOL_OR", cdt -> AggregationUtils::mergeBoolOr
+    );
     //@formatter:on
 
     protected final int _inputRef;

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -309,6 +309,10 @@
         "sql": "SET enableNullHandling=true; SELECT strCol1, intCol1, nIntCol1, nnIntCol1, strCol2, nStrCol2, nnStrCol2 FROM {tbl1} WHERE nStrCol2 IS NULL AND nIntCol1 IS NOT NULL",
         "h2Sql": "SELECT strCol1, intCol1, nIntCol1, nnIntCol1, strCol2, nStrCol2, 'null' FROM {tbl1} WHERE nStrCol2 IS NULL AND nIntCol1 IS NOT NULL"
       },
+      {
+        "description": "window function with NULL handling",
+        "sql": "SET enableNullHandling=true; SELECT SUM(intCol1) OVER() FROM {tbl1}"
+      },
 
       {
         "description": "Leaf stages should not return nulls",


### PR DESCRIPTION
Fix the wrong signature registered in the `Accumulator.MERGERS`:
- Other than regular aggregate functions, only `SUM0` is required, which can be generated by Calcite aggregate reduce rule
- Keep `$SUM0` for backward compatibility in case some old version is using function name instead of SqlKind