### PR TITLE
Reduce Kinesis default rate limit to 1 to account for replication

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
@@ -70,7 +70,12 @@ public class KinesisConfig {
   public static final String DEFAULT_IAM_ROLE_BASED_ACCESS_ENABLED = "false";
   public static final String DEFAULT_SESSION_DURATION_SECONDS = "900";
   public static final String DEFAULT_ASYNC_SESSION_UPDATED_ENABLED = "true";
-  public static final String DEFAULT_RPS_LIMIT = "5";
+
+  // Kinesis has a default limit of 5 getRecord requests per second per shard.
+  // This limit is enforced by Kinesis and is not configurable.
+  // We are setting it to 1 to avoid hitting the limit  in a replicated setup,
+  // where multiple replicas are fetching from the same shard.
+  public static final String DEFAULT_RPS_LIMIT = "1";
 
   private final String _streamTopicName;
   private final String _awsRegion;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConfig.java
@@ -75,6 +75,7 @@ public class KinesisConfig {
   // This limit is enforced by Kinesis and is not configurable.
   // We are setting it to 1 to avoid hitting the limit  in a replicated setup,
   // where multiple replicas are fetching from the same shard.
+  // see - https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html
   public static final String DEFAULT_RPS_LIMIT = "1";
 
   private final String _streamTopicName;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -66,7 +66,8 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     try {
       return getKinesisMessageBatch((KinesisPartitionGroupOffset) startMsgOffset);
     } catch (ProvisionedThroughputExceededException pte) {
-      LOGGER.debug("Provisioned throughput exceeded while fetching messages from Kinesis stream: {}", pte.getMessage());
+      LOGGER.error("Rate limit exceeded while fetching messages from Kinesis stream: {} with threshold: {}",
+          pte.getMessage(), _config.getRpsLimit());
       return new KinesisMessageBatch(List.of(), (KinesisPartitionGroupOffset) startMsgOffset, false);
     }
   }


### PR DESCRIPTION
For some reason, we are running into `ProvisionedThroughputExceededException` exception a lot. I think it's due to the bug in the code where we increment the currentSecond only by 1 instead of setting it to the current time. 

Not sure when this situation can come but it can definitely be one of the reasons

Also, using only debug log for this exception so as to not fill logs and also to not unnecessarily increment - too many realtime exceptions metric

The consumers runs unaffected throughout because we simply retry and succeed when we run into this exception.


The PR also changes the default kinesis rate limit. We are lowering the rate limit to 1 getRecords request per second from 5 currently as advised in the kinesis documentation https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html
This is because the current limit doesn't take replication factor into account and so you will occassionaly run into this exception. 