### PR TITLE
Remove ingestion metrics when consuming segment relocates

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/ForceCommitMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/ForceCommitMessage.java
@@ -49,7 +49,7 @@ public class ForceCommitMessage extends Message {
     super(message.getRecord());
     String msgSubType = message.getMsgSubType();
     Preconditions.checkArgument(msgSubType.equals(FORCE_COMMIT_MSG_SUB_TYPE),
-        "Invalid message sub type: " + msgSubType + " for SegmentReloadMessage");
+        "Invalid message sub type: " + msgSubType + " for ForceCommitMessage");
   }
 
   public String getTableName() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/IngestionMetricsRemoveMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/IngestionMetricsRemoveMessage.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.messages;
+
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+import org.apache.helix.model.Message;
+
+
+/**
+ * Ingestion metrics remove message is created on controller and get sent to servers to instruct them to remove
+ * ingestion metrics for the stream partition of the given segment when the new consuming segment is no longer served by
+ * the server.
+ */
+public class IngestionMetricsRemoveMessage extends Message {
+  public static final String INGESTION_METRICS_REMOVE_MSG_SUB_TYPE = "INGESTION_METRICS_REMOVE";
+
+  public IngestionMetricsRemoveMessage() {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setMsgSubType(INGESTION_METRICS_REMOVE_MSG_SUB_TYPE);
+    // Give it infinite time to process the message, as long as session is alive
+    setExecutionTimeout(-1);
+  }
+
+  public IngestionMetricsRemoveMessage(Message message) {
+    super(message.getRecord());
+    String msgSubType = message.getMsgSubType();
+    Preconditions.checkArgument(msgSubType.equals(INGESTION_METRICS_REMOVE_MSG_SUB_TYPE),
+        "Invalid message sub type: " + msgSubType + " for IngestionMetricsRemoveMessage");
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.AccessOption;
+import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.Criteria;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -50,6 +52,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.messages.ForceCommitMessage;
+import org.apache.pinot.common.messages.IngestionMetricsRemoveMessage;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -576,8 +579,9 @@ public class PinotLLCRealtimeSegmentManager {
     // to reduce this contention. We may still contend with RetentionManager, or other updates
     // to idealstate from other controllers, but then we have the retry mechanism to get around that.
     synchronized (_helixResourceManager.getIdealStateUpdaterLock(realtimeTableName)) {
-      updateIdealStateOnSegmentCompletion(realtimeTableName, committingSegmentName, newConsumingSegmentName,
-          segmentAssignment, instancePartitionsMap);
+      idealState =
+          updateIdealStateOnSegmentCompletion(realtimeTableName, committingSegmentName, newConsumingSegmentName,
+              segmentAssignment, instancePartitionsMap);
     }
 
     long endTimeNs = System.nanoTime();
@@ -598,6 +602,12 @@ public class PinotLLCRealtimeSegmentManager {
 
     // Trigger the metadata event notifier
     _metadataEventNotifierFactory.create().notifyOnSegmentFlush(tableConfig);
+
+    // Handle segment movement if necessary
+    if (newConsumingSegmentName != null) {
+      handleSegmentMovement(realtimeTableName, idealState.getRecord().getMapFields(), committingSegmentName,
+          newConsumingSegmentName);
+    }
   }
 
   /**
@@ -937,10 +947,10 @@ public class PinotLLCRealtimeSegmentManager {
    * Updates ideal state after completion of a realtime segment
    */
   @VisibleForTesting
-  void updateIdealStateOnSegmentCompletion(String realtimeTableName, String committingSegmentName,
+  IdealState updateIdealStateOnSegmentCompletion(String realtimeTableName, String committingSegmentName,
       String newSegmentName, SegmentAssignment segmentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
-    HelixHelper.updateIdealState(_helixManager, realtimeTableName, idealState -> {
+    return HelixHelper.updateIdealState(_helixManager, realtimeTableName, idealState -> {
       assert idealState != null;
       // When segment completion begins, the zk metadata is updated, followed by ideal state.
       // We allow only {@link PinotLLCRealtimeSegmentManager::MAX_SEGMENT_COMPLETION_TIME_MILLIS} ms for a segment to
@@ -1012,6 +1022,47 @@ public class PinotLLCRealtimeSegmentManager {
           SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
       LOGGER.info("Adding new CONSUMING segment: {} to instances: {}", newSegmentName, instancesAssigned);
     }
+  }
+
+  /**
+   * Handles segment movement between instances.
+   * If the new consuming segment is served by a different set of servers than the committed segment, notify the
+   * servers no longer serving the stream partition to remove the ingestion metrics. This can prevent servers from
+   * emitting high ingestion delay alerts on stream partitions no longer served.
+   */
+  private void handleSegmentMovement(String realtimeTableName, Map<String, Map<String, String>> instanceStatesMap,
+      String committedSegment, String newConsumingSegment) {
+    Set<String> oldInstances = instanceStatesMap.get(committedSegment).keySet();
+    Set<String> newInstances = instanceStatesMap.get(newConsumingSegment).keySet();
+    if (newInstances.containsAll(oldInstances)) {
+      return;
+    }
+    Set<String> instancesNoLongerServe = new HashSet<>(oldInstances);
+    instancesNoLongerServe.removeAll(newInstances);
+    LOGGER.info("Segment movement detected for committed segment: {} (served by: {}), "
+            + "consuming segment: {} (served by: {}) in table: {}, "
+            + "sending message to instances: {} to remove ingestion metrics", committedSegment, oldInstances,
+        newConsumingSegment, newInstances, realtimeTableName, instancesNoLongerServe);
+
+    ClusterMessagingService messagingService = _helixManager.getMessagingService();
+    List<String> instancesSent = new ArrayList<>(instancesNoLongerServe.size());
+    for (String instance : instancesNoLongerServe) {
+      Criteria recipientCriteria = new Criteria();
+      recipientCriteria.setInstanceName(instance);
+      recipientCriteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+      recipientCriteria.setResource(realtimeTableName);
+      recipientCriteria.setPartition(committedSegment);
+      recipientCriteria.setSessionSpecific(true);
+      IngestionMetricsRemoveMessage message = new IngestionMetricsRemoveMessage();
+      if (messagingService.send(recipientCriteria, message, null, -1) > 0) {
+        instancesSent.add(instance);
+      } else {
+        LOGGER.warn("Failed to send ingestion metrics remove message for table: {} segment: {} to instance: {}",
+            realtimeTableName, committedSegment, instance);
+      }
+    }
+    LOGGER.info("Sent ingestion metrics remove message for table: {} segment: {} to instances: {}", realtimeTableName,
+        committedSegment, instancesSent);
   }
 
   /*

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1212,13 +1212,14 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    void updateIdealStateOnSegmentCompletion(String realtimeTableName, String committingSegmentName,
+    IdealState updateIdealStateOnSegmentCompletion(String realtimeTableName, String committingSegmentName,
         String newSegmentName, SegmentAssignment segmentAssignment,
         Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
       updateInstanceStatesForNewConsumingSegment(_idealState.getRecord().getMapFields(), committingSegmentName, null,
           segmentAssignment, instancePartitionsMap);
       updateInstanceStatesForNewConsumingSegment(_idealState.getRecord().getMapFields(), null, newSegmentName,
           segmentAssignment, instancePartitionsMap);
+      return _idealState;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -964,6 +964,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     return _currentOffset;
   }
 
+  @Nullable
   public StreamPartitionMsgOffset getLatestStreamOffsetAtStartupTime() {
     return _latestStreamOffsetAtStartupTime;
   }
@@ -1683,22 +1684,27 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     return _idleTimer.getTimeSinceEventLastConsumedMs();
   }
 
+  @Nullable
   public StreamPartitionMsgOffset fetchLatestStreamOffset(long maxWaitTimeMs, boolean useDebugLog) {
     return fetchStreamOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, maxWaitTimeMs, useDebugLog);
   }
 
+  @Nullable
   public StreamPartitionMsgOffset fetchLatestStreamOffset(long maxWaitTimeMs) {
     return fetchLatestStreamOffset(maxWaitTimeMs, false);
   }
 
+  @Nullable
   public StreamPartitionMsgOffset fetchEarliestStreamOffset(long maxWaitTimeMs, boolean useDebugLog) {
     return fetchStreamOffset(OffsetCriteria.SMALLEST_OFFSET_CRITERIA, maxWaitTimeMs, useDebugLog);
   }
 
+  @Nullable
   public StreamPartitionMsgOffset fetchEarliestStreamOffset(long maxWaitTimeMs) {
     return fetchEarliestStreamOffset(maxWaitTimeMs, false);
   }
 
+  @Nullable
   private StreamPartitionMsgOffset fetchStreamOffset(OffsetCriteria offsetCriteria, long maxWaitTimeMs,
       boolean useDebugLog) {
     if (_partitionMetadataProvider == null) {
@@ -1797,9 +1803,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    * Assumes there is a valid instance of {@link PartitionGroupConsumer}
    */
   private void recreateStreamConsumer(String reason) {
-      _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
-      _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
-      closePartitionGroupConsumer();
+    _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
+    _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
+    closePartitionGroupConsumer();
     try {
       _partitionGroupConsumer =
           _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
@@ -1825,20 +1831,23 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     if (metadata != null) {
       try {
         StreamPartitionMsgOffset latestOffset = fetchLatestStreamOffset(5000, true);
-        _realtimeTableDataManager.updateIngestionMetrics(metadata.getRecordIngestionTimeMs(),
-            metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(), latestOffset, _partitionGroupId);
+        _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId,
+            metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(),
+            latestOffset);
       } catch (Exception e) {
         _segmentLogger.warn("Failed to fetch latest offset for updating ingestion delay", e);
       }
     }
   }
 
-  /*
+  /**
    * Sets ingestion delay to zero in situations where we are caught up processing events.
+   * TODO: Revisit if we should preserve the offset info.
    */
   private void setIngestionDelayToZero() {
     long currentTimeMs = System.currentTimeMillis();
-    _realtimeTableDataManager.updateIngestionMetrics(currentTimeMs, currentTimeMs, null, null, _partitionGroupId);
+    _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId, currentTimeMs, currentTimeMs,
+        null, null);
   }
 
   // This should be done during commit? We may not always commit when we build a segment....
@@ -1878,14 +1887,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   /**
    * Creates a {@link StreamMessageDecoder} using properties in {@link StreamConfig}.
    *
-   * @param streamConfig The stream config from the table config
    * @param fieldsToRead The fields to read from the source stream
    * @return The initialized StreamMessageDecoder
    */
   private StreamMessageDecoder createMessageDecoder(Set<String> fieldsToRead) {
     String decoderClass = _streamConfig.getDecoderClass();
     try {
-      Map<String, String> decoderProperties = _streamConfig.getDecoderProperties();
       StreamMessageDecoder decoder = PluginManager.get().createInstance(decoderClass);
       decoder.init(fieldsToRead, _streamConfig, _tableConfig, _schema);
       return decoder;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -74,6 +75,8 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.RowMetadata;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
@@ -262,57 +265,63 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     }
   }
 
-  /*
-   * Method used by RealtimeSegmentManagers to update their partition delays
+  /**
+   * Updates the ingestion metrics for the given partition.
    *
-   * @param ingestionTimeMs Ingestion delay being reported.
-   * @param firstStreamIngestionTimeMs Ingestion time of the first message in the stream.
-   * @param partitionGroupId Partition ID for which delay is being updated.
-   * @param offset last offset received for the partition.
-   * @param latestOffset latest upstream offset for the partition.
+   * @param segmentName name of the consuming segment
+   * @param partitionId partition id of the consuming segment (directly passed in to avoid parsing the segment name)
+   * @param ingestionTimeMs ingestion time of the last consumed message (from {@link RowMetadata})
+   * @param firstStreamIngestionTimeMs ingestion time of the last consumed message in the first stream (from
+   *                                   {@link RowMetadata})
+   * @param currentOffset offset of the last consumed message (from {@link RowMetadata})
+   * @param latestOffset offset of the latest message in the partition (from {@link StreamMetadataProvider})
    */
-  public void updateIngestionMetrics(long ingestionTimeMs, long firstStreamIngestionTimeMs,
-      StreamPartitionMsgOffset offset, StreamPartitionMsgOffset latestOffset, int partitionGroupId) {
-    _ingestionDelayTracker.updateIngestionMetrics(ingestionTimeMs, firstStreamIngestionTimeMs, offset, latestOffset,
-        partitionGroupId);
+  public void updateIngestionMetrics(String segmentName, int partitionId, long ingestionTimeMs,
+      long firstStreamIngestionTimeMs, @Nullable StreamPartitionMsgOffset currentOffset,
+      @Nullable StreamPartitionMsgOffset latestOffset) {
+    _ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, firstStreamIngestionTimeMs,
+        currentOffset, latestOffset);
   }
 
-  /*
-   * Method used during query execution (ServerQueryExecutorV1Impl) to get the current timestamp for the ingestion
-   * delay for a partition
-   *
-   * @param segmentNameStr name of segment for which we want the ingestion delay timestamp.
-   * @return timestamp of the ingestion delay for the partition.
+  /**
+   * Returns the ingestion time of the last consumed message for the partition of the given segment. Returns
+   * {@code Long.MIN_VALUE} when it is not available.
    */
-  public long getPartitionIngestionTimeMs(String segmentNameStr) {
-    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-    int partitionGroupId = segmentName.getPartitionGroupId();
-    return _ingestionDelayTracker.getPartitionIngestionTimeMs(partitionGroupId);
+  public long getPartitionIngestionTimeMs(String segmentName) {
+    return _ingestionDelayTracker.getPartitionIngestionTimeMs(new LLCSegmentName(segmentName).getPartitionGroupId());
   }
 
-  /*
+  /**
+   * Removes the ingestion metrics for the partition of the given segment, and also ignores the updates from the given
+   * segment. This is useful when we want to stop tracking the ingestion delay for a partition when the segment might
+   * still be consuming, e.g. when the new consuming segment is created on a different server.
+   */
+  public void removeIngestionMetrics(String segmentName) {
+    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(segmentName);
+  }
+
+  /**
    * Method to handle CONSUMING -> DROPPED segment state transitions:
    * We stop tracking partitions whose segments are dropped.
    *
-   * @param segmentNameStr name of segment which is transitioning state.
+   * @param segmentName name of segment which is transitioning state.
    */
   @Override
-  public void onConsumingToDropped(String segmentNameStr) {
-    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(segmentName.getPartitionGroupId());
+  public void onConsumingToDropped(String segmentName) {
+    // NOTE: No need to mark segment ignored here because it should have already been dropped.
+    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
   }
 
-  /*
+  /**
    * Method to handle CONSUMING -> ONLINE segment state transitions:
    * We mark partitions for verification against ideal state when we do not see a consuming segment for some time
    * for that partition. The idea is to remove the related metrics when the partition moves from the current server.
    *
-   * @param segmentNameStr name of segment which is transitioning state.
+   * @param segmentName name of segment which is transitioning state.
    */
   @Override
-  public void onConsumingToOnline(String segmentNameStr) {
-    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-    _ingestionDelayTracker.markPartitionForVerification(segmentName.getPartitionGroupId());
+  public void onConsumingToOnline(String segmentName) {
+    _ingestionDelayTracker.markPartitionForVerification(segmentName);
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.pinot.core.data.manager.realtime;
 
 import java.time.Clock;
@@ -24,8 +23,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,7 +34,8 @@ import static org.mockito.Mockito.mock;
 
 
 public class IngestionDelayTrackerTest {
-  private static final String REALTIME_TABLE_NAME = "testTable_REALTIME";
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
   private static final int TIMER_THREAD_TICK_INTERVAL_MS = 100;
 
   private final ServerMetrics _serverMetrics = mock(ServerMetrics.class);
@@ -66,8 +68,7 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
     // Test bad timer args to the constructor
     try {
-      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
-          0, () -> true);
+      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, 0, () -> true);
       Assert.fail("Must have asserted due to invalid arguments"); // Constructor must assert
     } catch (Exception e) {
       if ((e instanceof NullPointerException) || !(e instanceof RuntimeException)) {
@@ -80,7 +81,9 @@ public class IngestionDelayTrackerTest {
   public void testRecordIngestionDelayWithNoAging() {
     final long maxTestDelay = 100;
     final int partition0 = 0;
+    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final int partition1 = 1;
+    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
     // Use fixed clock so samples dont age
@@ -90,43 +93,54 @@ public class IngestionDelayTrackerTest {
     ingestionDelayTracker.setClock(clock);
 
     // Test we follow a single partition up and down
-    for (long i = 0; i <= maxTestDelay; i++) {
-      long firstStreamIngestionTimeMs = i + 1;
-      ingestionDelayTracker.updateIngestionDelay(i, firstStreamIngestionTimeMs, partition0);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), clock.millis() - i);
+    for (long ingestionTimeMs = 0; ingestionTimeMs <= maxTestDelay; ingestionTimeMs++) {
+      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
+      ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, firstStreamIngestionTimeMs,
+          null, null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
+          clock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0),
           clock.millis() - firstStreamIngestionTimeMs);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), i);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
     }
 
     // Test tracking down a measure for a given partition
-    for (long i = maxTestDelay; i >= 0; i--) {
-      ingestionDelayTracker.updateIngestionDelay(i, (i + 1), partition0);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), clock.millis() - i);
+    for (long ingestionTimeMs = maxTestDelay; ingestionTimeMs >= 0; ingestionTimeMs--) {
+      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
+      ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, firstStreamIngestionTimeMs,
+          null, null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
+          clock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0),
-          clock.millis() - (i + 1));
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), i);
+          clock.millis() - (ingestionTimeMs + 1));
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
     }
 
     // Make the current partition maximum
-    ingestionDelayTracker.updateIngestionDelay(maxTestDelay, maxTestDelay, partition0);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, maxTestDelay, maxTestDelay, null, null);
 
     // Bring up partition1 delay up and verify values
-    for (long i = 0; i <= 2 * maxTestDelay; i++) {
-      ingestionDelayTracker.updateIngestionDelay(i, (i + 1), partition1);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1), clock.millis() - i);
+    for (long ingestionTimeMs = 0; ingestionTimeMs <= 2 * maxTestDelay; ingestionTimeMs++) {
+      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
+      ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, firstStreamIngestionTimeMs,
+          null, null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1),
+          clock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1),
-          clock.millis() - (i + 1));
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), i);
+          clock.millis() - firstStreamIngestionTimeMs);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
     }
 
     // Bring down values of partition1 and verify values
-    for (long i = 2 * maxTestDelay; i >= 0; i--) {
-      ingestionDelayTracker.updateIngestionDelay(i, (i + 1), partition1);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1), clock.millis() - i);
+    for (long ingestionTimeMs = 2 * maxTestDelay; ingestionTimeMs >= 0; ingestionTimeMs--) {
+      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
+      ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, firstStreamIngestionTimeMs,
+          null, null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1),
+          clock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1),
-          clock.millis() - (i + 1));
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), i);
+          clock.millis() - firstStreamIngestionTimeMs);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
     }
 
     ingestionDelayTracker.shutdown();
@@ -136,11 +150,13 @@ public class IngestionDelayTrackerTest {
   @Test
   public void testRecordIngestionDelayWithAging() {
     final int partition0 = 0;
+    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final long partition0Delay0 = 1000;
     final long partition0Delay1 = 10; // record lower delay to make sure max gets reduced
     final long partition0Offset0Ms = 300;
     final long partition0Offset1Ms = 1000;
     final int partition1 = 1;
+    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
     final long partition1Delay0 = 11;
     final long partition1Offset0Ms = 150;
 
@@ -151,14 +167,12 @@ public class IngestionDelayTrackerTest {
     ZoneId zoneId = ZoneId.systemDefault();
     Clock clock = Clock.fixed(now, zoneId);
     ingestionDelayTracker.setClock(clock);
-    long ingestionTimeMs = (clock.millis() - partition0Delay0);
-    ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs,
-        (clock.millis() - partition0Delay0), partition0);
-    ingestionDelayTracker.updateIngestionDelay((clock.millis() - partition0Delay0), (clock.millis() - partition0Delay0),
-        partition0);
+    long ingestionTimeMs = clock.millis() - partition0Delay0;
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs, null, null);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), partition0Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0), partition0Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
+
     // Advance clock and test aging
     Clock offsetClock = Clock.offset(clock, Duration.ofMillis(partition0Offset0Ms));
     ingestionDelayTracker.setClock(offsetClock);
@@ -168,9 +182,8 @@ public class IngestionDelayTrackerTest {
         (partition0Delay0 + partition0Offset0Ms));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
 
-    ingestionTimeMs = (offsetClock.millis() - partition0Delay1);
-    ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs,
-        (offsetClock.millis() - partition0Delay1), partition0);
+    ingestionTimeMs = offsetClock.millis() - partition0Delay1;
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs, null, null);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), partition0Delay1);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0), partition0Delay1);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
@@ -181,9 +194,8 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
         (partition0Delay1 + partition0Offset1Ms));
 
-    ingestionTimeMs = (offsetClock.millis() - partition1Delay0);
-    ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs,
-        (offsetClock.millis() - partition1Delay0), partition1);
+    ingestionTimeMs = offsetClock.millis() - partition1Delay0;
+    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, ingestionTimeMs, null, null);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1), partition1Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1), partition1Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
@@ -210,24 +222,52 @@ public class IngestionDelayTrackerTest {
     ingestionDelayTracker.setClock(clock);
 
     // Record a number of partitions with delay equal to partition id
-    for (int partitionGroupId = 0; partitionGroupId <= maxTestDelay; partitionGroupId++) {
-      long ingestionTimeMs = (clock.millis() - partitionGroupId);
-      ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, ingestionTimeMs, partitionGroupId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionGroupId), partitionGroupId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionGroupId),
-          partitionGroupId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionGroupId), ingestionTimeMs);
+    for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
+      String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
+      long ingestionTimeMs = clock.millis() - partitionId;
+      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null,
+          null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionId), ingestionTimeMs);
     }
-    for (int partitionGroupId = maxPartition; partitionGroupId >= 0; partitionGroupId--) {
-      ingestionDelayTracker.stopTrackingPartitionIngestionDelay(partitionGroupId);
+    for (int partitionId = maxPartition; partitionId >= 0; partitionId--) {
+      ingestionDelayTracker.stopTrackingPartitionIngestionDelay(partitionId);
     }
-    for (int partitionGroupId = 0; partitionGroupId <= maxTestDelay; partitionGroupId++) {
+    for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
       // Untracked partitions must return 0
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionGroupId), 0);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionGroupId), 0);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(
-          partitionGroupId), Long.MIN_VALUE);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), 0);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), 0);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionId), Long.MIN_VALUE);
     }
+  }
+
+  @Test
+  public void testStopTrackingIngestionDelayWithSegment() {
+    IngestionDelayTracker ingestionDelayTracker = createTracker();
+    // Use fixed clock so samples don't age
+    Instant now = Instant.now();
+    ZoneId zoneId = ZoneId.systemDefault();
+    Clock clock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(clock);
+
+    String segmentName = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
+    long ingestionTimeMs = clock.millis() - 10;
+    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null, null);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 10);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 10);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), ingestionTimeMs);
+
+    ingestionDelayTracker.stopTrackingPartitionIngestionDelay(segmentName);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
+
+    // Should not update metrics for removed segment
+    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null, null);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
   }
 
   @Test
@@ -242,12 +282,13 @@ public class IngestionDelayTrackerTest {
     ingestionDelayTracker.setClock(clock);
 
     // Test Shutdown with partitions active
-    for (int partitionGroupId = 0; partitionGroupId <= maxTestDelay; partitionGroupId++) {
-      ingestionDelayTracker.updateIngestionDelay((clock.millis() - partitionGroupId),
-          (clock.millis() - partitionGroupId), partitionGroupId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionGroupId), partitionGroupId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionGroupId),
-          partitionGroupId);
+    for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
+      String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
+      long ingestionTimeMs = clock.millis() - partitionId;
+      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null,
+          null);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
     }
     ingestionDelayTracker.shutdown();
 
@@ -257,65 +298,35 @@ public class IngestionDelayTrackerTest {
   }
 
   @Test
-  public void testRecordIngestionDelayOffsetWithNoAging() {
+  public void testRecordIngestionDelayOffset() {
     final int partition0 = 0;
+    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final int partition1 = 1;
+    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
-    // Use fixed clock so samples don't age
-    Instant now = Instant.now();
-    ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
 
     // Test tracking offset lag for a single partition
     StreamPartitionMsgOffset msgOffset0 = new LongMsgOffset(100);
     StreamPartitionMsgOffset latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionOffsets(msgOffset0, latestOffset0, partition0);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0,
+        latestOffset0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 100);
 
     // Test tracking offset lag for another partition
     StreamPartitionMsgOffset msgOffset1 = new LongMsgOffset(50);
     StreamPartitionMsgOffset latestOffset1 = new LongMsgOffset(150);
-    ingestionDelayTracker.updateIngestionOffsets(msgOffset1, latestOffset1, partition1);
+    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset1,
+        latestOffset1);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition1), 100);
 
     // Update offset lag for partition0
     msgOffset0 = new LongMsgOffset(150);
     latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionOffsets(msgOffset0, latestOffset0, partition0);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0,
+        latestOffset0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 50);
 
-    ingestionDelayTracker.shutdown();
-  }
-
-  @Test
-  public void testRecordIngestionDelayOffsetWithAging() {
-    final int partition0 = 0;
-    final long partition0OffsetLag0 = 100;
-    final long partition0OffsetLag1 = 50;
-
-    IngestionDelayTracker ingestionDelayTracker = createTracker();
-
-    // With samples for a single partition, test that sample is aged as expected
-    Instant now = Instant.now();
-    ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
-
-    StreamPartitionMsgOffset msgOffset0 = new LongMsgOffset(100);
-    StreamPartitionMsgOffset latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionOffsets(msgOffset0, latestOffset0, partition0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), partition0OffsetLag0);
-
-    // Update offset lag and test aging
-    msgOffset0 = new LongMsgOffset(150);
-    latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionOffsets(msgOffset0, latestOffset0, partition0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), partition0OffsetLag1);
-
-
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), partition0OffsetLag1);
     ingestionDelayTracker.shutdown();
   }
 }


### PR DESCRIPTION
Solve #11448 

When controller detects the new consuming segment is relocated to different servers, it sends a Helix message to the servers no longer hosting the stream partition to remove the ingestion metrics. This way, there is no delay removing ingestion metrics, so that we can prevent false high ingestion delay alert.
One thing worth noting is that when the message is sent, the previous consuming segment might still consume. To handle that, we introduce a cache to store the previous consuming segment, and ignore ingestion metrics update from it.