### PR TITLE
Always use Unsafe as the default PinotBufferFactory

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
@@ -167,13 +167,8 @@ public abstract class PinotDataBuffer implements DataBuffer {
     String factoryClassName;
     factoryClassName = System.getenv("PINOT_BUFFER_LIBRARY");
     if (factoryClassName == null) {
-      if (JavaVersion.VERSION < 16) {
-        LOGGER.info("Using LArray as buffer on JVM version {}", JavaVersion.VERSION);
-        factoryClassName = LArrayPinotBufferFactory.class.getCanonicalName();
-      } else {
-        LOGGER.info("Using Unsafe as buffer on JVM version {}", JavaVersion.VERSION);
-        factoryClassName = UnsafePinotBufferFactory.class.getCanonicalName();
-      }
+      LOGGER.info("Using Unsafe as buffer on JVM version {}", JavaVersion.VERSION);
+      factoryClassName = UnsafePinotBufferFactory.class.getCanonicalName();
     }
     return createFactory(factoryClassName, prioritizeByteBuffer);
   }


### PR DESCRIPTION
We have been using UnsafePinotBufferFactory for a while with no regression detected. I think it is a good time to start working on the plan to remove LArray dependency (see #12810) 

This PR changes the default PinotBufferFactory used in Pinot. Before we were using LArrayPinotBufferFactory on Java < 16 but give LArray doesn't work in Java >= 16, we used UnsafePinotBufferFactory in newer JVMs. With this PR, we always use UnsafePinotBufferFactory.

Users that want to still use LArrayPinotBufferFactory can do that by providing the following config to Pinot:
```
pinot.offheap.buffer.factory=org.apache.pinot.segment.spi.memory.LArrayPinotBufferFactory
```

Remember that this is *not* recommended given LArray implementation has been proved to be incorrect several times (see for example https://github.com/apache/pinot/pull/10774).\

A side effect of this PR is that Pinot should be able to be executed (and probably compiled) in Mac computers using aarch64 (like M1, M2, etc) without having to enable Rosetta. We need to open a parallel PR to change [this doc page](https://github.com/apache/pinot/pull/10774)  and probably [this one](https://github.com/apache/pinot/pull/10774). There are still some issues in ARMs (AFAIR CLP lib does not include a binary for Mac + arm64, @suddendust may know more about that) and maybe other build pages that may not be updated.