### PR TITLE
Fix query response time metric

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -71,6 +71,10 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   public BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext, @Nullable HttpHeaders httpHeaders)
       throws Exception {
+    // Pinot installations may either use PinotClientRequest or this class in order to process a query that
+    // arrives via their custom container. The custom code may add its own overhead in either pre-processing
+    // or post-processing stages, and should be measured independently.
+    // In order to accommodate for both code paths, we set the request arrival time only if it is not already set.
     if (requestContext.getRequestArrivalTimeMillis() <= 0) {
       requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -71,6 +71,9 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   public BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext, @Nullable HttpHeaders httpHeaders)
       throws Exception {
+    if (requestContext.getRequestArrivalTimeMillis() == 0) {
+      requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
+    }
     // Parse the query if needed
     if (sqlNodeAndOptions == null) {
       try {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -71,7 +71,7 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   public BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext, @Nullable HttpHeaders httpHeaders)
       throws Exception {
-    if (requestContext.getRequestArrivalTimeMillis() == 0) {
+    if (requestContext.getRequestArrivalTimeMillis() <= 0) {
       requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
     }
     // Parse the query if needed


### PR DESCRIPTION
As of PR #13179, the query response time metrics started to get extremely high for all tables. The root cause tured out to be a missed initialization in which the query arrival time was set to 0 by default.

The refactor broke the contract that the broker request handler always returns the time taken to handle the request.

Added code to initialize the arrival time.

Since the refactor attempted to include client pre-processing time, added this code under the condition that the value is not already set.

Ideally, callers of the method should add on their own pre and post-processing time to the time returned by the handleRequest() method.