### PR TITLE
Automatically detect whether a v1 query could have run on the v2 query engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
@@ -63,10 +63,12 @@ public class GrpcBrokerRequestHandler extends BaseSingleStageBrokerRequestHandle
 
   @Override
   public void start() {
+    super.start();
   }
 
   @Override
   public void shutDown() {
+    super.shutDown();
     _streamingQueryClient.shutdown();
     _streamingReduceService.shutDown();
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -82,12 +82,14 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
 
   @Override
   public void start() {
+    super.start();
     _failureDetector.register(this);
     _failureDetector.start();
   }
 
   @Override
   public void shutDown() {
+    super.shutDown();
     _failureDetector.stop();
     _queryRouter.shutDown();
     _brokerReduceService.shutDown();

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -36,6 +36,13 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
    */
   QUERIES("queries", false),
   /**
+   * Number of single-stage queries that have been started.
+   * <p>
+   * Unlike {@link #QUERIES}, this metric is global and not attached to a particular table.
+   * That means it can be used to know how many single-stage queries have been started in total.
+   */
+  QUERIES_GLOBAL("queries", true),
+  /**
    * Number of multi-stage queries that have been started.
    * <p>
    * Unlike {@link #MULTI_STAGE_QUERIES}, this metric is global and not attached to a particular table.
@@ -49,7 +56,10 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
    * sum of this metric across all tables should be greater or equal than {@link #MULTI_STAGE_QUERIES_GLOBAL}.
    */
   MULTI_STAGE_QUERIES("queries", false),
-
+  /**
+   * Number of single-stage queries executed that would not have successfully run on the multi-stage query engine as is.
+   */
+  SINGLE_STAGE_QUERIES_INVALID_MULTI_STAGE("queries", true),
   // These metrics track the exceptions caught during query execution in broker side.
   // Query rejected by Jersey thread pool executor
   QUERY_REJECTED_EXCEPTIONS("exceptions", true),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests that verify JMX metrics emitted by various Pinot components.
+ */
+public class JmxMetricsIntegrationTest extends BaseClusterIntegrationTestSet {
+
+  private static final int NUM_BROKERS = 1;
+  private static final int NUM_SERVERS = 1;
+
+  private static final String PINOT_JMX_METRICS_DOMAIN = "\"org.apache.pinot.common.metrics\"";
+  private static final String BROKER_METRICS_TYPE = "\"BrokerMetrics\"";
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBrokers(NUM_BROKERS);
+    startServers(NUM_SERVERS);
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create and upload segments
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(getTableName(), _tarDir);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @Test
+  public void testMultiStageMigrationMetric() throws Exception {
+    ObjectName multiStageMigrationMetric = new ObjectName(PINOT_JMX_METRICS_DOMAIN,
+        new Hashtable<>(Map.of("type", BROKER_METRICS_TYPE,
+            "name", "\"pinot.broker.singleStageQueriesInvalidMultiStage\"")));
+
+    ObjectName queriesGlobalMetric = new ObjectName(PINOT_JMX_METRICS_DOMAIN,
+        new Hashtable<>(Map.of("type", BROKER_METRICS_TYPE,
+            "name", "\"pinot.broker.queriesGlobal\"")));
+
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    // Some queries are run during setup to ensure that all the docs are loaded
+    long initialQueryCount = (Long) mBeanServer.getAttribute(queriesGlobalMetric, "Count");
+    assertTrue(initialQueryCount > 0L);
+    assertEquals((Long) mBeanServer.getAttribute(multiStageMigrationMetric, "Count"), 0L);
+
+    postQuery("SELECT COUNT(*) FROM mytable");
+
+    // Run some queries that are known to not work as is with the multi-stage query engine
+
+    // Type differences
+    // STRING is VARCHAR in v2
+    JsonNode response = postQuery("SELECT CAST(ArrTime AS STRING) FROM mytable");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+    // LONG is BIGINT in v2
+    response = postQuery("SELECT CAST(ArrTime AS LONG) FROM mytable");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+    // FLOAT_ARRAY is FLOAT ARRAY in v2
+    response = postQuery("SELECT CAST(DivAirportIDs AS FLOAT_ARRAY) FROM mytable");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+
+    // MV column requires ARRAY_TO_MV wrapper to be used in filter predicates
+    response = postQuery("SELECT COUNT(*) FROM mytable WHERE DivAirports = 'JFK'");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+
+    // Unsupported function
+    response = postQuery("SELECT AirlineID, count(*) FROM mytable WHERE IN_SUBQUERY(airlineID, 'SELECT "
+        + "ID_SET(AirlineID) FROM mytable WHERE Carrier = ''AA''') = 1 GROUP BY AirlineID;");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+
+    // Repeated columns in an ORDER BY query
+    response = postQuery("SELECT AirTime, AirTime FROM mytable ORDER BY AirTime");
+    assertFalse(response.get("resultTable").get("rows").isEmpty());
+
+    assertEquals((Long) mBeanServer.getAttribute(multiStageMigrationMetric, "Count"), 6L);
+    assertEquals((Long) mBeanServer.getAttribute(queriesGlobalMetric, "Count"), initialQueryCount + 8L);
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(CommonConstants.Broker.CONFIG_OF_BROKER_ENABLE_MULTISTAGE_MIGRATION_METRIC, "true");
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
@@ -35,15 +35,11 @@ public class ParserUtils {
    */
   public static boolean canCompileWithMultiStageEngine(String query, String database, TableCache tableCache) {
     // try to parse and compile the query with the Calcite planner used by the multi-stage query engine
-    try {
-      LOGGER.info("Trying to compile query `{}` using the multi-stage query engine", query);
-      QueryEnvironment queryEnvironment = new QueryEnvironment(database, tableCache, null);
-      queryEnvironment.getTableNamesForQuery(query);
-      LOGGER.info("Successfully compiled query using the multi-stage query engine: `{}`", query);
-      return true;
-    } catch (Exception e) {
-      LOGGER.error("Encountered an error while compiling query `{}` using the multi-stage query engine", query, e);
-      return false;
-    }
+    long compileStartTime = System.currentTimeMillis();
+    LOGGER.debug("Trying to compile query `{}` using the multi-stage query engine", query);
+    QueryEnvironment queryEnvironment = new QueryEnvironment(database, tableCache, null);
+    boolean canCompile = queryEnvironment.canCompileQuery(query);
+    LOGGER.debug("Multi-stage query compilation time = {}ms", System.currentTimeMillis() - compileStartTime);
+    return canCompile;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -348,6 +348,14 @@ public class CommonConstants {
     public static final String CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS = "pinot.broker.new.segment.expiration.seconds";
     public static final long DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS = TimeUnit.MINUTES.toSeconds(5);
 
+    // If this config is set to true, the broker will check every query executed using the v1 query engine and attempt
+    // to determine whether the query could have successfully been run on the v2 / multi-stage query engine. If not,
+    // a counter metric will be incremented - if this counter remains 0 during regular query workload execution, it
+    // signals that users can potentially migrate their query workload to the multistage query engine.
+    public static final String CONFIG_OF_BROKER_ENABLE_MULTISTAGE_MIGRATION_METRIC
+        = "pinot.broker.enable.multistage.migration.metric";
+    public static final boolean DEFAULT_ENABLE_MULTISTAGE_MIGRATION_METRIC = false;
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";


### PR DESCRIPTION
- With the v2 / multi-stage query engine becoming more robust and feature complete (https://github.com/apache/pinot/pulls?q=is%3Apr+label%3Amulti-stage+is%3Aclosed), existing users might want to potentially migrate their existing v1 query workload to the multi-stage query engine.
- However, there are some differences between the two query engines in terms of supported syntax (some of which is documented in https://docs.pinot.apache.org/reference/troubleshooting/troubleshoot-multi-stage-query-engine).
- In case a user wants to migrate from the v1 query engine to the v2 query engine, it would be useful to be able to automatically detect whether the existing query workload would work as is without modification. This patch adds a counter metric (optionally enabled via a broker configuration that defaults to false for performance reasons) that is incremented each time a v1 query is run that fails during compilation with the v2 query engine. If this counter remains 0 during regular query workload execution, it signals that users can potentially migrate their query workload to the multi-stage query engine. 
- Note that there could be situations where a query compiles successfully but fails during execution. There could also be cases where a query runs successfully but there are differences in the result between the v1 and the v2 query engine - in terms of result types, result set size etc.
- In order to address these above concerns, we plan to also add a tool / API in the near future that actually executes a given query against both the query engines and compares the results. This is much more heavyweight and shouldn't be done for every query during regular execution and is intended more for ad-hoc use cases.