### PR TITLE
Remove usage of the deprecated replicaPerPartition.

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -66,8 +66,6 @@ public class TableConfigTest {
     assertEquals(offlineTableConfig.getReplication(), 2);
     offlineTableConfig.getValidationConfig().setReplication("4");
     assertEquals(offlineTableConfig.getReplication(), 4);
-    offlineTableConfig.getValidationConfig().setReplication("3");
-    assertEquals(offlineTableConfig.getReplication(), 4);
 
     TableConfig realtimeTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(2).build();

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -66,7 +66,7 @@ public class TableConfigTest {
     assertEquals(offlineTableConfig.getReplication(), 2);
     offlineTableConfig.getValidationConfig().setReplication("4");
     assertEquals(offlineTableConfig.getReplication(), 4);
-    offlineTableConfig.getValidationConfig().setReplicasPerPartition("3");
+    offlineTableConfig.getValidationConfig().setReplication("3");
     assertEquals(offlineTableConfig.getReplication(), 4);
 
     TableConfig realtimeTableConfig =
@@ -74,7 +74,7 @@ public class TableConfigTest {
     assertEquals(realtimeTableConfig.getReplication(), 2);
     realtimeTableConfig.getValidationConfig().setReplication("4");
     assertEquals(realtimeTableConfig.getReplication(), 4);
-    realtimeTableConfig.getValidationConfig().setReplicasPerPartition("3");
+    realtimeTableConfig.getValidationConfig().setReplication("3");
     assertEquals(realtimeTableConfig.getReplication(), 3);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -299,7 +299,7 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
     TableConfig replicaTestOfflineTableConfig = createOfflineTableConfig(tableName);
     TableConfig replicaTestRealtimeTableConfig = createRealtimeTableConfig(tableName);
     replicaTestOfflineTableConfig.getValidationConfig().setReplication("1");
-    replicaTestRealtimeTableConfig.getValidationConfig().setReplicasPerPartition("1");
+    replicaTestRealtimeTableConfig.getValidationConfig().setReplication("1");
     tableConfigs = new TableConfigs(tableName, createDummySchema(tableName), replicaTestOfflineTableConfig,
         replicaTestRealtimeTableConfig);
     sendPostRequest(_createTableConfigsUrl, tableConfigs.toPrettyJsonString());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -119,7 +119,7 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
             .setStreamConfigs(streamConfigs).build();
     // Update the replication by changing the NUM_REPLICAS_PER_PARTITION
-    tableConfig.getValidationConfig().setReplicasPerPartition(NUM_REPLICAS_PER_PARTITION);
+    tableConfig.getValidationConfig().setReplication(NUM_REPLICAS_PER_PARTITION);
     SegmentAssignment segmentAssignment =
         SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -138,7 +138,7 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends BaseRealtimeC
         new SegmentsValidationAndRetentionConfig();
     CompletionConfig completionConfig = new CompletionConfig("DOWNLOAD");
     segmentsValidationAndRetentionConfig.setCompletionConfig(completionConfig);
-    segmentsValidationAndRetentionConfig.setReplicasPerPartition(String.valueOf(NUM_SERVERS));
+    segmentsValidationAndRetentionConfig.setReplication(String.valueOf(NUM_SERVERS));
     // Important: enable peer to peer download.
     segmentsValidationAndRetentionConfig.setPeerSegmentDownloadScheme("http");
     tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -139,6 +139,7 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends BaseRealtimeC
     CompletionConfig completionConfig = new CompletionConfig("DOWNLOAD");
     segmentsValidationAndRetentionConfig.setCompletionConfig(completionConfig);
     segmentsValidationAndRetentionConfig.setReplication(String.valueOf(NUM_SERVERS));
+    segmentsValidationAndRetentionConfig.setReplicasPerPartition(String.valueOf(NUM_SERVERS));
     // Important: enable peer to peer download.
     segmentsValidationAndRetentionConfig.setPeerSegmentDownloadScheme("http");
     tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1428,7 +1428,6 @@ public final class TableConfigUtils {
     if (replication < defaultTableMinReplicas) {
       LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
           defaultTableMinReplicas, replication);
-      validationConfig.setReplication(null);
       validationConfig.setReplication(String.valueOf(defaultTableMinReplicas));
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1428,7 +1428,7 @@ public final class TableConfigUtils {
     if (replication < defaultTableMinReplicas) {
       LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
           defaultTableMinReplicas, replication);
-      validationConfig.setReplicasPerPartition(null);
+      validationConfig.setReplication(null);
       validationConfig.setReplication(String.valueOf(defaultTableMinReplicas));
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -35,6 +35,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @Deprecated
   private String _segmentPushType;
   private String _replication;
+  @Deprecated // Use _replication instead
+  private String _replicasPerPartition;
   @Deprecated // Schema name should be the same as raw table name
   private String _schemaName;
   private String _timeColumnName;
@@ -139,6 +141,27 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
+   * Try to Use {@link TableConfig#getReplication()}
+   * @deprecated Use _replication instead
+   *
+   * Will be deleted in future version of Pinot
+   */
+  @Deprecated
+  public String getReplicasPerPartition() {
+    return _replicasPerPartition;
+  }
+
+  /**
+   * Try to Use {@link SegmentsValidationAndRetentionConfig#setReplication(String)}
+   *
+   * Will be deleted in future version of Pinot
+   */
+  @Deprecated
+  public void setReplicasPerPartition(String replicasPerPartition) {
+    _replicasPerPartition = replicasPerPartition;
+  }
+
+  /**
    * @deprecated Schema name should be the same as raw table name
    */
   @Deprecated
@@ -174,6 +197,17 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @JsonIgnore
   public int getReplicationNumber() {
     return Integer.parseInt(_replication);
+  }
+
+  /**
+   * Try to Use {@link TableConfig#getReplication()}
+   *
+   * Will be deleted in future version of Pinot
+   */
+  @Deprecated
+  @JsonIgnore
+  public int getReplicasPerPartitionNumber() {
+    return Integer.parseInt(_replicasPerPartition);
   }
 
   public String getPeerSegmentDownloadScheme() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -35,8 +35,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @Deprecated
   private String _segmentPushType;
   private String _replication;
-  @Deprecated // Use _replication instead
-  private String _replicasPerPartition;
   @Deprecated // Schema name should be the same as raw table name
   private String _schemaName;
   private String _timeColumnName;
@@ -141,20 +139,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * Try to Use {@link TableConfig#getReplication()}
-   * @deprecated Use _replication instead
-   */
-  @Deprecated
-  public String getReplicasPerPartition() {
-    return _replicasPerPartition;
-  }
-
-  @Deprecated
-  public void setReplicasPerPartition(String replicasPerPartition) {
-    _replicasPerPartition = replicasPerPartition;
-  }
-
-  /**
    * @deprecated Schema name should be the same as raw table name
    */
   @Deprecated
@@ -190,15 +174,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @JsonIgnore
   public int getReplicationNumber() {
     return Integer.parseInt(_replication);
-  }
-
-  /**
-   * Try to Use {@link TableConfig#getReplication()}
-   */
-  @Deprecated
-  @JsonIgnore
-  public int getReplicasPerPartitionNumber() {
-    return Integer.parseInt(_replicasPerPartition);
   }
 
   public String getPeerSegmentDownloadScheme() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -434,7 +434,7 @@ public class TableConfig extends BaseJsonConfig {
   public int getReplication() {
     if (_tableType == TableType.REALTIME) {
       // Use replicasPerPartition for real-time table if exists
-      String replicasPerPartition = _validationConfig.getReplication();
+      String replicasPerPartition = _validationConfig.getReplicasPerPartition();
       if (replicasPerPartition != null) {
         return Integer.parseInt(replicasPerPartition);
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -434,7 +434,7 @@ public class TableConfig extends BaseJsonConfig {
   public int getReplication() {
     if (_tableType == TableType.REALTIME) {
       // Use replicasPerPartition for real-time table if exists
-      String replicasPerPartition = _validationConfig.getReplicasPerPartition();
+      String replicasPerPartition = _validationConfig.getReplication();
       if (replicasPerPartition != null) {
         return Integer.parseInt(replicasPerPartition);
       }


### PR DESCRIPTION
**Labels**
`cleanup`

**Description**
We marked the `getReplicationPerPartition` and `setReoplicationPerPartition` [methods](https://github.com/apache/pinot/pull/11590/files#diff-b40104bb94a315fb720efb79ca588742275fba0c3a9d3f646e417f2522a00737R145) as deprecated from some time. This PR removes the usage of the methods and test cases from the code. 