### PR TITLE
Database storage quota

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/DatabaseSizeInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/DatabaseSizeInfo.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseSizeInfo {
+  private final String _databaseName;
+  private final long _diskSizeInBytes;
+  private final List<TableSizeInfo> _tables;
+
+  @JsonCreator
+  public DatabaseSizeInfo(@JsonProperty("databaseName") String databaseName,
+      @JsonProperty("diskSizeInBytes") long sizeInBytes,
+      @JsonProperty("tables") List<TableSizeInfo> tables) {
+    _databaseName = databaseName;
+    _diskSizeInBytes = sizeInBytes;
+    _tables = tables;
+  }
+
+  public String getDatabaseName() {
+    return _databaseName;
+  }
+
+  public long getDiskSizeInBytes() {
+    return _diskSizeInBytes;
+  }
+
+  public List<TableSizeInfo> getTables() {
+    return _tables;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -491,7 +491,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
             .build());
     _tableSizeReader =
         new TableSizeReader(_executorService, _connectionManager, _controllerMetrics, _helixResourceManager,
-            _leadControllerManager);
+            _leadControllerManager, _config);
     _storageQuotaChecker = new StorageQuotaChecker(_tableSizeReader, _controllerMetrics, _leadControllerManager,
         _helixResourceManager, _config);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDatabaseRestletResource.java
@@ -139,14 +139,14 @@ public class PinotDatabaseRestletResource {
   @ApiOperation(value = "Update database quotas", notes = "Update database quotas")
   public SuccessResponse addTable(
       @PathParam("databaseName") String databaseName, @QueryParam("maxQueriesPerSecond") String queryQuota,
-      @Context HttpHeaders httpHeaders) {
+      @QueryParam("storage") String storage, @Context HttpHeaders httpHeaders) {
     if (!databaseName.equals(DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders))) {
       throw new ControllerApplicationException(LOGGER, "Database config name and request context does not match",
           Response.Status.BAD_REQUEST);
     }
     try {
       DatabaseConfig databaseConfig = _pinotHelixResourceManager.getDatabaseConfig(databaseName);
-      QuotaConfig quotaConfig = new QuotaConfig(null, queryQuota);
+      QuotaConfig quotaConfig = new QuotaConfig(storage, queryQuota);
       if (databaseConfig == null) {
          databaseConfig = new DatabaseConfig(databaseName, quotaConfig);
         _pinotHelixResourceManager.addDatabaseConfig(databaseConfig);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -502,6 +502,11 @@ public class PinotHelixResourceManager {
         .collect(Collectors.toList());
   }
 
+  public List<String> getAllServerInstances() {
+    return HelixHelper.getAllInstances(_helixAdmin, _helixClusterName).stream().filter(InstanceTypeUtils::isServer)
+        .collect(Collectors.toList());
+  }
+
   public List<InstanceConfig> getAllBrokerInstanceConfigs() {
     return HelixHelper.getInstanceConfigs(_helixZkManager).stream()
         .filter(instance -> InstanceTypeUtils.isBroker(instance.getId())).collect(Collectors.toList());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -714,6 +714,12 @@ public class PinotHelixResourceManager {
     return false;
   }
 
+  public Map<String, String> getClusterConfigsByKeys(List<String> keys) {
+    HelixConfigScope configScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
+        .forCluster(_helixClusterName).build();
+    return _helixAdmin.getConfig(configScope, keys);
+  }
+
   /**
    * Tenant related APIs
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
@@ -57,15 +57,15 @@ public class CompletionServiceHelper {
     _endpointsToServers = endpointsToServers;
   }
 
-  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String tableNameWithType,
+  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String resourceName,
       boolean multiRequestPerServer, int timeoutMs) {
-    return doMultiGetRequest(serverURLs, tableNameWithType, multiRequestPerServer, null, timeoutMs, null);
+    return doMultiGetRequest(serverURLs, resourceName, multiRequestPerServer, null, timeoutMs, null);
   }
 
   /**
    * This method makes a MultiGet call to all given URLs.
    * @param serverURLs server urls to send GET request.
-   * @param tableNameWithType table name with type suffix
+   * @param resourceName resource name for which the requests are being made. Resource can be a table or database
    * @param multiRequestPerServer it's possible that need to send multiple requests to a same server.
    *                              If multiRequestPerServer is set as false, return as long as one of the requests get
    *                              response; If multiRequestPerServer is set as true, wait until all requests
@@ -77,20 +77,20 @@ public class CompletionServiceHelper {
    * @return CompletionServiceResponse Map of the endpoint(server instance, or full request path if
    * multiRequestPerServer is true) to the response from that endpoint.
    */
-  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String tableNameWithType,
+  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String resourceName,
       boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders, int timeoutMs,
       @Nullable String useCase) {
     // TODO: use some service other than completion service so that we know which server encounters the error
     CompletionService<MultiHttpRequestResponse> completionService =
         new MultiHttpRequest(_executor, _httpConnectionManager).executeGet(serverURLs, requestHeaders, timeoutMs);
 
-    return collectResponse(tableNameWithType, serverURLs.size(), completionService, multiRequestPerServer, useCase);
+    return collectResponse(resourceName, serverURLs.size(), completionService, multiRequestPerServer, useCase);
   }
 
   /**
    * This method makes a MultiPost call to all given URLs and its corresponding bodies.
    * @param serverURLsAndRequestBodies server urls to send POST request.
-   * @param tableNameWithType table name with type suffix
+   * @param resourceName resource name for which the requests are being made. Resource can be a table or database
    * @param multiRequestPerServer it's possible that need to send multiple requests to a same server.
    *                              If multiRequestPerServer is set as false, return as long as one of the requests return
    *                              response; If multiRequestPerServer is set as true, wait until all requests
@@ -103,18 +103,18 @@ public class CompletionServiceHelper {
    * multiRequestPerServer is true) to the response from that endpoint.
    */
   public CompletionServiceResponse doMultiPostRequest(List<Pair<String, String>> serverURLsAndRequestBodies,
-      String tableNameWithType, boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders,
+      String resourceName, boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders,
       int timeoutMs, @Nullable String useCase) {
 
     CompletionService<MultiHttpRequestResponse> completionService =
         new MultiHttpRequest(_executor, _httpConnectionManager).executePost(serverURLsAndRequestBodies, requestHeaders,
             timeoutMs);
 
-    return collectResponse(tableNameWithType, serverURLsAndRequestBodies.size(), completionService,
+    return collectResponse(resourceName, serverURLsAndRequestBodies.size(), completionService,
         multiRequestPerServer, useCase);
   }
 
-  private CompletionServiceResponse collectResponse(String tableNameWithType, int size,
+  private CompletionServiceResponse collectResponse(String resourceName, int size,
       CompletionService<MultiHttpRequestResponse> completionService, boolean multiRequestPerServer,
       @Nullable String useCase) {
     CompletionServiceResponse completionServiceResponse = new CompletionServiceResponse();
@@ -160,22 +160,22 @@ public class CompletionServiceHelper {
 
     int numServerRequestsResponded = completionServiceResponse._httpResponses.size();
     if (numServerRequestsResponded != size) {
-      LOGGER.warn("Finished reading information for table: {} with {}/{} server-request responses", tableNameWithType,
+      LOGGER.warn("Finished reading information for resource: {} with {}/{} server-request responses", resourceName,
           numServerRequestsResponded, size);
     } else {
-      LOGGER.info("Finished reading information for table: {}", tableNameWithType);
+      LOGGER.info("Finished reading information for resource: {}", resourceName);
     }
     return completionServiceResponse;
   }
 
-  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String tableNameWithType,
+  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String resourceName,
       boolean multiRequestPerServer, int timeoutMs, @Nullable String useCase) {
-    return doMultiGetRequest(serverURLs, tableNameWithType, multiRequestPerServer, null, timeoutMs, useCase);
+    return doMultiGetRequest(serverURLs, resourceName, multiRequestPerServer, null, timeoutMs, useCase);
   }
 
-  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String tableNameWithType,
+  public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String resourceName,
       boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders, int timeoutMs) {
-    return doMultiGetRequest(serverURLs, tableNameWithType, multiRequestPerServer, requestHeaders, timeoutMs, null);
+    return doMultiGetRequest(serverURLs, resourceName, multiRequestPerServer, requestHeaders, timeoutMs, null);
   }
 
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
   public static final long DEFAULT_SIZE_WHEN_MISSING_OR_ERROR = -1L;
+  public static final int DATABASE_SIZE_TTL_SECONDS = 300;
 
   private final PinotHelixResourceManager _helixResourceManager;
   private final ControllerMetrics _controllerMetrics;
@@ -75,7 +76,7 @@ public class TableSizeReader {
     _leadControllerManager = leadControllerManager;
     _serverTableSizeReader = new ServerTableSizeReader(executor, connectionManager, controllerConf);
     _databaseSizeBytes = CacheBuilder.newBuilder()
-        .refreshAfterWrite(Duration.ofMinutes(5))
+        .refreshAfterWrite(Duration.ofSeconds(DATABASE_SIZE_TTL_SECONDS))
         .build(new CacheLoader<>() {
           @Override
           public Long load(String key)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
@@ -19,6 +19,10 @@
 package org.apache.pinot.controller.validation;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import java.time.Duration;
+import java.util.Collections;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -27,8 +31,10 @@ import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
+import org.apache.pinot.spi.config.DatabaseConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StorageQuotaChecker {
   private static final Logger LOGGER = LoggerFactory.getLogger(StorageQuotaChecker.class);
+  public static final int DEFAULT_QUOTA_CONFIG_TTL = 5;
 
   private final TableSizeReader _tableSizeReader;
   private final ControllerMetrics _controllerMetrics;
@@ -47,6 +54,7 @@ public class StorageQuotaChecker {
   private final PinotHelixResourceManager _pinotHelixResourceManager;
   private final boolean _isEnabled;
   private final int _timeoutMs;
+  private final Supplier<Long> _defaultDatabaseQuotaBytesSupplier;
 
   public StorageQuotaChecker(TableSizeReader tableSizeReader,
       ControllerMetrics controllerMetrics, LeadControllerManager leadControllerManager,
@@ -58,6 +66,8 @@ public class StorageQuotaChecker {
     _isEnabled = controllerConf.getEnableStorageQuotaCheck();
     _timeoutMs = controllerConf.getServerAdminRequestTimeoutSeconds() * 1000;
     Preconditions.checkArgument(_timeoutMs > 0, "Timeout value must be > 0, input: %s", _timeoutMs);
+    _defaultDatabaseQuotaBytesSupplier = Suppliers.memoizeWithExpiration(this::getDefaultStorageQuotaForDatabase,
+        Duration.ofSeconds(DEFAULT_QUOTA_CONFIG_TTL));
   }
 
   public static class QuotaCheckerResponse {
@@ -76,6 +86,22 @@ public class StorageQuotaChecker {
 
   public static QuotaCheckerResponse failure(String msg) {
     return new QuotaCheckerResponse(false, msg);
+  }
+
+  private long getDefaultStorageQuotaForDatabase() {
+    String configKey = CommonConstants.Helix.DATABASE_MAX_STORAGE;
+    return DataSizeUtils.toBytes(_pinotHelixResourceManager
+        .getClusterConfigsByKeys(Collections.singletonList(configKey))
+        .getOrDefault(configKey, "0"));
+  }
+
+  private long getEffectiveDatabaseStorageQuota(String databaseName) {
+    DatabaseConfig databaseConfig = _pinotHelixResourceManager.getDatabaseConfig(databaseName);
+    if (databaseConfig != null && databaseConfig.getQuotaConfig() != null
+        && databaseConfig.getQuotaConfig().getStorageInBytes() > 0) {
+      return databaseConfig.getQuotaConfig().getStorageInBytes();
+    }
+    return _defaultDatabaseQuotaBytesSupplier.get();
   }
 
   /**
@@ -97,6 +123,15 @@ public class StorageQuotaChecker {
 
     final String tableNameWithType = tableConfig.getTableName();
 
+    String databaseName = DatabaseUtils.extractDatabaseFromFullyQualifiedTableName(tableNameWithType);
+    long databaseStorageQuotaBytes = getEffectiveDatabaseStorageQuota(databaseName);
+    long dbSize = _tableSizeReader.getDatabaseSizeBytes(databaseName);
+    if (databaseStorageQuotaBytes > 0 && dbSize + segmentSizeInBytes > databaseStorageQuotaBytes) {
+      return failure("Database storage quota exceeded for database " + databaseName + ". Estimated database size is "
+          + DataSizeUtils.fromBytes(dbSize + segmentSizeInBytes) + " while the database storage quota is "
+          + DataSizeUtils.fromBytes(databaseStorageQuotaBytes));
+    }
+
     if (quotaConfig == null || quotaConfig.getStorage() == null) {
       // no quota configuration...so ignore for backwards compatibility
       String message =
@@ -107,16 +142,6 @@ public class StorageQuotaChecker {
 
     long allowedStorageBytes = numReplicas * quotaConfig.getStorageInBytes();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_QUOTA, allowedStorageBytes);
-
-    // Temporary hardcoded value
-    // populate the right storage quota once database quota config pr is merged
-    int storageQuotaBytes = 100000;
-    // read database size
-    String databaseName = DatabaseUtils.extractDatabaseFromFullyQualifiedTableName(tableNameWithType);
-    long dbSize = _tableSizeReader.getDatabaseSizeBytes(databaseName);
-    if (dbSize + segmentSizeInBytes > storageQuotaBytes) {
-      return failure("Database storage quota exceeded for database " + databaseName);
-    }
 
     // read table size
     TableSizeReader.TableSubTypeSizeDetails tableSubtypeSize;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
@@ -106,6 +107,16 @@ public class StorageQuotaChecker {
 
     long allowedStorageBytes = numReplicas * quotaConfig.getStorageInBytes();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_QUOTA, allowedStorageBytes);
+
+    // Temporary hardcoded value
+    // populate the right storage quota once database quota config pr is merged
+    int storageQuotaBytes = 100000;
+    // read database size
+    String databaseName = DatabaseUtils.extractDatabaseFromFullyQualifiedTableName(tableNameWithType);
+    long dbSize = _tableSizeReader.getDatabaseSizeBytes(databaseName);
+    if (dbSize + segmentSizeInBytes > storageQuotaBytes) {
+      return failure("Database storage quota exceeded for database " + databaseName);
+    }
 
     // read table size
     TableSizeReader.TableSubTypeSizeDetails tableSubtypeSize;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -194,4 +194,11 @@ public interface InstanceDataManager {
    * @param isServerReadyToServeQueries supplier to retrieve state of server.
    */
   void setSupplierOfIsServerReadyToServeQueries(Supplier<Boolean> isServerReadyToServeQueries);
+
+  /**
+   * Returns the total size of the tables under the provided database in bytes.
+   *
+   * @return Size of the database in bytes
+   */
+  long getDatabaseSizeBytes(String databaseName);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -80,6 +80,13 @@ public interface TableDataManager {
   boolean isShutDown();
 
   /**
+   * Returns the total size of the table in bytes.
+   *
+   * @return Size of the table in bytes
+   */
+  long getTableSizeBytes();
+
+  /**
    * Returns the segment lock for a segment in the table.
    */
   Lock getSegmentLock(String segmentName);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DatabaseSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DatabaseSizeResource.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.restlet.resources.DatabaseSizeInfo;
+import org.apache.pinot.common.restlet.resources.ResourceUtils;
+import org.apache.pinot.common.restlet.resources.TableSizeInfo;
+import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.server.starter.ServerInstance;
+
+import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+
+/**
+ * API to provide database sizes
+ */
+@Api(tags = "Database", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
+    @Authorization(value = DATABASE)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        key = SWAGGER_AUTHORIZATION_KEY,
+        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
+    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
+        description = "Database context passed through http header. If no context is provided 'default' database "
+            + "context will be considered.")}))
+@Path("/")
+public class DatabaseSizeResource {
+
+  @Inject
+  private ServerInstance _serverInstance;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/databases/{databaseName}/size")
+  @ApiOperation(value = "Show database storage size", notes = "Lists size of all the tables of the database")
+  public String getDatabaseSize(
+      @ApiParam(value = "Database Name") @PathParam("databaseName") String databaseName,
+      @ApiParam(value = "Provide size for all tables") @QueryParam("detailed") boolean detailed,
+      @Context HttpHeaders headers)
+      throws WebApplicationException {
+    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
+
+    if (instanceDataManager == null) {
+      throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    List<TableSizeInfo> tableSizeInfos = new ArrayList<>();
+    if (detailed) {
+      List<String> databaseTables = instanceDataManager.getAllTables().stream()
+          .filter(table -> DatabaseUtils.isPartOfDatabase(table, databaseName))
+          .collect(Collectors.toList());
+      for (String tableName : databaseTables) {
+        TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableName);
+        if (tableDataManager != null) {
+          long size = tableDataManager.getTableSizeBytes();
+          tableSizeInfos.add(new TableSizeInfo(tableName, size, new ArrayList<>()));
+        }
+      }
+    }
+
+    DatabaseSizeInfo databaseSizeInfo =
+        new DatabaseSizeInfo(databaseName, instanceDataManager.getDatabaseSizeBytes(databaseName), tableSizeInfos);
+    return ResourceUtils.convertToJsonString(databaseSizeInfo);
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -86,6 +86,7 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public class HelixInstanceDataManager implements InstanceDataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixInstanceDataManager.class);
+  public static final int DATABASE_SIZE_TTL_SECONDS = 60;
 
   private final ConcurrentHashMap<String, TableDataManager> _tableDataManagerMap = new ConcurrentHashMap<>();
   private LoadingCache<String, Long> _databaseSizeBytes;
@@ -168,7 +169,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
         });
 
     _databaseSizeBytes = CacheBuilder.newBuilder()
-        .refreshAfterWrite(Duration.ofMinutes(1))
+        .refreshAfterWrite(Duration.ofSeconds(DATABASE_SIZE_TTL_SECONDS))
         .build(new CacheLoader<>() {
           @Override
           public Long load(String database)

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -25,15 +25,18 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
@@ -52,6 +55,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
+import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploader;
@@ -84,6 +88,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixInstanceDataManager.class);
 
   private final ConcurrentHashMap<String, TableDataManager> _tableDataManagerMap = new ConcurrentHashMap<>();
+  private LoadingCache<String, Long> _databaseSizeBytes;
   // TODO: Consider making segment locks per table instead of per instance
   private final SegmentLocks _segmentLocks = new SegmentLocks();
 
@@ -159,6 +164,20 @@ public class HelixInstanceDataManager implements InstanceDataManager {
           public SegmentErrorInfo load(Pair<String, String> tableSegmentPair) {
             // This cache is populated only via the put api.
             return null;
+          }
+        });
+
+    _databaseSizeBytes = CacheBuilder.newBuilder()
+        .refreshAfterWrite(Duration.ofMinutes(1))
+        .build(new CacheLoader<>() {
+          @Override
+          public Long load(String database)
+              throws Exception {
+            AtomicLong sizeInBytes = new AtomicLong();
+            _tableDataManagerMap.entrySet().stream()
+                .filter(entry -> DatabaseUtils.isPartOfDatabase(entry.getKey(), database))
+                .forEach(entry -> sizeInBytes.addAndGet(entry.getValue().getTableSizeBytes()));
+            return sizeInBytes.get();
           }
         });
   }
@@ -280,6 +299,16 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       throws Exception {
     _tableDataManagerMap.computeIfAbsent(realtimeTableName, this::createTableDataManager)
         .addConsumingSegment(segmentName);
+  }
+
+  @Override
+  public long getDatabaseSizeBytes(String databaseName) {
+    try {
+      return _databaseSizeBytes.get(databaseName);
+    } catch (ExecutionException e) {
+      LOGGER.error("Error while computing database size.", e);
+      return 0;
+    }
   }
 
   private TableDataManager createTableDataManager(String tableNameWithType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QuotaConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QuotaConfig.java
@@ -35,7 +35,7 @@ public class QuotaConfig extends BaseJsonConfig {
   private static final long INVALID_STORAGE_IN_BYTES = -1L;
   private static final double INVALID_MAX_QPS = -1.0;
 
-  @JsonPropertyDescription("Storage allocated for this table, e.g. \"10G\"")
+  @JsonPropertyDescription("Storage allocated for this table/database, e.g. \"10G\"")
   private final String _storage;
 
   private final String _maxQueriesPerSecond;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -83,6 +83,7 @@ public class CommonConstants {
     public static final String QUERIES_DISABLED = "queriesDisabled";
     public static final String QUERY_RATE_LIMIT_DISABLED = "queryRateLimitDisabled";
     public static final String DATABASE_MAX_QUERIES_PER_SECOND = "databaseMaxQueriesPerSecond";
+    public static final String DATABASE_MAX_STORAGE = "databaseMaxStorage";
 
     public static final String INSTANCE_CONNECTED_METRIC_NAME = "helix.connected";
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow for checking database storage quota: controller queries servers for database size via HTTP, sums table sizes, and compares against quota\.

```mermaid
flowchart TD
  N0["StorageQuotaChecker#46;isSegmentStorageWithinQuota #40;F5#41;"]:::stModified
  N1["TableSizeReader#46;getDatabaseSizeBytes #40;F4#41;"]:::stModified
  N2["ServerTableSizeReader#46;getDatabaseSizeInfoFromServers #40;F14#41;"]:::stModified
  N3["CompletionServiceHelper#46;doMultiGetRequest #40;F3#41;"]:::stModified
  N4["DatabaseSizeResource#46;getDatabaseSize #40;F17#41;"]:::stAdded
  N5["HelixInstanceDataManager#46;getDatabaseSizeBytes #40;F9#41;"]:::stModified
  N6["BaseTableDataManager#46;getTableSizeBytes #40;F6#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"cache miss delegates to"| N2
  N2 -->|"uses helper for HTTP"| N3
  N3 -->|"HTTP request to server endpoint"| N4
  N4 -->|"delegates to instance data manager"| N5
  N5 -->|"sums table sizes from"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F3: pinot\-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java)
- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java)
- F5: pinot\-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java)
- F6: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)
- F9: pinot\-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java)
- F14: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader\.java — [before](https://github.com/apache/pinot/blob/c395d09c1f5efa6c46e540d6dbc0223102139e20/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java) · [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java)
- F17: pinot\-server/src/main/java/org/apache/pinot/server/api/resources/DatabaseSizeResource\.java — [after](https://github.com/apache/pinot/blob/4747ab0ff5588fa4ad40cb03711840853b1a2ba6/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DatabaseSizeResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImMzOTVkMDljMWY1ZWZhNmM0NmU1NDBkNmRiYzAyMjMxMDIxMzllMjAiLCJjb250ZXh0X2hhc2giOiIwN2U0MzMwZTc2NzFlNjMxMmQzZmViOTQ5NjJkYjVhZGQxZDBhN2U0ZmVkZTY2MGRiYWNjNDA2ZDMyOGY3YzkxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODY2Mzg2LCJoZWFkX3NoYSI6IjQ3NDdhYjBmZjU1ODhmYTRhZDQwY2IwMzcxMTg0MDg1M2IxYTJiYTYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjMzk1ZDA5YzFmNWVmYTZjNDZlNTQwZDZkYmMwMjIzMTAyMTM5ZTIwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f9b128e77a804c8533887951629719ccbe76302a8e303fec09b58ad761e7987c -->
<!-- pinot-pr-flow:end -->

Do not review, still under development.
