### PR TITLE
Add logs indicating the star-tree config diff to understand the rebuild purpose

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
@@ -127,8 +127,22 @@ public class MultipleTreesBuilder implements Closeable {
       throws Exception {
     List<StarTreeV2Metadata> starTreeMetadataList = new SegmentMetadataImpl(_indexDir).getStarTreeV2MetadataList();
     if (starTreeMetadataList == null) {
+      LOGGER.error("No existing star-tree. Building all new start-trees.");
       return null;
     }
+
+    // log the existing and incoming star-tree configs
+    StringBuilder starTreeConfigsDiff = new StringBuilder();
+    starTreeConfigsDiff.append("Existing star-tree configs :");
+    for (StarTreeV2Metadata startree : starTreeMetadataList) {
+      starTreeConfigsDiff.append("\n").append(StarTreeV2BuilderConfig.fromMetadata(startree));
+    }
+    starTreeConfigsDiff.append("\n").append("Updated star-tree configs :");
+    for (StarTreeV2BuilderConfig startree : _builderConfigs) {
+      starTreeConfigsDiff.append("\n").append(startree);
+    }
+    LOGGER.error(starTreeConfigsDiff.toString());
+
     try {
       _separatorTempDir = new File(_segmentDirectory, StarTreeV2Constants.EXISTING_STAR_TREE_TEMP_DIR);
       FileUtils.forceMkdir(_separatorTempDir);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
@@ -91,12 +91,14 @@ public class MultipleTreesBuilder implements Closeable {
         CommonsConfigurationUtils.fromFile(new File(_segmentDirectory, V1Constants.MetadataKeys.METADATA_FILE_NAME));
     _separator = getSeparator();
     // log the updated star-tree configs
-    StringBuilder logUpdatedStarTrees = new StringBuilder();
-    logUpdatedStarTrees.append("Updated star-tree configs :");
-    for (StarTreeV2BuilderConfig startree : _builderConfigs) {
-      logUpdatedStarTrees.append("\n").append(startree);
+    if (LOGGER.isDebugEnabled()) {
+      StringBuilder logUpdatedStarTrees = new StringBuilder();
+      logUpdatedStarTrees.append("Updated star-tree configs :");
+      for (StarTreeV2BuilderConfig startree : _builderConfigs) {
+        logUpdatedStarTrees.append("\n").append(startree);
+      }
+      LOGGER.debug(logUpdatedStarTrees.toString());
     }
-    LOGGER.debug(logUpdatedStarTrees.toString());
     _segment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
@@ -90,6 +90,13 @@ public class MultipleTreesBuilder implements Closeable {
     _metadataProperties =
         CommonsConfigurationUtils.fromFile(new File(_segmentDirectory, V1Constants.MetadataKeys.METADATA_FILE_NAME));
     _separator = getSeparator();
+    // log the updated star-tree configs
+    StringBuilder logUpdatedStarTrees = new StringBuilder();
+    logUpdatedStarTrees.append("Updated star-tree configs :");
+    for (StarTreeV2BuilderConfig startree : _builderConfigs) {
+      logUpdatedStarTrees.append("\n").append(startree);
+    }
+    LOGGER.debug(logUpdatedStarTrees.toString());
     _segment = ImmutableSegmentLoader.load(indexDir, ReadMode.mmap);
   }
 
@@ -127,22 +134,9 @@ public class MultipleTreesBuilder implements Closeable {
       throws Exception {
     List<StarTreeV2Metadata> starTreeMetadataList = new SegmentMetadataImpl(_indexDir).getStarTreeV2MetadataList();
     if (starTreeMetadataList == null) {
-      LOGGER.error("No existing star-tree. Building all new start-trees.");
+      LOGGER.info("No existing star-tree. Building all new start-trees.");
       return null;
     }
-
-    // log the existing and incoming star-tree configs
-    StringBuilder starTreeConfigsDiff = new StringBuilder();
-    starTreeConfigsDiff.append("Existing star-tree configs :");
-    for (StarTreeV2Metadata startree : starTreeMetadataList) {
-      starTreeConfigsDiff.append("\n").append(StarTreeV2BuilderConfig.fromMetadata(startree));
-    }
-    starTreeConfigsDiff.append("\n").append("Updated star-tree configs :");
-    for (StarTreeV2BuilderConfig startree : _builderConfigs) {
-      starTreeConfigsDiff.append("\n").append(startree);
-    }
-    LOGGER.error(starTreeConfigsDiff.toString());
-
     try {
       _separatorTempDir = new File(_segmentDirectory, StarTreeV2Constants.EXISTING_STAR_TREE_TEMP_DIR);
       FileUtils.forceMkdir(_separatorTempDir);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
@@ -61,15 +61,19 @@ public class StarTreeIndexSeparator implements Closeable {
     int numStarTrees = starTreeMetadataList.size();
     _builderConfigList = new ArrayList<>(numStarTrees);
     _numDocsList = new ArrayList<>(numStarTrees);
-    StringBuilder logExistingStarTrees = new StringBuilder();
-    logExistingStarTrees.append("Existing star-tree configs :");
     for (StarTreeV2Metadata starTreeMetadata : starTreeMetadataList) {
       StarTreeV2BuilderConfig config = StarTreeV2BuilderConfig.fromMetadata(starTreeMetadata);
       _builderConfigList.add(config);
-      logExistingStarTrees.append("\n").append(config);
       _numDocsList.add(starTreeMetadata.getNumDocs());
     }
-    LOGGER.debug(logExistingStarTrees.toString());
+    if (LOGGER.isDebugEnabled()) {
+      StringBuilder logExistingStarTrees = new StringBuilder();
+      logExistingStarTrees.append("Existing star-tree configs :");
+      for (StarTreeV2BuilderConfig config : _builderConfigList) {
+        logExistingStarTrees.append("\n").append(config);
+      }
+      LOGGER.debug(logExistingStarTrees.toString());
+    }
     _indexFileChannel = new RandomAccessFile(indexFile, "r").getChannel();
   }
 


### PR DESCRIPTION
This PR prints the `StarTreeV2BuilderConfig` for existing star-trees on the segment and the incoming star-trees from the updated table config.
This will help to understand why certain star-trees were rebuild during segment reload or server restart.