### PR TITLE
Make ARRAY_TO_MV a not deterministic function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -107,8 +107,18 @@ public enum TransformFunctionType {
   ARRAY_TO_MV("arrayToMV",
       ReturnTypes.cascade(opBinding -> positionalComponentReturnType(opBinding, 0), SqlTypeTransforms.FORCE_NULLABLE),
       OperandTypes.family(SqlTypeFamily.ARRAY), "array_to_mv") {
+
     @Override
     public boolean isDeterministic() {
+      // ARRAY_TO_MV is not deterministic. In fact, it has no implementation
+      // We need to explicitly set it as not deterministic in order to do not let Calcite to optimize expressions like
+      // `ARRAY_TO_MV(RandomAirports) = 'MFR' and ARRAY_TO_MV(RandomAirports) = 'GTR'` as `false`.
+      // If the function were deterministic, its value would never be MFR and GTR at the same time, so Calcite is
+      // smart enough to know there is no value that satisfies the condition.
+      // In fact what ARRAY_TO_MV does is just to trick Calcite typesystem, but then what the leaf stage executor
+      // receives is `RandomAirports = 'MFR' and RandomAirports = 'GTR'`, which in the V1 semantics means:
+      // true if and only if RandomAirports contains a value equal to 'MFR' and RandomAirports contains a value equal
+      // to 'GTR'
       return false;
     }
   },

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -106,7 +106,12 @@ public enum TransformFunctionType {
   // object type
   ARRAY_TO_MV("arrayToMV",
       ReturnTypes.cascade(opBinding -> positionalComponentReturnType(opBinding, 0), SqlTypeTransforms.FORCE_NULLABLE),
-      OperandTypes.family(SqlTypeFamily.ARRAY), "array_to_mv"),
+      OperandTypes.family(SqlTypeFamily.ARRAY), "array_to_mv") {
+    @Override
+    public boolean isDeterministic() {
+      return false;
+    }
+  },
 
   // string functions
   JSON_EXTRACT_SCALAR("jsonExtractScalar",
@@ -356,6 +361,10 @@ public enum TransformFunctionType {
 
   public SqlFunctionCategory getSqlFunctionCategory() {
     return _sqlFunctionCategory;
+  }
+
+  public boolean isDeterministic() {
+    return true;
   }
 
   /** Returns the optional explicit returning type specification. */

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/PinotSqlTransformFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/PinotSqlTransformFunction.java
@@ -35,12 +35,6 @@ public class PinotSqlTransformFunction extends SqlFunction {
 
   public PinotSqlTransformFunction(String name, SqlKind kind, @Nullable SqlReturnTypeInference returnTypeInference,
       @Nullable SqlOperandTypeInference operandTypeInference, @Nullable SqlOperandTypeChecker operandTypeChecker,
-      SqlFunctionCategory category) {
-    this(name, kind, returnTypeInference, operandTypeInference, operandTypeChecker, category, false);
-  }
-
-  public PinotSqlTransformFunction(String name, SqlKind kind, @Nullable SqlReturnTypeInference returnTypeInference,
-      @Nullable SqlOperandTypeInference operandTypeInference, @Nullable SqlOperandTypeChecker operandTypeChecker,
       SqlFunctionCategory category, boolean isDeterministic) {
     super(name, kind, returnTypeInference, operandTypeInference, operandTypeChecker, category);
     _isDeterministic = isDeterministic;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/PinotSqlTransformFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/PinotSqlTransformFunction.java
@@ -31,10 +31,23 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Pinot SqlAggFunction class to register the Pinot aggregation functions with the Calcite operator table.
  */
 public class PinotSqlTransformFunction extends SqlFunction {
+  private final boolean _isDeterministic;
 
   public PinotSqlTransformFunction(String name, SqlKind kind, @Nullable SqlReturnTypeInference returnTypeInference,
       @Nullable SqlOperandTypeInference operandTypeInference, @Nullable SqlOperandTypeChecker operandTypeChecker,
       SqlFunctionCategory category) {
+    this(name, kind, returnTypeInference, operandTypeInference, operandTypeChecker, category, false);
+  }
+
+  public PinotSqlTransformFunction(String name, SqlKind kind, @Nullable SqlReturnTypeInference returnTypeInference,
+      @Nullable SqlOperandTypeInference operandTypeInference, @Nullable SqlOperandTypeChecker operandTypeChecker,
+      SqlFunctionCategory category, boolean isDeterministic) {
     super(name, kind, returnTypeInference, operandTypeInference, operandTypeChecker, category);
+    _isDeterministic = isDeterministic;
+  }
+
+  @Override
+  public boolean isDeterministic() {
+    return _isDeterministic;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -149,7 +149,7 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
       PinotSqlTransformFunction sqlTransformFunction =
           new PinotSqlTransformFunction(functionName.toUpperCase(Locale.ROOT), functionType.getSqlKind(),
               functionType.getReturnTypeInference(), null, functionType.getOperandTypeChecker(),
-              functionType.getSqlFunctionCategory());
+              functionType.getSqlFunctionCategory(), functionType.isDeterministic());
       if (notRegistered(sqlTransformFunction)) {
         register(sqlTransformFunction);
       }


### PR DESCRIPTION
Fixes #13595 by making ARRAY_TO_MV a non deterministic function.

As defined in [SqlOperator Calcite javadoc](https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/SqlOperator.html#isDeterministic()), a function is deterministic if and only if

> Returns whether a call to this operator is guaranteed to always return the same result given the same operands; true is assumed by default.

Which is not true in the case of `ARRAY_TO_MV`, whose semantic is actually not implementable in Calcite because it actually depends what is being done with the value returned.
