### PR TITLE
Accept Request in controller AccessControl

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.core.auth.FineGrainedAccessControl;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.glassfish.grizzly.http.server.Request;
 
 
 @InterfaceAudience.Public
@@ -34,14 +35,47 @@ public interface AccessControl extends FineGrainedAccessControl {
   /**
    * Return whether the client has permission to the given table
    *
+   * @deprecated Use the methods that accept a request parameter instead
+   *
    * @param tableName name of the table to be accessed
    * @param accessType type of the access
    * @param httpHeaders HTTP headers containing requester identity
    * @param endpointUrl the request url for which this access control is called
    * @return whether the client has permission
    */
+  @Deprecated
+  default boolean hasAccess(@Nullable String tableName, AccessType accessType, HttpHeaders httpHeaders,
+                        @Nullable String endpointUrl) {
+    return hasAccess(tableName, accessType, httpHeaders, endpointUrl, null);
+  }
+
+  /**
+   * Return whether the client has permission to access the endpoints with are not table level
+   *
+   * @deprecated Use the methods that accept a request parameter instead
+   *
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers
+   * @param endpointUrl the request url for which this access control is called
+   * @return whether the client has permission
+   */
+  @Deprecated
+  default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, @Nullable String endpointUrl) {
+    return hasAccess(null, accessType, httpHeaders, endpointUrl, null);
+  }
+
+  /**
+   * Return whether the client has permission to the given table
+   *
+   * @param tableName name of the table to be accessed
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity
+   * @param endpointUrl the request url for which this access control is called
+   * @param request the request for which this access control is called
+   * @return whether the client has permission
+   */
   boolean hasAccess(@Nullable String tableName, AccessType accessType, HttpHeaders httpHeaders,
-      @Nullable String endpointUrl);
+      @Nullable String endpointUrl, @Nullable Request request);
 
   /**
    * Return whether the client has permission to access the endpoints with are not table level
@@ -49,10 +83,12 @@ public interface AccessControl extends FineGrainedAccessControl {
    * @param accessType type of the access
    * @param httpHeaders HTTP headers
    * @param endpointUrl the request url for which this access control is called
+   * @param request the request for which this access control is called
    * @return whether the client has permission
    */
-  default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, @Nullable String endpointUrl) {
-    return hasAccess(null, accessType, httpHeaders, endpointUrl);
+  default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, @Nullable String endpointUrl,
+                            @Nullable Request request) {
+    return hasAccess(null, accessType, httpHeaders, endpointUrl, request);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.glassfish.grizzly.http.server.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,17 +51,18 @@ public final class AccessControlUtils {
    * @param accessControl AccessControl object which does the actual validation
    */
   public static void validatePermission(@Nullable String tableName, AccessType accessType,
-      @Nullable HttpHeaders httpHeaders, @Nullable String endpointUrl, AccessControl accessControl) {
+                                        @Nullable HttpHeaders httpHeaders, @Nullable String endpointUrl,
+                                        @Nullable Request request, AccessControl accessControl) {
     String userMessage = getUserMessage(tableName, accessType, endpointUrl);
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
 
     try {
       if (rawTableName == null) {
-        if (accessControl.hasAccess(accessType, httpHeaders, endpointUrl)) {
+        if (accessControl.hasAccess(accessType, httpHeaders, endpointUrl, request)) {
           return;
         }
       } else {
-        if (accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl)) {
+        if (accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl, request)) {
           return;
         }
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AllowAllAccessFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AllowAllAccessFactory.java
@@ -20,11 +20,13 @@ package org.apache.pinot.controller.api.access;
 
 import javax.ws.rs.core.HttpHeaders;
 
+import org.glassfish.grizzly.http.server.Request;
+
 
 public class AllowAllAccessFactory implements AccessControlFactory {
   private static final AccessControl ALLOW_ALL_ACCESS = new AccessControl() {
     @Override
-    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl, Request request) {
       return true;
     }
   };

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -103,7 +103,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       tableName = DatabaseUtils.translateTableName(tableName, _httpHeaders);
     }
     AccessType accessType = extractAccessType(endpointMethod);
-    AccessControlUtils.validatePermission(tableName, accessType, _httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(tableName, accessType, _httpHeaders, endpointUrl, request, accessControl);
 
     FineGrainedAuthUtils.validateFineGrainedAuth(endpointMethod, uriInfo, _httpHeaders, accessControl);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.glassfish.grizzly.http.server.Request;
 
 
 /**
@@ -77,13 +78,13 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl, Request request) {
       return getPrincipal(httpHeaders)
           .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
-    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl, Request request) {
       if (getPrincipal(httpHeaders).isEmpty()) {
         throw new NotAuthorizedException("Basic");
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -33,6 +33,7 @@ import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.glassfish.grizzly.http.server.Request;
 
 
 /**
@@ -79,14 +80,14 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl, Request request) {
       return getPrincipal(httpHeaders).filter(
           p -> p.hasTable(TableNameBuilder.extractRawTableName(tableName))
               && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
-    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl, Request request) {
       return getPrincipal(httpHeaders).isPresent();
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -247,7 +247,7 @@ public class PinotSchemaRestletResource {
     schema.setSchemaName(schemaName);
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(schemaName, AccessType.CREATE, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(schemaName, AccessType.CREATE, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, schemaName, Actions.Table.CREATE_SCHEMA)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
@@ -289,7 +289,7 @@ public class PinotSchemaRestletResource {
     schema.setSchemaName(schemaName);
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(schemaName, AccessType.CREATE, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(schemaName, AccessType.CREATE, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, schemaName, Actions.Table.CREATE_SCHEMA)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
@@ -319,7 +319,7 @@ public class PinotSchemaRestletResource {
     validateSchemaInternal(schema);
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(schemaName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(schemaName, AccessType.READ, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, schemaName, Actions.Table.VALIDATE_SCHEMA)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
@@ -359,7 +359,7 @@ public class PinotSchemaRestletResource {
     validateSchemaInternal(schema);
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(schemaName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(schemaName, AccessType.READ, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, schemaName, Actions.Table.VALIDATE_SCHEMA)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -220,7 +220,7 @@ public class PinotTableRestletResource {
       // validate permission
       String endpointUrl = request.getRequestURL().toString();
       AccessControl accessControl = _accessControlFactory.create();
-      AccessControlUtils.validatePermission(tableNameWithType, AccessType.CREATE, httpHeaders, endpointUrl,
+      AccessControlUtils.validatePermission(tableNameWithType, AccessType.CREATE, httpHeaders, endpointUrl, request,
           accessControl);
       if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, tableNameWithType, Actions.Table.CREATE_TABLE)) {
         throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
@@ -563,7 +563,7 @@ public class PinotTableRestletResource {
     // validate permission
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(tableNameWithType, AccessType.READ, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(tableNameWithType, AccessType.READ, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, tableNameWithType,
         Actions.Table.VALIDATE_TABLE_CONFIGS)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -209,7 +209,7 @@ public class TableConfigsRestletResource {
       // validate permission
       String endpointUrl = request.getRequestURL().toString();
       AccessControl accessControl = _accessControlFactory.create();
-      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl,
+      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl, request,
           accessControl);
       if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
         throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
@@ -413,7 +413,7 @@ public class TableConfigsRestletResource {
     // validate permission
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, request, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.VALIDATE_TABLE_CONFIGS)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.api.access;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.glassfish.grizzly.http.server.Request;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -35,21 +36,23 @@ public class AccessControlUtilsTest {
   public void testValidatePermissionAllowed() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    Request mockRequest = Mockito.mock(Request.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint)).thenReturn(true);
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest)).thenReturn(true);
 
-    AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+    AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest, ac);
   }
 
   @Test
   public void testValidatePermissionDenied() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    Request mockRequest = Mockito.mock(Request.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint)).thenReturn(false);
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest)).thenReturn(false);
 
     try {
-      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest, ac);
       Assert.fail("Expected ControllerApplicationException");
     } catch (ControllerApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Permission is denied"));
@@ -61,12 +64,13 @@ public class AccessControlUtilsTest {
   public void testValidatePermissionWithNoSuchMethodError() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    Request mockRequest = Mockito.mock(Request.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint))
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest))
         .thenThrow(new NoSuchMethodError("Method not found"));
 
     try {
-      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, mockRequest, ac);
     } catch (ControllerApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission"));
       Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());


### PR DESCRIPTION
### Context
- https://github.com/apache/pinot/issues/13556

This allows for using properties of the `Request` object in the `AccessControl` to achieve things like using the peer TLS certificates to assign roles.