### PR TITLE
Fix colocated join when no mapping project is used

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
@@ -29,17 +29,23 @@ import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.mapping.IntPair;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalAggregate;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -52,6 +58,7 @@ import org.apache.pinot.query.planner.plannode.AggregateNode;
 public class PinotRelDistributionTraitRule extends RelOptRule {
   public static final PinotRelDistributionTraitRule INSTANCE =
       new PinotRelDistributionTraitRule(PinotRuleUtils.PINOT_REL_FACTORY);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotRelDistributionTraitRule.class);
 
   public PinotRelDistributionTraitRule(RelBuilderFactory factory) {
     super(operand(RelNode.class, any()));
@@ -110,10 +117,22 @@ public class PinotRelDistributionTraitRule extends RelOptRule {
       LogicalProject project = (LogicalProject) node;
       try {
         if (inputRelDistribution != null) {
-          return inputRelDistribution.apply(project.getMapping());
+          Mappings.TargetMapping mapping =
+              Project.getPartialMapping(input.getRowType().getFieldCount(), project.getProjects());
+          // Note(gonzalo): In Calcite 1.37 mapping.getTargetOpt will fail in what it looks like a Calcite bug.
+          //  Therefore here we apply a workaround and create a new map where the same elements (extracted with
+          //  iterator, which actually work) are added to the new mapping.
+          //  See https://lists.apache.org/thread/qz18qxrfp5bqldnoln2tg4582g402zyv
+          Mapping actualMapping = Mappings.create(MappingType.PARTIAL_FUNCTION, input.getRowType().getFieldCount(),
+              project.getRowType().getFieldCount());
+          for (IntPair intPair : mapping) {
+            actualMapping.set(intPair.source, intPair.target);
+          }
+          return inputRelDistribution.apply(actualMapping);
         }
       } catch (Exception e) {
         // ... skip;
+        LOGGER.debug("Failed to derive distribution from input for node: {}", node, e);
       }
     } else if (node instanceof LogicalFilter) {
       assert inputs.size() == 1;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
@@ -132,7 +132,7 @@ public class PinotRelDistributionTraitRule extends RelOptRule {
         }
       } catch (Exception e) {
         // ... skip;
-        LOGGER.debug("Failed to derive distribution from input for node: {}", node, e);
+        LOGGER.warn("Failed to derive distribution from input for node: {}", node, e);
       }
     } else if (node instanceof LogicalFilter) {
       assert inputs.size() == 1;

--- a/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
@@ -449,6 +449,58 @@
           "                                    └── [5]@localhost:1|[0] TABLE SCAN (b) null\n",
           ""
         ]
+      },
+      {
+        "description": "explain plan with colocated join and a projection that is not mapping",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.mySum, b.col3 FROM (select col2, col3 + col2 as mySum from a /*+ tableOptions(partition_function='hashcode', partition_key='col2', partition_size='4') */) as a JOIN b /*+ tableOptions(partition_function='hashcode', partition_key='col1', partition_size='4') */ ON a.col2 = b.col1",
+        "output": [
+          "[0]@localhost:3|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:2|[2] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)\n",
+          "├── [1]@localhost:2|[3] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)\n",
+          "├── [1]@localhost:1|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:1|[1] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]}\n",
+          "    └── [1]@localhost:1|[1] PROJECT\n",
+          "        └── [1]@localhost:1|[1] JOIN\n",
+          "            ├── [1]@localhost:1|[1] MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "            │   ├── [2]@localhost:2|[2] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:2|[2]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:2|[3] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:2|[3]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:1|[0]} (Subtree Omitted)\n",
+          "            │   └── [2]@localhost:1|[1] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:1|[1]}\n",
+          "            │       └── [2]@localhost:1|[1] PROJECT\n",
+          "            │           └── [2]@localhost:1|[1] TABLE SCAN (a) null\n",
+          "            └── [1]@localhost:1|[1] MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "                ├── [3]@localhost:2|[2] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:2|[2]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:2|[3] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:2|[3]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:1|[0]} (Subtree Omitted)\n",
+          "                └── [3]@localhost:1|[1] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:1|[1]}\n",
+          "                    └── [3]@localhost:1|[1] PROJECT\n",
+          "                        └── [3]@localhost:1|[1] TABLE SCAN (b) null\n"
+        ]
+      },
+      {
+        "description": "explain plan with colocated join and a projection that doesn't keep the key column",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.mySum, b.col3 FROM (select col3 as col2, col3 + col2 as mySum from a /*+ tableOptions(partition_function='hashcode', partition_key='col2', partition_size='4') */) as a JOIN b /*+ tableOptions(partition_function='hashcode', partition_key='col1', partition_size='4') */ ON a.col2 = b.col1",
+        "output": [
+          "[0]@localhost:3|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:1|[1] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:2|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]}\n",
+          "    └── [1]@localhost:2|[0] PROJECT\n",
+          "        └── [1]@localhost:2|[0] JOIN\n",
+          "            ├── [1]@localhost:2|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "            │   ├── [2]@localhost:2|[2] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:2|[3] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "            │   └── [2]@localhost:1|[1] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]}\n",
+          "            │       └── [2]@localhost:1|[1] PROJECT\n",
+          "            │           └── [2]@localhost:1|[1] TABLE SCAN (a) null\n",
+          "            └── [1]@localhost:2|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "                ├── [3]@localhost:2|[2] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:2|[3] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]} (Subtree Omitted)\n",
+          "                └── [3]@localhost:1|[1] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[1],[1]@localhost:2|[0]}\n",
+          "                    └── [3]@localhost:1|[1] PROJECT\n",
+          "                        └── [3]@localhost:1|[1] TABLE SCAN (b) null\n"
+        ]
       }
     ]
   }


### PR DESCRIPTION
This PR fixes an issue related to colocated join.

For example, in ColocatedJoinEngineQuickStart, the following query should be executed in colocated fashion given:
1. We are specifying the correct tableOptions
2. We are joining by the partition key

```sql
EXPLAIN IMPLEMENTATION PLAN FOR
SELECT a.mySum, b.totalTrips
FROM (select userUUID, totalTrips + daysSinceFirstTrip as mySum
      FROM userAttributes /*+ tableOptions(partition_key='userUUID', partition_size='4') */) as a
JOIN userAttributes /*+ tableOptions(partition_key='userUUID', partition_size='4') */ as b
ON a.userUUID = b.userUUID
```

But the actual plan is:
```
[0]@192.168.1.42:46431|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)
├── [1]@192.168.1.42:37333|[3] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.1.42:46431|[0]} (Subtree Omitted)
├── [1]@192.168.1.42:42455|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.1.42:46431|[0]} (Subtree Omitted)
├── [1]@192.168.1.42:37933|[2] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.1.42:46431|[0]} (Subtree Omitted)
└── [1]@192.168.1.42:43961|[1] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@192.168.1.42:46431|[0]}
    └── [1]@192.168.1.42:43961|[1] PROJECT
        └── [1]@192.168.1.42:43961|[1] JOIN
            ├── [1]@192.168.1.42:43961|[1] MAIL_RECEIVE(HASH_DISTRIBUTED)
            │   ├── [2]@192.168.1.42:37333|[0] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
            │   ├── [2]@192.168.1.42:37333|[2] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
            │   ├── [2]@192.168.1.42:37933|[1] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
            │   └── [2]@192.168.1.42:37933|[3] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]}
            │       └── [2]@192.168.1.42:37933|[3] PROJECT
            │           └── [2]@192.168.1.42:37933|[3] TABLE SCAN (userAttributes) null
            └── [1]@192.168.1.42:43961|[1] MAIL_RECEIVE(HASH_DISTRIBUTED)
                ├── [3]@192.168.1.42:37333|[0] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
                ├── [3]@192.168.1.42:37333|[2] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
                ├── [3]@192.168.1.42:37933|[1] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]} (Subtree Omitted)
                └── [3]@192.168.1.42:37933|[3] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@192.168.1.42:34523|[0],[1]@192.168.1.42:42163|[1],[1]@192.168.1.42:43717|[2],[1]@192.168.1.42:46477|[3]}
                    └── [3]@192.168.1.42:37933|[3] PROJECT
                        └── [3]@192.168.1.42:37933|[3] TABLE SCAN (userAttributes) null
```

Which is not colocated (see the first join input).

The reason is that `PinotRelDistributionTraitRule.deriveDistribution` is doing `inputRelDistribution.apply(project.getMapping())` for projects. `project.getMapping()` returns null if the project is not a mapping, which is defined as _all inputs are references. In our case the project includes the projection key, but it also includes a call to `+` so it is not mapping.

What `PinotRelDistributionTraitRule.deriveDistribution` should be doing is similar to Calcites [RelMdDistribution#L165](https://github.com/apache/calcite/blob/e371b336a8b404ed36955f517196a5e8606455d7/core/src/main/java/org/apache/calcite/rel/metadata/RelMdDistribution.java#L165C17-L165C34) (in fact we should be using that class, but that would require some refactors) which is ask for a partial mapping instead of complete mapping.

I've tried that solution, but found what it looks to be a bug in Calcite. I've reported the issue in Calcite's dev mailist (see https://lists.apache.org/thread/qz18qxrfp5bqldnoln2tg4582g402zyv). But there is a simple solution that consist on creating a copy of the mapping itself and that is what I'm adding here (including a note to try to remove my hack once the issue or my lack of knowledge is solved).