### PR TITLE
Added support to upload segments in batch mode with METADATA upload type

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -113,6 +113,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
   private static final String SCHEMA_PATH = "/schemas";
   private static final String OLD_SEGMENT_PATH = "/segments";
   private static final String SEGMENT_PATH = "/v2/segments";
+  private static final String BATCH_SEGMENT_UPLOAD_PATH = "/segments/batchUpload";
   private static final String TABLES_PATH = "/tables";
   private static final String TYPE_DELIMITER = "type=";
   private static final String START_REPLACE_SEGMENTS_PATH = "/startReplaceSegments";
@@ -363,6 +364,12 @@ public class FileUploadDownloadClient implements AutoCloseable {
   public static URI getUploadSegmentURI(URI controllerURI)
       throws URISyntaxException {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_PATH);
+  }
+
+  public static URI getBatchSegmentUploadURI(URI controllerURI)
+      throws URISyntaxException {
+    return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(),
+        BATCH_SEGMENT_UPLOAD_PATH);
   }
 
   public static URI getStartReplaceSegmentsURI(URI controllerURI, String rawTableName, String tableType,

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientTest.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -126,6 +128,14 @@ public class FileUploadDownloadClientTest {
       Assert.assertEquals(response.getStatusCode(), HttpStatus.SC_OK);
       Assert.assertEquals(response.getResponse(), "OK");
     }
+  }
+
+  @Test
+  public void testGetUploadSegmentListURI()
+      throws URISyntaxException {
+    URI controllerURI = new URI("https://myhost:9443");
+    URI uriWithEndpoint = FileUploadDownloadClient.getBatchSegmentUploadURI(controllerURI);
+    Assert.assertEquals(new URI("https://myhost:9443/segments/batchUpload"), uriWithEndpoint);
   }
 
   @AfterClass

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -29,14 +29,20 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -59,6 +65,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -73,6 +80,7 @@ import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.FileUploadDownloadClient.FileUploadType;
+import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.controller.ControllerConf;
@@ -81,6 +89,8 @@ import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.api.upload.SegmentMetadataInfo;
+import org.apache.pinot.controller.api.upload.SegmentUploadMetadata;
 import org.apache.pinot.controller.api.upload.SegmentValidationUtils;
 import org.apache.pinot.controller.api.upload.ZKOperator;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -90,7 +100,9 @@ import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.metadata.DefaultMetadataExtractor;
 import org.apache.pinot.core.metadata.MetadataExtractorFactory;
+import org.apache.pinot.segment.local.constants.SegmentUploadConstants;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.crypt.PinotCrypter;
@@ -101,6 +113,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.server.ManagedAsync;
@@ -295,13 +308,18 @@ public class PinotSegmentUploadDownloadRestletResource {
               extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE);
           copySegmentToFinalLocation = Boolean.parseBoolean(copySegmentToDeepStore);
           createSegmentFileFromMultipart(multiPart, destFile);
+          PinotFS pinotFS = null;
           try {
             URI segmentURI = new URI(sourceDownloadURIStr);
-            PinotFS pinotFS = PinotFSFactory.create(segmentURI.getScheme());
+            pinotFS = PinotFSFactory.create(segmentURI.getScheme());
             segmentSizeInBytes = pinotFS.length(segmentURI);
           } catch (Exception e) {
             segmentSizeInBytes = -1;
             LOGGER.warn("Could not fetch segment size for metadata push", e);
+          } finally {
+            if (pinotFS != null) {
+              pinotFS.close();
+            }
           }
           break;
         default:
@@ -403,6 +421,150 @@ public class PinotSegmentUploadDownloadRestletResource {
     }
   }
 
+  // Method used to update a list of segments in batch mode with the METADATA upload type.
+  private SuccessResponse uploadSegments(String tableName, TableType tableType, FormDataMultiPart multiPart,
+      boolean enableParallelPushProtection, boolean allowRefresh, HttpHeaders headers, Request request) {
+    long segmentsUploadStartTimeMs = System.currentTimeMillis();
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    String tableNameWithType = tableType == TableType.OFFLINE ? TableNameBuilder.OFFLINE.tableNameWithType(rawTableName)
+        : TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      throw new ControllerApplicationException(LOGGER, "Failed to fetch table config for table: " + tableNameWithType,
+          Response.Status.BAD_REQUEST);
+    }
+
+    String clientAddress;
+    try {
+      clientAddress = InetAddress.getByName(request.getRemoteAddr()).getHostName();
+    } catch (UnknownHostException e) {
+      throw new ControllerApplicationException(LOGGER, "Failed to resolve hostname from input request",
+          Response.Status.BAD_REQUEST, e);
+    }
+
+    String uploadTypeStr = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE);
+    FileUploadType uploadType = getUploadType(uploadTypeStr);
+    if (!FileUploadType.METADATA.equals(uploadType)) {
+      throw new ControllerApplicationException(LOGGER, "Unsupported upload type: " + uploadTypeStr,
+          Response.Status.BAD_REQUEST);
+    }
+
+    String crypterClassNameInHeader = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.CRYPTER);
+    String ingestionDescriptor = extractHttpHeader(headers, CommonConstants.Controller.INGESTION_DESCRIPTOR);
+    ControllerFilePathProvider provider = ControllerFilePathProvider.getInstance();
+    List<SegmentUploadMetadata> segmentUploadMetadataList = new ArrayList<>();
+    List<File> tempFiles = new ArrayList<>();
+    List<String> segmentNames = new ArrayList<>();
+    Map<String, SegmentMetadataInfo> segmentsMetadataInfoMap = createSegmentsMetadataInfoMap(multiPart);
+    LOGGER.info("Uploading segments in batch mode of size: {}", segmentsMetadataInfoMap.size());
+
+    try {
+      int entryCount = 0;
+      for (Map.Entry<String, SegmentMetadataInfo> entry: segmentsMetadataInfoMap.entrySet()) {
+        String segmentName = entry.getKey();
+        SegmentMetadataInfo segmentMetadataInfo = entry.getValue();
+        segmentNames.add(segmentName);
+        File tempEncryptedFile;
+        File tempDecryptedFile;
+        File tempSegmentDir;
+        String sourceDownloadURIStr = segmentMetadataInfo.getSegmentDownloadURI();
+        if (StringUtils.isEmpty(sourceDownloadURIStr)) {
+          throw new ControllerApplicationException(LOGGER,
+              "'DOWNLOAD_URI' is required as a field within the multipart object for METADATA batch upload mode.",
+              Response.Status.BAD_REQUEST);
+        }
+        // The downloadUri for putting into segment zk metadata
+        String segmentDownloadURIStr = sourceDownloadURIStr;
+
+        String tempFileName = TMP_DIR_PREFIX + UUID.randomUUID();
+        tempEncryptedFile = new File(provider.getFileUploadTempDir(), tempFileName + ENCRYPTED_SUFFIX);
+        tempFiles.add(tempEncryptedFile);
+        tempDecryptedFile = new File(provider.getFileUploadTempDir(), tempFileName);
+        tempFiles.add(tempDecryptedFile);
+        tempSegmentDir = new File(provider.getUntarredFileTempDir(), tempFileName);
+        tempFiles.add(tempSegmentDir);
+
+        boolean encryptSegment = StringUtils.isNotEmpty(crypterClassNameInHeader);
+        File destFile = encryptSegment ? tempEncryptedFile : tempDecryptedFile;
+        // override copySegmentToFinalLocation if override provided in headers:COPY_SEGMENT_TO_DEEP_STORE
+        // else set to false for backward compatibility
+        String copySegmentToDeepStore = extractHttpHeader(headers,
+            FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE);
+        boolean copySegmentToFinalLocation = Boolean.parseBoolean(copySegmentToDeepStore);
+        createSegmentFileFromSegmentMetadataInfo(segmentMetadataInfo, destFile);
+        if (encryptSegment) {
+          decryptFile(crypterClassNameInHeader, tempEncryptedFile, tempDecryptedFile);
+        }
+
+        String metadataProviderClass = DefaultMetadataExtractor.class.getName();
+        SegmentMetadata segmentMetadata = getSegmentMetadata(tempDecryptedFile, tempSegmentDir, metadataProviderClass);
+        LOGGER.info("Processing upload request for segment: {} of table: {} with upload type: {} from client: {}, "
+                + "ingestion descriptor: {}", segmentName, tableNameWithType, uploadType, clientAddress,
+            ingestionDescriptor);
+
+        // Validate segment
+        if (tableConfig.getIngestionConfig() == null || tableConfig.getIngestionConfig().isSegmentTimeValueCheck()) {
+          SegmentValidationUtils.validateTimeInterval(segmentMetadata, tableConfig);
+        }
+        // TODO: Include the un-tarred segment size when using the METADATA push rest API. Currently we can only use the
+        //  tarred segment size as an approximation. Additionally, add the storage quota check for batch upload mode.
+        long segmentSizeInBytes = getSegmentSizeFromFile(sourceDownloadURIStr);
+
+        // Encrypt segment
+        String crypterNameInTableConfig = tableConfig.getValidationConfig().getCrypterClassName();
+        Pair<String, File> encryptionInfo =
+            encryptSegmentIfNeeded(tempDecryptedFile, tempEncryptedFile, encryptSegment, crypterClassNameInHeader,
+                crypterNameInTableConfig, segmentName, tableNameWithType);
+        File segmentFile = encryptionInfo.getRight();
+
+        // Update download URI if controller is responsible for moving the segment to the deep store
+        URI finalSegmentLocationURI = null;
+        if (copySegmentToFinalLocation) {
+          URI dataDirURI = provider.getDataDirURI();
+          String dataDirPath = dataDirURI.toString();
+          String encodedSegmentName = URIUtils.encode(segmentName);
+          String finalSegmentLocationPath = URIUtils.getPath(dataDirPath, rawTableName, encodedSegmentName);
+          if (dataDirURI.getScheme().equalsIgnoreCase(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
+            segmentDownloadURIStr = URIUtils.getPath(provider.getVip(), "segments", rawTableName, encodedSegmentName);
+          } else {
+            segmentDownloadURIStr = finalSegmentLocationPath;
+          }
+          finalSegmentLocationURI = URIUtils.getUri(finalSegmentLocationPath);
+        }
+        SegmentUploadMetadata segmentUploadMetadata =
+            new SegmentUploadMetadata(segmentDownloadURIStr, sourceDownloadURIStr, finalSegmentLocationURI,
+                segmentSizeInBytes, segmentMetadata, encryptionInfo);
+        segmentUploadMetadataList.add(segmentUploadMetadata);
+        LOGGER.info("Using segment download URI: {} for segment: {} of table: {} (move segment: {})",
+            segmentDownloadURIStr, segmentFile, tableNameWithType, copySegmentToFinalLocation);
+        // complete segment operations for all the segments
+        if (++entryCount == segmentsMetadataInfoMap.size()) {
+          ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
+          zkOperator.completeSegmentsOperations(tableNameWithType, uploadType, enableParallelPushProtection,
+              allowRefresh, headers, segmentUploadMetadataList);
+        }
+      }
+    } catch (Exception e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR,
+          segmentUploadMetadataList.size());
+      throw new ControllerApplicationException(LOGGER,
+          "Exception while processing segments to upload: " + e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    } finally {
+      cleanupTempFiles(tempFiles);
+      multiPart.cleanup();
+    }
+
+    return new SuccessResponse(String.format("Successfully uploaded segments: %s of table: %s in %s ms",
+        segmentNames, tableNameWithType, System.currentTimeMillis() - segmentsUploadStartTimeMs));
+  }
+
+  private void cleanupTempFiles(List<File> tempFiles) {
+    for (File tempFile : tempFiles) {
+      FileUtils.deleteQuietly(tempFile);
+    }
+  }
+
   @Nullable
   private String extractHttpHeader(HttpHeaders headers, String name) {
     String value = headers.getHeaderString(name);
@@ -499,12 +661,12 @@ public class PinotSegmentUploadDownloadRestletResource {
   // it keeps it at the downloadURI header that is set. We will not support this endpoint going forward.
   public void uploadSegmentAsJson(String segmentJsonStr,
       @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME)
-          String tableName,
+      String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection,
+      boolean enableParallelPushProtection,
       @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
@@ -538,18 +700,79 @@ public class PinotSegmentUploadDownloadRestletResource {
   // For the multipart endpoint, we will always move segment to final location regardless of the segment endpoint.
   public void uploadSegmentAsMultiPart(FormDataMultiPart multiPart,
       @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME)
-          String tableName,
+      String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection,
+      boolean enableParallelPushProtection,
       @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, true,
           enableParallelPushProtection, allowRefresh, headers, request));
+    } catch (Throwable t) {
+      asyncResponse.resume(t);
+    }
+  }
+
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/segments/batchUpload")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Cluster.UPLOAD_SEGMENT)
+  @Authenticate(AccessType.CREATE)
+  @ApiOperation(value = "Upload a batch of segments", notes = "Upload a batch of segments with METADATA upload type")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Successfully uploaded segment"),
+      @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 403, message = "Segment validation fails"),
+      @ApiResponse(code = 409, message = "Segment already exists or another parallel push in progress"),
+      @ApiResponse(code = 410, message = "Segment to refresh does not exist"),
+      @ApiResponse(code = 412, message = "CRC check fails"),
+      @ApiResponse(code = 500, message = "Internal error")
+  })
+  @TrackInflightRequestMetrics
+  @TrackedByGauge(gauge = ControllerGauge.SEGMENT_UPLOADS_IN_PROGRESS)
+  // This multipart based endpoint is used to upload a list of segments in batch mode. The multipart request contains
+  // a single part which is an uber tar of all the segment metadata files. Additionally, the uber tar contains a special
+  // file which has the segment to segment download URI mappings.
+  public void uploadSegmentsAsMultiPart(FormDataMultiPart multiPart,
+      @ApiParam(value = "Name of the table", required = true)
+      @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME)
+      String tableName,
+      @ApiParam(value = "Type of the table", required = true)
+      @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
+      String tableType,
+      @ApiParam(value = "Whether to enable parallel push protection")
+      @DefaultValue("false")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
+      boolean enableParallelPushProtection,
+      @ApiParam(value = "Whether to refresh if the segment already exists")
+      @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH)
+      boolean allowRefresh,
+      @Context HttpHeaders headers,
+      @Context Request request,
+      @Suspended final AsyncResponse asyncResponse) {
+    if (StringUtils.isEmpty(tableName)) {
+      throw new ControllerApplicationException(LOGGER,
+          "tableName is a required field while uploading segments in batch mode.", Response.Status.BAD_REQUEST);
+    }
+    if (StringUtils.isEmpty(tableType)) {
+      throw new ControllerApplicationException(LOGGER,
+          "tableType is a required field while uploading segments in batch mode.", Response.Status.BAD_REQUEST);
+    }
+    if (multiPart == null) {
+      throw new ControllerApplicationException(LOGGER,
+          "multiPart is a required field while uploading segments in batch mode.", Response.Status.BAD_REQUEST);
+    }
+    try {
+      asyncResponse.resume(
+          uploadSegments(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, enableParallelPushProtection,
+              allowRefresh, headers, request));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -579,12 +802,12 @@ public class PinotSegmentUploadDownloadRestletResource {
   // endpoint in how it moves the segment to a Pinot-determined final directory.
   public void uploadSegmentAsJsonV2(String segmentJsonStr,
       @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME)
-          String tableName,
+      String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection,
+      boolean enableParallelPushProtection,
       @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
@@ -619,12 +842,12 @@ public class PinotSegmentUploadDownloadRestletResource {
   // This behavior does not differ from v1 of the same endpoint.
   public void uploadSegmentAsMultiPartV2(FormDataMultiPart multiPart,
       @ApiParam(value = "Name of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_NAME)
-          String tableName,
+      String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection,
+      boolean enableParallelPushProtection,
       @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
@@ -679,7 +902,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Segment lineage entry id returned by startReplaceSegments API", required = true)
       @QueryParam("segmentLineageEntryId") String segmentLineageEntryId,
       @ApiParam(value = "Fields belonging to end replace segment request")
-          EndReplaceSegmentsRequest endReplaceSegmentsRequest, @Context HttpHeaders headers) {
+      EndReplaceSegmentsRequest endReplaceSegmentsRequest, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == null) {
@@ -710,7 +933,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "Segment lineage entry id to revert", required = true) @QueryParam("segmentLineageEntryId")
-          String segmentLineageEntryId,
+      String segmentLineageEntryId,
       @ApiParam(value = "Force revert in case the user knows that the lineage entry is interrupted")
       @QueryParam("forceRevert") @DefaultValue("false") boolean forceRevert,
       @ApiParam(value = "Fields belonging to revert replace segment request")
@@ -752,11 +975,160 @@ public class PinotSegmentUploadDownloadRestletResource {
     }
   }
 
+  @VisibleForTesting
+  static void createSegmentFileFromBodyPart(FormDataBodyPart segmentMetadataBodyPart, File destFile)
+      throws IOException {
+    try (InputStream inputStream = segmentMetadataBodyPart.getValueAs(InputStream.class);
+        OutputStream outputStream = new FileOutputStream(destFile)) {
+      IOUtils.copyLarge(inputStream, outputStream);
+    } finally {
+      segmentMetadataBodyPart.cleanup();
+    }
+  }
+
+  @VisibleForTesting
+  static void createSegmentFileFromSegmentMetadataInfo(SegmentMetadataInfo metadataInfo, File destFile)
+      throws IOException {
+    File creationMetaFile = metadataInfo.getSegmentCreationMetaFile();
+    File metadataPropertiesFile = metadataInfo.getSegmentMetadataPropertiesFile();
+    String uuid = UUID.randomUUID().toString();
+    File segmentMetadataDir =
+        new File(FileUtils.getTempDirectory(), SegmentUploadConstants.SEGMENT_METADATA_DIR_PREFIX + uuid);
+    FileUtils.copyFile(creationMetaFile, new File(segmentMetadataDir, V1Constants.SEGMENT_CREATION_META));
+    FileUtils.copyFile(metadataPropertiesFile,
+        new File(segmentMetadataDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+    File segmentMetadataTarFile = new File(FileUtils.getTempDirectory(),
+        SegmentUploadConstants.SEGMENT_METADATA_TAR_FILE_PREFIX + uuid + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    if (segmentMetadataTarFile.exists()) {
+      FileUtils.forceDelete(segmentMetadataTarFile);
+    }
+    TarCompressionUtils.createCompressedTarFile(segmentMetadataDir, segmentMetadataTarFile);
+    try {
+      FileUtils.copyFile(segmentMetadataTarFile, destFile);
+    } finally {
+      FileUtils.forceDelete(segmentMetadataTarFile);
+    }
+  }
+
+  // The multipart input would contain a single multipart and this part would contain the segment metadata
+  // files (creation.meta, metadata.properties), and an additional mapping file names 'all_segments_metadata' which
+  // would contain the mappings from segment names to segment download URI's.
+  private static Map<String, SegmentMetadataInfo> createSegmentsMetadataInfoMap(FormDataMultiPart multiPart) {
+    List<BodyPart> bodyParts = multiPart.getBodyParts();
+    validateMultiPartForBatchSegmentUpload(bodyParts);
+    FormDataBodyPart bodyPartFromReq = (FormDataBodyPart) bodyParts.get(0);
+
+    String uuid = UUID.randomUUID().toString();
+    File allSegmentsMetadataTarFile = new File(FileUtils.getTempDirectory(),
+        SegmentUploadConstants.ALL_SEGMENTS_METADATA_TAR_FILE_PREFIX + uuid
+            + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    try {
+      createSegmentFileFromBodyPart(bodyPartFromReq, allSegmentsMetadataTarFile);
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Failed to extract segment metadata files from the input "
+          + "request. ", Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+
+    List<File> segmentsMetadataFiles = new ArrayList<>();
+    File allSegmentsMetadataDir = new File(FileUtils.getTempDirectory(),
+        SegmentUploadConstants.ALL_SEGMENTS_METADATA_DIR_PREFIX + uuid);
+    try {
+      FileUtils.forceMkdir(allSegmentsMetadataDir);
+      List<File> metadataFiles = TarCompressionUtils.untar(allSegmentsMetadataTarFile, allSegmentsMetadataDir);
+      if (!metadataFiles.isEmpty()) {
+        segmentsMetadataFiles.addAll(metadataFiles);
+      }
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Failed to unzip the segment metadata files. ",
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+
+    Map<String, SegmentMetadataInfo> segmentsMetadataInfoMap = new HashMap<>();
+    for (File file: segmentsMetadataFiles) {
+      String fileName = file.getName();
+      if (fileName.equalsIgnoreCase(SegmentUploadConstants.ALL_SEGMENTS_METADATA_FILENAME)) {
+        try (InputStream inputStream = FileUtils.openInputStream(file)) {
+          final InputStreamReader reader = new InputStreamReader(inputStream, Charsets.toCharset(
+              StandardCharsets.UTF_8));
+          try (BufferedReader bufReader = IOUtils.toBufferedReader(reader)) {
+            String segmentNameLine;
+            String segmentDownloadURILine;
+            // Within the ALL_SEGMENTS_METADATA_FILENAME file, odd lines represent segment names and even lines
+            // represent the segment download uri.
+            while ((segmentNameLine = bufReader.readLine()) != null) {
+              segmentDownloadURILine = bufReader.readLine();
+              if (StringUtils.isEmpty(segmentDownloadURILine)) {
+                throw new ControllerApplicationException(LOGGER, String.format("Failed to find the segment download uri"
+                        + " within the file: %s for segment: %s", SegmentUploadConstants.ALL_SEGMENTS_METADATA_FILENAME,
+                    segmentNameLine), Response.Status.INTERNAL_SERVER_ERROR);
+              }
+              SegmentMetadataInfo segmentMetadataInfo = segmentsMetadataInfoMap.getOrDefault(segmentNameLine,
+                  new SegmentMetadataInfo());
+              segmentMetadataInfo.setSegmentDownloadURI(segmentDownloadURILine);
+              segmentsMetadataInfoMap.put(segmentNameLine, segmentMetadataInfo);
+            }
+          }
+        } catch (IOException e) {
+          throw new ControllerApplicationException(LOGGER, String.format("Failed to read the file: %s",
+              SegmentUploadConstants.ALL_SEGMENTS_METADATA_FILENAME), Response.Status.INTERNAL_SERVER_ERROR, e);
+        }
+      } else if (fileName.endsWith("." + V1Constants.SEGMENT_CREATION_META)) {
+        int suffixLength = V1Constants.SEGMENT_CREATION_META.length() + 1;
+        String segmentName = fileName.substring(0, fileName.length() - suffixLength);
+        SegmentMetadataInfo segmentMetadataInfo = segmentsMetadataInfoMap.getOrDefault(segmentName,
+            new SegmentMetadataInfo());
+        segmentMetadataInfo.setSegmentCreationMetaFile(file);
+        segmentsMetadataInfoMap.put(segmentName, segmentMetadataInfo);
+      } else if (fileName.endsWith("." + V1Constants.MetadataKeys.METADATA_FILE_NAME)) {
+        int suffixLength = V1Constants.MetadataKeys.METADATA_FILE_NAME.length() + 1;
+        String segmentName = fileName.substring(0, fileName.length() - suffixLength);
+        SegmentMetadataInfo segmentMetadataInfo = segmentsMetadataInfoMap.getOrDefault(segmentName,
+            new SegmentMetadataInfo());
+        segmentMetadataInfo.setSegmentMetadataPropertiesFile(file);
+        segmentsMetadataInfoMap.put(segmentName, segmentMetadataInfo);
+      }
+    }
+    return segmentsMetadataInfoMap;
+  }
+
   private FileUploadType getUploadType(String uploadTypeStr) {
     if (uploadTypeStr != null) {
       return FileUploadType.valueOf(uploadTypeStr);
     } else {
       return FileUploadType.getDefaultUploadType();
+    }
+  }
+
+  @VisibleForTesting
+  static long getSegmentSizeFromFile(String sourceDownloadURIStr)
+      throws IOException {
+    long segmentSizeInBytes = -1;
+    PinotFS pinotFS = null;
+    try {
+      URI segmentURI = new URI(sourceDownloadURIStr);
+      pinotFS = PinotFSFactory.create(segmentURI.getScheme());
+      segmentSizeInBytes = pinotFS.length(segmentURI);
+    } catch (Exception e) {
+      LOGGER.warn(String.format("Exception while determining segment size for segment download uri: %s",
+          sourceDownloadURIStr), e);
+    } finally {
+      if (pinotFS != null) {
+        pinotFS.close();
+      }
+    }
+    return segmentSizeInBytes;
+  }
+
+  @VisibleForTesting
+  static void validateMultiPartForBatchSegmentUpload(List<BodyPart> bodyParts) {
+    if (bodyParts.isEmpty()) {
+      throw new ControllerApplicationException(LOGGER, "Multipart request contains zero parts.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    if (bodyParts.size() > 1) {
+      throw new ControllerApplicationException(LOGGER, "Multipart request contains more than one part in batch mode.",
+          Response.Status.BAD_REQUEST);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentMetadataInfo.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentMetadataInfo.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.upload;
+
+import java.io.File;
+import java.util.Objects;
+
+
+/**
+ * Data object used to capture the segment metadata files information along with the segment download URI while
+ * uploading segments in the mode.
+ *
+ * <ol>
+ *   <li>segmentDownloadURI – The segment download URI</li>
+ *   <li>segmentCreationMeta – The creation.meta file within the segment metadata tar file.</li>
+ *   <li>segmentMetadataProperties – The metadata.properties file within the segment metadata tar file.</li>
+ * </ol>
+ */
+public class SegmentMetadataInfo {
+  private String _segmentDownloadURI;
+  private File _segmentCreationMetaFile;
+  private File _segmentMetadataPropertiesFile;
+
+  public String getSegmentDownloadURI() {
+    return _segmentDownloadURI;
+  }
+
+  public void setSegmentDownloadURI(String segmentDownloadURI) {
+    _segmentDownloadURI = segmentDownloadURI;
+  }
+
+  public File getSegmentCreationMetaFile() {
+    return _segmentCreationMetaFile;
+  }
+
+  public File getSegmentMetadataPropertiesFile() {
+    return _segmentMetadataPropertiesFile;
+  }
+
+  public void setSegmentCreationMetaFile(File file) {
+    _segmentCreationMetaFile = file;
+  }
+
+  public void setSegmentMetadataPropertiesFile(File file) {
+    _segmentMetadataPropertiesFile = file;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SegmentMetadataInfo that = (SegmentMetadataInfo) o;
+    return Objects.equals(_segmentDownloadURI, that._segmentDownloadURI) && Objects.equals(_segmentCreationMetaFile,
+        that._segmentCreationMetaFile) && Objects.equals(_segmentMetadataPropertiesFile,
+        that._segmentMetadataPropertiesFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_segmentDownloadURI, _segmentCreationMetaFile, _segmentMetadataPropertiesFile);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentUploadMetadata.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentUploadMetadata.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.upload;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Objects;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+
+
+/**
+ * Data object used while adding or updating segments. It's comprised of the following fields:
+ * <ol>
+ *   <li>segmentDownloadURIStr – The segment download URI persisted into the ZK metadata.</li>
+ *   <li>sourceDownloadURIStr – The URI from where the segment could be downloaded.</li>
+ *   <li>finalSegmentLocationURI – The final location of the segment in the deep-store.</li>
+ *   <li>segmentSizeInBytes – The segment size in bytes.</li>
+ *   <li>segmentMetadata – The segment metadata as defined in {@link org.apache.pinot.segment.spi.SegmentMetadata}.</li>
+ *   <li>encryptionInfo – A pair consisting of the crypter class used to encrypt the segment, and the encrypted segment
+ *   file.</li>
+ *   <li>segmentMetadataZNRecord – The segment metadata represented as a helix
+ *   {@link org.apache.helix.zookeeper.datamodel.ZNRecord}.</li>
+ * </ol>
+ */
+public class SegmentUploadMetadata {
+  private final String _segmentDownloadURIStr;
+  private final String _sourceDownloadURIStr;
+  private final URI _finalSegmentLocationURI;
+  private final Long _segmentSizeInBytes;
+  private final SegmentMetadata _segmentMetadata;
+  private final Pair<String, File> _encryptionInfo;
+  private ZNRecord _segmentMetadataZNRecord;
+
+  public SegmentUploadMetadata(String segmentDownloadURIStr, String sourceDownloadURIStr, URI finalSegmentLocationURI,
+      Long segmentSizeInBytes, SegmentMetadata segmentMetadata, Pair<String, File> encryptionInfo) {
+    _segmentDownloadURIStr = segmentDownloadURIStr;
+    _sourceDownloadURIStr = sourceDownloadURIStr;
+    _segmentSizeInBytes = segmentSizeInBytes;
+    _segmentMetadata = segmentMetadata;
+    _encryptionInfo = encryptionInfo;
+    _finalSegmentLocationURI = finalSegmentLocationURI;
+  }
+
+  public String getSegmentDownloadURIStr() {
+    return _segmentDownloadURIStr;
+  }
+
+  public String getSourceDownloadURIStr() {
+    return _sourceDownloadURIStr;
+  }
+
+  public URI getFinalSegmentLocationURI() {
+    return _finalSegmentLocationURI;
+  }
+
+  public Long getSegmentSizeInBytes() {
+    return _segmentSizeInBytes;
+  }
+
+  public SegmentMetadata getSegmentMetadata() {
+    return _segmentMetadata;
+  }
+
+  public Pair<String, File> getEncryptionInfo() {
+    return _encryptionInfo;
+  }
+
+  public void setSegmentMetadataZNRecord(ZNRecord segmentMetadataZNRecord) {
+    _segmentMetadataZNRecord = segmentMetadataZNRecord;
+  }
+
+  public ZNRecord getSegmentMetadataZNRecord() {
+    return _segmentMetadataZNRecord;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SegmentUploadMetadata that = (SegmentUploadMetadata) o;
+    return Objects.equals(_segmentDownloadURIStr, that._segmentDownloadURIStr)
+        && Objects.equals(_sourceDownloadURIStr, that._sourceDownloadURIStr)
+        && Objects.equals(_finalSegmentLocationURI, that._finalSegmentLocationURI)
+        && Objects.equals(_segmentSizeInBytes, that._segmentSizeInBytes)
+        && Objects.equals(_segmentMetadata, that._segmentMetadata)
+        && Objects.equals(_encryptionInfo, that._encryptionInfo)
+        && Objects.equals(_segmentMetadataZNRecord, that._segmentMetadataZNRecord);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_segmentDownloadURIStr, _sourceDownloadURIStr, _finalSegmentLocationURI,
+        _segmentSizeInBytes, _segmentMetadata, _encryptionInfo, _segmentMetadataZNRecord);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -21,9 +21,14 @@ package org.apache.pinot.controller.api.upload;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -108,6 +113,61 @@ public class ZKOperator {
           finalSegmentLocationURI, segmentFile, sourceDownloadURIStr, segmentDownloadURIStr, crypterName,
           segmentSizeInBytes, enableParallelPushProtection, headers);
     }
+  }
+
+  // Complete segment operations for a list of segments in batch mode
+  public void completeSegmentsOperations(String tableNameWithType, FileUploadType uploadType,
+      boolean enableParallelPushProtection, boolean allowRefresh, HttpHeaders headers,
+      List<SegmentUploadMetadata> segmentUploadMetadataList)
+      throws Exception {
+    boolean refreshOnly =
+        Boolean.parseBoolean(headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY));
+    List<SegmentUploadMetadata> newSegmentsList = new ArrayList<>();
+    List<SegmentUploadMetadata> existingSegmentsList = new ArrayList<>();
+    for (SegmentUploadMetadata segmentUploadMetadata: segmentUploadMetadataList) {
+      SegmentMetadata segmentMetadata = segmentUploadMetadata.getSegmentMetadata();
+      String segmentName = segmentMetadata.getName();
+
+      ZNRecord existingSegmentMetadataZNRecord =
+          _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
+      if (existingSegmentMetadataZNRecord != null && shouldProcessAsNewSegment(tableNameWithType, segmentName,
+          existingSegmentMetadataZNRecord, enableParallelPushProtection)) {
+        LOGGER.warn("Removing segment ZK metadata (recovering from previous upload failure) for table: {}, segment: {}",
+            tableNameWithType, segmentName);
+        Preconditions.checkState(_pinotHelixResourceManager.removeSegmentZKMetadata(tableNameWithType, segmentName),
+            "Failed to remove segment ZK metadata for table: %s, segment: %s", tableNameWithType, segmentName);
+        existingSegmentMetadataZNRecord = null;
+      }
+
+      if (existingSegmentMetadataZNRecord == null) {
+        // Add a new segment
+        if (refreshOnly) {
+          throw new ControllerApplicationException(LOGGER,
+              String.format("Cannot refresh non-existing segment: %s for table: %s", segmentName, tableNameWithType),
+              Response.Status.GONE);
+        }
+        LOGGER.info("Adding new segment: {} to table: {}", segmentName, tableNameWithType);
+        newSegmentsList.add(segmentUploadMetadata);
+      } else {
+        // Refresh an existing segment
+        if (!allowRefresh) {
+          // We cannot perform this check up-front in UploadSegment API call. If a segment doesn't exist during the
+          // check done up-front but ends up getting created before the check here, we could incorrectly refresh an
+          // existing segment.
+          throw new ControllerApplicationException(LOGGER,
+              String.format("Segment: %s already exists in table: %s. Refresh not permitted.", segmentName,
+                  tableNameWithType), Response.Status.CONFLICT);
+        }
+        LOGGER.info("Segment: {} already exists in table: {}, refreshing it", segmentName, tableNameWithType);
+        segmentUploadMetadata.setSegmentMetadataZNRecord(existingSegmentMetadataZNRecord);
+        existingSegmentsList.add(segmentUploadMetadata);
+      }
+    }
+    // process new segments
+    processNewSegments(tableNameWithType, uploadType, enableParallelPushProtection, headers, newSegmentsList);
+
+    // process existing segments
+    processExistingSegments(tableNameWithType, uploadType, enableParallelPushProtection, headers, existingSegmentsList);
   }
 
   /**
@@ -276,6 +336,144 @@ public class ZKOperator {
     }
   }
 
+  // process a batch of existing segments
+  private void processExistingSegments(String tableNameWithType, FileUploadType uploadType,
+      boolean enableParallelPushProtection, HttpHeaders headers, List<SegmentUploadMetadata> segmentUploadMetadataList)
+      throws Exception {
+    for (SegmentUploadMetadata segmentUploadMetadata: segmentUploadMetadataList) {
+      SegmentMetadata segmentMetadata = segmentUploadMetadata.getSegmentMetadata();
+      String segmentDownloadURIStr = segmentUploadMetadata.getSegmentDownloadURIStr();
+      String sourceDownloadURIStr = segmentUploadMetadata.getSourceDownloadURIStr();
+      URI finalSegmentLocationURI = segmentUploadMetadata.getFinalSegmentLocationURI();
+      Pair<String, File> encryptionInfo = segmentUploadMetadata.getEncryptionInfo();
+      String crypterName = encryptionInfo.getLeft();
+      File segmentFile = encryptionInfo.getRight();
+      String segmentName = segmentMetadata.getName();
+      ZNRecord existingSegmentMetadataZNRecord = segmentUploadMetadata.getSegmentMetadataZNRecord();
+      long segmentSizeInBytes = segmentUploadMetadata.getSegmentSizeInBytes();
+      int expectedVersion = existingSegmentMetadataZNRecord.getVersion();
+
+      // Check if CRC match when IF-MATCH header is set
+      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(existingSegmentMetadataZNRecord);
+      long existingCrc = segmentZKMetadata.getCrc();
+      checkCRC(headers, tableNameWithType, segmentName, existingCrc);
+
+      // Check segment upload start time when parallel push protection enabled
+      if (enableParallelPushProtection) {
+        // When segment upload start time is larger than 0, that means another upload is in progress
+        long segmentUploadStartTime = segmentZKMetadata.getSegmentUploadStartTime();
+        if (segmentUploadStartTime > 0) {
+          handleParallelPush(tableNameWithType, segmentName, segmentUploadStartTime);
+        }
+
+        // Lock the segment by setting the upload start time in ZK
+        segmentZKMetadata.setSegmentUploadStartTime(System.currentTimeMillis());
+        if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata, expectedVersion)) {
+          throw new ControllerApplicationException(LOGGER,
+              String.format("Failed to lock the segment: %s of table: %s, retry later", segmentName, tableNameWithType),
+              Response.Status.CONFLICT);
+        } else {
+          // The version will increment if the zk metadata update is successful
+          expectedVersion++;
+        }
+      }
+
+      // Reset segment upload start time to unlock the segment later
+      // NOTE: reset this value even if parallel push protection is not enabled so that segment can recover in case
+      // previous segment upload did not finish properly and the parallel push protection is turned off
+      segmentZKMetadata.setSegmentUploadStartTime(-1);
+
+      try {
+        // Construct the segment ZK metadata custom map modifier
+        String customMapModifierStr =
+            headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER);
+        SegmentZKMetadataCustomMapModifier customMapModifier =
+            customMapModifierStr != null ? new SegmentZKMetadataCustomMapModifier(customMapModifierStr) : null;
+
+        // Update ZK metadata and refresh the segment if necessary
+        long newCrc = Long.parseLong(segmentMetadata.getCrc());
+        if (newCrc == existingCrc) {
+          LOGGER.info(
+              "New segment crc '{}' is the same as existing segment crc for segment '{}'. Updating ZK metadata without "
+                  + "refreshing the segment.", newCrc, segmentName);
+          // NOTE: Even though we don't need to refresh the segment, we should still update the following fields:
+          // - Creation time (not included in the crc)
+          // - Refresh time
+          // - Custom map
+          segmentZKMetadata.setCreationTime(segmentMetadata.getIndexCreationTime());
+          segmentZKMetadata.setRefreshTime(System.currentTimeMillis());
+          if (customMapModifier != null) {
+            segmentZKMetadata.setCustomMap(customMapModifier.modifyMap(segmentZKMetadata.getCustomMap()));
+          } else {
+            // If no modifier is provided, use the custom map from the segment metadata
+            segmentZKMetadata.setCustomMap(segmentMetadata.getCustomMap());
+          }
+          if (!segmentZKMetadata.getDownloadUrl().equals(segmentDownloadURIStr)) {
+            // For offline ingestion, it is quite common that the download.uri would change but the crc would be the
+            // same. E.g. a user re-runs the job which process the same data and segments are stored/pushed from a
+            // different path from the Deepstore. Read more: https://github.com/apache/pinot/issues/11535
+            LOGGER.info("Updating segment download url from: {} to: {} even though crc is the same",
+                segmentZKMetadata.getDownloadUrl(), segmentDownloadURIStr);
+            segmentZKMetadata.setDownloadUrl(segmentDownloadURIStr);
+            // When download URI changes, we also need to copy the segment to the final location if existed.
+            // This typically means users changed the push type from METADATA to SEGMENT or SEGMENT to METADATA.
+            // Note that switching push type from SEGMENT to METADATA may lead orphan segments in the controller
+            // managed directory. Read more: https://github.com/apache/pinot/pull/11720
+            if (finalSegmentLocationURI != null) {
+              copySegmentToDeepStore(tableNameWithType, segmentName, uploadType, segmentFile, sourceDownloadURIStr,
+                  finalSegmentLocationURI);
+            }
+          }
+          if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata, expectedVersion)) {
+            throw new RuntimeException(
+                String.format("Failed to update ZK metadata for segment: %s, table: %s, expected version: %d",
+                    segmentName, tableNameWithType, expectedVersion));
+          }
+        } else {
+          // New segment is different with the existing one, update ZK metadata and refresh the segment
+          LOGGER.info(
+              "New segment crc {} is different than the existing segment crc {}. Updating ZK metadata and refreshing "
+                  + "segment {}", newCrc, existingCrc, segmentName);
+          if (finalSegmentLocationURI != null) {
+            copySegmentToDeepStore(tableNameWithType, segmentName, uploadType, segmentFile, sourceDownloadURIStr,
+                finalSegmentLocationURI);
+          }
+
+          // NOTE: Must first set the segment ZK metadata before trying to refresh because servers and brokers rely on
+          // segment ZK metadata to refresh the segment (server will compare the segment ZK metadata with the local
+          // metadata to decide whether to download the new segment; broker will update the segment partition info &
+          // time boundary based on the segment ZK metadata)
+          if (customMapModifier == null) {
+            // If no modifier is provided, use the custom map from the segment metadata
+            segmentZKMetadata.setCustomMap(null);
+            ZKMetadataUtils.refreshSegmentZKMetadata(tableNameWithType, segmentZKMetadata, segmentMetadata,
+                segmentDownloadURIStr, crypterName, segmentSizeInBytes);
+          } else {
+            // If modifier is provided, first set the custom map from the segment metadata, then apply the modifier
+            ZKMetadataUtils.refreshSegmentZKMetadata(tableNameWithType, segmentZKMetadata, segmentMetadata,
+                segmentDownloadURIStr, crypterName, segmentSizeInBytes);
+            segmentZKMetadata.setCustomMap(customMapModifier.modifyMap(segmentZKMetadata.getCustomMap()));
+          }
+          if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata, expectedVersion)) {
+            throw new RuntimeException(
+                String.format("Failed to update ZK metadata for segment: %s, table: %s, expected version: %d",
+                    segmentName, tableNameWithType, expectedVersion));
+          }
+          LOGGER.info("Updated segment: {} of table: {} to property store", segmentName, tableNameWithType);
+
+          // Send a message to servers and brokers hosting the table to refresh the segment
+          _pinotHelixResourceManager.sendSegmentRefreshMessage(tableNameWithType, segmentName, true, true);
+        }
+      } catch (Exception e) {
+        if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata, expectedVersion)) {
+          LOGGER.error("Failed to update ZK metadata for segment: {}, table: {}, expected version: {}", segmentName,
+              tableNameWithType, expectedVersion);
+        }
+        throw e;
+      }
+    }
+  }
+
   private void checkCRC(HttpHeaders headers, String tableNameWithType, String segmentName, long existingCrc) {
     String expectedCrcStr = headers.getHeaderString(HttpHeaders.IF_MATCH);
     if (expectedCrcStr != null) {
@@ -374,6 +572,102 @@ public class ZKOperator {
     }
   }
 
+  // process a batch of new segments
+  private void processNewSegments(String tableNameWithType, FileUploadType uploadType,
+      boolean enableParallelPushProtection, HttpHeaders headers, List<SegmentUploadMetadata> segmentUploadMetadataList)
+      throws Exception {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
+    List<String> segmentNames = new ArrayList<>();
+    long segmentUploadStartTime = System.currentTimeMillis();
+    for (SegmentUploadMetadata segmentUploadMetadata: segmentUploadMetadataList) {
+      SegmentMetadata segmentMetadata = segmentUploadMetadata.getSegmentMetadata();
+      String segmentName = segmentMetadata.getName();
+      SegmentZKMetadata newSegmentZKMetadata;
+      URI finalSegmentLocationURI = segmentUploadMetadata.getFinalSegmentLocationURI();
+      String segmentDownloadURIStr = segmentUploadMetadata.getSegmentDownloadURIStr();
+      String sourceDownloadURIStr = segmentUploadMetadata.getSourceDownloadURIStr();
+      String crypterName = segmentUploadMetadata.getEncryptionInfo().getLeft();
+      long segmentSizeInBytes = segmentUploadMetadata.getSegmentSizeInBytes();
+      File segmentFile = segmentUploadMetadata.getEncryptionInfo().getRight();
+      try {
+        newSegmentZKMetadata = ZKMetadataUtils.createSegmentZKMetadata(tableNameWithType, segmentMetadata,
+            segmentDownloadURIStr, crypterName, segmentSizeInBytes);
+        segmentZKMetadataMap.put(segmentName, newSegmentZKMetadata);
+        segmentNames.add(segmentName);
+      } catch (IllegalArgumentException e) {
+        throw new ControllerApplicationException(LOGGER,
+            String.format("Got invalid segment metadata when adding segment: %s for table: %s, reason: %s", segmentName,
+                tableNameWithType, e.getMessage()), Response.Status.BAD_REQUEST);
+      }
+
+      // Lock if enableParallelPushProtection is true.
+      if (enableParallelPushProtection) {
+        newSegmentZKMetadata.setSegmentUploadStartTime(segmentUploadStartTime);
+      }
+
+      // Update zk metadata custom map
+      String segmentZKMetadataCustomMapModifierStr = headers != null ? headers.getHeaderString(
+          FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER) : null;
+      if (segmentZKMetadataCustomMapModifierStr != null) {
+        SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier = new SegmentZKMetadataCustomMapModifier(
+            segmentZKMetadataCustomMapModifierStr);
+        newSegmentZKMetadata.setCustomMap(segmentZKMetadataCustomMapModifier.modifyMap(
+            newSegmentZKMetadata.getCustomMap()));
+      }
+      if (!_pinotHelixResourceManager.createSegmentZkMetadata(tableNameWithType, newSegmentZKMetadata)) {
+        throw new RuntimeException(String.format("Failed to create ZK metadata for segment: %s of table: %s",
+            segmentName, tableNameWithType));
+      }
+
+      if (finalSegmentLocationURI != null) {
+        try {
+          copySegmentToDeepStore(tableNameWithType, segmentName, uploadType, segmentFile, sourceDownloadURIStr,
+              finalSegmentLocationURI);
+        } catch (Exception e) {
+          // Cleanup the Zk entry and the segment from the permanent directory if it exists.
+          LOGGER.error("Could not move segment {} from table {} to permanent directory",
+              segmentName, tableNameWithType, e);
+          // Delete all segments that are getting processed as we are in batch mode
+          deleteSegmentsIfNeeded(tableNameWithType, segmentNames, segmentUploadStartTime, enableParallelPushProtection);
+          throw e;
+        }
+      }
+    }
+
+    try {
+      _pinotHelixResourceManager.assignTableSegments(tableNameWithType, segmentNames);
+    } catch (Exception e) {
+      // assignTableSegment removes the zk entry.
+      // Call deleteSegment to remove the segment from permanent location if needed.
+      LOGGER.error("Caught exception while calling assignTableSegments for adding segments: {} to table: {}",
+          segmentZKMetadataMap.keySet(), tableNameWithType, e);
+      deleteSegmentsIfNeeded(tableNameWithType, segmentNames, segmentUploadStartTime, enableParallelPushProtection);
+      throw e;
+    }
+
+    for (Map.Entry<String, SegmentZKMetadata> segmentZKMetadataEntry: segmentZKMetadataMap.entrySet()) {
+      SegmentZKMetadata newSegmentZKMetadata = segmentZKMetadataEntry.getValue();
+      String segmentName = segmentZKMetadataEntry.getKey();
+      if (enableParallelPushProtection) {
+        // Release lock. Expected version will be 0 as we hold a lock and no updates could take place meanwhile.
+        newSegmentZKMetadata.setSegmentUploadStartTime(-1);
+        if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, newSegmentZKMetadata, 0)) {
+          // There is a race condition when it took too much time for the 1st segment upload to process (due to slow
+          // PinotFS access), which leads to the 2nd attempt of segment upload, and the 2nd segment upload succeeded.
+          // In this case, when the 1st upload comes back, it shouldn't blindly delete the segment when it failed to
+          // update the zk metadata. Instead, the 1st attempt should validate the upload start time one more time.
+          // If the start time doesn't match with the one persisted in zk metadata, segment deletion should be skipped.
+          String errorMsg = String.format("Failed to update ZK metadata for segment: %s of table: %s", segmentName,
+              tableNameWithType);
+          LOGGER.error(errorMsg);
+          // Delete all segments that are getting processed as we are in batch mode
+          deleteSegmentsIfNeeded(tableNameWithType, segmentNames, segmentUploadStartTime, true);
+          throw new RuntimeException(errorMsg);
+        }
+      }
+    }
+  }
+
   /**
    * Deletes the segment to be uploaded if either one of the criteria is qualified:
    * 1) the uploadStartTime matches with the one persisted in ZK metadata.
@@ -394,6 +688,35 @@ public class ZKOperator {
     if (!enableParallelPushProtection || currentSegmentUploadStartTime == existingSegmentUploadStartTime) {
       _pinotHelixResourceManager.deleteSegment(tableNameWithType, segmentName);
       LOGGER.info("Deleted zk entry and segment {} for table {}.", segmentName, tableNameWithType);
+    }
+  }
+
+  /**
+   * Deletes the segments to be uploaded if either one of the criteria is qualified:
+   * 1) the uploadStartTime matches with the one persisted in ZK metadata.
+   * 2) enableParallelPushProtection is not enabled.
+   */
+  private void deleteSegmentsIfNeeded(String tableNameWithType, List<String> segmentNames,
+      long currentSegmentUploadStartTime, boolean enableParallelPushProtection) {
+    List<String> segmentsToDelete = new ArrayList<>();
+    for (String segmentName: segmentNames) {
+      ZNRecord existingSegmentMetadataZNRecord =
+          _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
+      if (existingSegmentMetadataZNRecord == null) {
+        continue;
+      }
+      // Check if the upload start time is set by this thread itself, if yes delete the segment.
+      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(existingSegmentMetadataZNRecord);
+      long existingSegmentUploadStartTime = segmentZKMetadata.getSegmentUploadStartTime();
+      LOGGER.info("Parallel push protection is {} for segment: {}.",
+          (enableParallelPushProtection ? "enabled" : "disabled"), segmentName);
+      if (!enableParallelPushProtection || currentSegmentUploadStartTime == existingSegmentUploadStartTime) {
+        segmentsToDelete.add(segmentName);
+      }
+    }
+    if (!segmentsToDelete.isEmpty()) {
+      _pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentsToDelete);
+      LOGGER.info("Deleted zk entry and segments {} for table {}.", segmentsToDelete, tableNameWithType);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2362,6 +2362,84 @@ public class PinotHelixResourceManager {
     }
   }
 
+  // Assign a list of segments in batch mode
+  public void assignTableSegments(String tableNameWithType, List<String> segmentNames) {
+    Map<String, String> segmentZKMetadataPathMap = new HashMap<>();
+    for (String segmentName: segmentNames) {
+      String segmentZKMetadataPath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType,
+          segmentName);
+      segmentZKMetadataPathMap.put(segmentName, segmentZKMetadataPath);
+    }
+    // Assign instances for the segment and add it into IdealState
+    try {
+      TableConfig tableConfig = getTableConfig(tableNameWithType);
+      Preconditions.checkState(tableConfig != null, "Failed to find table config for table: " + tableNameWithType);
+
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap =
+          fetchOrComputeInstancePartitions(tableNameWithType, tableConfig);
+
+      // Initialize tier information only in case direct tier assignment is configured
+      if (_enableTieredSegmentAssignment && CollectionUtils.isNotEmpty(tableConfig.getTierConfigsList())) {
+        List<Tier> sortedTiers = TierConfigUtils.getSortedTiersForStorageType(tableConfig.getTierConfigsList(),
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, _helixZkManager);
+        for (String segmentName: segmentNames) {
+          // Update segment tier to support direct assignment for multiple data directories
+          updateSegmentTargetTier(tableNameWithType, segmentName, sortedTiers);
+          InstancePartitions tierInstancePartitions = TierConfigUtils.getTieredInstancePartitionsForSegment(
+              tableNameWithType, segmentName, sortedTiers, _helixZkManager);
+          if (tierInstancePartitions != null && TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
+            // Override instance partitions for offline table
+            LOGGER.info("Overriding with tiered instance partitions: {} for segment: {} of table: {}",
+                tierInstancePartitions, segmentName, tableNameWithType);
+            instancePartitionsMap = Collections.singletonMap(InstancePartitionsType.OFFLINE, tierInstancePartitions);
+          }
+        }
+      }
+
+      SegmentAssignment segmentAssignment =
+          SegmentAssignmentFactory.getSegmentAssignment(_helixZkManager, tableConfig, _controllerMetrics);
+      synchronized (getIdealStateUpdaterLock(tableNameWithType)) {
+        long segmentAssignmentStartTs = System.currentTimeMillis();
+        Map<InstancePartitionsType, InstancePartitions> finalInstancePartitionsMap = instancePartitionsMap;
+        HelixHelper.updateIdealState(_helixZkManager, tableNameWithType, idealState -> {
+          assert idealState != null;
+          for (String segmentName: segmentNames) {
+            Map<String, Map<String, String>> currentAssignment = idealState.getRecord().getMapFields();
+            if (currentAssignment.containsKey(segmentName)) {
+              LOGGER.warn("Segment: {} already exists in the IdealState for table: {}, do not update", segmentName,
+                  tableNameWithType);
+            } else {
+              List<String> assignedInstances =
+                  segmentAssignment.assignSegment(segmentName, currentAssignment, finalInstancePartitionsMap);
+              LOGGER.info("Assigning segment: {} to instances: {} for table: {}", segmentName, assignedInstances,
+                  tableNameWithType);
+              currentAssignment.put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(assignedInstances,
+                  SegmentStateModel.ONLINE));
+            }
+          }
+          return idealState;
+        });
+        LOGGER.info("Added {} segments: {} to IdealState for table: {} in {} ms", segmentNames.size(), segmentNames,
+            tableNameWithType, System.currentTimeMillis() - segmentAssignmentStartTs);
+      }
+    } catch (Exception e) {
+      LOGGER.error(
+          "Caught exception while adding segments: {} to IdealState for table: {}, deleting segments ZK metadata",
+          segmentNames, tableNameWithType, e);
+      for (Map.Entry<String, String> segmentZKMetadataPathEntry: segmentZKMetadataPathMap.entrySet()) {
+        String segmentName = segmentZKMetadataPathEntry.getKey();
+        String segmentZKMetadataPath = segmentZKMetadataPathEntry.getValue();
+        if (_propertyStore.remove(segmentZKMetadataPath, AccessOption.PERSISTENT)) {
+          LOGGER.info("Deleted segment ZK metadata for segment: {} of table: {}", segmentName, tableNameWithType);
+        } else {
+          LOGGER.error("Failed to delete segment ZK metadata for segment: {} of table: {}", segmentName,
+              tableNameWithType);
+        }
+      }
+      throw e;
+    }
+  }
+
   private Map<InstancePartitionsType, InstancePartitions> fetchOrComputeInstancePartitions(String tableNameWithType,
       TableConfig tableConfig) {
     if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResourceTest.java
@@ -18,17 +18,36 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.api.upload.SegmentMetadataInfo;
 import org.apache.pinot.spi.crypt.NoOpPinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.glassfish.jersey.media.multipart.BodyPart;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -41,6 +60,18 @@ public class PinotSegmentUploadDownloadRestletResourceTest {
   private PinotSegmentUploadDownloadRestletResource _resource = new PinotSegmentUploadDownloadRestletResource();
   private File _encryptedFile;
   private File _decryptedFile;
+  private File _tempDir;
+
+  @BeforeMethod
+  public void setUp() throws IOException {
+    _tempDir = new File(FileUtils.getTempDirectory(), "test-" + UUID.randomUUID());
+    FileUtils.forceMkdir(_tempDir);
+  }
+
+  @AfterMethod
+  public void tearDown() throws IOException {
+    FileUtils.deleteDirectory(_tempDir);
+  }
 
   @BeforeClass
   public void setup()
@@ -124,5 +155,98 @@ public class PinotSegmentUploadDownloadRestletResourceTest {
     // assert
     assertNull(encryptionInfo.getLeft());
     assertEquals(_decryptedFile, encryptionInfo.getRight());
+  }
+
+  @Test
+  public void testCreateSegmentFileFromBodyPart() throws IOException {
+    // Arrange
+    FormDataBodyPart mockBodyPart = mock(FormDataBodyPart.class);
+    File destFile = new File("testSegmentFile.txt");
+    String testContent = "This is a test content";
+
+    // Mock input stream to return the test content
+    InputStream mockInputStream = new ByteArrayInputStream(testContent.getBytes());
+    when(mockBodyPart.getValueAs(InputStream.class)).thenReturn(mockInputStream);
+
+    // Act
+    PinotSegmentUploadDownloadRestletResource.createSegmentFileFromBodyPart(mockBodyPart, destFile);
+
+    // Assert
+    try (BufferedReader reader = new BufferedReader(new FileReader(destFile))) {
+      StringBuilder fileContent = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        fileContent.append(line);
+      }
+      Assert.assertEquals(fileContent.toString(), testContent);
+    } finally {
+      // Clean up
+      destFile.delete();
+    }
+
+    // Verify that the cleanup method was called
+    verify(mockBodyPart).cleanup();
+  }
+
+  @Test
+  public void testCreateSegmentFileFromSegmentMetadataInfo()
+      throws IOException {
+    // setup
+    SegmentMetadataInfo metadataInfo = new SegmentMetadataInfo();
+
+    File segmentDir = new File(_tempDir, "segments");
+    FileUtils.forceMkdir(segmentDir);
+    File creationMetaFile = new File(segmentDir, "creation.meta");
+    FileUtils.touch(creationMetaFile);
+    File metadataPropertiesFile = new File(segmentDir, "metadata.properties");
+    FileUtils.touch(metadataPropertiesFile);
+
+    metadataInfo.setSegmentCreationMetaFile(creationMetaFile);
+    metadataInfo.setSegmentMetadataPropertiesFile(metadataPropertiesFile);
+
+    File destFile = new File(_tempDir, "outputSegment");
+
+    // test
+    PinotSegmentUploadDownloadRestletResource.createSegmentFileFromSegmentMetadataInfo(metadataInfo, destFile);
+
+    // verify
+    Assert.assertTrue(FileUtils.getFile(destFile).exists());
+  }
+
+  @Test
+  public void testGetSegmentSizeFromFile()
+      throws IOException {
+    // setup
+    File segmentDir = new File(_tempDir, "segments");
+    FileUtils.forceMkdir(segmentDir);
+    File creationMetaFile = new File(segmentDir, "creation.meta");
+    FileUtils.touch(creationMetaFile);
+    File metadataPropertiesFile = new File(segmentDir, "metadata.properties");
+    FileUtils.touch(metadataPropertiesFile);
+
+    File allSegmentsMetadataFile = new File(segmentDir, "all_segments_metadata");
+    FileUtils.touch(allSegmentsMetadataFile);
+    List<String> lines = List.of("mySegmentName", "/path/to/segment/download/uri");
+    FileUtils.writeLines(allSegmentsMetadataFile, lines);
+
+    File allSegmentsMetadataTarFile = new File(segmentDir, "allSegments.tar.gz");
+    TarCompressionUtils.createCompressedTarFile(segmentDir, allSegmentsMetadataTarFile);
+
+    // test
+    long segmentSizeInBytes =
+        PinotSegmentUploadDownloadRestletResource.getSegmentSizeFromFile(allSegmentsMetadataTarFile.toURI().toString());
+
+    // verify
+    Assert.assertTrue(segmentSizeInBytes > 0);
+  }
+
+  @Test
+  public void testValidateMultiPartForBatchSegmentUpload() {
+    // setup
+    FileDataBodyPart bodyPart = new FileDataBodyPart("allSegments.tar.gz", new File(_tempDir, "dummyFile"));
+    List<BodyPart> bodyParts = List.of(bodyPart);
+
+    // validate – should not throw exception
+    PinotSegmentUploadDownloadRestletResource.validateMultiPartForBatchSegmentUpload(bodyParts);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
 import org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner;
@@ -59,6 +60,7 @@ import org.testng.annotations.Test;
  * todo: add test for URI push
  */
 public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
+  private static String _tableNameSuffix;
 
   @Override
   protected Map<String, String> getStreamConfigs() {
@@ -93,6 +95,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
   @BeforeMethod
   public void setUpTest()
       throws IOException {
+    _tableNameSuffix = RandomStringUtils.randomAlphabetic(12);
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
   }
 
@@ -136,15 +139,15 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(DEFAULT_TABLE_NAME);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    tableSpec.setTableName(getTableName());
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(getTableName()));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());
     jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
 
     File dataDir = new File(_controllerConfig.getDataDir());
-    File dataDirSegments = new File(dataDir, DEFAULT_TABLE_NAME);
+    File dataDirSegments = new File(dataDir, getTableName());
 
     // Not present in dataDir, only present in sourceDir
     Assert.assertFalse(dataDirSegments.exists());
@@ -204,6 +207,77 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     testCountStar(numDocs);
   }
 
+  @Test
+  public void testUploadMultipleSegmentsInBatchModeAndQuery()
+      throws Exception {
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig offlineTableConfig = createOfflineTableConfig();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
+    addTableConfig(offlineTableConfig);
+
+    List<File> avroFiles = getAllAvroFiles();
+
+    // Create the list of segments
+    for (int segNum = 0; segNum < 12; segNum++) {
+      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(segNum), offlineTableConfig, schema,
+          "_seg" + segNum, _segmentDir, _tarDir);
+    }
+
+    SegmentMetadataPushJobRunner runner = new SegmentMetadataPushJobRunner();
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    pushJobSpec.setCopyToDeepStoreForMetadataPush(true);
+    // enable batch mode
+    pushJobSpec.setBatchSegmentUpload(true);
+    jobSpec.setPushJobSpec(pushJobSpec);
+    PinotFSSpec fsSpec = new PinotFSSpec();
+    fsSpec.setScheme("file");
+    fsSpec.setClassName("org.apache.pinot.spi.filesystem.LocalPinotFS");
+    jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
+    jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName(getTableName() + "_OFFLINE");
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(getTableName()));
+    jobSpec.setTableSpec(tableSpec);
+    PinotClusterSpec clusterSpec = new PinotClusterSpec();
+    clusterSpec.setControllerURI(getControllerBaseApiUrl());
+    jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
+
+    File dataDir = new File(_controllerConfig.getDataDir());
+    File dataDirSegments = new File(dataDir, getTableName());
+
+    // Not present in dataDir, only present in sourceDir
+    Assert.assertFalse(dataDirSegments.exists());
+    Assert.assertEquals(_tarDir.listFiles().length, 12);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Segment should be seen in dataDir
+    Assert.assertTrue(dataDirSegments.exists());
+    Assert.assertEquals(dataDirSegments.listFiles().length, 12);
+    Assert.assertEquals(_tarDir.listFiles().length, 12);
+
+    // test segment loaded
+    JsonNode segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 12);
+    long numDocs = 0;
+    for (JsonNode segmentName: segmentsList) {
+      numDocs += getNumDocs(segmentName.asText());
+    }
+    testCountStar(numDocs);
+
+    // Clear segment and tar dir
+    for (File segment : _segmentDir.listFiles()) {
+      FileUtils.deleteQuietly(segment);
+    }
+    for (File tar : _tarDir.listFiles()) {
+      FileUtils.deleteQuietly(tar);
+    }
+  }
+
   /**
    * Runs both SegmentMetadataPushJobRunner and SegmentTarPushJobRunner while enabling consistent data push.
    * Checks that segments are properly loaded and segment lineage entry were also in expected states.
@@ -237,15 +311,15 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(DEFAULT_TABLE_NAME);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    tableSpec.setTableName(getTableName());
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(getTableName()));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());
     jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
 
     File dataDir = new File(_controllerConfig.getDataDir());
-    File dataDirSegments = new File(dataDir, DEFAULT_TABLE_NAME);
+    File dataDirSegments = new File(dataDir, getTableName());
 
     Assert.assertEquals(_tarDir.listFiles().length, 1);
 
@@ -268,7 +342,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     // Fetch segment lineage entry after running segment metadata push with consistent push enabled.
     String segmentLineageResponse = ControllerTest.sendGetRequest(
         ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
-            .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+            .forListAllSegmentLineages(getTableName(), TableType.OFFLINE.toString()));
     // Segment lineage should be in completed state.
     Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
     // SegmentsFrom should be empty as we started with a blank table.
@@ -317,7 +391,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     // Fetch segment lineage entry after running segment tar push with consistent push enabled.
     segmentLineageResponse = ControllerTest.sendGetRequest(
         ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
-            .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+            .forListAllSegmentLineages(getTableName(), TableType.OFFLINE.toString()));
     // Segment lineage should be in completed state.
     Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
     // SegmentsFrom should contain the previous segment
@@ -337,14 +411,14 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
   private long getNumDocs(String segmentName)
       throws IOException {
     return JsonUtils.stringToJsonNode(
-            sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(DEFAULT_TABLE_NAME, segmentName)))
+            sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(getTableName(), segmentName)))
         .get("segment.total.docs").asLong();
   }
 
   private JsonNode getSegmentsList()
       throws IOException {
     return JsonUtils.stringToJsonNode(sendGetRequest(
-            _controllerRequestURLBuilder.forSegmentListAPI(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString())))
+            _controllerRequestURLBuilder.forSegmentListAPI(getTableName(), TableType.OFFLINE.toString())))
         .get(0).get("OFFLINE");
   }
 
@@ -360,6 +434,11 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
         }
       }
     }, 100L, 300_000, "Failed to load " + countStarResult + " documents", true);
+  }
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME + _tableNameSuffix;
   }
 
   @AfterMethod

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -182,14 +183,14 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     _pinotTaskConfig = pinotTaskConfig;
     _eventObserver = MinionEventObservers.getInstance().getMinionEventObserver(pinotTaskConfig.getTaskId());
     String taskType = pinotTaskConfig.getTaskType();
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
-    String inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
+    Map<String, String> taskConfigs = pinotTaskConfig.getConfigs();
+    String tableNameWithType = taskConfigs.get(MinionConstants.TABLE_NAME_KEY);
+    String inputSegmentNames = taskConfigs.get(MinionConstants.SEGMENT_NAME_KEY);
     String[] segmentNames = inputSegmentNames.split(MinionConstants.SEGMENT_NAME_SEPARATOR);
-    String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-    String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
+    String uploadURL = taskConfigs.get(MinionConstants.UPLOAD_URL_KEY);
+    String downloadURLString = taskConfigs.get(MinionConstants.DOWNLOAD_URL_KEY);
     String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
-    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
+    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(taskConfigs.get(MinionConstants.AUTH_TOKEN));
     LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
         tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
@@ -279,6 +280,9 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
       SegmentUploadContext segmentUploadContext = new SegmentUploadContext(pinotTaskConfig, segmentConversionResults);
       preUploadSegments(segmentUploadContext);
+      Map<String, String> segmentUriToTarPathMap = new HashMap<>();
+      PushJobSpec pushJobSpec = getPushJobSpec(taskConfigs);
+      boolean batchSegmentUpload = pushJobSpec.isBatchSegmentUpload();
 
       // Upload the tarred segments
       for (int i = 0; i < numOutputSegments; i++) {
@@ -287,51 +291,62 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         String resultSegmentName = segmentConversionResult.getSegmentName();
         _eventObserver.notifyProgress(_pinotTaskConfig,
             String.format("Uploading segment: %s (%d out of %d)", resultSegmentName, (i + 1), numOutputSegments));
-
-        // Set segment ZK metadata custom map modifier into HTTP header to modify the segment ZK metadata
-        SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
-            getSegmentZKMetadataCustomMapModifier(pinotTaskConfig, segmentConversionResult);
-        Header segmentZKMetadataCustomMapModifierHeader =
-            new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
-                segmentZKMetadataCustomMapModifier.toJsonString());
-
-        String pushMode =
-            configs.getOrDefault(BatchConfigProperties.PUSH_MODE, BatchConfigProperties.SegmentPushType.TAR.name());
+        String pushMode = taskConfigs.getOrDefault(BatchConfigProperties.PUSH_MODE,
+            BatchConfigProperties.SegmentPushType.TAR.name());
         URI outputSegmentTarURI;
         if (BatchConfigProperties.SegmentPushType.valueOf(pushMode.toUpperCase())
             != BatchConfigProperties.SegmentPushType.TAR) {
-          outputSegmentTarURI = moveSegmentToOutputPinotFS(configs, convertedTarredSegmentFile);
+          outputSegmentTarURI = moveSegmentToOutputPinotFS(taskConfigs, convertedTarredSegmentFile);
           LOGGER.info("Moved generated segment from [{}] to location: [{}]", convertedTarredSegmentFile,
               outputSegmentTarURI);
         } else {
           outputSegmentTarURI = convertedTarredSegmentFile.toURI();
         }
 
-        List<Header> httpHeaders = new ArrayList<>();
-        httpHeaders.add(segmentZKMetadataCustomMapModifierHeader);
-        httpHeaders.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
-
+        // Set segment ZK metadata custom map modifier into HTTP header to modify the segment ZK metadata
+        List<Header> httpHeaders = getSegmentPushCommonHeaders(pinotTaskConfig, authProvider, segmentConversionResults);
         // Set parameters for upload request
-        NameValuePair enableParallelPushProtectionParameter =
-            new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true");
-        NameValuePair tableNameParameter = new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
-            TableNameBuilder.extractRawTableName(tableNameWithType));
-        NameValuePair tableTypeParameter = new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE,
-            TableNameBuilder.getTableTypeFromTableName(tableNameWithType).toString());
+        List<NameValuePair> parameters = getSegmentPushCommonParams(tableNameWithType);
+
         // RealtimeToOfflineSegmentsTask pushed segments to the corresponding offline table
         // TODO: This is not clean to put the override here, but let's think about it harder to see what is the proper
         //  way to override it.
         if (MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE.equals(taskType)) {
-          tableTypeParameter =
-              new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE, TableType.OFFLINE.toString());
+          Iterator<NameValuePair> paramItr = parameters.iterator();
+          while (paramItr.hasNext()) {
+            NameValuePair nameValuePair = paramItr.next();
+            if (FileUploadDownloadClient.QueryParameters.TABLE_TYPE.equals(nameValuePair.getName())) {
+              paramItr.remove();
+              break;
+            }
+          }
+          parameters.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE,
+              TableType.OFFLINE.toString()));
         }
-        List<NameValuePair> parameters =
-            Arrays.asList(enableParallelPushProtectionParameter, tableNameParameter, tableTypeParameter);
 
-        pushSegment(tableNameParameter.getValue(), configs, outputSegmentTarURI, httpHeaders, parameters,
-            segmentConversionResult);
-        if (!FileUtils.deleteQuietly(convertedTarredSegmentFile)) {
-          LOGGER.warn("Failed to delete tarred converted segment: {}", convertedTarredSegmentFile.getAbsolutePath());
+        if (batchSegmentUpload) {
+          updateSegmentUriToTarPathMap(taskConfigs, outputSegmentTarURI, segmentConversionResult,
+              segmentUriToTarPathMap, pushJobSpec);
+        } else {
+          String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+          pushSegment(rawTableName, taskConfigs, outputSegmentTarURI, httpHeaders, parameters, segmentConversionResult);
+          if (!FileUtils.deleteQuietly(convertedTarredSegmentFile)) {
+            LOGGER.warn("Failed to delete tarred converted segment: {}", convertedTarredSegmentFile.getAbsolutePath());
+          }
+        }
+      }
+
+      if (batchSegmentUpload) {
+        try {
+          pushSegments(tableNameWithType, taskConfigs, pinotTaskConfig, segmentUriToTarPathMap, pushJobSpec,
+              authProvider, segmentConversionResults);
+        } finally {
+          for (File convertedTarredSegmentFile: tarredSegmentFiles) {
+            if (!FileUtils.deleteQuietly(convertedTarredSegmentFile)) {
+              LOGGER.warn("Failed to delete converted tarred segment file: {}",
+                  convertedTarredSegmentFile.getAbsolutePath());
+            }
+          }
         }
       }
 
@@ -349,6 +364,95 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     }
   }
 
+  @VisibleForTesting
+  void updateSegmentUriToTarPathMap(Map<String, String> taskConfigs, URI outputSegmentTarURI,
+      SegmentConversionResult segmentConversionResult, Map<String, String> segmentUriToTarPathMap,
+      PushJobSpec pushJobSpec) {
+    String segmentName = segmentConversionResult.getSegmentName();
+    if (!taskConfigs.containsKey(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI)) {
+      throw new RuntimeException(String.format("Output dir URI missing for metadata push while processing segment: %s",
+          segmentName));
+    }
+    URI outputSegmentDirURI = URI.create(taskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI));
+    Map<String, String> localSegmentUriToTarPathMap =
+        SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI, pushJobSpec,
+            new String[]{outputSegmentTarURI.toString()});
+    if (!localSegmentUriToTarPathMap.isEmpty()) {
+      segmentUriToTarPathMap.putAll(localSegmentUriToTarPathMap);
+    }
+  }
+
+  @VisibleForTesting
+  PushJobSpec getPushJobSpec(Map<String, String> taskConfigs) {
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    pushJobSpec.setPushAttempts(DEFUALT_PUSH_ATTEMPTS);
+    pushJobSpec.setPushParallelism(DEFAULT_PUSH_PARALLELISM);
+    pushJobSpec.setPushRetryIntervalMillis(DEFAULT_PUSH_RETRY_INTERVAL_MILLIS);
+    pushJobSpec.setSegmentUriPrefix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_PREFIX));
+    pushJobSpec.setSegmentUriSuffix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_SUFFIX));
+    boolean batchSegmentUpload = Boolean.parseBoolean(taskConfigs.getOrDefault(
+        BatchConfigProperties.BATCH_SEGMENT_UPLOAD, "false"));
+    if (batchSegmentUpload) {
+      pushJobSpec.setBatchSegmentUpload(true);
+    }
+    return pushJobSpec;
+  }
+
+  @VisibleForTesting
+  List<Header> getSegmentPushCommonHeaders(PinotTaskConfig pinotTaskConfig, AuthProvider authProvider,
+      List<SegmentConversionResult> segmentConversionResults) {
+    SegmentConversionResult segmentConversionResult;
+    if (segmentConversionResults.size() == 1) {
+      segmentConversionResult = segmentConversionResults.get(0);
+    } else {
+      // Setting to null as the base method expects a single object. This is ok for now, since the
+      // segmentConversionResult is not made use of while generating the customMap.
+      segmentConversionResult = null;
+    }
+    SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
+        getSegmentZKMetadataCustomMapModifier(pinotTaskConfig, segmentConversionResult);
+    Header segmentZKMetadataCustomMapModifierHeader =
+        new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
+            segmentZKMetadataCustomMapModifier.toJsonString());
+
+    List<Header> headers = new ArrayList<>();
+    headers.add(segmentZKMetadataCustomMapModifierHeader);
+    headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
+    return headers;
+  }
+
+  @VisibleForTesting
+  List<NameValuePair> getSegmentPushCommonParams(String tableNameWithType) {
+    List<NameValuePair> params = new ArrayList<>();
+    params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
+        "true"));
+    params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+        TableNameBuilder.extractRawTableName(tableNameWithType)));
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    if (tableType != null) {
+      params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE, tableType.toString()));
+    } else {
+      throw new RuntimeException(String.format("Failed to determine the tableType from name: %s", tableNameWithType));
+    }
+    return params;
+  }
+
+  private void pushSegments(String tableNameWithType, Map<String, String> taskConfigs, PinotTaskConfig pinotTaskConfig,
+      Map<String, String> segmentUriToTarPathMap, PushJobSpec pushJobSpec,
+      AuthProvider authProvider, List<SegmentConversionResult> segmentConversionResults)
+      throws Exception {
+    String tableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    SegmentGenerationJobSpec spec = generateSegmentGenerationJobSpec(tableName, taskConfigs, pushJobSpec);
+
+    List<Header> headers = getSegmentPushCommonHeaders(pinotTaskConfig, authProvider, segmentConversionResults);
+    List<NameValuePair> parameters = getSegmentPushCommonParams(tableNameWithType);
+
+    URI outputSegmentDirURI = URI.create(taskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI));
+    try (PinotFS outputFileFS = MinionTaskUtils.getOutputPinotFS(taskConfigs, outputSegmentDirURI)) {
+      SegmentPushUtils.sendSegmentsUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap, headers, parameters);
+    }
+  }
+
   private void pushSegment(String tableName, Map<String, String> taskConfigs, URI outputSegmentTarURI,
       List<Header> headers, List<NameValuePair> parameters, SegmentConversionResult segmentConversionResult)
       throws Exception {
@@ -363,7 +467,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     pushJobSpec.setSegmentUriPrefix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_PREFIX));
     pushJobSpec.setSegmentUriSuffix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_SUFFIX));
 
-    SegmentGenerationJobSpec spec = generatePushJobSpec(tableName, taskConfigs, pushJobSpec);
+    SegmentGenerationJobSpec spec = generateSegmentGenerationJobSpec(tableName, taskConfigs, pushJobSpec);
 
     switch (BatchConfigProperties.SegmentPushType.valueOf(pushMode.toUpperCase())) {
       case TAR:
@@ -392,7 +496,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     }
   }
 
-  private SegmentGenerationJobSpec generatePushJobSpec(String tableName, Map<String, String> taskConfigs,
+  private SegmentGenerationJobSpec generateSegmentGenerationJobSpec(String tableName, Map<String, String> taskConfigs,
       PushJobSpec pushJobSpec) {
 
     TableSpec tableSpec = new TableSpec();
@@ -419,9 +523,8 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
           URI.create(MinionTaskUtils.normalizeDirectoryURI(outputSegmentDirURI) + localSegmentTarFile.getName());
       if (!Boolean.parseBoolean(taskConfigs.get(BatchConfigProperties.OVERWRITE_OUTPUT)) && outputFileFS.exists(
           outputSegmentTarURI)) {
-        throw new RuntimeException(
-            String.format("Output file: %s already exists. " + "Set 'overwriteOutput' to true to ignore this error",
-                outputSegmentTarURI));
+        throw new RuntimeException(String.format("Output file: %s already exists. "
+            + "Set 'overwriteOutput' to true to ignore this error", outputSegmentTarURI));
       } else {
         outputFileFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutorTest.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class BaseMultipleSegmentsConversionExecutorTest {
+
+  private AuthProvider _mockAuthProvider;
+  private BaseMultipleSegmentsConversionExecutor _executor;
+  private SegmentZKMetadataCustomMapModifier _zkMetadataCustomMapModifier;
+  private File _tempDir;
+
+  @AfterMethod
+  public void tearDown() throws IOException {
+    // Clean up the temporary directory
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  @BeforeMethod
+  private void setup()
+      throws IOException {
+    _tempDir = new File(FileUtils.getTempDirectory(), "test-" + UUID.randomUUID());
+    FileUtils.forceMkdir(_tempDir);
+
+    _mockAuthProvider = Mockito.mock(AuthProvider.class);
+    _zkMetadataCustomMapModifier = new SegmentZKMetadataCustomMapModifier(
+        SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, new HashMap<>());
+    _executor = new BaseMultipleSegmentsConversionExecutor(null) {
+      @Override
+      protected List<SegmentConversionResult> convert(PinotTaskConfig pinotTaskConfig, List<File> segmentDirs,
+          File workingDir) {
+        return null;
+      }
+
+      @Override
+      protected SegmentZKMetadataCustomMapModifier getSegmentZKMetadataCustomMapModifier(
+          PinotTaskConfig pinotTaskConfig, SegmentConversionResult segmentConversionResult) {
+        return _zkMetadataCustomMapModifier;
+      }
+    };
+  }
+
+  @Test
+  public void testGetPushJobSpec() {
+    Map<String, String> taskConfigs = new HashMap<>();
+    taskConfigs.put(BatchConfigProperties.BATCH_SEGMENT_UPLOAD, "true");
+
+    PushJobSpec batchPushJobSpec = _executor.getPushJobSpec(taskConfigs);
+    Assert.assertTrue(batchPushJobSpec.isBatchSegmentUpload());
+  }
+
+  @Test
+  public void testGetSegmentPushCommonHeaders() {
+    PinotTaskConfig pinotTaskConfig = new PinotTaskConfig("customMinionTask", new HashMap<>());
+    List<SegmentConversionResult> segmentConversionResults = new ArrayList<>();
+    List<Header> headers =
+        _executor.getSegmentPushCommonHeaders(pinotTaskConfig, _mockAuthProvider, segmentConversionResults);
+    Assert.assertEquals(headers.size(), 1);
+  }
+
+  @Test
+  public void testGetSegmentPushCommonParams() {
+    String tableNameWithType = "myTable_OFFLINE";
+
+    List<NameValuePair> params = _executor.getSegmentPushCommonParams(tableNameWithType);
+    Assert.assertEquals(params.size(), 3);
+    Assert.assertTrue(
+        params.contains(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, "myTable")));
+    Assert.assertTrue(
+        params.contains(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE, "OFFLINE")));
+  }
+
+  @Test
+  public void testUpdateSegmentURIToTarPathMap()
+      throws IOException {
+    // setup
+    File segmentDir = new File(_tempDir, "segments");
+    FileUtils.forceMkdir(segmentDir);
+    File segmentTarFile = new File(segmentDir, "segment.tar.gz");
+    FileUtils.touch(segmentTarFile);
+
+    URI outputSegmentTarURI = segmentTarFile.toURI();
+    URI outputSegmentDirURI = segmentDir.toURI();
+
+    Map<String, String> taskConfigs = new HashMap<>();
+    taskConfigs.put(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI, outputSegmentDirURI.getPath());
+
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    SegmentConversionResult conversionResult =
+        new SegmentConversionResult.Builder().setSegmentName("mySegment").build();
+    Map<String, String> segmentUriToTarPathMap = new HashMap<>();
+
+    // test
+    _executor.updateSegmentUriToTarPathMap(taskConfigs, outputSegmentTarURI, conversionResult, segmentUriToTarPathMap,
+        pushJobSpec);
+
+    // validate
+    Assert.assertEquals(segmentUriToTarPathMap.size(), 1);
+    Assert.assertTrue(segmentUriToTarPathMap.containsKey(_tempDir.toURI() + "segments/segment.tar.gz"));
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/constants/SegmentUploadConstants.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/constants/SegmentUploadConstants.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.constants;
+
+public final class SegmentUploadConstants {
+  private SegmentUploadConstants() {
+  }
+  // batch segment upload constants
+  public static final String ALL_SEGMENTS_METADATA_TAR_FILE_PREFIX = "allSegmentsMetadataTar-";
+  public static final String ALL_SEGMENTS_METADATA_DIR_PREFIX = "allSegmentsMetadataDir-";
+  public static final String ALL_SEGMENTS_METADATA_FILENAME = "all_segments_metadata";
+  public static final String SEGMENT_METADATA_DIR_PREFIX = "segmentMetadata-";
+  public static final String SEGMENT_METADATA_TAR_FILE_PREFIX = "segmentMetadataTar-";
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.segment.local.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
@@ -45,6 +47,7 @@ import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.segment.local.constants.SegmentUploadConstants;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.name.SegmentNameUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
@@ -136,7 +139,13 @@ public class SegmentPushUtils implements Serializable {
     AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
     List<Header> headers = AuthProviderUtils.toRequestHeaders(authProvider);
     List<NameValuePair> parameters = FileUploadDownloadClient.makeTableParam(tableName);
-    sendSegmentUriAndMetadata(spec, fileSystem, segmentUriToTarPathMap, headers, parameters);
+    PushJobSpec pushJobSpec = spec.getPushJobSpec();
+    if (pushJobSpec != null && pushJobSpec.isBatchSegmentUpload()) {
+      // segments are uploaded in batch when batch mode is enabled.
+      sendSegmentsUriAndMetadata(spec, fileSystem, segmentUriToTarPathMap, headers, parameters);
+    } else {
+      sendSegmentUriAndMetadata(spec, fileSystem, segmentUriToTarPathMap, headers, parameters);
+    }
   }
 
   public static void pushSegments(SegmentGenerationJobSpec spec, PinotFS fileSystem, List<String> tarFilePaths,
@@ -357,6 +366,151 @@ public class SegmentPushUtils implements Serializable {
         FileUtils.deleteQuietly(segmentMetadataFile);
       }
     }
+  }
+
+  public static void sendSegmentsUriAndMetadata(SegmentGenerationJobSpec spec, PinotFS fileSystem,
+      Map<String, String> segmentUriToTarPathMap, List<Header> headers, List<NameValuePair> parameters)
+      throws Exception {
+    String tableName = spec.getTableSpec().getTableName();
+    Map<String, File> segmentMetadataFileMap = new HashMap<>();
+    List<String> segmentURIs = new ArrayList<>();
+    LOGGER.info("Start pushing segment metadata: {} to locations: {} for table: {}", segmentUriToTarPathMap,
+        Arrays.toString(spec.getPinotClusterSpecs()), tableName);
+    for (String segmentUriPath : segmentUriToTarPathMap.keySet()) {
+      String tarFilePath = segmentUriToTarPathMap.get(segmentUriPath);
+      String fileName = new File(tarFilePath).getName();
+      // segments stored in Pinot deep store do not have .tar.gz extension
+      String segmentName = fileName.endsWith(Constants.TAR_GZ_FILE_EXT)
+          ? fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length()) : fileName;
+      SegmentNameUtils.validatePartialOrFullSegmentName(segmentName);
+      File segmentMetadataFile;
+      // Check if there is a segment metadata tar gz file named `segmentName.metadata.tar.gz`, already in the remote
+      // directory. This is to avoid generating a new segment metadata tar gz file every time we push a segment,
+      // which requires downloading the entire segment tar gz file.
+
+      URI metadataTarGzFilePath = generateSegmentMetadataURI(tarFilePath, segmentName);
+      LOGGER.info("Checking if metadata tar gz file {} exists", metadataTarGzFilePath);
+      if (spec.getPushJobSpec().isPreferMetadataTarGz() && fileSystem.exists(metadataTarGzFilePath)) {
+        segmentMetadataFile = new File(FileUtils.getTempDirectory(),
+            SegmentUploadConstants.SEGMENT_METADATA_DIR_PREFIX + UUID.randomUUID()
+                + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
+        if (segmentMetadataFile.exists()) {
+          FileUtils.forceDelete(segmentMetadataFile);
+        }
+        fileSystem.copyToLocalFile(metadataTarGzFilePath, segmentMetadataFile);
+      } else {
+        segmentMetadataFile = generateSegmentMetadataFile(fileSystem, URI.create(tarFilePath));
+      }
+      segmentMetadataFileMap.put(segmentName, segmentMetadataFile);
+      segmentURIs.add(segmentName);
+      segmentURIs.add(segmentUriPath);
+    }
+
+    File allSegmentsMetadataTarFile = createSegmentsMetadataTarFile(segmentURIs, segmentMetadataFileMap);
+    Map<String, File> allSegmentsMetadataMap = new HashMap<>();
+    // the key is unused in batch upload mode and hence 'noopKey'
+    allSegmentsMetadataMap.put("noopKey", allSegmentsMetadataTarFile);
+
+    // perform metadata push in batch mode for every cluster
+    try {
+      for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
+        URI controllerURI;
+        try {
+          controllerURI = new URI(pinotClusterSpec.getControllerURI());
+        } catch (URISyntaxException e) {
+          throw new RuntimeException("Got invalid controller uri: " + pinotClusterSpec.getControllerURI());
+        }
+        LOGGER.info("Pushing segments: {} to location: {} for table: {}",
+            segmentMetadataFileMap.keySet(), controllerURI, tableName);
+        int attempts = 1;
+        if (spec.getPushJobSpec() != null && spec.getPushJobSpec().getPushAttempts() > 0) {
+          attempts = spec.getPushJobSpec().getPushAttempts();
+        }
+        long retryWaitMs = 1000L;
+        if (spec.getPushJobSpec() != null && spec.getPushJobSpec().getPushRetryIntervalMillis() > 0) {
+          retryWaitMs = spec.getPushJobSpec().getPushRetryIntervalMillis();
+        }
+        RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
+          List<Header> reqHttpHeaders = new ArrayList<>(headers);
+          try {
+            addHeaders(spec, reqHttpHeaders);
+            URI segmentUploadURI = getBatchSegmentUploadURI(controllerURI);
+            SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.uploadSegmentMetadataFiles(segmentUploadURI,
+                allSegmentsMetadataMap, reqHttpHeaders, parameters, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+            LOGGER.info("Response for pushing table {} segments {} to location {} - {}: {}", tableName,
+                segmentMetadataFileMap.keySet(), controllerURI, response.getStatusCode(), response.getResponse());
+            return true;
+          } catch (HttpErrorStatusException e) {
+            int statusCode = e.getStatusCode();
+            if (statusCode >= 500) {
+              // Temporary exception
+              LOGGER.warn("Caught temporary exception while pushing table: {} segments: {} to {}, will retry",
+                  tableName, segmentMetadataFileMap.keySet(), controllerURI, e);
+              return false;
+            } else {
+              // Permanent exception
+              LOGGER.error("Caught permanent exception while pushing table: {} segments: {} to {}, won't retry",
+                  tableName, segmentMetadataFileMap.keySet(), controllerURI, e);
+              throw e;
+            }
+          }
+        });
+      }
+    } finally {
+      for (Map.Entry<String, File> metadataFileEntry: segmentMetadataFileMap.entrySet()) {
+        FileUtils.deleteQuietly(metadataFileEntry.getValue());
+      }
+      FileUtils.forceDelete(allSegmentsMetadataTarFile);
+    }
+  }
+
+  private static URI getBatchSegmentUploadURI(URI controllerURI)
+      throws URISyntaxException {
+    return FileUploadDownloadClient.getBatchSegmentUploadURI(controllerURI);
+  }
+
+  private static void addHeaders(SegmentGenerationJobSpec jobSpec, List<Header> headers) {
+    headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
+        FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+    if (jobSpec.getPushJobSpec() != null) {
+      headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE,
+          String.valueOf(jobSpec.getPushJobSpec().getCopyToDeepStoreForMetadataPush())));
+    }
+  }
+
+  // Method helps create an uber tar file which contains the metadata files for all segments that are to be uploaded.
+  // Additionally, it contains a segmentName to segmentDownloadURI mapping file which allows us to avoid sending the
+  // segmentDownloadURI as a header field as there are limitations on the number of headers allowed in the http request.
+  @VisibleForTesting
+  static File createSegmentsMetadataTarFile(List<String> segmentURIs, Map<String, File> segmentMetadataFileMap)
+      throws IOException {
+    String uuid = UUID.randomUUID().toString();
+    File allSegmentsMetadataDir =
+        new File(FileUtils.getTempDirectory(), SegmentUploadConstants.ALL_SEGMENTS_METADATA_DIR_PREFIX + uuid);
+    FileUtils.forceMkdir(allSegmentsMetadataDir);
+    for (Map.Entry<String, File> segmentMetadataTarFileEntry: segmentMetadataFileMap.entrySet()) {
+      String segmentName = segmentMetadataTarFileEntry.getKey();
+      File tarFile = segmentMetadataTarFileEntry.getValue();
+      TarCompressionUtils.untarOneFile(tarFile, V1Constants.MetadataKeys.METADATA_FILE_NAME,
+          new File(allSegmentsMetadataDir, segmentName + "." + V1Constants.MetadataKeys.METADATA_FILE_NAME));
+      TarCompressionUtils.untarOneFile(tarFile, V1Constants.SEGMENT_CREATION_META,
+          new File(allSegmentsMetadataDir, segmentName + "." + V1Constants.SEGMENT_CREATION_META));
+    }
+    File allSegmentsMetadataTarFile = new File(FileUtils.getTempDirectory(),
+        SegmentUploadConstants.ALL_SEGMENTS_METADATA_TAR_FILE_PREFIX + uuid
+            + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    if (allSegmentsMetadataTarFile.exists()) {
+      FileUtils.forceDelete(allSegmentsMetadataTarFile);
+    }
+    // Add a file which contains the download URI of all the segments
+    File segmentsURIFile = new File(allSegmentsMetadataDir, SegmentUploadConstants.ALL_SEGMENTS_METADATA_FILENAME);
+    FileUtils.writeLines(segmentsURIFile, segmentURIs);
+    try {
+      TarCompressionUtils.createCompressedTarFile(allSegmentsMetadataDir, allSegmentsMetadataTarFile);
+    } finally {
+      FileUtils.deleteDirectory(allSegmentsMetadataDir);
+    }
+    return allSegmentsMetadataTarFile;
   }
 
   public static Map<String, String> getSegmentUriToTarPathMap(URI outputDirURI, PushJobSpec pushSpec,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
@@ -18,12 +18,21 @@
  */
 package org.apache.pinot.segment.local.utils;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -31,6 +40,18 @@ import static org.testng.Assert.assertTrue;
 
 
 public class SegmentPushUtilsTest {
+  private File _tempDir;
+
+  @BeforeMethod
+  public void setUp() throws IOException {
+    _tempDir = new File(FileUtils.getTempDirectory(), "test-" + UUID.randomUUID());
+    FileUtils.forceMkdir(_tempDir);
+  }
+
+  @AfterMethod
+  public void tearDown() throws IOException {
+    FileUtils.deleteDirectory(_tempDir);
+  }
 
   @Test
   public void testGetSegmentUriToTarPathMap()
@@ -79,5 +100,41 @@ public class SegmentPushUtilsTest {
     assertEquals(
         SegmentPushUtils.generateSegmentMetadataURI("hdfs://a/b/c/my-segment.tar.gz", "my-segment"),
         URI.create("hdfs://a/b/c/my-segment.metadata.tar.gz"));
+  }
+
+  @Test
+  public void testCreateSegmentsMetadataTarFile() throws IOException {
+    // setup
+    List<String> segmentURIs = Arrays.asList("http://example.com/segment1", "http://example.com/segment2");
+
+    Map<String, File> segmentMetadataFileMap = new HashMap<>();
+
+    File segment1 = new File(_tempDir, "segment1");
+    FileUtils.forceMkdir(segment1);
+    File creationMetaSeg1 = new File(segment1, "creation.meta");
+    FileUtils.touch(creationMetaSeg1);
+    File metadataPropertiesSeg1 = new File(segment1, "metadata.properties");
+    FileUtils.touch(metadataPropertiesSeg1);
+    File segment1Tar = new File(segment1, "segment1.tar.gz");
+    TarCompressionUtils.createCompressedTarFile(segment1, segment1Tar);
+
+    File segment2 = new File(_tempDir, "segment2");
+    FileUtils.forceMkdir(segment2);
+    File creationMetaSeg2 = new File(segment2, "creation.meta");
+    FileUtils.touch(creationMetaSeg2);
+    File metadataPropertiesSeg2 = new File(segment2, "metadata.properties");
+    FileUtils.touch(metadataPropertiesSeg2);
+    File segment2Tar = new File(segment2, "segment2.tar.gz");
+    TarCompressionUtils.createCompressedTarFile(segment2, segment2Tar);
+
+    segmentMetadataFileMap.put("segment1", segment1Tar);
+    segmentMetadataFileMap.put("segment2", segment2Tar);
+
+    // test
+    File result = SegmentPushUtils.createSegmentsMetadataTarFile(segmentURIs, segmentMetadataFileMap);
+
+    // verify
+    assertTrue(result.exists(), "The resulting tar.gz file should exist");
+    assertTrue(result.getName().endsWith(".tar.gz"), "The resulting file should have a .tar.gz extension");
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -65,6 +65,7 @@ public class BatchConfigProperties {
   public static final String AUTH_TOKEN = "authToken";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
   public static final String EXCLUDE_TIME_IN_SEGMENT_NAME = "exclude.time.in.segment.name";
+  public static final String BATCH_SEGMENT_UPLOAD = "batchSegmentUpload";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -46,6 +46,13 @@ public class PushJobSpec implements Serializable {
    * If true, and if segment was not already in the deep store, move it to deep store.
    */
   private boolean _copyToDeepStoreForMetadataPush;
+
+  /**
+   * Applicable for METADATA push type.
+   * If true, multiple segment metadata files are uploaded to the controller in a single call.
+   */
+  private boolean _batchSegmentUpload;
+
   /**
    * Used in SegmentUriPushJobRunner, which is used to composite the segment uri to send to pinot controller.
    * The URI sends to controller is in the format ${segmentUriPrefix}${segmentPath}${segmentUriSuffix}
@@ -147,5 +154,13 @@ public class PushJobSpec implements Serializable {
 
   public void setCopyToDeepStoreForMetadataPush(boolean copyToDeepStoreForMetadataPush) {
     _copyToDeepStoreForMetadataPush = copyToDeepStoreForMetadataPush;
+  }
+
+  public boolean isBatchSegmentUpload() {
+    return _batchSegmentUpload;
+  }
+
+  public void setBatchSegmentUpload(boolean batchSegmentUpload) {
+    _batchSegmentUpload = batchSegmentUpload;
   }
 }


### PR DESCRIPTION
Notes: Closed the [PR-13597](https://github.com/apache/pinot/pull/13597) and opening this new PR since the other PR was based off-of the master branch by mistake. Apologies for the inconvenience.

### What
Added support to upload segments in batch mode when METADATA upload type is used. The new API endpoint `/segments/batchUpload` is introduced which supports this capability. 

### Why
Segment assignment was observed to be a bottleneck when multiple segments were getting updated at the same time. This was due to the fact that each segment could be updated only after acquiring the table update lock. The issue significantly affected ingestion and segment refresh when multiple minions (~100) were working at the same time.

### How
With this change a bunch of segments could be updated in one-go after acquiring the table update lock.


### Feature Flag
The batch segment upload functionality can be turned on by setting the following config in the minion task configs. By default, the behavior is off.
```
...
"batchSegmentUpload": "true"
...
```

The property could also be set onto the `PushJobSpec` for batch ingestion – [ref](https://docs.pinot.apache.org/basics/data-import/batch-ingestion#ingestion-jobs)
```
pushJobSpec:
  pushAttempts: 2
  batchSegmentUpload: true
```

### Testing
Added integration test which adds multiple segments in batch mode.

Results from testing on a real cluster using the nytaxi dataset are shared below for comparison.

Batch mode update of 19 segments took just **8 milliseconds** as seen below.
```
2024/07/20 03:11:39.465 INFO [PinotHelixResourceManager] [jersey-server-managed-async-executor-1] Added segments: [refreshed_1721444607103_0_nyt14_1721439197614_1721439200313_18, refreshed_1721444607103_0_nyt14_1
721438994994_1721439008401_3, refreshed_1721444607103_0_nyt14_1721439170531_1721439184031_16, refreshed_1721444607103_0_nyt14_1721439008401_1721439021665_4, refreshed_1721444607103_0_nyt14_1721439116099_1721439129763_12, refreshed_1721444607103_0_nyt14_1721439102326_1721439116099_11, refreshed_1721444607103_0_nyt14_1721439129763_1721439143290_13, refreshed_1721444607103_0_nyt14_1721439184031_1721439197614_17, refreshed_1721444607103_0_nyt14_1721438955126_1721438968379_0, refreshed_1721444607103_0_nyt14_1721439088559_1721439102326_10, refreshed_1721444607103_0_nyt14_1721438968379_1721438981679_1, refreshed_1721444607103_0_nyt14_1721439061678_1721439075000_8, refreshed_1721444607103_0_nyt14_1721439075000_1721439088559_9, refreshed_1721444607103_0_nyt14_1721439035003_1721439048371_6, refreshed_1721444607103_0_nyt14_1721439143290_1721439156928_14, refreshed_1721444607103_0_nyt14_1721439021665_1721439035003_5, refreshed_1721444607103_0_nyt14_1721439156928_1721439170531_15, refreshed_1721444607103_0_nyt14_1721438981679_1721438994994_2, refreshed_1721444607103_0_nyt14_1721439048371_1721439061678_7] to IdealState for table: nyt14_OFFLINE in 8 ms
```

Updating the same 19 segments one-by-one took around **22 seconds**.
```
2024/07/21 18:35:29.830 INFO [PinotHelixResourceManager] [jersey-server-managed-async-executor-1] Added segment: refreshed_1721586518754_0_nyt5_1721586538598_1721586538598_1 to IdealState for table: nyt5_OFFLINE
2024/07/21 18:35:52.013 INFO [PinotHelixResourceManager] [jersey-server-managed-async-executor-1] Added segment: refreshed_1721586518754_0_nyt5_1721586538598_1721586538598_18 to IdealState for table: nyt5_OFFLINE
```