### PR TITLE
Removing unnecessary com.github.sgroschupf dependency exclusion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,10 +545,6 @@
         <version>${helix.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>com.github.sgroschupf</groupId>
-            <artifactId>zkclient</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>


### PR DESCRIPTION
**Labels**
- `cleanup`
- `dependencies`

**Description**
While working on the Helix dependency upgrade, I noticed the dependency `com.101tec:zkclient` usage. 

I also noticed that it's also getting used in the Helix `rabitmq-consumer-group` submodule. I suppose that's why we wanted to ignore the `zkclient` from Helix to avoid the version collision issue. However, the `zkclient` is relocated from `com.github.sgroschupf` to `com.101tec` ([reference](https://mvnrepository.com/artifact/com.github.sgroschupf)) and also we are not getting collision issue. 

I remove the unnecessary exclusion block from the parent pom in this PR. 