### PR TITLE
Fixing missing toInternal() implementation for BOOLEAN_ARRAY and TIMESTAMP_ARRAY types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -901,12 +901,34 @@ public enum PinotDataType {
     public boolean[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toBooleanArray(value);
     }
+
+    @Override
+    public Integer[] toInternal(Object value) {
+      boolean[] booleanArray = (boolean[]) value;
+      int length = booleanArray.length;
+      Integer[] intArray = new Integer[length];
+      for (int i = 0; i < length; i++) {
+        intArray[i] = booleanArray[i] ? 1 : 0;
+      }
+      return intArray;
+    }
   },
 
   TIMESTAMP_ARRAY {
     @Override
     public Object convert(Object value, PinotDataType sourceType) {
       return sourceType.toTimestampArray(value);
+    }
+
+    @Override
+    public Long[] toInternal(Object value) {
+      Timestamp[] timestampArray = (Timestamp[]) value;
+      int length = timestampArray.length;
+      Long[] longArray = new Long[length];
+      for (int i = 0; i < length; i++) {
+        longArray[i] = timestampArray[i].getTime();
+      }
+      return longArray;
     }
   },
 
@@ -1272,6 +1294,8 @@ public enum PinotDataType {
    * <ul>
    *   <li>BOOLEAN -> int</li>
    *   <li>TIMESTAMP -> long</li>
+   *   <li>BOOLEAN_ARRAY -> int[]</li>
+   *   <li>TIMESTAMP_ARRAY -> long[]</li>
    * </ul>
    */
   public Object toInternal(Object value) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -42,6 +43,8 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
 
   private static final String DEFAULT_TABLE_NAME = "ArrayTest";
   private static final String BOOLEAN_COLUMN = "boolCol";
+  private static final String BOOLEAN_FROM_INT_COLUMN = "boolColFromInt";
+  private static final String BOOLEAN_FROM_STRING_COLUMN = "boolColFromString";
   private static final String INT_COLUMN = "intCol";
   private static final String LONG_COLUMN = "longCol";
   private static final String FLOAT_COLUMN = "floatCol";
@@ -49,6 +52,9 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   private static final String STRING_COLUMN = "stringCol";
   private static final String TIMESTAMP_COLUMN = "timestampCol";
   private static final String GROUP_BY_COLUMN = "groupKey";
+  private static final String BOOLEAN_ARRAY_COLUMN = "booleanArrayCol";
+  private static final String BOOLEAN_FROM_INT_ARRAY_COLUMN = "booleanArrayColFromIntArray";
+  private static final String BOOLEAN_FROM_STRING_ARRAY_COLUMN = "booleanArrayColFromStringArray";
   private static final String LONG_ARRAY_COLUMN = "longArrayCol";
   private static final String DOUBLE_ARRAY_COLUMN = "doubleArrayCol";
 
@@ -58,7 +64,8 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
-  public void testArrayAggWithEmptyPredicate(boolean useMultiStageQueryEngine) throws Exception {
+  public void testArrayAggWithEmptyPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     String query =
         String.format("SELECT "
@@ -780,6 +787,74 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
     assertEquals(jsonNode.get("exceptions").size(), 1);
   }
 
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testBooleanTypes(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query =
+        String.format("SELECT %s, %s, %s, %s FROM %s LIMIT %d", INT_COLUMN, BOOLEAN_COLUMN, BOOLEAN_FROM_INT_COLUMN,
+            BOOLEAN_FROM_STRING_COLUMN, getTableName(), getCountStarResult());
+    JsonNode result = postQuery(query).get("resultTable");
+    System.out.println("result = " + result);
+    JsonNode columnDataTypesNode = result.get("dataSchema").get("columnDataTypes");
+    assertEquals(columnDataTypesNode.get(0).textValue(), "INT");
+    assertEquals(columnDataTypesNode.get(1).textValue(), "BOOLEAN");
+    assertEquals(columnDataTypesNode.get(2).textValue(), "BOOLEAN");
+    assertEquals(columnDataTypesNode.get(3).textValue(), "BOOLEAN");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), getCountStarResult());
+    for (int rowId = 0; rowId < rows.size(); rowId++) {
+      JsonNode row = rows.get(rowId);
+      assertEquals(row.size(), 4);
+      assertEquals(row.get(0).asInt() % 4 < 2, row.get(1).asBoolean());
+      assertEquals(row.get(1).asBoolean(), row.get(2).asBoolean());
+      assertEquals(row.get(2).asBoolean(), row.get(2).asBoolean());
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testBooleanArrayTypes(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query =
+        String.format("SELECT %s, %s, %s FROM %s LIMIT %d", BOOLEAN_ARRAY_COLUMN, BOOLEAN_FROM_INT_ARRAY_COLUMN,
+            BOOLEAN_FROM_STRING_ARRAY_COLUMN, getTableName(), getCountStarResult());
+    JsonNode result = postQuery(query).get("resultTable");
+    System.out.println("result = " + result);
+    JsonNode columnDataTypesNode = result.get("dataSchema").get("columnDataTypes");
+    assertEquals(columnDataTypesNode.get(0).textValue(), "BOOLEAN_ARRAY");
+    assertEquals(columnDataTypesNode.get(1).textValue(), "BOOLEAN_ARRAY");
+    assertEquals(columnDataTypesNode.get(2).textValue(), "BOOLEAN_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), getCountStarResult());
+
+    for (int rowId = 0; rowId < rows.size(); rowId++) {
+      JsonNode row = rows.get(rowId);
+      assertEquals(row.size(), 3);
+      JsonNode booleanArray0 = row.get(0);
+      JsonNode booleanArray1 = row.get(1);
+      JsonNode booleanArray2 = row.get(2);
+      assertEquals(booleanArray0.size(), 4);
+      assertEquals(booleanArray1.size(), 4);
+      assertEquals(booleanArray2.size(), 4);
+
+      assertTrue(booleanArray0.get(0).asBoolean());
+      assertTrue(booleanArray0.get(1).asBoolean());
+      assertFalse(booleanArray0.get(2).asBoolean());
+      assertFalse(booleanArray0.get(3).asBoolean());
+
+      assertTrue(booleanArray1.get(0).asBoolean());
+      assertTrue(booleanArray1.get(1).asBoolean());
+      assertFalse(booleanArray1.get(2).asBoolean());
+      assertFalse(booleanArray1.get(3).asBoolean());
+
+      assertTrue(booleanArray2.get(0).asBoolean());
+      assertTrue(booleanArray2.get(1).asBoolean());
+      assertFalse(booleanArray2.get(2).asBoolean());
+      assertFalse(booleanArray2.get(3).asBoolean());
+    }
+  }
+
   @Override
   public String getTableName() {
     return DEFAULT_TABLE_NAME;
@@ -789,6 +864,8 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   public Schema createSchema() {
     return new Schema.SchemaBuilder().setSchemaName(getTableName())
         .addSingleValueDimension(BOOLEAN_COLUMN, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(BOOLEAN_FROM_INT_COLUMN, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(BOOLEAN_FROM_STRING_COLUMN, FieldSpec.DataType.BOOLEAN)
         .addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
         .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG)
         .addSingleValueDimension(FLOAT_COLUMN, FieldSpec.DataType.FLOAT)
@@ -796,6 +873,9 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
         .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP)
         .addSingleValueDimension(GROUP_BY_COLUMN, FieldSpec.DataType.STRING)
+        .addMultiValueDimension(BOOLEAN_ARRAY_COLUMN, FieldSpec.DataType.BOOLEAN)
+        .addMultiValueDimension(BOOLEAN_FROM_INT_ARRAY_COLUMN, FieldSpec.DataType.BOOLEAN)
+        .addMultiValueDimension(BOOLEAN_FROM_STRING_ARRAY_COLUMN, FieldSpec.DataType.BOOLEAN)
         .addMultiValueDimension(LONG_ARRAY_COLUMN, FieldSpec.DataType.LONG)
         .addMultiValueDimension(DOUBLE_ARRAY_COLUMN, FieldSpec.DataType.DOUBLE)
         .build();
@@ -809,6 +889,12 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
     avroSchema.setFields(ImmutableList.of(
         new org.apache.avro.Schema.Field(BOOLEAN_COLUMN,
             org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN),
+            null, null),
+        new org.apache.avro.Schema.Field(BOOLEAN_FROM_INT_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+            null, null),
+        new org.apache.avro.Schema.Field(BOOLEAN_FROM_STRING_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
             null, null),
         new org.apache.avro.Schema.Field(INT_COLUMN, org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
             null, null),
@@ -827,6 +913,15 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
             null, null),
         new org.apache.avro.Schema.Field(GROUP_BY_COLUMN,
             org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+            null, null),
+        new org.apache.avro.Schema.Field(BOOLEAN_ARRAY_COLUMN,
+            org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN)),
+            null, null),
+        new org.apache.avro.Schema.Field(BOOLEAN_FROM_INT_ARRAY_COLUMN,
+            org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT)),
+            null, null),
+        new org.apache.avro.Schema.Field(BOOLEAN_FROM_STRING_ARRAY_COLUMN,
+            org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)),
             null, null),
         new org.apache.avro.Schema.Field(LONG_ARRAY_COLUMN,
             org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG)),
@@ -848,6 +943,8 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
               // create avro record
               GenericData.Record record = new GenericData.Record(avroSchema);
               record.put(BOOLEAN_COLUMN, finalI % 4 == 0 || finalI % 4 == 1);
+              record.put(BOOLEAN_FROM_INT_COLUMN, finalI % 4 == 0 || finalI % 4 == 1 ? 1 : 0);
+              record.put(BOOLEAN_FROM_STRING_COLUMN, finalI % 4 == 0 || finalI % 4 == 1 ? "true" : "false");
               record.put(INT_COLUMN, finalI);
               record.put(LONG_COLUMN, finalI);
               record.put(FLOAT_COLUMN, finalI + RANDOM.nextFloat());
@@ -855,6 +952,9 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
               record.put(STRING_COLUMN, RandomStringUtils.random(finalI));
               record.put(TIMESTAMP_COLUMN, finalI);
               record.put(GROUP_BY_COLUMN, String.valueOf(finalI % 10));
+              record.put(BOOLEAN_ARRAY_COLUMN, ImmutableList.of(true, true, false, false));
+              record.put(BOOLEAN_FROM_INT_ARRAY_COLUMN, ImmutableList.of(1, 1, 0, 0));
+              record.put(BOOLEAN_FROM_STRING_ARRAY_COLUMN, ImmutableList.of("true", "true", "false", "false"));
               record.put(LONG_ARRAY_COLUMN, ImmutableList.of(0, 1, 2, 3));
               record.put(DOUBLE_ARRAY_COLUMN, ImmutableList.of(0.0, 0.1, 0.2, 0.3));
               return record;


### PR DESCRIPTION
Per https://github.com/apache/pinot/issues/13626, the ingestion is failed for boolean array and timestamp array.
Pinot DataType missed the toInternal() implementation for `BOOLEAN_ARRAY` and `TIMESTAMP_ARRAY`.