### PR TITLE
Disallow duplicate CTE aliases

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
@@ -159,7 +159,7 @@ public class Validator extends SqlValidatorImpl {
     for (SqlNode sqlWithItem : with.withList) {
       for (String name : ((SqlWithItem) sqlWithItem).name.names) {
         if (withNames.contains(name)) {
-          throw new RuntimeException("Duplicate alias in WITH: '" + name + "'");
+          throw new RuntimeException("Duplicate alias in WITH: '" + name + "' at " + sqlWithItem.getParserPosition());
         }
         withNames.add(name);
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.validate;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,10 +33,13 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.validate.SelectScope;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
 
 
 /**
@@ -146,5 +150,21 @@ public class Validator extends SqlValidatorImpl {
       }
     }
     super.addToSelectList(list, aliases, fieldList, exp, scope, includeSystemVars);
+  }
+
+  @Override
+  public void validateWith(SqlWith with, SqlValidatorScope scope) {
+    Set<String> withNames = new HashSet<>();
+
+    for (SqlNode sqlWithItem : with.withList) {
+      for (String name : ((SqlWithItem) sqlWithItem).name.names) {
+        if (withNames.contains(name)) {
+          throw new RuntimeException("Duplicate alias in WITH: '" + name + "'");
+        }
+        withNames.add(name);
+      }
+    }
+
+    super.validateWith(with, scope);
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -388,12 +388,8 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
   @Test
   public void testDuplicateWithAlias() {
     String query = "WITH tmp AS (SELECT * FROM a LIMIT 1), tmp AS (SELECT * FROM a LIMIT 2) SELECT * FROM tmp";
-    try {
-      _queryEnvironment.getTableNamesForQuery(query);
-      fail("Expected compilation of query with duplicate CTE alias to throw an exception");
-    } catch (RuntimeException e) {
-      assertTrue(e.getCause().getMessage().contains("Duplicate alias in WITH: 'tmp'"));
-    }
+    RuntimeException e = expectThrows(RuntimeException.class, () -> _queryEnvironment.getTableNamesForQuery(query));
+    assertTrue(e.getCause().getMessage().contains("Duplicate alias in WITH: 'tmp'"));
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -385,10 +385,15 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     assertEquals(tableNames.get(0), "a");
   }
 
-  @Test(expectedExceptions = RuntimeException.class)
+  @Test
   public void testDuplicateWithAlias() {
     String query = "WITH tmp AS (SELECT * FROM a LIMIT 1), tmp AS (SELECT * FROM a LIMIT 2) SELECT * FROM tmp";
-    _queryEnvironment.getTableNamesForQuery(query);
+    try {
+      _queryEnvironment.getTableNamesForQuery(query);
+      fail("Expected compilation of query with duplicate CTE alias to throw an exception");
+    } catch (RuntimeException e) {
+      assertTrue(e.getCause().getMessage().contains("Duplicate alias in WITH: 'tmp'"));
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -385,6 +385,12 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     assertEquals(tableNames.get(0), "a");
   }
 
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testDuplicateWithAlias() {
+    String query = "WITH tmp AS (SELECT * FROM a LIMIT 1), tmp AS (SELECT * FROM a LIMIT 2) SELECT * FROM tmp";
+    _queryEnvironment.getTableNamesForQuery(query);
+  }
+
   // --------------------------------------------------------------------------
   // Test Utils.
   // --------------------------------------------------------------------------


### PR DESCRIPTION
- Currently, a query like `WITH tmp AS (SELECT * FROM a LIMIT 1), tmp AS (SELECT * FROM a LIMIT 2) SELECT * FROM tmp` doesn't return an error and runs fine.
- By default, Calcite just uses the last CTE for the alias in such cases. However, this can lead to confusing and unexpected results in case there was a human error while writing a complex query with many CTEs.
- In databases like Postgres and MySQL too, such queries return a clear error.
- Postgres:
```
ERROR:  WITH query name "tmp" specified more than once
```
- MySQL:
```
ERROR 1066 (42000): Not unique table/alias: 'tmp'
```
- Pinot (after this patch):
```
Duplicate alias in WITH: 'tmp' at line 1, column 40
```