### PR TITLE
Use argument type to lookup function for literal only query

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -73,6 +73,7 @@ import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -96,8 +97,6 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.DatabaseConflictException;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.Tracing;
-import org.apache.pinot.spi.utils.BigDecimalUtils;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -1393,16 +1392,18 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   private BrokerResponseNative processLiteralOnlyQuery(long requestId, PinotQuery pinotQuery,
       RequestContext requestContext) {
     BrokerResponseNative brokerResponse = new BrokerResponseNative();
-    List<String> columnNames = new ArrayList<>();
-    List<DataSchema.ColumnDataType> columnTypes = new ArrayList<>();
-    List<Object> row = new ArrayList<>();
-    for (Expression expression : pinotQuery.getSelectList()) {
-      computeResultsForExpression(expression, columnNames, columnTypes, row);
+    List<Expression> selectList = pinotQuery.getSelectList();
+    int numColumns = selectList.size();
+    String[] columnNames = new String[numColumns];
+    ColumnDataType[] columnTypes = new ColumnDataType[numColumns];
+    Object[] values = new Object[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      computeResultsForExpression(selectList.get(i), columnNames, columnTypes, values, i);
+      values[i] = columnTypes[i].format(values[i]);
     }
-    DataSchema dataSchema =
-        new DataSchema(columnNames.toArray(new String[0]), columnTypes.toArray(new DataSchema.ColumnDataType[0]));
-    List<Object[]> rows = new ArrayList<>();
-    rows.add(row.toArray());
+    DataSchema dataSchema = new DataSchema(columnNames, columnTypes);
+    List<Object[]> rows = new ArrayList<>(1);
+    rows.add(values);
     ResultTable resultTable = new ResultTable(dataSchema, rows);
     brokerResponse.setResultTable(resultTable);
     brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
@@ -1414,87 +1415,28 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   }
 
   // TODO(xiangfu): Move Literal function computation here from Calcite Parser.
-  private void computeResultsForExpression(Expression e, List<String> columnNames,
-      List<DataSchema.ColumnDataType> columnTypes, List<Object> row) {
-    if (e.getType() == ExpressionType.LITERAL) {
-      computeResultsForLiteral(e.getLiteral(), columnNames, columnTypes, row);
+  private void computeResultsForExpression(Expression expression, String[] columnNames, ColumnDataType[] columnTypes,
+      Object[] values, int index) {
+    if (expression.getType() == ExpressionType.LITERAL) {
+      computeResultsForLiteral(expression.getLiteral(), columnNames, columnTypes, values, index);
     }
-    if (e.getType() == ExpressionType.FUNCTION) {
-      if (e.getFunctionCall().getOperator().equals("as")) {
-        String columnName = e.getFunctionCall().getOperands().get(1).getIdentifier().getName();
-        computeResultsForExpression(e.getFunctionCall().getOperands().get(0), columnNames, columnTypes, row);
-        columnNames.set(columnNames.size() - 1, columnName);
+    if (expression.getType() == ExpressionType.FUNCTION) {
+      if (expression.getFunctionCall().getOperator().equals("as")) {
+        String columnName = expression.getFunctionCall().getOperands().get(1).getIdentifier().getName();
+        computeResultsForExpression(expression.getFunctionCall().getOperands().get(0), columnNames, columnTypes, values,
+            index);
+        columnNames[index] = columnName;
       } else {
         throw new IllegalStateException(
-            "No able to compute results for function - " + e.getFunctionCall().getOperator());
+            "No able to compute results for function - " + expression.getFunctionCall().getOperator());
       }
     }
   }
 
-  private void computeResultsForLiteral(Literal literal, List<String> columnNames,
-      List<DataSchema.ColumnDataType> columnTypes, List<Object> row) {
-    columnNames.add(RequestUtils.prettyPrint(literal));
-    switch (literal.getSetField()) {
-      case NULL_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.UNKNOWN);
-        row.add(null);
-        break;
-      case BOOL_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.BOOLEAN);
-        row.add(literal.getBoolValue());
-        break;
-      case INT_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.INT);
-        row.add(literal.getIntValue());
-        break;
-      case LONG_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.LONG);
-        row.add(literal.getLongValue());
-        break;
-      case FLOAT_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.FLOAT);
-        row.add(Float.intBitsToFloat(literal.getFloatValue()));
-        break;
-      case DOUBLE_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.DOUBLE);
-        row.add(literal.getDoubleValue());
-        break;
-      case BIG_DECIMAL_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.BIG_DECIMAL);
-        row.add(BigDecimalUtils.deserialize(literal.getBigDecimalValue()));
-        break;
-      case STRING_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.STRING);
-        row.add(literal.getStringValue());
-        break;
-      case BINARY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.BYTES);
-        row.add(BytesUtils.toHexString(literal.getBinaryValue()));
-        break;
-      // TODO: Revisit the array handling. Currently we are setting List into the row.
-      case INT_ARRAY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.INT_ARRAY);
-        row.add(literal.getIntArrayValue());
-        break;
-      case LONG_ARRAY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.LONG_ARRAY);
-        row.add(literal.getLongArrayValue());
-        break;
-      case FLOAT_ARRAY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.FLOAT_ARRAY);
-        row.add(literal.getFloatArrayValue().stream().map(Float::intBitsToFloat).collect(Collectors.toList()));
-        break;
-      case DOUBLE_ARRAY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.DOUBLE_ARRAY);
-        row.add(literal.getDoubleArrayValue());
-        break;
-      case STRING_ARRAY_VALUE:
-        columnTypes.add(DataSchema.ColumnDataType.STRING_ARRAY);
-        row.add(literal.getStringArrayValue());
-        break;
-      default:
-        throw new IllegalStateException("Unsupported literal: " + literal);
-    }
+  private void computeResultsForLiteral(Literal literal, String[] columnNames, ColumnDataType[] columnTypes,
+      Object[] values, int index) {
+    columnNames[index] = RequestUtils.prettyPrint(literal);
+    RequestUtils.getLiteralTypeAndValue(literal, columnTypes, values, index);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -35,12 +35,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -48,6 +50,7 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
@@ -343,21 +346,124 @@ public class RequestUtils {
       case BINARY_VALUE:
         return literal.getBinaryValue();
       case INT_ARRAY_VALUE:
-        return literal.getIntArrayValue().stream().mapToInt(Integer::intValue).toArray();
+        return getIntArrayValue(literal);
       case LONG_ARRAY_VALUE:
-        return literal.getLongArrayValue().stream().mapToLong(Long::longValue).toArray();
+        return getLongArrayValue(literal);
       case FLOAT_ARRAY_VALUE:
-        List<Integer> floatList = literal.getFloatArrayValue();
-        int numFloats = floatList.size();
-        float[] floatArray = new float[numFloats];
-        for (int i = 0; i < numFloats; i++) {
-          floatArray[i] = Float.intBitsToFloat(floatList.get(i));
-        }
-        return floatArray;
+        return getFloatArrayValue(literal);
       case DOUBLE_ARRAY_VALUE:
-        return literal.getDoubleArrayValue().stream().mapToDouble(Double::doubleValue).toArray();
+        return getDoubleArrayValue(literal);
       case STRING_ARRAY_VALUE:
-        return literal.getStringArrayValue().toArray(new String[0]);
+        return getStringArrayValue(literal);
+      default:
+        throw new IllegalStateException("Unsupported field type: " + type);
+    }
+  }
+
+  private static int[] getIntArrayValue(Literal literal) {
+    List<Integer> intList = literal.getIntArrayValue();
+    int numInts = intList.size();
+    int[] intArray = new int[numInts];
+    for (int i = 0; i < numInts; i++) {
+      intArray[i] = intList.get(i);
+    }
+    return intArray;
+  }
+
+  private static long[] getLongArrayValue(Literal literal) {
+    List<Long> longList = literal.getLongArrayValue();
+    int numLongs = longList.size();
+    long[] longArray = new long[numLongs];
+    for (int i = 0; i < numLongs; i++) {
+      longArray[i] = longList.get(i);
+    }
+    return longArray;
+  }
+
+  private static float[] getFloatArrayValue(Literal literal) {
+    List<Integer> floatList = literal.getFloatArrayValue();
+    int numFloats = floatList.size();
+    float[] floatArray = new float[numFloats];
+    for (int i = 0; i < numFloats; i++) {
+      floatArray[i] = Float.intBitsToFloat(floatList.get(i));
+    }
+    return floatArray;
+  }
+
+  private static double[] getDoubleArrayValue(Literal literal) {
+    List<Double> doubleList = literal.getDoubleArrayValue();
+    int numDoubles = doubleList.size();
+    double[] doubleArray = new double[numDoubles];
+    for (int i = 0; i < numDoubles; i++) {
+      doubleArray[i] = doubleList.get(i);
+    }
+    return doubleArray;
+  }
+
+  private static String[] getStringArrayValue(Literal literal) {
+    return literal.getStringArrayValue().toArray(new String[0]);
+  }
+
+  public static void getLiteralTypeAndValue(Literal literal, ColumnDataType[] types,
+      Object[] values, int index) {
+    Literal._Fields type = literal.getSetField();
+    switch (type) {
+      case NULL_VALUE:
+        types[index] = ColumnDataType.UNKNOWN;
+        values[index] = null;
+        break;
+      case BOOL_VALUE:
+        types[index] = ColumnDataType.BOOLEAN;
+        values[index] = literal.getBoolValue();
+        break;
+      case INT_VALUE:
+        types[index] = ColumnDataType.INT;
+        values[index] = literal.getIntValue();
+        break;
+      case LONG_VALUE:
+        types[index] = ColumnDataType.LONG;
+        values[index] = literal.getLongValue();
+        break;
+      case FLOAT_VALUE:
+        types[index] = ColumnDataType.FLOAT;
+        values[index] = Float.intBitsToFloat(literal.getFloatValue());
+        break;
+      case DOUBLE_VALUE:
+        types[index] = ColumnDataType.DOUBLE;
+        values[index] = literal.getDoubleValue();
+        break;
+      case BIG_DECIMAL_VALUE:
+        types[index] = ColumnDataType.BIG_DECIMAL;
+        values[index] = BigDecimalUtils.deserialize(literal.getBigDecimalValue());
+        break;
+      case STRING_VALUE:
+        types[index] = ColumnDataType.STRING;
+        values[index] = literal.getStringValue();
+        break;
+      case BINARY_VALUE:
+        types[index] = ColumnDataType.BYTES;
+        values[index] = literal.getBinaryValue();
+        break;
+      case INT_ARRAY_VALUE:
+        types[index] = ColumnDataType.INT_ARRAY;
+        values[index] = getIntArrayValue(literal);
+        break;
+      case LONG_ARRAY_VALUE:
+        types[index] = ColumnDataType.LONG_ARRAY;
+        values[index] = getLongArrayValue(literal);
+        break;
+      case FLOAT_ARRAY_VALUE:
+        types[index] = ColumnDataType.FLOAT_ARRAY;
+        values[index] = getFloatArrayValue(literal);
+        break;
+      case DOUBLE_ARRAY_VALUE:
+        types[index] = ColumnDataType.DOUBLE_ARRAY;
+        values[index] = getDoubleArrayValue(literal);
+        break;
+      case STRING_ARRAY_VALUE:
+        types[index] = ColumnDataType.STRING_ARRAY;
+        values[index] = getStringArrayValue(literal);
+        break;
       default:
         throw new IllegalStateException("Unsupported field type: " + type);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -26,12 +26,15 @@ import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
 
 
 public class CompileTimeFunctionsInvoker implements QueryRewriter {
+
   @Override
   public PinotQuery rewrite(PinotQuery pinotQuery) {
     for (int i = 0; i < pinotQuery.getSelectListSize(); i++) {
@@ -61,38 +64,40 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
     List<Expression> operands = function.getOperands();
     int numOperands = operands.size();
     boolean compilable = true;
+    ColumnDataType[] argumentTypes = new ColumnDataType[numOperands];
+    Object[] arguments = new Object[numOperands];
     for (int i = 0; i < numOperands; i++) {
       Expression operand = invokeCompileTimeFunctionExpression(operands.get(i));
-      if (operand.getLiteral() == null) {
+      operands.set(i, operand);
+      Literal literal = operand.getLiteral();
+      if (compilable && literal != null) {
+        RequestUtils.getLiteralTypeAndValue(literal, argumentTypes, arguments, i);
+      } else {
         compilable = false;
       }
-      operands.set(i, operand);
     }
-    if (compilable) {
-      String canonicalName = FunctionRegistry.canonicalize(function.getOperator());
-      FunctionInfo functionInfo = FunctionRegistry.lookupFunctionInfo(canonicalName, numOperands);
-      if (functionInfo != null) {
-        Object[] arguments = new Object[numOperands];
-        for (int i = 0; i < numOperands; i++) {
-          arguments[i] = RequestUtils.getLiteralValue(function.getOperands().get(i).getLiteral());
-        }
-        try {
-          FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-          Object result;
-          if (invoker.getMethod().isVarArgs()) {
-            result = invoker.invoke(new Object[] {arguments});
-          } else {
-            invoker.convertTypes(arguments);
-            result = invoker.invoke(arguments);
-          }
-          return RequestUtils.getLiteralExpression(result);
-        } catch (Exception e) {
-          throw new SqlCompilationException(
-              "Caught exception while invoking method: " + functionInfo.getMethod() + " with arguments: "
-                  + Arrays.toString(arguments), e);
-        }
+    if (!compilable) {
+      return expression;
+    }
+    String canonicalName = FunctionRegistry.canonicalize(function.getOperator());
+    FunctionInfo functionInfo = FunctionRegistry.lookupFunctionInfo(canonicalName, argumentTypes);
+    if (functionInfo == null) {
+      return expression;
+    }
+    try {
+      FunctionInvoker invoker = new FunctionInvoker(functionInfo);
+      Object result;
+      if (invoker.getMethod().isVarArgs()) {
+        result = invoker.invoke(new Object[]{arguments});
+      } else {
+        invoker.convertTypes(arguments);
+        result = invoker.invoke(arguments);
       }
+      return RequestUtils.getLiteralExpression(result);
+    } catch (Exception e) {
+      throw new SqlCompilationException(
+          "Caught exception while invoking method: " + functionInfo.getMethod() + " with arguments: " + Arrays.toString(
+              arguments), e);
     }
-    return expression;
   }
 }


### PR DESCRIPTION
- Use argument types instead of argument count to lookup functions in `FunctionRegistry` to support polymorphism
- Extract common code for extracting literal type and value from thrift `Literal`
- Fix bug on array type response type
- Format the literal to comply with broker response format