### PR TITLE
Track segments consistently for consistent upsert view

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/DuoSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/DuoSegmentDataManager.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.spi.IndexSegment;
+
+
+/**
+ * Segment data manager tracking two segments associated with one segment name, e.g. when committing a mutable
+ * segment, a new immutable segment is created to replace the mutable one, and the two segments are having same name.
+ * By tracked both with this segment data manager, we can provide queries both segments for complete data view.
+ */
+public class DuoSegmentDataManager extends SegmentDataManager {
+  private final SegmentDataManager _primary;
+  private final List<SegmentDataManager> _segmentDataManagers;
+
+  public DuoSegmentDataManager(SegmentDataManager primary, SegmentDataManager secondary) {
+    _primary = primary;
+    _segmentDataManagers = Arrays.asList(_primary, secondary);
+  }
+
+  @Override
+  public String getSegmentName() {
+    return _primary.getSegmentName();
+  }
+
+  @Override
+  public IndexSegment getSegment() {
+    return _primary.getSegment();
+  }
+
+  @Override
+  public synchronized boolean increaseReferenceCount() {
+    boolean any = false;
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      if (segmentDataManager.increaseReferenceCount()) {
+        any = true;
+      }
+    }
+    return any;
+  }
+
+  @Override
+  public synchronized boolean decreaseReferenceCount() {
+    boolean any = false;
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      if (segmentDataManager.decreaseReferenceCount()) {
+        any = true;
+      }
+    }
+    return any;
+  }
+
+  @Override
+  public boolean hasMultiSegments() {
+    return true;
+  }
+
+  @Override
+  public List<IndexSegment> getSegments() {
+    List<IndexSegment> segments = new ArrayList<>(_segmentDataManagers.size());
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      if (segmentDataManager.getReferenceCount() > 0) {
+        segments.add(segmentDataManager.getSegment());
+      }
+    }
+    return segments;
+  }
+
+  @Override
+  public void doOffload() {
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      if (segmentDataManager.getReferenceCount() == 0) {
+        segmentDataManager.offload();
+      }
+    }
+  }
+
+  @Override
+  protected void doDestroy() {
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      if (segmentDataManager.getReferenceCount() == 0) {
+        segmentDataManager.destroy();
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/DuoSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/DuoSegmentDataManager.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
  * Segment data manager tracking two segments associated with one segment name, e.g. when committing a mutable
  * segment, a new immutable segment is created to replace the mutable one, and the two segments are having same name.
  * By tracked both with this segment data manager, we can provide queries both segments for complete data view.
+ * The primary segment represents all segments tracked by this manager for places asking for segment metadata.
  */
 public class DuoSegmentDataManager extends SegmentDataManager {
   private final SegmentDataManager _primary;
@@ -37,6 +38,16 @@ public class DuoSegmentDataManager extends SegmentDataManager {
   public DuoSegmentDataManager(SegmentDataManager primary, SegmentDataManager secondary) {
     _primary = primary;
     _segmentDataManagers = Arrays.asList(_primary, secondary);
+  }
+
+  @Override
+  public long getLoadTimeMs() {
+    return _primary.getLoadTimeMs();
+  }
+
+  @Override
+  public synchronized int getReferenceCount() {
+    return _primary.getReferenceCount();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1565,6 +1565,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
             .setNullHandlingEnabled(_nullHandlingEnabled)
             .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
+            .setUpsertConsistencyMode(tableConfig.getUpsertConsistencyMode())
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
             .setUpsertComparisonColumns(tableConfig.getUpsertComparisonColumns())
             .setUpsertDeleteRecordColumn(tableConfig.getUpsertDeleteRecordColumn())

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -644,7 +644,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       SegmentDataManager duoSegmentDataManager = new DuoSegmentDataManager(newSegmentManager, oldSegmentManager);
       registerSegment(segmentName, duoSegmentDataManager, partitionUpsertMetadataManager);
       partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
-      registerSegment(segmentName, newSegmentManager);
+      registerSegment(segmentName, newSegmentManager, partitionUpsertMetadataManager);
     }
     _logger.info("Replaced {} segment: {} with upsert enabled and consistency mode: {}",
         oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, consistencyMode);
@@ -655,7 +655,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private void registerSegment(String segmentName, SegmentDataManager segmentDataManager,
       @Nullable PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
     if (partitionUpsertMetadataManager != null) {
-      // Register segment to the upsert metadata manager before registering it to table manager, so that the upser
+      // Register segment to the upsert metadata manager before registering it to table manager, so that the upsert
       // metadata manger can update the upsert view before the segment becomes visible to queries.
       partitionUpsertMetadataManager.trackSegmentForUpsertView(segmentDataManager.getSegment());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -49,6 +49,7 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
+import org.apache.pinot.core.data.manager.DuoSegmentDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
@@ -98,7 +99,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   // The semaphores will stay in the hash map even if the consuming partitions move to a different host.
   // We expect that there will be a small number of semaphores, but that may be ok.
   private final Map<Integer, Semaphore> _partitionGroupIdToSemaphoreMap = new ConcurrentHashMap<>();
-
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes
   private static final String STATS_FILE_NAME = "segment-stats.ser";
@@ -507,9 +507,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         new RealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(), indexLoadingConfig,
             schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
             partitionDedupMetadataManager, _isTableReadyToConsumeData);
+    registerSegment(segmentName, realtimeSegmentDataManager, partitionUpsertMetadataManager);
     realtimeSegmentDataManager.startConsumption();
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1);
-    registerSegment(segmentName, realtimeSegmentDataManager);
 
     _logger.info("Added new CONSUMING segment: {}", segmentName);
   }
@@ -603,7 +603,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       // Preloading segment is ensured to be handled by a single thread, so no need to take the segment upsert lock.
       // Besides, preloading happens before the table partition is made ready for any queries.
       partitionUpsertMetadataManager.preloadSegment(immutableSegment);
-      registerSegment(segmentName, newSegmentManager);
+      registerSegment(segmentName, newSegmentManager, partitionUpsertMetadataManager);
       _logger.info("Preloaded immutable segment: {} with upsert enabled", segmentName);
       return;
     }
@@ -614,24 +614,52 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       // segments may be invalidated, making the queries see less valid docs than expected. We should let query
       // access the new segment asap even though its validDocId bitmap is still being filled by
       // partitionUpsertMetadataManager.
-      registerSegment(segmentName, newSegmentManager);
+      registerSegment(segmentName, newSegmentManager, partitionUpsertMetadataManager);
       partitionUpsertMetadataManager.addSegment(immutableSegment);
       _logger.info("Added new immutable segment: {} with upsert enabled", segmentName);
     } else {
-      // When replacing a segment, we should register the new segment 'after' it is fully initialized by
-      // partitionUpsertMetadataManager to fill up its validDocId bitmap. Otherwise, the queries will lose the access
-      // to the valid docs in the old segment immediately, but the validDocId bitmap of the new segment is still
-      // being filled by partitionUpsertMetadataManager, making the queries see less valid docs than expected.
-      // When replacing a segment, the new and old segments are assumed to have same set of valid docs for data
-      // consistency, otherwise the new segment should be named differently to go through the addSegment flow above.
-      IndexSegment oldSegment = oldSegmentManager.getSegment();
+      replaceUpsertSegment(segmentName, oldSegmentManager, newSegmentManager, partitionUpsertMetadataManager);
+    }
+  }
+
+  private void replaceUpsertSegment(String segmentName, SegmentDataManager oldSegmentManager,
+      ImmutableSegmentDataManager newSegmentManager, PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
+    // When replacing a segment, we should register the new segment 'after' it is fully initialized by
+    // partitionUpsertMetadataManager to fill up its validDocId bitmap. Otherwise, the queries will lose the access
+    // to the valid docs in the old segment immediately, but the validDocId bitmap of the new segment is still
+    // being filled by partitionUpsertMetadataManager, making the queries see less valid docs than expected.
+    IndexSegment oldSegment = oldSegmentManager.getSegment();
+    ImmutableSegment immutableSegment = newSegmentManager.getSegment();
+    UpsertConfig.ConsistencyMode consistencyMode = _tableUpsertMetadataManager.getUpsertConsistencyMode();
+    if (consistencyMode == UpsertConfig.ConsistencyMode.NONE) {
+      partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
+      registerSegment(segmentName, newSegmentManager, partitionUpsertMetadataManager);
+    } else {
+      // By default, when replacing a segment, the old segment is kept intact and visible to query until the new
+      // segment is registered as in the if-branch above. But the newly ingested records will invalidate valid
+      // docs in the new segment as the upsert metadata gets updated during replacement, so the query will miss the
+      // new updates in the new segment, until it's registered after the replacement is done.
+      // For consistent data view, we make both old and new segment visible to the query and update both in place
+      // when segment replacement and new data ingestion are happening in parallel.
+      SegmentDataManager duoSegmentDataManager = new DuoSegmentDataManager(newSegmentManager, oldSegmentManager);
+      registerSegment(segmentName, duoSegmentDataManager, partitionUpsertMetadataManager);
       partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
       registerSegment(segmentName, newSegmentManager);
-      _logger.info("Replaced {} segment: {} with upsert enabled",
-          oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName);
-      oldSegmentManager.offload();
-      releaseSegment(oldSegmentManager);
     }
+    _logger.info("Replaced {} segment: {} with upsert enabled and consistency mode: {}",
+        oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, consistencyMode);
+    oldSegmentManager.offload();
+    releaseSegment(oldSegmentManager);
+  }
+
+  private void registerSegment(String segmentName, SegmentDataManager segmentDataManager,
+      @Nullable PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
+    if (partitionUpsertMetadataManager != null) {
+      // Register segment to the upsert metadata manager before registering it to table manager, so that the upser
+      // metadata manger can update the upsert view before the segment becomes visible to queries.
+      partitionUpsertMetadataManager.trackSegmentForUpsertView(segmentDataManager.getSegment());
+    }
+    registerSegment(segmentName, segmentDataManager);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/DuoSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/DuoSegmentDataManagerTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+public class DuoSegmentDataManagerTest {
+  @Test
+  public void testGetSegments() {
+    SegmentDataManager sdm1 = mockSegmentDataManager("seg01", false, 1);
+    SegmentDataManager sdm2 = mockSegmentDataManager("seg01", true, 1);
+    DuoSegmentDataManager dsdm = new DuoSegmentDataManager(sdm1, sdm2);
+
+    assertTrue(dsdm.hasMultiSegments());
+    assertSame(dsdm.getSegment(), sdm1.getSegment());
+    assertEquals(dsdm.getSegments(), Arrays.asList(sdm1.getSegment(), sdm2.getSegment()));
+
+    when(sdm1.getReferenceCount()).thenReturn(0);
+    assertTrue(dsdm.hasMultiSegments());
+    assertSame(dsdm.getSegment(), sdm1.getSegment());
+    assertEquals(dsdm.getSegments(), Collections.singletonList(sdm2.getSegment()));
+
+    when(sdm2.getReferenceCount()).thenReturn(0);
+    assertTrue(dsdm.hasMultiSegments());
+    assertSame(dsdm.getSegment(), sdm1.getSegment());
+    assertTrue(dsdm.getSegments().isEmpty());
+  }
+
+  @Test
+  public void testIncDecRefCnt() {
+    SegmentDataManager sdm1 = mockSegmentDataManager("seg01", false, 1);
+    SegmentDataManager sdm2 = mockSegmentDataManager("seg01", true, 1);
+    DuoSegmentDataManager dsdm = new DuoSegmentDataManager(sdm1, sdm2);
+
+    when(sdm1.increaseReferenceCount()).thenReturn(false);
+    when(sdm2.increaseReferenceCount()).thenReturn(false);
+    when(sdm1.decreaseReferenceCount()).thenReturn(false);
+    when(sdm2.decreaseReferenceCount()).thenReturn(false);
+    assertFalse(dsdm.increaseReferenceCount());
+    assertFalse(dsdm.decreaseReferenceCount());
+
+    when(sdm1.increaseReferenceCount()).thenReturn(true);
+    when(sdm2.increaseReferenceCount()).thenReturn(false);
+    when(sdm1.decreaseReferenceCount()).thenReturn(true);
+    when(sdm2.decreaseReferenceCount()).thenReturn(false);
+    assertTrue(dsdm.increaseReferenceCount());
+    assertTrue(dsdm.decreaseReferenceCount());
+
+    when(sdm1.increaseReferenceCount()).thenReturn(true);
+    when(sdm2.increaseReferenceCount()).thenReturn(true);
+    when(sdm1.decreaseReferenceCount()).thenReturn(true);
+    when(sdm2.decreaseReferenceCount()).thenReturn(true);
+    assertTrue(dsdm.increaseReferenceCount());
+    assertTrue(dsdm.decreaseReferenceCount());
+  }
+
+  @Test
+  public void testDoOffloadDestroy() {
+    SegmentDataManager sdm1 = mockSegmentDataManager("seg01", false, 1);
+    SegmentDataManager sdm2 = mockSegmentDataManager("seg01", true, 1);
+    DuoSegmentDataManager dsdm = new DuoSegmentDataManager(sdm1, sdm2);
+
+    dsdm.doOffload();
+    verify(sdm1, times(0)).offload();
+    verify(sdm2, times(0)).offload();
+    dsdm.doDestroy();
+    verify(sdm1, times(0)).destroy();
+    verify(sdm2, times(0)).destroy();
+
+    when(sdm1.getReferenceCount()).thenReturn(0);
+    dsdm.doOffload();
+    verify(sdm1, times(1)).offload();
+    verify(sdm2, times(0)).offload();
+    dsdm.doDestroy();
+    verify(sdm1, times(1)).destroy();
+    verify(sdm2, times(0)).destroy();
+
+    reset(sdm1);
+    when(sdm2.getReferenceCount()).thenReturn(0);
+    dsdm.doOffload();
+    verify(sdm1, times(1)).offload();
+    verify(sdm2, times(1)).offload();
+    dsdm.doDestroy();
+    verify(sdm1, times(1)).destroy();
+    verify(sdm2, times(1)).destroy();
+  }
+
+  private SegmentDataManager mockSegmentDataManager(String segmentName, boolean isMutable, int refCnt) {
+    SegmentDataManager segmentDataManager =
+        isMutable ? mock(RealtimeSegmentDataManager.class) : mock(ImmutableSegmentDataManager.class);
+    IndexSegment segment = isMutable ? mock(MutableSegment.class) : mock(ImmutableSegment.class);
+    when(segmentDataManager.getSegmentName()).thenReturn(segmentName);
+    when(segmentDataManager.getSegment()).thenReturn(segment);
+    when(segmentDataManager.getReferenceCount()).thenReturn(refCnt);
+    return segmentDataManager;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.data.manager;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,7 +37,6 @@ public abstract class SegmentDataManager {
     return _loadTimeMs;
   }
 
-  @VisibleForTesting
   public synchronized int getReferenceCount() {
     return _referenceCount;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.segment.local.data.manager;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pinot.segment.spi.IndexSegment;
 
@@ -73,6 +75,14 @@ public abstract class SegmentDataManager {
   public abstract String getSegmentName();
 
   public abstract IndexSegment getSegment();
+
+  public boolean hasMultiSegments() {
+    return false;
+  }
+
+  public List<IndexSegment> getSegments() {
+    return Collections.emptyList();
+  }
 
   /**
    * Offloads the segment from the metadata management (e.g. upsert metadata), but not releases the resources yet

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -265,6 +265,9 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   public void destroy() {
     String segmentName = getSegmentName();
     LOGGER.info("Trying to destroy segment : {}", segmentName);
+    if (_partitionUpsertMetadataManager != null) {
+      _partitionUpsertMetadataManager.untrackSegmentForUpsertView(this);
+    }
     // StarTreeIndexContainer refers to other column index containers, so close it firstly.
     if (_starTreeIndexContainer != null) {
       try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -60,6 +60,7 @@ public class RealtimeSegmentConfig {
   private final boolean _aggregateMetrics;
   private final boolean _nullHandlingEnabled;
   private final UpsertConfig.Mode _upsertMode;
+  private final UpsertConfig.ConsistencyMode _upsertConsistencyMode;
   private final List<String> _upsertComparisonColumns;
   private final String _upsertDeleteRecordColumn;
   private final String _upsertOutOfOrderRecordColumn;
@@ -74,14 +75,14 @@ public class RealtimeSegmentConfig {
   // TODO: Clean up this constructor. Most of these things can be extracted from tableConfig.
   private RealtimeSegmentConfig(String tableNameWithType, String segmentName, String streamName, Schema schema,
       String timeColumnName, int capacity, int avgNumMultiValues, Map<String, FieldIndexConfigs> indexConfigByCol,
-      SegmentZKMetadata segmentZKMetadata, boolean offHeap,
-      PinotDataBufferMemoryManager memoryManager, RealtimeSegmentStatsHistory statsHistory, String partitionColumn,
-      PartitionFunction partitionFunction, int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled,
-      String consumerDir, UpsertConfig.Mode upsertMode, List<String> upsertComparisonColumns,
-      String upsertDeleteRecordColumn, String upsertOutOfOrderRecordColumn, boolean upsertDropOutOfOrderRecord,
-      PartitionUpsertMetadataManager partitionUpsertMetadataManager, String dedupTimeColumn,
-      PartitionDedupMetadataManager partitionDedupMetadataManager, List<FieldConfig> fieldConfigList,
-      List<AggregationConfig> ingestionAggregationConfigs) {
+      SegmentZKMetadata segmentZKMetadata, boolean offHeap, PinotDataBufferMemoryManager memoryManager,
+      RealtimeSegmentStatsHistory statsHistory, String partitionColumn, PartitionFunction partitionFunction,
+      int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled, String consumerDir,
+      UpsertConfig.Mode upsertMode, UpsertConfig.ConsistencyMode upsertConsistencyMode,
+      List<String> upsertComparisonColumns, String upsertDeleteRecordColumn, String upsertOutOfOrderRecordColumn,
+      boolean upsertDropOutOfOrderRecord, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      String dedupTimeColumn, PartitionDedupMetadataManager partitionDedupMetadataManager,
+      List<FieldConfig> fieldConfigList, List<AggregationConfig> ingestionAggregationConfigs) {
     _tableNameWithType = tableNameWithType;
     _segmentName = segmentName;
     _streamName = streamName;
@@ -101,6 +102,7 @@ public class RealtimeSegmentConfig {
     _nullHandlingEnabled = nullHandlingEnabled;
     _consumerDir = consumerDir;
     _upsertMode = upsertMode != null ? upsertMode : UpsertConfig.Mode.NONE;
+    _upsertConsistencyMode = upsertConsistencyMode != null ? upsertConsistencyMode : UpsertConfig.ConsistencyMode.NONE;
     _upsertComparisonColumns = upsertComparisonColumns;
     _upsertDeleteRecordColumn = upsertDeleteRecordColumn;
     _upsertOutOfOrderRecordColumn = upsertOutOfOrderRecordColumn;
@@ -188,6 +190,10 @@ public class RealtimeSegmentConfig {
     return _upsertMode;
   }
 
+  public UpsertConfig.ConsistencyMode getUpsertConsistencyMode() {
+    return _upsertConsistencyMode;
+  }
+
   public boolean isDedupEnabled() {
     return _partitionDedupMetadataManager != null;
   }
@@ -248,6 +254,7 @@ public class RealtimeSegmentConfig {
     private boolean _nullHandlingEnabled = false;
     private String _consumerDir;
     private UpsertConfig.Mode _upsertMode;
+    private UpsertConfig.ConsistencyMode _upsertConsistencyMode;
     private List<String> _upsertComparisonColumns;
     private String _upsertDeleteRecordColumn;
     private String _upsertOutOfOrderRecordColumn;
@@ -383,6 +390,11 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setUpsertConsistencyMode(UpsertConfig.ConsistencyMode upsertConsistencyMode) {
+      _upsertConsistencyMode = upsertConsistencyMode;
+      return this;
+    }
+
     public Builder setUpsertComparisonColumns(List<String> upsertComparisonColumns) {
       _upsertComparisonColumns = upsertComparisonColumns;
       return this;
@@ -437,8 +449,8 @@ public class RealtimeSegmentConfig {
       return new RealtimeSegmentConfig(_tableNameWithType, _segmentName, _streamName, _schema, _timeColumnName,
           _capacity, _avgNumMultiValues, Collections.unmodifiableMap(indexConfigByCol), _segmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
-          _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertComparisonColumns, _upsertDeleteRecordColumn,
-          _upsertOutOfOrderRecordColumn, _upsertDropOutOfOrderRecord,
+          _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertConsistencyMode, _upsertComparisonColumns,
+          _upsertDeleteRecordColumn, _upsertOutOfOrderRecordColumn, _upsertDropOutOfOrderRecord,
           _partitionUpsertMetadataManager, _dedupTimeColumn, _partitionDedupMetadataManager, _fieldConfigList,
           _ingestionAggregationConfigs);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -58,7 +57,6 @@ import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
 import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
-import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.EmptyIndexSegment;
@@ -70,7 +68,6 @@ import org.apache.pinot.segment.local.utils.HashUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
-import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
@@ -138,19 +135,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   private final Lock _preloadLock = new ReentrantLock();
   private volatile boolean _isPreloading;
 
-  // There are two consistency modes:
-  // If using SYNC mode, the upsert threads take the WLock when the upsert involves two segments' bitmaps; and
-  // the query threads take the RLock when getting bitmaps for all its selected segments.
-  // If using SNAPSHOT mode, the query threads don't need to take lock when getting bitmaps for all its selected
-  // segments, as the query threads access a copy of bitmaps that are kept updated by upsert thread periodically. But
-  // the query thread can specify a freshness threshold query option to refresh the bitmap copies if not fresh enough.
-  // By default, the mode is NONE to disable the support for data consistency.
-  private final UpsertConfig.ConsistencyMode _consistencyMode;
-  private final long _upsertViewRefreshIntervalMs;
-  private final ReadWriteLock _upsertViewLock = new ReentrantReadWriteLock();
-  private final Set<IndexSegment> _updatedSegmentsSinceLastRefresh = ConcurrentHashMap.newKeySet();
-  private volatile long _lastUpsertViewRefreshTimeMs = 0;
-  private volatile Map<IndexSegment, MutableRoaringBitmap> _segmentQueryableDocIdsMap;
+  // By default, the upsert consistency mode is NONE and upsertViewManager is disabled.
+  private final UpsertViewManager _upsertViewManager;
 
   protected BasePartitionUpsertMetadataManager(String tableNameWithType, int partitionId, UpsertContext context) {
     _tableNameWithType = tableNameWithType;
@@ -168,8 +154,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _deletedKeysTTL = context.getDeletedKeysTTL();
     _tableIndexDir = context.getTableIndexDir();
     UpsertConfig.ConsistencyMode cmode = context.getConsistencyMode();
-    _consistencyMode = cmode != null ? cmode : UpsertConfig.ConsistencyMode.NONE;
-    _upsertViewRefreshIntervalMs = context.getUpsertViewRefreshIntervalMs();
+    if (cmode == UpsertConfig.ConsistencyMode.SYNC || cmode == UpsertConfig.ConsistencyMode.SNAPSHOT) {
+      _upsertViewManager = new UpsertViewManager(cmode, context);
+    } else {
+      _upsertViewManager = null;
+    }
     _serverMetrics = ServerMetrics.get();
     _logger = LoggerFactory.getLogger(tableNameWithType + "-" + partitionId + "-" + getClass().getSimpleName());
     if (_metadataTTL > 0) {
@@ -706,8 +695,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     //       (1) skip loading segments without any invalid docs.
     //       (2) assign the invalid docs from the replaced segment to the new segment.
     String segmentName = segment.getSegmentName();
-    MutableRoaringBitmap validDocIdsForOldSegment =
-        oldSegment.getValidDocIds() != null ? oldSegment.getValidDocIds().getMutableRoaringBitmap() : null;
+    MutableRoaringBitmap validDocIdsForOldSegment = null;
+    if (_upsertViewManager == null) {
+      // When not using consistency mode, we use a copy of the validDocIds bitmap of the old segment to keep the old
+      // segment intact during segment replacement and queries access the old segment during segment replacement.
+      validDocIdsForOldSegment = getValidDocIdsForOldSegment(oldSegment);
+    }
     if (recordInfoIterator != null) {
       Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
           "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
@@ -721,7 +714,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       addOrReplaceSegment((ImmutableSegmentImpl) segment, validDocIds, queryableDocIds, recordInfoIterator, oldSegment,
           validDocIdsForOldSegment);
     }
-
+    if (_upsertViewManager != null) {
+      // When using consistency mode, the old segment's bitmap is updated in place, so we get the validDocIds after
+      // segment replacement is done.
+      validDocIdsForOldSegment = getValidDocIdsForOldSegment(oldSegment);
+    }
     if (validDocIdsForOldSegment != null && !validDocIdsForOldSegment.isEmpty()) {
       int numKeysNotReplaced = validDocIdsForOldSegment.getCardinality();
       if (_partialUpsertHandler != null) {
@@ -738,6 +735,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
       removeSegment(oldSegment, validDocIdsForOldSegment);
     }
+  }
+
+  private MutableRoaringBitmap getValidDocIdsForOldSegment(IndexSegment oldSegment) {
+    return oldSegment.getValidDocIds() != null ? oldSegment.getValidDocIds().getMutableRoaringBitmap() : null;
   }
 
   protected void removeSegment(IndexSegment segment, MutableRoaringBitmap validDocIds) {
@@ -1132,31 +1133,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected void replaceDocId(IndexSegment newSegment, ThreadSafeMutableRoaringBitmap validDocIds,
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, IndexSegment oldSegment, int oldDocId, int newDocId,
       RecordInfo recordInfo) {
-    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
-      _upsertViewLock.writeLock().lock();
-      try {
-        doRemoveDocId(oldSegment, oldDocId);
-        doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
-      } finally {
-        _upsertViewLock.writeLock().unlock();
-      }
-    } else if (_consistencyMode == UpsertConfig.ConsistencyMode.SNAPSHOT) {
-      _upsertViewLock.readLock().lock();
-      try {
-        doRemoveDocId(oldSegment, oldDocId);
-        doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
-        _updatedSegmentsSinceLastRefresh.add(newSegment);
-        _updatedSegmentsSinceLastRefresh.add(oldSegment);
-      } finally {
-        _upsertViewLock.readLock().unlock();
-        // Batch refresh takes WLock. Do it outside RLock for clarity. The R/W lock ensures that only one thread
-        // can refresh the bitmaps. The other threads that are about to update the bitmaps will be blocked until
-        // refreshing is done.
-        doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs);
-      }
+    if (_upsertViewManager == null) {
+      UpsertUtils.doRemoveDocId(oldSegment, oldDocId);
+      UpsertUtils.doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
     } else {
-      doRemoveDocId(oldSegment, oldDocId);
-      doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+      _upsertViewManager.replaceDocId(newSegment, validDocIds, queryableDocIds, oldSegment, oldDocId, newDocId,
+          recordInfo);
     }
     trackUpdatedSegmentsSinceLastSnapshot(oldSegment);
   }
@@ -1169,71 +1151,27 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
    */
   protected void replaceDocId(IndexSegment segment, ThreadSafeMutableRoaringBitmap validDocIds,
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int oldDocId, int newDocId, RecordInfo recordInfo) {
-    if (_consistencyMode != UpsertConfig.ConsistencyMode.SNAPSHOT) {
-      doReplaceDocId(validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
+    if (_upsertViewManager == null) {
+      UpsertUtils.doReplaceDocId(validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
     } else {
-      _upsertViewLock.readLock().lock();
-      try {
-        doReplaceDocId(validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
-        _updatedSegmentsSinceLastRefresh.add(segment);
-      } finally {
-        _upsertViewLock.readLock().unlock();
-        // Batch refresh takes WLock. Do it outside RLock for clarity.
-        doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs);
-      }
-    }
-  }
-
-  private void doReplaceDocId(ThreadSafeMutableRoaringBitmap validDocIds,
-      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int oldDocId, int newDocId, RecordInfo recordInfo) {
-    validDocIds.replace(oldDocId, newDocId);
-    if (queryableDocIds != null) {
-      if (recordInfo.isDeleteRecord()) {
-        queryableDocIds.remove(oldDocId);
-      } else {
-        queryableDocIds.replace(oldDocId, newDocId);
-      }
+      _upsertViewManager.replaceDocId(segment, validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
     }
   }
 
   protected void addDocId(IndexSegment segment, ThreadSafeMutableRoaringBitmap validDocIds,
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int docId, RecordInfo recordInfo) {
-    if (_consistencyMode != UpsertConfig.ConsistencyMode.SNAPSHOT) {
-      doAddDocId(validDocIds, queryableDocIds, docId, recordInfo);
+    if (_upsertViewManager == null) {
+      UpsertUtils.doAddDocId(validDocIds, queryableDocIds, docId, recordInfo);
     } else {
-      _upsertViewLock.readLock().lock();
-      try {
-        doAddDocId(validDocIds, queryableDocIds, docId, recordInfo);
-        _updatedSegmentsSinceLastRefresh.add(segment);
-      } finally {
-        _upsertViewLock.readLock().unlock();
-        // Batch refresh takes WLock. Do it outside RLock for clarity.
-        doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs);
-      }
-    }
-  }
-
-  private void doAddDocId(ThreadSafeMutableRoaringBitmap validDocIds,
-      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int docId, RecordInfo recordInfo) {
-    validDocIds.add(docId);
-    if (queryableDocIds != null && !recordInfo.isDeleteRecord()) {
-      queryableDocIds.add(docId);
+      _upsertViewManager.addDocId(segment, validDocIds, queryableDocIds, docId, recordInfo);
     }
   }
 
   protected void removeDocId(IndexSegment segment, int docId) {
-    if (_consistencyMode != UpsertConfig.ConsistencyMode.SNAPSHOT) {
-      doRemoveDocId(segment, docId);
+    if (_upsertViewManager == null) {
+      UpsertUtils.doRemoveDocId(segment, docId);
     } else {
-      _upsertViewLock.readLock().lock();
-      try {
-        doRemoveDocId(segment, docId);
-        _updatedSegmentsSinceLastRefresh.add(segment);
-      } finally {
-        _upsertViewLock.readLock().unlock();
-        // Batch refresh takes WLock. Do it outside RLock for clarity.
-        doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs);
-      }
+      _upsertViewManager.removeDocId(segment, docId);
     }
     trackUpdatedSegmentsSinceLastSnapshot(segment);
   }
@@ -1249,112 +1187,25 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
   }
 
-  private void doRemoveDocId(IndexSegment segment, int docId) {
-    Objects.requireNonNull(segment.getValidDocIds()).remove(docId);
-    ThreadSafeMutableRoaringBitmap currentQueryableDocIds = segment.getQueryableDocIds();
-    if (currentQueryableDocIds != null) {
-      currentQueryableDocIds.remove(docId);
-    }
-  }
-
-  /**
-   * Use the segmentContexts to collect the contexts for selected segments. Reuse the segmentContext object if
-   * present, to avoid overwriting the contexts specified at the others places.
-   */
-  public void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
-    if (_consistencyMode == UpsertConfig.ConsistencyMode.NONE) {
-      setSegmentContexts(segmentContexts);
-      return;
-    }
-    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
-      _upsertViewLock.readLock().lock();
-      try {
-        setSegmentContexts(segmentContexts);
-        return;
-      } finally {
-        _upsertViewLock.readLock().unlock();
-      }
-    }
-    // If batch refresh is enabled, the copy of bitmaps is kept updated and ready to use for a consistent view.
-    // The locking between query threads and upsert threads can be avoided when using batch refresh.
-    // Besides, queries can share the copy of bitmaps, w/o cloning the bitmaps by every single query.
-    // If query has specified a need for certain freshness, check the view and refresh it as needed.
-    // When refreshing the copy of map, we need to take the WLock so only one thread is refreshing view.
-    long upsertViewFreshnessMs =
-        Math.min(QueryOptionsUtils.getUpsertViewFreshnessMs(queryOptions), _upsertViewRefreshIntervalMs);
-    if (upsertViewFreshnessMs < 0) {
-      upsertViewFreshnessMs = _upsertViewRefreshIntervalMs;
-    }
-    doBatchRefreshUpsertView(upsertViewFreshnessMs);
-    Map<IndexSegment, MutableRoaringBitmap> currentUpsertView = _segmentQueryableDocIdsMap;
-    for (SegmentContext segmentContext : segmentContexts) {
-      IndexSegment segment = segmentContext.getIndexSegment();
-      MutableRoaringBitmap segmentView = currentUpsertView.get(segment);
-      if (segmentView != null) {
-        segmentContext.setQueryableDocIdsSnapshot(segmentView);
-      }
-    }
-  }
-
-  private void setSegmentContexts(List<SegmentContext> segmentContexts) {
-    for (SegmentContext segmentContext : segmentContexts) {
-      IndexSegment segment = segmentContext.getIndexSegment();
-      if (_trackedSegments.contains(segment)) {
-        segmentContext.setQueryableDocIdsSnapshot(UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment));
-      }
-    }
-  }
-
-  private boolean skipUpsertViewRefresh(long upsertViewFreshnessMs) {
-    if (upsertViewFreshnessMs < 0) {
-      return true;
-    }
-    return _lastUpsertViewRefreshTimeMs + upsertViewFreshnessMs > System.currentTimeMillis();
-  }
-
-  private void doBatchRefreshUpsertView(long upsertViewFreshnessMs) {
-    // Always refresh if the current view is still empty.
-    if (skipUpsertViewRefresh(upsertViewFreshnessMs) && _segmentQueryableDocIdsMap != null) {
-      return;
-    }
-    _upsertViewLock.writeLock().lock();
-    try {
-      // Check again with lock, and always refresh if the current view is still empty.
-      Map<IndexSegment, MutableRoaringBitmap> current = _segmentQueryableDocIdsMap;
-      if (skipUpsertViewRefresh(upsertViewFreshnessMs) && current != null) {
-        return;
-      }
-      Map<IndexSegment, MutableRoaringBitmap> updated = new HashMap<>();
-      for (IndexSegment segment : _trackedSegments) {
-        // Update bitmap for segment updated since last refresh or not in the view yet. This also handles segments
-        // that are tracked by _trackedSegments but not by _updatedSegmentsSinceLastRefresh, like those didn't update
-        // any bitmaps as their docs simply lost all the upsert comparisons with the existing docs.
-        if (current == null || current.get(segment) == null || _updatedSegmentsSinceLastRefresh.contains(segment)) {
-          updated.put(segment, UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment));
-        } else {
-          updated.put(segment, current.get(segment));
-        }
-      }
-      // Swap in the new consistent set of bitmaps.
-      _segmentQueryableDocIdsMap = updated;
-      _updatedSegmentsSinceLastRefresh.clear();
-      _lastUpsertViewRefreshTimeMs = System.currentTimeMillis();
-    } finally {
-      _upsertViewLock.writeLock().unlock();
-    }
-  }
-
-  @VisibleForTesting
-  Map<IndexSegment, MutableRoaringBitmap> getSegmentQueryableDocIdsMap() {
-    return _segmentQueryableDocIdsMap;
-  }
-
-  @VisibleForTesting
-  Set<IndexSegment> getUpdatedSegmentsSinceLastRefresh() {
-    return _updatedSegmentsSinceLastRefresh;
-  }
-
   protected void doClose()
       throws IOException {
+  }
+
+  public UpsertViewManager getUpsertViewManager() {
+    return _upsertViewManager;
+  }
+
+  @Override
+  public void trackSegmentForUpsertView(IndexSegment segment) {
+    if (_upsertViewManager != null) {
+      _upsertViewManager.trackSegment(segment);
+    }
+  }
+
+  @Override
+  public void untrackSegmentForUpsertView(IndexSegment segment) {
+    if (_upsertViewManager != null) {
+      _upsertViewManager.untrackSegment(segment);
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -112,6 +112,11 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   }
 
   @Override
+  public UpsertConfig.ConsistencyMode getUpsertConsistencyMode() {
+    return _consistencyMode;
+  }
+
+  @Override
   public boolean isEnablePreload() {
     return _enablePreload;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -103,9 +103,15 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               // snapshot for the old segment, which can be updated and used to track the docs not replaced yet.
               if (currentSegment == oldSegment) {
                 if (comparisonResult >= 0) {
-                  addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
-                  if (validDocIdsForOldSegment != null) {
-                    validDocIdsForOldSegment.remove(currentDocId);
+                  if (validDocIdsForOldSegment == null && oldSegment != null && oldSegment.getValidDocIds() != null) {
+                    // Update the old segment's bitmap in place if a copy of the bitmap was not provided.
+                    replaceDocId(segment, validDocIds, queryableDocIds, oldSegment, currentDocId, recordInfo.getDocId(),
+                        recordInfo);
+                  } else {
+                    addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
+                    if (validDocIdsForOldSegment != null) {
+                      validDocIdsForOldSegment.remove(currentDocId);
+                    }
                   }
                   return new RecordLocation(segment, newDocId, newComparisonValue);
                 } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -105,8 +105,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
                 if (comparisonResult >= 0) {
                   if (validDocIdsForOldSegment == null && oldSegment != null && oldSegment.getValidDocIds() != null) {
                     // Update the old segment's bitmap in place if a copy of the bitmap was not provided.
-                    replaceDocId(segment, validDocIds, queryableDocIds, oldSegment, currentDocId, recordInfo.getDocId(),
-                        recordInfo);
+                    replaceDocId(segment, validDocIds, queryableDocIds, oldSegment, currentDocId, newDocId, recordInfo);
                   } else {
                     addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
                     if (validDocIdsForOldSegment != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -120,9 +120,14 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
               // snapshot for the old segment, which can be updated and used to track the docs not replaced yet.
               if (currentSegment == oldSegment) {
                 if (comparisonResult >= 0) {
-                  addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
-                  if (validDocIdsForOldSegment != null) {
-                    validDocIdsForOldSegment.remove(currentDocId);
+                  if (validDocIdsForOldSegment == null && oldSegment != null && oldSegment.getValidDocIds() != null) {
+                    // Update the old segment's bitmap in place if a copy of the bitmap was not provided.
+                    replaceDocId(segment, validDocIds, queryableDocIds, oldSegment, currentDocId, newDocId, recordInfo);
+                  } else {
+                    addDocId(segment, validDocIds, queryableDocIds, newDocId, recordInfo);
+                    if (validDocIdsForOldSegment != null) {
+                      validDocIdsForOldSegment.remove(currentDocId);
+                    }
                   }
                   return new RecordLocation(segment, newDocId, newComparisonValue,
                       RecordLocation.incrementSegmentCount(currentDistinctSegmentCount));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -20,14 +20,19 @@ package org.apache.pinot.segment.local.upsert;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -35,6 +40,8 @@ import org.apache.pinot.spi.config.table.UpsertConfig;
  */
 @ThreadSafe
 public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMetadataManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentMapTableUpsertMetadataManager.class);
+
   private final Map<Integer, BasePartitionUpsertMetadataManager> _partitionMetadataManagerMap =
       new ConcurrentHashMap<>();
 
@@ -63,20 +70,53 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
+  public void lockForSegmentContexts() {
+    _partitionMetadataManagerMap.forEach(
+        (partitionID, upsertMetadataManager) -> upsertMetadataManager.getUpsertViewManager().lockTrackedSegments());
+  }
+
+  @Override
+  public void unlockForSegmentContexts() {
+    _partitionMetadataManagerMap.forEach(
+        (partitionID, upsertMetadataManager) -> upsertMetadataManager.getUpsertViewManager().unlockTrackedSegments());
+  }
+
+  @Override
+  public Set<String> getOptionalSegments() {
+    Set<String> optionalSegments = new HashSet<>();
+    _partitionMetadataManagerMap.forEach((partitionID, upsertMetadataManager) -> optionalSegments.addAll(
+        upsertMetadataManager.getUpsertViewManager().getOptionalSegments()));
+    return optionalSegments;
+  }
+
+  @Override
   public void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
-    if (_consistencyMode != UpsertConfig.ConsistencyMode.NONE && !QueryOptionsUtils.isSkipUpsertView(queryOptions)) {
-      // Get queryableDocIds bitmaps from partitionMetadataManagers if any consistency mode is used.
-      _partitionMetadataManagerMap.forEach(
-          (partitionID, upsertMetadataManager) -> upsertMetadataManager.setSegmentContexts(segmentContexts,
-              queryOptions));
-    }
-    // If no consistency mode is used, we get queryableDocIds bitmaps as kept by the segment objects directly.
-    // Even if consistency mode is used, we should still check if any segment doesn't get its validDocIds bitmap,
-    // because partitionMetadataManagers may not track all segments of the table, like those out of the metadata TTL.
-    for (SegmentContext segmentContext : segmentContexts) {
-      if (segmentContext.getQueryableDocIdsSnapshot() == null) {
+    // Get queryableDocIds bitmaps from partitionMetadataManagers if any consistency mode is used.
+    // Otherwise, get queryableDocIds bitmaps as kept by the segment objects directly as before.
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.NONE || QueryOptionsUtils.isSkipUpsertView(queryOptions)) {
+      for (SegmentContext segmentContext : segmentContexts) {
         IndexSegment segment = segmentContext.getIndexSegment();
         segmentContext.setQueryableDocIdsSnapshot(UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment));
+      }
+      return;
+    }
+    // All segments should have been tracked by partitionMetadataManagers to provide queries consistent upsert view.
+    _partitionMetadataManagerMap.forEach(
+        (partitionID, upsertMetadataManager) -> upsertMetadataManager.getUpsertViewManager()
+            .setSegmentContexts(segmentContexts, queryOptions));
+    if (LOGGER.isDebugEnabled()) {
+      for (SegmentContext segmentContext : segmentContexts) {
+        IndexSegment segment = segmentContext.getIndexSegment();
+        if (segmentContext.getQueryableDocIdsSnapshot() == null) {
+          LOGGER.debug("No upsert view for segment: {}, type: {}, ref: {}, total: {}", segment.getSegmentName(),
+              (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+              segment.getSegmentMetadata().getTotalDocs());
+        } else {
+          int cardCnt = segmentContext.getQueryableDocIdsSnapshot().getCardinality();
+          LOGGER.debug("Got upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}",
+              segment.getSegmentName(), (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+              segment.getSegmentMetadata().getTotalDocs(), cardCnt);
+        }
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -108,14 +108,13 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
       for (SegmentContext segmentContext : segmentContexts) {
         IndexSegment segment = segmentContext.getIndexSegment();
         if (segmentContext.getQueryableDocIdsSnapshot() == null) {
-          LOGGER.debug("No upsert view for segment: {}, type: {}, ref: {}, total: {}", segment.getSegmentName(),
-              (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
-              segment.getSegmentMetadata().getTotalDocs());
+          LOGGER.debug("No upsert view for segment: {}, type: {}, total: {}", segment.getSegmentName(),
+              (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.getSegmentMetadata().getTotalDocs());
         } else {
           int cardCnt = segmentContext.getQueryableDocIdsSnapshot().getCardinality();
-          LOGGER.debug("Got upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}",
-              segment.getSegmentName(), (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
-              segment.getSegmentMetadata().getTotalDocs(), cardCnt);
+          LOGGER.debug("Got upsert view of segment: {}, type: {}, total: {}, valid: {}", segment.getSegmentName(),
+              (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.getSegmentMetadata().getTotalDocs(),
+              cardCnt);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -116,4 +116,17 @@ public interface PartitionUpsertMetadataManager extends Closeable {
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */
   void stop();
+
+  /**
+   * Track segments for upsert view, and this method must be called before registering segment to the table manager,
+   * so that the segment is included in the upsert view before it becomes visible to the query.
+   */
+  void trackSegmentForUpsertView(IndexSegment segment);
+
+  /**
+   * Untrack segments for upsert view, and this method must be called when segment is to be destroyed, when the
+   * segment is not used by any queries. Untrack segment after unregistering the segment is not safe, as there may be
+   * ongoing queries that are still accessing the segment.
+   */
+  void untrackSegmentForUpsertView(IndexSegment segment);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -19,8 +19,10 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.spi.SegmentContext;
@@ -41,6 +43,8 @@ public interface TableUpsertMetadataManager extends Closeable {
 
   UpsertConfig.Mode getUpsertMode();
 
+  UpsertConfig.ConsistencyMode getUpsertConsistencyMode();
+
   boolean isEnablePreload();
 
   /**
@@ -56,5 +60,15 @@ public interface TableUpsertMetadataManager extends Closeable {
   Map<Integer, Long> getPartitionToPrimaryKeyCount();
 
   default void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
+  }
+
+  default void lockForSegmentContexts() {
+  }
+
+  default void unlockForSegmentContexts() {
+  }
+
+  default Set<String> getOptionalSegments() {
+    return Collections.emptySet();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
@@ -197,7 +197,8 @@ public class UpsertViewManager {
     }
   }
 
-  private boolean needForceRefresh() {
+  @VisibleForTesting
+  boolean needForceRefresh() {
     // Check if any segment membership changes against the current upsert view, if so, force refresh. Need this check
     // because when replacing segment, we need to include the new segment into the upsert view for the query, and we
     // need to remove the old segment from upsert view when replacement is done for the query. This check is done by
@@ -226,7 +227,8 @@ public class UpsertViewManager {
     return _lastUpsertViewRefreshTimeMs + upsertViewFreshnessMs > System.currentTimeMillis();
   }
 
-  private void doBatchRefreshUpsertView(long upsertViewFreshnessMs, boolean forceRefresh) {
+  @VisibleForTesting
+  void doBatchRefreshUpsertView(long upsertViewFreshnessMs, boolean forceRefresh) {
     // Always refresh if the current view is still empty.
     if (!forceRefresh && skipUpsertViewRefresh(upsertViewFreshnessMs) && _segmentQueryableDocIdsMap != null) {
       return;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class is used to provide the specified consistency mode for upsert table by tracking the segments and
+ * synchronizing the accesses to the validDocIds of those tracked segments properly. Two consistency modes are
+ * supported currently:
+ * - SYNC mode, the upsert threads take the WLock when the upsert involves two segments' bitmaps; and the query
+ * threads take the RLock when getting bitmaps for all its selected segments.
+ * - SNAPSHOT mode, the query threads don't need to take lock when getting bitmaps for all its selected segments, as
+ * the query threads access a copy of bitmaps that are kept updated by upsert thread periodically. But the query
+ * thread can specify a freshness threshold query option to refresh the bitmap copies if not fresh enough.
+ */
+public class UpsertViewManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpsertViewManager.class);
+  private final UpsertConfig.ConsistencyMode _consistencyMode;
+
+  // NOTE that we can't reuse _trackedSegments map in BasePartitionUpsertMetadataManager, as it doesn't track all
+  // segments like those out of the metadata TTL, and it's called after adding segments to the table manager so the
+  // new segments become queryable before upsert view can get updated. So we use a separate map to track the segments
+  // properly. Besides, updating the set of tracked segments must be synchronized with queries getting segment
+  // contexts, so the need of the R/W lock.
+  private final ReadWriteLock _trackedSegmentsLock = new ReentrantReadWriteLock();
+  private final Set<IndexSegment> _trackedSegments = ConcurrentHashMap.newKeySet();
+  // Optional segments are part of the tracked segments. They can get processed by server before getting included in
+  // broker's routing table, like the new consuming segment. Although broker misses such segments, the server needs
+  // to acquire them to avoid missing the new valid docs in them.
+  private final Set<String> _optionalSegments = ConcurrentHashMap.newKeySet();
+
+  // Updating and accessing segments' validDocIds bitmaps are synchronized with a separate R/W lock for clarity.
+  // The query threads always get _upsertViewTrackedSegmentsLock then _upsertViewSegmentDocIdsLock to avoid deadlock.
+  // And the upsert threads never nest the two locks.
+  private final ReadWriteLock _upsertViewLock = new ReentrantReadWriteLock();
+  private volatile Map<IndexSegment, MutableRoaringBitmap> _segmentQueryableDocIdsMap;
+
+  // For SNAPSHOT mode, track segments that get new updates since last refresh to reduce the overhead of refreshing.
+  private final Set<IndexSegment> _updatedSegmentsSinceLastRefresh = ConcurrentHashMap.newKeySet();
+  private volatile long _lastUpsertViewRefreshTimeMs = 0;
+  private final long _upsertViewRefreshIntervalMs;
+
+  public UpsertViewManager(UpsertConfig.ConsistencyMode consistencyMode, UpsertContext context) {
+    _consistencyMode = consistencyMode;
+    _upsertViewRefreshIntervalMs = context.getUpsertViewRefreshIntervalMs();
+  }
+
+  public void replaceDocId(IndexSegment newSegment, ThreadSafeMutableRoaringBitmap validDocIds,
+      ThreadSafeMutableRoaringBitmap queryableDocIds, IndexSegment oldSegment, int oldDocId, int newDocId,
+      RecordInfo recordInfo) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
+      _upsertViewLock.writeLock().lock();
+      try {
+        UpsertUtils.doRemoveDocId(oldSegment, oldDocId);
+        UpsertUtils.doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+        return;
+      } finally {
+        _upsertViewLock.writeLock().unlock();
+      }
+    }
+    // For SNAPSHOT mode, take read lock to sync with the batch refresh.
+    _upsertViewLock.readLock().lock();
+    try {
+      UpsertUtils.doRemoveDocId(oldSegment, oldDocId);
+      UpsertUtils.doAddDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+      _updatedSegmentsSinceLastRefresh.add(newSegment);
+      _updatedSegmentsSinceLastRefresh.add(oldSegment);
+    } finally {
+      _upsertViewLock.readLock().unlock();
+      // Batch refresh takes WLock. Do it outside RLock for clarity. The R/W lock ensures that only one thread
+      // can refresh the bitmaps. The other threads that are about to update the bitmaps will be blocked until
+      // refreshing is done.
+      doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs, false);
+    }
+  }
+
+  public void replaceDocId(IndexSegment segment, ThreadSafeMutableRoaringBitmap validDocIds,
+      ThreadSafeMutableRoaringBitmap queryableDocIds, int oldDocId, int newDocId, RecordInfo recordInfo) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
+      UpsertUtils.doReplaceDocId(validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
+      return;
+    }
+    // For SNAPSHOT mode, take read lock to sync with the batch refresh.
+    _upsertViewLock.readLock().lock();
+    try {
+      UpsertUtils.doReplaceDocId(validDocIds, queryableDocIds, oldDocId, newDocId, recordInfo);
+      _updatedSegmentsSinceLastRefresh.add(segment);
+    } finally {
+      _upsertViewLock.readLock().unlock();
+      // Batch refresh takes WLock. Do it outside RLock for clarity.
+      doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs, false);
+    }
+  }
+
+  public void addDocId(IndexSegment segment, ThreadSafeMutableRoaringBitmap validDocIds,
+      ThreadSafeMutableRoaringBitmap queryableDocIds, int docId, RecordInfo recordInfo) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
+      UpsertUtils.doAddDocId(validDocIds, queryableDocIds, docId, recordInfo);
+      return;
+    }
+    // For SNAPSHOT mode, take read lock to sync with the batch refresh.
+    _upsertViewLock.readLock().lock();
+    try {
+      UpsertUtils.doAddDocId(validDocIds, queryableDocIds, docId, recordInfo);
+      _updatedSegmentsSinceLastRefresh.add(segment);
+    } finally {
+      _upsertViewLock.readLock().unlock();
+      // Batch refresh takes WLock. Do it outside RLock for clarity.
+      doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs, false);
+    }
+  }
+
+  public void removeDocId(IndexSegment segment, int docId) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
+      UpsertUtils.doRemoveDocId(segment, docId);
+      return;
+    }
+    // For SNAPSHOT mode, take read lock to sync with the batch refresh.
+    _upsertViewLock.readLock().lock();
+    try {
+      UpsertUtils.doRemoveDocId(segment, docId);
+      _updatedSegmentsSinceLastRefresh.add(segment);
+    } finally {
+      _upsertViewLock.readLock().unlock();
+      // Batch refresh takes WLock. Do it outside RLock for clarity.
+      doBatchRefreshUpsertView(_upsertViewRefreshIntervalMs, false);
+    }
+  }
+
+  /**
+   * Use the segmentContexts to collect the contexts for selected segments. Reuse the segmentContext object if
+   * present, to avoid overwriting the contexts specified at the others places.
+   */
+  public void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
+    if (_consistencyMode == UpsertConfig.ConsistencyMode.SYNC) {
+      _upsertViewLock.readLock().lock();
+      try {
+        setSegmentContexts(segmentContexts);
+        return;
+      } finally {
+        _upsertViewLock.readLock().unlock();
+      }
+    }
+    // If batch refresh is enabled, the copy of bitmaps is kept updated and ready to use for a consistent view.
+    // The locking between query threads and upsert threads can be avoided when using batch refresh.
+    // Besides, queries can share the copy of bitmaps, w/o cloning the bitmaps by every single query.
+    // If query has specified a need for certain freshness, check the view and refresh it as needed.
+    // When refreshing the copy of map, we need to take the WLock so only one thread is refreshing view.
+    long upsertViewFreshnessMs =
+        Math.min(QueryOptionsUtils.getUpsertViewFreshnessMs(queryOptions), _upsertViewRefreshIntervalMs);
+    if (upsertViewFreshnessMs < 0) {
+      upsertViewFreshnessMs = _upsertViewRefreshIntervalMs;
+    }
+    doBatchRefreshUpsertView(upsertViewFreshnessMs, needForceRefresh());
+    Map<IndexSegment, MutableRoaringBitmap> currentUpsertView = _segmentQueryableDocIdsMap;
+    for (SegmentContext segmentContext : segmentContexts) {
+      IndexSegment segment = segmentContext.getIndexSegment();
+      MutableRoaringBitmap segmentView = currentUpsertView.get(segment);
+      if (segmentView != null) {
+        segmentContext.setQueryableDocIdsSnapshot(segmentView);
+      }
+    }
+  }
+
+  private boolean needForceRefresh() {
+    // Check if any segment membership changes against the current upsert view, if so, force refresh. Need this check
+    // because when replacing segment, we need to include the new segment into the upsert view for the query, and we
+    // need to remove the old segment from upsert view when replacement is done for the query. This check is done by
+    // the query thread after getting the _upsertViewTrackedSegmentsLock, so that the tracked segments are not changed.
+    Map<IndexSegment, MutableRoaringBitmap> currentView = _segmentQueryableDocIdsMap;
+    if (currentView == null) {
+      return true;
+    }
+    Set<IndexSegment> currentSegments = currentView.keySet();
+    return !_trackedSegments.containsAll(currentSegments) || !currentSegments.containsAll(_trackedSegments);
+  }
+
+  private void setSegmentContexts(List<SegmentContext> segmentContexts) {
+    for (SegmentContext segmentContext : segmentContexts) {
+      IndexSegment segment = segmentContext.getIndexSegment();
+      if (_trackedSegments.contains(segment)) {
+        segmentContext.setQueryableDocIdsSnapshot(UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment, true));
+      }
+    }
+  }
+
+  private boolean skipUpsertViewRefresh(long upsertViewFreshnessMs) {
+    if (upsertViewFreshnessMs < 0) {
+      return true;
+    }
+    return _lastUpsertViewRefreshTimeMs + upsertViewFreshnessMs > System.currentTimeMillis();
+  }
+
+  private void doBatchRefreshUpsertView(long upsertViewFreshnessMs, boolean forceRefresh) {
+    // Always refresh if the current view is still empty.
+    if (!forceRefresh && skipUpsertViewRefresh(upsertViewFreshnessMs) && _segmentQueryableDocIdsMap != null) {
+      return;
+    }
+    _upsertViewLock.writeLock().lock();
+    try {
+      // Check again with lock, and always refresh if the current view is still empty.
+      Map<IndexSegment, MutableRoaringBitmap> current = _segmentQueryableDocIdsMap;
+      if (!forceRefresh && skipUpsertViewRefresh(upsertViewFreshnessMs) && current != null) {
+        return;
+      }
+      if (LOGGER.isDebugEnabled()) {
+        if (current == null) {
+          LOGGER.debug("Current upsert view is still null");
+        } else {
+          current.forEach((segment, bitmap) -> LOGGER.debug(
+              "Current upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}", segment.getSegmentName(),
+              (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+              segment.getSegmentMetadata().getTotalDocs(), bitmap.getCardinality()));
+        }
+      }
+      Map<IndexSegment, MutableRoaringBitmap> updated = new HashMap<>();
+      for (IndexSegment segment : _trackedSegments) {
+        // Update bitmap for segment updated since last refresh or not in the view yet. This also handles segments
+        // that are tracked by _trackedSegments but not by _updatedSegmentsSinceLastRefresh, like those didn't update
+        // any bitmaps as their docs simply lost all the upsert comparisons with the existing docs.
+        if (current == null || current.get(segment) == null || _updatedSegmentsSinceLastRefresh.contains(segment)) {
+          updated.put(segment, UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment, true));
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Update upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}, reason: {}",
+                segment.getSegmentName(), (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+                segment.getSegmentMetadata().getTotalDocs(), updated.get(segment).getCardinality(),
+                current == null || current.get(segment) == null ? "no view yet" : "bitmap updated");
+          }
+        } else {
+          updated.put(segment, current.get(segment));
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Reuse upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}",
+                segment.getSegmentName(), (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+                segment.getSegmentMetadata().getTotalDocs(), updated.get(segment).getCardinality());
+          }
+        }
+      }
+      // Swap in the new consistent set of bitmaps.
+      if (LOGGER.isDebugEnabled()) {
+        updated.forEach((segment, bitmap) -> LOGGER.debug(
+            "Updated upsert view of segment: {}, type: {}, ref: {}, total: {}, valid: {}", segment.getSegmentName(),
+            (segment instanceof ImmutableSegment ? "imm" : "mut"), segment.hashCode(),
+            segment.getSegmentMetadata().getTotalDocs(), bitmap.getCardinality()));
+      }
+      _segmentQueryableDocIdsMap = updated;
+      _updatedSegmentsSinceLastRefresh.clear();
+      _lastUpsertViewRefreshTimeMs = System.currentTimeMillis();
+    } finally {
+      _upsertViewLock.writeLock().unlock();
+    }
+  }
+
+  public void lockTrackedSegments() {
+    _trackedSegmentsLock.readLock().lock();
+  }
+
+  public void unlockTrackedSegments() {
+    _trackedSegmentsLock.readLock().unlock();
+  }
+
+  public Set<String> getOptionalSegments() {
+    return _optionalSegments;
+  }
+
+  public void trackSegment(IndexSegment segment) {
+    _trackedSegmentsLock.writeLock().lock();
+    try {
+      _trackedSegments.add(segment);
+      if (segment instanceof MutableSegment) {
+        _optionalSegments.add(segment.getSegmentName());
+      }
+    } finally {
+      _trackedSegmentsLock.writeLock().unlock();
+    }
+  }
+
+  public void untrackSegment(IndexSegment segment) {
+    _trackedSegmentsLock.writeLock().lock();
+    try {
+      _trackedSegments.remove(segment);
+      if (segment instanceof MutableSegment) {
+        _optionalSegments.remove(segment.getSegmentName());
+      }
+    } finally {
+      _trackedSegmentsLock.writeLock().unlock();
+    }
+  }
+
+  @VisibleForTesting
+  Map<IndexSegment, MutableRoaringBitmap> getSegmentQueryableDocIdsMap() {
+    return _segmentQueryableDocIdsMap;
+  }
+
+  @VisibleForTesting
+  Set<IndexSegment> getUpdatedSegmentsSinceLastRefresh() {
+    return _updatedSegmentsSinceLastRefresh;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -369,19 +369,19 @@ public class BasePartitionUpsertMetadataManagerTest {
       latch.await();
       return validDocIds01;
     });
-    upsertMetadataManager.trackSegment(seg01);
+    upsertMetadataManager.trackSegmentForUpsertView(seg01);
     segmentQueryableDocIdsMap.put(seg01, validDocIds01);
 
     IndexSegment seg02 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds02 = createThreadSafeMutableRoaringBitmap(11);
     when(seg02.getValidDocIds()).thenReturn(validDocIds02);
-    upsertMetadataManager.trackSegment(seg02);
+    upsertMetadataManager.trackSegmentForUpsertView(seg02);
     segmentQueryableDocIdsMap.put(seg02, validDocIds02);
 
     IndexSegment seg03 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds03 = createThreadSafeMutableRoaringBitmap(12);
     when(seg03.getValidDocIds()).thenReturn(validDocIds03);
-    upsertMetadataManager.trackSegment(seg03);
+    upsertMetadataManager.trackSegmentForUpsertView(seg03);
     segmentQueryableDocIdsMap.put(seg03, validDocIds03);
 
     List<SegmentContext> segmentContexts = new ArrayList<>();
@@ -400,7 +400,7 @@ public class BasePartitionUpsertMetadataManagerTest {
           Thread.sleep(10);
         }
         segmentQueryableDocIdsMap.forEach((k, v) -> segmentContexts.add(new SegmentContext(k)));
-        upsertMetadataManager.setSegmentContexts(segmentContexts, new HashMap<>());
+        upsertMetadataManager.getUpsertViewManager().setSegmentContexts(segmentContexts, new HashMap<>());
         return System.currentTimeMillis() - startMs;
       });
       // The first thread can only finish after the latch is counted down after 2s.
@@ -449,19 +449,19 @@ public class BasePartitionUpsertMetadataManagerTest {
       latch.await();
       return validDocIds01;
     });
-    upsertMetadataManager.trackSegment(seg01);
+    upsertMetadataManager.trackSegmentForUpsertView(seg01);
     segmentQueryableDocIdsMap.put(seg01, validDocIds01);
 
     IndexSegment seg02 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds02 = createThreadSafeMutableRoaringBitmap(11);
     when(seg02.getValidDocIds()).thenReturn(validDocIds02);
-    upsertMetadataManager.trackSegment(seg02);
+    upsertMetadataManager.trackSegmentForUpsertView(seg02);
     segmentQueryableDocIdsMap.put(seg02, validDocIds02);
 
     IndexSegment seg03 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds03 = createThreadSafeMutableRoaringBitmap(12);
     when(seg03.getValidDocIds()).thenReturn(validDocIds03);
-    upsertMetadataManager.trackSegment(seg03);
+    upsertMetadataManager.trackSegmentForUpsertView(seg03);
     segmentQueryableDocIdsMap.put(seg03, validDocIds03);
 
     List<SegmentContext> segmentContexts = new ArrayList<>();
@@ -481,7 +481,7 @@ public class BasePartitionUpsertMetadataManagerTest {
         }
         segmentQueryableDocIdsMap.forEach((k, v) -> segmentContexts.add(new SegmentContext(k)));
         // This thread reuses the upsert view refreshed by the first thread above.
-        upsertMetadataManager.setSegmentContexts(segmentContexts, new HashMap<>());
+        upsertMetadataManager.getUpsertViewManager().setSegmentContexts(segmentContexts, new HashMap<>());
         return System.currentTimeMillis() - startMs;
       });
       // The first thread can only finish after the latch is counted down after 2s.
@@ -494,14 +494,14 @@ public class BasePartitionUpsertMetadataManagerTest {
       executor.shutdownNow();
     }
     assertEquals(segmentContexts.size(), 3);
-    assertEquals(upsertMetadataManager.getSegmentQueryableDocIdsMap().size(), 3);
-    assertTrue(upsertMetadataManager.getUpdatedSegmentsSinceLastRefresh().isEmpty());
+    assertEquals(upsertMetadataManager.getUpsertViewManager().getSegmentQueryableDocIdsMap().size(), 3);
+    assertTrue(upsertMetadataManager.getUpsertViewManager().getUpdatedSegmentsSinceLastRefresh().isEmpty());
 
     // Get the upsert view again, and the existing bitmap objects should be set in segment contexts.
     // The segmentContexts initialized above holds the same bitmaps objects as from the upsert view.
     List<SegmentContext> reuseSegmentContexts = new ArrayList<>();
     segmentQueryableDocIdsMap.forEach((k, v) -> reuseSegmentContexts.add(new SegmentContext(k)));
-    upsertMetadataManager.setSegmentContexts(reuseSegmentContexts, new HashMap<>());
+    upsertMetadataManager.getUpsertViewManager().setSegmentContexts(reuseSegmentContexts, new HashMap<>());
     for (SegmentContext reuseSC : reuseSegmentContexts) {
       for (SegmentContext sc : segmentContexts) {
         if (reuseSC.getIndexSegment() == sc.getIndexSegment()) {
@@ -524,12 +524,13 @@ public class BasePartitionUpsertMetadataManagerTest {
     }
 
     // Force refresh the upsert view when getting it, so different bitmap objects should be set in segment contexts.
-    upsertMetadataManager.getUpdatedSegmentsSinceLastRefresh().addAll(Arrays.asList(seg01, seg02, seg03));
+    upsertMetadataManager.getUpsertViewManager().getUpdatedSegmentsSinceLastRefresh()
+        .addAll(Arrays.asList(seg01, seg02, seg03));
     List<SegmentContext> refreshSegmentContexts = new ArrayList<>();
     segmentQueryableDocIdsMap.forEach((k, v) -> refreshSegmentContexts.add(new SegmentContext(k)));
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("upsertViewFreshnessMs", "0");
-    upsertMetadataManager.setSegmentContexts(refreshSegmentContexts, queryOptions);
+    upsertMetadataManager.getUpsertViewManager().setSegmentContexts(refreshSegmentContexts, queryOptions);
     for (SegmentContext refreshSC : refreshSegmentContexts) {
       for (SegmentContext sc : segmentContexts) {
         if (refreshSC.getIndexSegment() == sc.getIndexSegment()) {
@@ -561,25 +562,23 @@ public class BasePartitionUpsertMetadataManagerTest {
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 
-    CountDownLatch latch = new CountDownLatch(1);
     Map<IndexSegment, ThreadSafeMutableRoaringBitmap> segmentQueryableDocIdsMap = new HashMap<>();
     IndexSegment seg01 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds01 = createThreadSafeMutableRoaringBitmap(10);
-    AtomicBoolean called = new AtomicBoolean(false);
     when(seg01.getValidDocIds()).thenReturn(validDocIds01);
-    upsertMetadataManager.trackSegment(seg01);
+    upsertMetadataManager.trackSegmentForUpsertView(seg01);
     segmentQueryableDocIdsMap.put(seg01, validDocIds01);
 
     IndexSegment seg02 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds02 = createThreadSafeMutableRoaringBitmap(11);
     when(seg02.getValidDocIds()).thenReturn(validDocIds02);
-    upsertMetadataManager.trackSegment(seg02);
+    upsertMetadataManager.trackSegmentForUpsertView(seg02);
     segmentQueryableDocIdsMap.put(seg02, validDocIds02);
 
     IndexSegment seg03 = mock(IndexSegment.class);
     ThreadSafeMutableRoaringBitmap validDocIds03 = createThreadSafeMutableRoaringBitmap(12);
     when(seg03.getValidDocIds()).thenReturn(validDocIds03);
-    upsertMetadataManager.trackSegment(seg03);
+    upsertMetadataManager.trackSegmentForUpsertView(seg03);
     segmentQueryableDocIdsMap.put(seg03, validDocIds03);
 
     RecordInfo recordInfo = new RecordInfo(null, 5, null, false);
@@ -587,20 +586,20 @@ public class BasePartitionUpsertMetadataManagerTest {
 
     List<SegmentContext> segmentContexts = new ArrayList<>();
     segmentQueryableDocIdsMap.forEach((k, v) -> segmentContexts.add(new SegmentContext(k)));
-    upsertMetadataManager.setSegmentContexts(segmentContexts, new HashMap<>());
+    upsertMetadataManager.getUpsertViewManager().setSegmentContexts(segmentContexts, new HashMap<>());
     assertEquals(segmentContexts.size(), 3);
-    assertEquals(upsertMetadataManager.getSegmentQueryableDocIdsMap().size(), 3);
+    assertEquals(upsertMetadataManager.getUpsertViewManager().getSegmentQueryableDocIdsMap().size(), 3);
 
     // We can force to refresh the upsert view by clearing up the current upsert view, even though there are no updated
     // segments tracked in _updatedSegmentsSinceLastRefresh.
-    assertTrue(upsertMetadataManager.getUpdatedSegmentsSinceLastRefresh().isEmpty());
-    upsertMetadataManager.getSegmentQueryableDocIdsMap().clear();
+    assertTrue(upsertMetadataManager.getUpsertViewManager().getUpdatedSegmentsSinceLastRefresh().isEmpty());
+    upsertMetadataManager.getUpsertViewManager().getSegmentQueryableDocIdsMap().clear();
 
     List<SegmentContext> refreshSegmentContexts = new ArrayList<>();
     segmentQueryableDocIdsMap.forEach((k, v) -> refreshSegmentContexts.add(new SegmentContext(k)));
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("upsertViewFreshnessMs", "0");
-    upsertMetadataManager.setSegmentContexts(refreshSegmentContexts, queryOptions);
+    upsertMetadataManager.getUpsertViewManager().setSegmentContexts(refreshSegmentContexts, queryOptions);
     for (SegmentContext refreshSC : refreshSegmentContexts) {
       for (SegmentContext sc : segmentContexts) {
         if (refreshSC.getIndexSegment() == sc.getIndexSegment()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+public class UpsertViewManagerTest {
+  @Test
+  public void testTrackUntrackSegments() {
+    UpsertViewManager mgr = new UpsertViewManager(UpsertConfig.ConsistencyMode.SYNC, mock(UpsertContext.class));
+    IndexSegment seg1 = mock(MutableSegment.class);
+    ThreadSafeMutableRoaringBitmap threadSafeMutableRoaringBitmap = mock(ThreadSafeMutableRoaringBitmap.class);
+    MutableRoaringBitmap mutableRoaringBitmap = new MutableRoaringBitmap();
+    when(threadSafeMutableRoaringBitmap.getMutableRoaringBitmap()).thenReturn(mutableRoaringBitmap);
+    when(seg1.getValidDocIds()).thenReturn(threadSafeMutableRoaringBitmap);
+    when(seg1.getSegmentName()).thenReturn("seg1");
+
+    SegmentContext segCtx1 = new SegmentContext(seg1);
+    mgr.trackSegment(seg1);
+    assertEquals(mgr.getOptionalSegments(), Collections.singleton(seg1.getSegmentName()));
+    mgr.setSegmentContexts(Collections.singletonList(segCtx1), new HashMap<>());
+    assertSame(segCtx1.getQueryableDocIdsSnapshot(), mutableRoaringBitmap);
+
+    mgr.untrackSegment(seg1);
+    assertTrue(mgr.getOptionalSegments().isEmpty());
+    segCtx1 = new SegmentContext(seg1);
+    mgr.setSegmentContexts(Collections.singletonList(segCtx1), new HashMap<>());
+    assertNull(segCtx1.getQueryableDocIdsSnapshot());
+  }
+
+  @Test
+  public void testNeedForceRefresh() {
+    UpsertViewManager mgr = new UpsertViewManager(UpsertConfig.ConsistencyMode.SYNC, mock(UpsertContext.class));
+    assertNull(mgr.getSegmentQueryableDocIdsMap());
+    assertTrue(mgr.needForceRefresh());
+
+    IndexSegment seg1 = mock(MutableSegment.class);
+    when(seg1.getSegmentName()).thenReturn("seg1");
+    IndexSegment seg2 = mock(ImmutableSegment.class);
+    when(seg2.getSegmentName()).thenReturn("seg2");
+    mgr.trackSegment(seg1);
+    mgr.trackSegment(seg2);
+    assertTrue(mgr.needForceRefresh());
+
+    mgr.doBatchRefreshUpsertView(-1, true);
+    Map<IndexSegment, MutableRoaringBitmap> upsertView = mgr.getSegmentQueryableDocIdsMap();
+    assertNotNull(upsertView);
+    // Empty bitmaps are set in segmentContexts for segments without validDocIds bitmaps.
+    assertTrue(upsertView.get(seg1).isEmpty());
+    assertTrue(upsertView.get(seg2).isEmpty());
+    assertFalse(mgr.needForceRefresh());
+
+    // Missing segment in upsert view.
+    IndexSegment seg3 = mock(ImmutableSegment.class);
+    when(seg3.getSegmentName()).thenReturn("seg3");
+    mgr.trackSegment(seg3);
+    assertTrue(mgr.needForceRefresh());
+
+    // Having extra segment in upsert view.
+    mgr.doBatchRefreshUpsertView(-1, true);
+    assertFalse(mgr.needForceRefresh());
+    mgr.untrackSegment(seg3);
+    assertTrue(mgr.needForceRefresh());
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -384,6 +384,11 @@ public class TableConfig extends BaseJsonConfig {
   }
 
   @JsonIgnore
+  public UpsertConfig.ConsistencyMode getUpsertConsistencyMode() {
+    return _upsertConfig == null ? UpsertConfig.ConsistencyMode.NONE : _upsertConfig.getConsistencyMode();
+  }
+
+  @JsonIgnore
   @Nullable
   public List<String> getUpsertComparisonColumns() {
     return _upsertConfig == null ? null : _upsertConfig.getComparisonColumns();


### PR DESCRIPTION
Recently, we added support for consistent upsert view by synchronizing between updates on segments' validDocIds bitmaps and queries reading those bitmaps in PR #12976. But from recent tests, we find that's not enough. Other than that, we also need to track segments belonging to a table partition completely and consistently. 

The current segment tracking logic for upsert view is broken in those places:
1. (completeness) using `_trackedSegments` is not right to ensure the consistent upsert view, because this Set is updated after the segment is registered to table manager. So query can see a segment before it is included in the upsert view. If so, today, the query falls back to get segment's bitmap outside the locking logic used to ensure consistency;
2. (completeness) when committing mutable segment, a new immutable segment is created to replace the mutable one, but the mutable segment is kept intact during segment replacement for query to access. The query can't access the new immutable segment as it's not registered until replacement is done. However, the upsert metadata gets updated (mainly the map from PK to record location) during segment replacement, so the newly ingested records start to invalidate docs in the new immutable segments, instead of the old mutable segment. This causes queries to see more than expected valid docs.
3. (completeness) the server can start a consuming segment before the broker can add it to routing table, even with this early fix (PR # 11978). Because handling the change of IdealState on server and broker is not sync'ed and we don't want to sync brokers and servers anyway due to the cost and complexity.
4. (consistency) when executing a query, the server acquires segments firstly, then get their validDocIds bitmaps. But between the two steps, new segments can get added, which can be a new consuming segment or a new immutable segment used to replace the mutable segment. And the query can't access the new segments' bitmap as not acquired them, thus getting less than expected valid docs.

To address those issues
1. A new Set is used to track segments completely and consistently. A segment is always added to this Set before registering to table mgr. And server locks the Set when acquiring segments and getting their validDocIds bitmaps to ensure no segment membership changes. All upsert view related logic is moved to a new util class UpsertViewManager for easier maintenance.
2. When committing a mutable segment, we create a new segment data mgr, called DuoSegmentDataManager, to register both the mutable and immutable segment to table mgr before segment replacement starts, so that query can acquire both. Meanwhile, we update mutable segment in place during replacement, instead of keeping it intact. In this way, we don't need to block the data ingestion to provide queries a complete data view when committing a segment.
3. A query always tries to acquire the latest consuming segment, if it's not included in the broker's query request, so that the query doesn't miss the newly ingested docs, in case broker hasn't updated its routing table yet. 

A few other misc fixes
1. In mutable segment, we should update _numDocsIndexed before updating the upsert metadata, otherwise, query might see one less valid docs. 
2. Return an empty bitmap instead of null when if a segment doesn't have bitmap yet, so that we don't fall back to get the bitmap again out side the locking logic, as when getting again, the segment might have created its bitmap.

All the new changes in this PR are supposed to be enabled via the new feature flag upsertConfig.consistencyMode added in PR #12976, so upsert tables not using this feature shouldn't be affected.

As to tests:
1. Added more unit tests
2. And stress tested both modes with a load generator in staging env, that kept ingesting records with a known set of PKs and committing segments every few seconds