### PR TITLE
wip: support for deleting segments using sql

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlDelete;
 import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
@@ -128,6 +129,14 @@ public class CalciteSqlParser {
     for (SqlNode sqlNode : sqlNodeList) {
       if (sqlNode instanceof SqlInsertFromFile) {
         // extract insert statement (execution statement)
+        if (sqlType == null) {
+          sqlType = PinotSqlType.DML;
+          statementNode = sqlNode;
+        } else {
+          throw new SqlCompilationException("SqlNode with executable statement already exist with type: " + sqlType);
+        }
+      } else if (sqlNode instanceof SqlDelete) {
+        // extract delete statement (execution statement)
         if (sqlType == null) {
           sqlType = PinotSqlType.DML;
           statementNode = sqlNode;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatement.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatement.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.dml;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlDelete;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.config.task.AdhocTaskConfig;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class DeleteSegmentStatement implements DataManipulationStatement {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeleteSegmentStatement.class);
+  private static final DataSchema DELETE_FROM_RESPONSE_SCHEMA =
+      new DataSchema(new String[]{"tableName", "taskJobName"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+  private static final Set<String> VALID_OPERATORS = Set.of("LIKE", "=");
+  private static final String TASK_NAME = "taskName";
+  private static final String TASK_TYPE = "taskType";
+  private static final String DEFAULT_TASK_TYPE = "SegmentDeletionTask";
+  private static final String SEGMENT_NAME = "segmentName";
+  private static final String OPERATOR = "operator";
+
+  private final String _table;
+  private final Map<String, String> _queryOptions;
+
+  public DeleteSegmentStatement(String table, Map<String, String> queryOptions) {
+    _table = table;
+    _queryOptions = queryOptions;
+  }
+
+  public String getTable() {
+    return _table;
+  }
+
+  public Map<String, String> getQueryOptions() {
+    return _queryOptions;
+  }
+
+  public static DeleteSegmentStatement parse(SqlNodeAndOptions sqlNodeAndOptions) {
+    SqlNode sqlNode = sqlNodeAndOptions.getSqlNode();
+    assert sqlNode instanceof SqlDelete;
+    SqlDelete sqlDelete = (SqlDelete) sqlNode;
+    String tableName = sqlDelete.getTargetTable().toString();
+    SqlBasicCall condition = (SqlBasicCall) sqlDelete.getCondition();
+    if (condition == null) {
+      throw new IllegalStateException("missing WHERE clause");
+    }
+    List<SqlNode> operandList = condition.getOperandList();
+    if (operandList.size() != 2) {
+      throw new IllegalStateException("expected 2 operands. Found: " + operandList.size());
+    }
+
+    String operator = (condition.getOperator() == null) ? null : condition.getOperator().toString().toUpperCase();
+
+    if (!VALID_OPERATORS.contains(operator)) {
+      throw new IllegalStateException("unsupported operator: " + operator);
+    }
+
+    Map<String, String> optionsMap = sqlNodeAndOptions.getOptions();
+    optionsMap.put(OPERATOR, operator);
+
+    if (operandList.get(0).toString().equals("$segmentName")) {
+      optionsMap.put(SEGMENT_NAME, operandList.get(1).toString());
+    } else {
+      throw new IllegalStateException("missing $segmentName in WHERE clause");
+    }
+
+    return new DeleteSegmentStatement(tableName, optionsMap);
+  }
+
+  @Override
+  public ExecutionType getExecutionType() {
+    return ExecutionType.MINION;
+  }
+
+  @Override
+  public AdhocTaskConfig generateAdhocTaskConfig() {
+    Map<String, String> queryOptions = this.getQueryOptions();
+    String taskName = queryOptions.get(TASK_NAME);
+    String taskType = queryOptions.getOrDefault(TASK_TYPE, DEFAULT_TASK_TYPE);
+    return new AdhocTaskConfig(taskType, this.getTable(), taskName, queryOptions);
+  }
+
+  @Override
+  public List<Object[]> execute() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DataSchema getResultSchema() {
+    return DELETE_FROM_RESPONSE_SCHEMA;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParserTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParserTest.java
@@ -46,7 +46,7 @@ public class DataManipulationStatementParserTest {
   }
 
   @Test
-  public void testInvalidDeleteSegmentStatement_missing_where_clause() {
+  public void testInvalidDeleteSegmentStatementMissingWhereClause() {
     String sql = "DELETE FROM mytable";
     SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
     try {
@@ -58,7 +58,7 @@ public class DataManipulationStatementParserTest {
   }
 
   @Test
-  public void testInvalidDeleteSegmentStatement_missing_segment_name() {
+  public void testInvalidDeleteSegmentStatementMissingSegmentName() {
     String sql = "DELETE FROM mytable WHERE a = b";
     SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
     try {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParserTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParserTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.dml;
+
+import java.util.Map;
+import org.apache.pinot.spi.config.task.AdhocTaskConfig;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+public class DataManipulationStatementParserTest {
+  @Test
+  public void testDeleteSegmentStatement() {
+    String sql = "DELETE FROM mytable WHERE $segmentName = 'mySegmentName'";
+    SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
+
+    DataManipulationStatement statement = DataManipulationStatementParser.parse(nodeAndOptions);
+    assertTrue(statement instanceof DeleteSegmentStatement);
+    assertEquals(statement.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);
+    AdhocTaskConfig config = statement.generateAdhocTaskConfig();
+    assertEquals(config.getTableName(), "mytable");
+    assertEquals(config.getTaskType(), "SegmentDeletionTask");
+    assertEquals(config.getTaskConfigs(),
+        Map.of("operator", "=", "segmentName", "'mySegmentName'"));
+  }
+
+  @Test
+  public void testInvalidDeleteSegmentStatement_missing_where_clause() {
+    String sql = "DELETE FROM mytable";
+    SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
+    try {
+      DataManipulationStatementParser.parse(nodeAndOptions);
+      fail("expected exception was not thrown");
+    } catch (IllegalStateException ex) {
+      assertEquals(ex.getMessage(), "missing WHERE clause");
+    }
+  }
+
+  @Test
+  public void testInvalidDeleteSegmentStatement_missing_segment_name() {
+    String sql = "DELETE FROM mytable WHERE a = b";
+    SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
+    try {
+      DataManipulationStatementParser.parse(nodeAndOptions);
+      fail("expected exception was not thrown");
+    } catch (IllegalStateException ex) {
+      assertEquals(ex.getMessage(), "missing $segmentName in WHERE clause");
+    }
+  }
+
+  @Test
+  public void testInsertIntoFromFileStatement() {
+    String sql = "INSERT INTO \"baseballStats\"\n"
+        + "FROM FILE 's3://my-bucket/path/to/data/';\n"
+        + "SET taskName = 'myTask-1';\n"
+        + "SET \"input.fs.className\" = 'org.apache.pinot.plugin.filesystem.S3PinotFS';\n"
+        + "SET \"input.fs.prop.accessKey\" = 'my-access-key';\n"
+        + "SET \"input.fs.prop.secretKey\" = 'my-secret-key';\n"
+        + "SET \"input.fs.prop.region\" = 'us-west-2';";
+    SqlNodeAndOptions nodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
+
+    DataManipulationStatement statement = DataManipulationStatementParser.parse(nodeAndOptions);
+    assertTrue(statement instanceof InsertIntoFile);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatementTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatementTest.java
@@ -33,10 +33,12 @@ public class DeleteSegmentStatementTest {
       throws Exception {
     String deleteFromSql = "DELETE FROM \"baseballStats\"\n"
         + "WHERE $segmentName = 'foobar';";
-    DeleteSegmentStatement deleteSegmentStatement = DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+    DeleteSegmentStatement deleteSegmentStatement =
+        DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
     Assert.assertEquals(deleteSegmentStatement.getTable(), "baseballStats");
     Assert.assertEquals(deleteSegmentStatement.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);
-    Assert.assertEquals(deleteSegmentStatement.getResultSchema(), new DataSchema(new String[]{"tableName", "taskJobName"},
+    Assert.assertEquals(deleteSegmentStatement.getResultSchema(),
+        new DataSchema(new String[]{"tableName", "taskJobName"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING}));
     Assert.assertEquals(deleteSegmentStatement.getQueryOptions(),
         Map.of("segmentName", "'foobar'", "operator", "="));
@@ -53,10 +55,12 @@ public class DeleteSegmentStatementTest {
       throws Exception {
     String deleteFromSql = "DELETE FROM \"baseballStats\"\n"
         + "WHERE $segmentName LIKE 'mySegment';";
-    DeleteSegmentStatement deleteSegmentStatement = DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+    DeleteSegmentStatement deleteSegmentStatement =
+        DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
     Assert.assertEquals(deleteSegmentStatement.getTable(), "baseballStats");
     Assert.assertEquals(deleteSegmentStatement.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);
-    Assert.assertEquals(deleteSegmentStatement.getResultSchema(), new DataSchema(new String[]{"tableName", "taskJobName"},
+    Assert.assertEquals(deleteSegmentStatement.getResultSchema(),
+        new DataSchema(new String[]{"tableName", "taskJobName"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING}));
     Assert.assertEquals(deleteSegmentStatement.getQueryOptions(),
         Map.of("segmentName", "'mySegment'", "operator", "LIKE"));
@@ -72,7 +76,8 @@ public class DeleteSegmentStatementTest {
   public void testDeleteStatementMissingWhereClause() {
     String deleteFromSql = "DELETE FROM \"baseballStats\"\n";
     try {
-      DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+      DeleteSegmentStatement.parse(
+          CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
       Assert.fail("expected exception was not thrown");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getMessage(), "missing WHERE clause");

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatementTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatementTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.dml;
+
+import java.util.Map;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.config.task.AdhocTaskConfig;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DeleteSegmentStatementTest {
+
+  @Test
+  public void testDeleteFromWhereSegmentEqual()
+      throws Exception {
+    String deleteFromSql = "DELETE FROM \"baseballStats\"\n"
+        + "WHERE $segmentName = 'foobar';";
+    DeleteSegmentStatement deleteSegmentStatement = DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+    Assert.assertEquals(deleteSegmentStatement.getTable(), "baseballStats");
+    Assert.assertEquals(deleteSegmentStatement.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);
+    Assert.assertEquals(deleteSegmentStatement.getResultSchema(), new DataSchema(new String[]{"tableName", "taskJobName"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING}));
+    Assert.assertEquals(deleteSegmentStatement.getQueryOptions(),
+        Map.of("segmentName", "'foobar'", "operator", "="));
+    AdhocTaskConfig adhocTaskConfig = deleteSegmentStatement.generateAdhocTaskConfig();
+    Assert.assertEquals(adhocTaskConfig.getTaskType(), "SegmentDeletionTask");
+    Assert.assertNull(adhocTaskConfig.getTaskName());
+    Assert.assertEquals(adhocTaskConfig.getTableName(), "baseballStats");
+    Assert.assertEquals(adhocTaskConfig.getTaskConfigs(),
+        Map.of("segmentName", "'foobar'", "operator", "="));
+  }
+
+  @Test
+  public void testDeleteFromWhereSegmentLike()
+      throws Exception {
+    String deleteFromSql = "DELETE FROM \"baseballStats\"\n"
+        + "WHERE $segmentName LIKE 'mySegment';";
+    DeleteSegmentStatement deleteSegmentStatement = DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+    Assert.assertEquals(deleteSegmentStatement.getTable(), "baseballStats");
+    Assert.assertEquals(deleteSegmentStatement.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);
+    Assert.assertEquals(deleteSegmentStatement.getResultSchema(), new DataSchema(new String[]{"tableName", "taskJobName"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING}));
+    Assert.assertEquals(deleteSegmentStatement.getQueryOptions(),
+        Map.of("segmentName", "'mySegment'", "operator", "LIKE"));
+    AdhocTaskConfig adhocTaskConfig = deleteSegmentStatement.generateAdhocTaskConfig();
+    Assert.assertEquals(adhocTaskConfig.getTaskType(), "SegmentDeletionTask");
+    Assert.assertNull(adhocTaskConfig.getTaskName());
+    Assert.assertEquals(adhocTaskConfig.getTableName(), "baseballStats");
+    Assert.assertEquals(adhocTaskConfig.getTaskConfigs(),
+        Map.of("segmentName", "'mySegment'", "operator", "LIKE"));
+  }
+
+  @Test
+  public void testDeleteStatementMissingWhereClause() {
+    String deleteFromSql = "DELETE FROM \"baseballStats\"\n";
+    try {
+      DeleteSegmentStatement.parse(CalciteSqlParser.compileToSqlNodeAndOptions(deleteFromSql));
+      Assert.fail("expected exception was not thrown");
+    } catch (Exception ex) {
+      Assert.assertEquals(ex.getMessage(), "missing WHERE clause");
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -26,6 +26,7 @@ public class MinionConstants {
 
   public static final String TABLE_NAME_KEY = "tableName";
   public static final String SEGMENT_NAME_KEY = "segmentName";
+  public static final String OPERATOR_KEY = "operator";
   public static final String DOWNLOAD_URL_KEY = "downloadURL";
   public static final String UPLOAD_URL_KEY = "uploadURL";
   public static final String DOT_SEPARATOR = ".";
@@ -70,6 +71,10 @@ public class MinionConstants {
     public static final String TASK_TYPE = "PurgeTask";
     public static final String LAST_PURGE_TIME_THREESOLD_PERIOD = "lastPurgeTimeThresholdPeriod";
     public static final String DEFAULT_LAST_PURGE_TIME_THRESHOLD_PERIOD = "14d";
+  }
+
+  public static class SegmentDeletionTask {
+    public static final String TASK_TYPE = "SegmentDeletionTask";
   }
 
   // Common config keys for segment merge tasks.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentDeletionMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentDeletionMinionClusterIntegrationTest.java
@@ -1,0 +1,264 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.File;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class SegmentDeletionMinionClusterIntegrationTest extends BaseClusterIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDeletionMinionClusterIntegrationTest.class);
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
+
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+    startMinion();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    try {
+      stopMinion();
+      stopServer();
+      stopBroker();
+      stopController();
+      stopZk();
+    } finally {
+      FileUtils.deleteQuietly(_tempDir);
+    }
+  }
+
+  private int getTotalDocs(String tableName)
+      throws Exception {
+    String query = "SELECT COUNT(*) FROM " + tableName;
+    JsonNode response = postQuery(query);
+    JsonNode resTbl = response.get("resultTable");
+    return (resTbl == null) ? 0 : resTbl.get("rows").get(0).get(0).asInt();
+  }
+
+  private Collection<String> getSegmentNames(String tableName) {
+    try {
+      String query = "SELECT $segmentName FROM " + tableName;
+      JsonNode response = postQuery(query);
+      JsonNode resTbl = response.get("resultTable");
+      Collection<String> segmentNames = new LinkedHashSet<>();
+      if (resTbl == null) {
+        return segmentNames;
+      }
+      ArrayNode rowsArray = (ArrayNode) resTbl.get("rows");
+      if (rowsArray == null) {
+        return segmentNames;
+      }
+      rowsArray.forEach(row -> {
+        ArrayNode oneRow = (ArrayNode) row;
+        segmentNames.add(oneRow.get(0).asText());
+      });
+      return segmentNames;
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  private boolean deleteSegmentEqualToName(String tableName, String segmentName, String taskName)
+      throws Exception {
+
+    String deleteFromStatement =
+        String.format("DELETE FROM %s WHERE $segmentName = '%s' OPTION(taskName=%s)",
+            tableName, segmentName, taskName);
+
+    JsonNode response = postQueryToController(deleteFromStatement);
+    JsonNode resTbl = response.get("resultTable");
+    if (resTbl == null) {
+      return false;
+    } else {
+      ArrayNode rows = (ArrayNode) resTbl.get("rows");
+      if (rows == null) {
+        return false;
+      } else {
+        return (rows.size() == 1);
+      }
+    }
+  }
+
+  private boolean deleteSegmentLikeName(String tableName, String segmentNamePattern, String taskName)
+      throws Exception {
+
+    String deleteFromStatement =
+        String.format("DELETE FROM %s WHERE $segmentName LIKE '%s' OPTION(taskName=%s)",
+            tableName, segmentNamePattern, taskName);
+
+    JsonNode response = postQueryToController(deleteFromStatement);
+    JsonNode resTbl = response.get("resultTable");
+    if (resTbl == null) {
+      return false;
+    } else {
+      ArrayNode rows = (ArrayNode) resTbl.get("rows");
+      if (rows == null) {
+        return false;
+      } else {
+        return (rows.size() == 1);
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteSegmentEqualNameSqlToController()
+      throws Exception {
+
+    String tableName = "testDeleteSegmentEqualNameSqlToController";
+
+    testInsertIntoFromFile(tableName, tableName + "_InsertInto_Task", true);
+
+    final int totalDocsBeforeDelete = getTotalDocs(tableName);
+    Assert.assertEquals(totalDocsBeforeDelete, 70);
+
+    Collection<String> segmentNames = getSegmentNames(tableName);
+
+    final int segmentCountBeforeDelete = segmentNames.size();
+    Assert.assertEquals(segmentCountBeforeDelete, 1);
+
+    final String segmentToDelete = segmentNames.iterator().next();
+
+    final String deleteSegmentTaskName = tableName + "_DeleteFrom_Task";
+
+    Assert.assertTrue(deleteSegmentEqualToName(tableName, segmentToDelete, deleteSegmentTaskName));
+
+    TestUtils.waitForCondition(aVoid -> {
+        int segmentCountAfterDelete = getSegmentNames(tableName).size();
+        return segmentCountAfterDelete < segmentCountBeforeDelete;
+        },
+        3000L,
+        30_000L,
+        String.format("segmentCountAfterDelete never dropped below segmentCountBeforeDelete (%s)",
+            segmentCountBeforeDelete),
+        true);
+  }
+
+  @Test
+  public void testDeleteSegmentLikeNameSqlToController()
+      throws Exception {
+
+    String tableName = "testDeleteSegmentLikeNameSqlToController";
+
+    testInsertIntoFromFile(tableName, tableName + "_InsertInto_Task", true);
+
+    final int totalDocsBeforeDelete = getTotalDocs(tableName);
+    Assert.assertEquals(totalDocsBeforeDelete, 70);
+
+    Collection<String> segmentNames = getSegmentNames(tableName);
+
+    final int segmentCountBeforeDelete = segmentNames.size();
+    Assert.assertEquals(segmentCountBeforeDelete, 1);
+
+    final String segmentToDelete = segmentNames.iterator().next();
+
+    final String deleteSegmentTaskName = tableName + "_DeleteFrom_Task";
+
+    Assert.assertTrue(deleteSegmentLikeName(tableName, segmentToDelete, deleteSegmentTaskName));
+
+    TestUtils.waitForCondition(aVoid -> {
+          int segmentCountAfterDelete = getSegmentNames(tableName).size();
+          return segmentCountAfterDelete < segmentCountBeforeDelete;
+        },
+        3000L,
+        30_000L,
+        String.format("segmentCountAfterDelete never dropped below segmentCountBeforeDelete (%s)",
+            segmentCountBeforeDelete),
+        true);
+  }
+
+  private void testInsertIntoFromFile(String tableName, String taskName, boolean queryController)
+      throws Exception {
+    addSchemaAndTableConfig(tableName);
+
+    File inputDir = new File(_tempDir, tableName);
+    int rowCnt = prepInputFiles(inputDir, 7, 10);
+    assertEquals(rowCnt, 70);
+
+    String insertFileStatement =
+        String.format("INSERT INTO %s FROM FILE '%s' OPTION(taskName=%s)", tableName, inputDir.getAbsolutePath(),
+            taskName);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        if (getTotalDocs(tableName) < rowCnt) {
+          JsonNode response = queryController ? postQueryToController(insertFileStatement)
+              : postQuery(insertFileStatement);
+          Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(0).asText(),
+              tableName + "_OFFLINE");
+          Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(1).asText(),
+              "Task_SegmentGenerationAndPushTask_" + taskName);
+        }
+        return getTotalDocs(tableName) == rowCnt;
+      } catch (Exception e) {
+        LOGGER.error("Failed to get expected totalDocs: {}", rowCnt, e);
+        return false;
+      }
+    }, 5000L, 600_000L, "Failed to load " + rowCnt + " documents", true);
+    JsonNode result = postQuery("SELECT COUNT(*) FROM " + tableName);
+    // One segment per file.
+    assertEquals(result.get("numSegmentsQueried").asInt(), 7);
+  }
+
+  private void addSchemaAndTableConfig(String tableName)
+      throws Exception {
+    addSchema(new Schema.SchemaBuilder().setSchemaName(tableName).addSingleValueDimension("id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING).build());
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).build();
+    sendPostRequest(_controllerRequestURLBuilder.forTableCreate(), tableConfig.toString(),
+        BasicAuthTestUtils.AUTH_HEADER);
+  }
+
+  private int prepInputFiles(File inputDir, int fileNum, int rowsPerFile)
+      throws Exception {
+    int rowCnt = 0;
+    for (int i = 0; i < fileNum; i++) {
+      File csvFile = new File(inputDir, String.format("tempFile_%05d.csv", i));
+      FileUtils.write(csvFile, "id,name\n", false);
+      for (int j = 0; j < rowsPerFile; j++) {
+        FileUtils.write(csvFile, String.format("%d,n%d\n", rowCnt, rowCnt), true);
+        rowCnt++;
+      }
+    }
+    return rowCnt;
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionResult.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionResult.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segmentdeletion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * The class <code>SegmentDeletionResult</code> wraps the segment deletion result
+ */
+public class SegmentDeletionResult {
+  private final boolean _succeed;
+  private final String _segmentName;
+  private final Exception _exception;
+  private final Map<String, Object> _customProperties;
+
+  private SegmentDeletionResult(boolean succeed, String segmentName, Exception exception,
+      Map<String, Object> customProperties) {
+    _succeed = succeed;
+    _segmentName = segmentName;
+    _exception = exception;
+    _customProperties = customProperties;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> T getCustomProperty(String key) {
+    return (T) _customProperties.get(key);
+  }
+
+  public Exception getException() {
+    return _exception;
+  }
+
+  public boolean isSucceed() {
+    return _succeed;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public static class Builder {
+    private boolean _succeed;
+    private String _segmentName;
+    private Exception _exception;
+    private final Map<String, Object> _customProperties = new HashMap<>();
+
+    public Builder setSucceed(boolean succeed) {
+      _succeed = succeed;
+      return this;
+    }
+
+    public void setSegmentName(String segmentName) {
+      _segmentName = segmentName;
+    }
+
+    public Builder setException(Exception exception) {
+      _exception = exception;
+      return this;
+    }
+
+    public Builder setCustomProperty(String key, Object property) {
+      _customProperties.put(key, property);
+      return this;
+    }
+
+    public SegmentDeletionResult build() {
+      return new SegmentDeletionResult(_succeed, _segmentName, _exception, _customProperties);
+    }
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutor.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segmentdeletion;
+
+import java.util.Collections;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutor;
+import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentDeletionTaskExecutor extends BaseTaskExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDeletionTaskExecutor.class);
+  private MinionConf _minionConf;
+
+  public SegmentDeletionTaskExecutor(MinionConf minionConf) {
+    _minionConf = minionConf;
+  }
+
+  @Override
+  protected SegmentZKMetadataCustomMapModifier getSegmentZKMetadataCustomMapModifier(PinotTaskConfig pinotTaskConfig,
+      SegmentConversionResult segmentConversionResult) {
+    return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE,
+        Collections.singletonMap(MinionConstants.SegmentDeletionTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX,
+            String.valueOf(System.currentTimeMillis())));
+  }
+
+  @Override
+  public Object executeTask(PinotTaskConfig pinotTaskConfig)
+      throws Exception {
+
+    SegmentDeletionResult.Builder resultBuilder = new SegmentDeletionResult.Builder();
+
+    String tableName = pinotTaskConfig.getTableName();
+    String segmentName = pinotTaskConfig.getConfigs().get("segmentName");
+    String operator = pinotTaskConfig.getConfigs().get("operator");
+
+    boolean success = false;
+
+    if (tableName == null) {
+      LOGGER.warn("tableName is missing");
+    }
+
+    if (segmentName == null) {
+      LOGGER.warn("segmentName is missing");
+    }
+
+    if (operator == null) {
+      LOGGER.warn("operator is missing");
+    }
+
+    if ((segmentName != null) && (operator != null) && (tableName != null)) {
+      /*
+
+            TODO need to implement "delete segment" behavior
+
+            what is the correct mechanism for deleting segments?
+
+            should we use the pinotHelixResourceManager to delete segments?
+
+                pinotHelixResourceManager.deleteSegments(tableName, List.of(segmentName));
+
+            We do not have a reference to pinotHelixResourceManager
+
+          TODO need to handle two specific use cases:
+              1)  where $segmentName = 'foo'
+              1)  where $segmentName LIKE 'segNamePattern'
+
+       */
+      success = true;
+    }
+
+    resultBuilder.setSucceed(success);
+    resultBuilder.setSegmentName(segmentName);
+    return resultBuilder.build();
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutorFactory.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segmentdeletion;
+
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
+import org.apache.pinot.minion.executor.PinotTaskExecutor;
+import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
+
+
+@TaskExecutorFactory
+public class SegmentDeletionTaskExecutorFactory implements PinotTaskExecutorFactory {
+  private MinionConf _minionConf;
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
+  }
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
+    _minionConf = minionConf;
+  }
+
+  @Override
+  public String getTaskType() {
+    return MinionConstants.SegmentDeletionTask.TASK_TYPE;
+  }
+
+  @Override
+  public PinotTaskExecutor create() {
+    return new SegmentDeletionTaskExecutor(_minionConf);
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskGenerator.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segmentdeletion;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.spi.annotations.minion.TaskGenerator;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@TaskGenerator
+public class SegmentDeletionTaskGenerator extends BaseTaskGenerator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDeletionTaskGenerator.class);
+
+  @Override
+  public String getTaskType() {
+    return MinionConstants.SegmentDeletionTask.TASK_TYPE;
+  }
+
+  @Override
+  public List<PinotTaskConfig> generateTasks(TableConfig tableConfig, Map<String, String> taskConfigs)
+      throws Exception {
+
+    String taskType = MinionConstants.SegmentDeletionTask.TASK_TYPE;
+
+    Map<String, String> configs = new HashMap<>(
+        getBaseTaskConfigs(tableConfig, List.of(taskConfigs.get("segmentName"))));
+    configs.put(MinionConstants.OPERATOR_KEY, taskConfigs.get("operator"));
+    return List.of(new PinotTaskConfig(taskType, configs));
+  }
+
+  @Override
+  public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
+    throw new UnsupportedOperationException("not supported");
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskProgressObserverFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskProgressObserverFactory.java
@@ -16,25 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.sql.parsers.dml;
+package org.apache.pinot.plugin.minion.tasks.segmentdeletion;
 
-import org.apache.calcite.sql.SqlDelete;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
-import org.apache.pinot.sql.parsers.parser.SqlInsertFromFile;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.minion.event.BaseMinionProgressObserverFactory;
+import org.apache.pinot.spi.annotations.minion.EventObserverFactory;
 
 
-public class DataManipulationStatementParser {
-  private DataManipulationStatementParser() {
-  }
+@EventObserverFactory
+public class SegmentDeletionTaskProgressObserverFactory extends BaseMinionProgressObserverFactory {
 
-  public static DataManipulationStatement parse(SqlNodeAndOptions sqlNodeAndOptions) {
-    SqlNode sqlNode = sqlNodeAndOptions.getSqlNode();
-    if (sqlNode instanceof SqlInsertFromFile) {
-      return InsertIntoFile.parse(sqlNodeAndOptions);
-    } else if (sqlNode instanceof SqlDelete) {
-      return DeleteSegmentStatement.parse(sqlNodeAndOptions);
-    }
-    throw new UnsupportedOperationException("Unsupported DML SqlKind - " + sqlNode.getKind());
+  @Override
+  public String getTaskType() {
+    return MinionConstants.SegmentDeletionTask.TASK_TYPE;
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Parsing DELETE FROM table WHERE $segmentName \.\.\. creates a MINION task to delete a segment\.

```mermaid
flowchart TD
  N0["CalciteSqlParser parses DELETE to SqlDelete #40;F1#41;"]:::stModified
  N1["DataManipulationStatementParser routes SqlDelete to DeleteSegmentStatement #40;F2#41;"]:::stModified
  N2["DeleteSegmentStatement#46;parse extracts table#44; operator#44; #36;segmentName #40;F3#41;"]:::stAdded
  N3["DeleteSegmentStatement#46;getExecutionType returns MINION #40;F3#41;"]:::stAdded
  N4["DeleteSegmentStatement#46;generateAdhocTaskConfig builds AdhocTaskConfig #40;F3#41;"]:::stAdded
  N5["SegmentDeletionTaskGenerator creates PinotTaskConfig from options #40;F8#41;"]:::stAdded
  N6["SegmentDeletionTaskExecutor#46;executeTask reads configs and builds result #40;F6#41;"]:::stAdded
  N0 -->|"SqlDelete node passed to parser"| N1
  N1 -->|"returns DeleteSegmentStatement"| N2
  N2 -->|"getExecutionType"| N3
  N2 -->|"generateAdhocTaskConfig"| N4
  N4 -->|"taskConfigs map from AdhocTaskConfig"| N5
  N5 -->|"PinotTaskConfig passed to executeTask"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser\.java — [before](https://github.com/apache/pinot/blob/15a8f16b38130e2ea48287382b68aa0095dd626a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java) · [after](https://github.com/apache/pinot/blob/54de3a78af71176c087e685c0e55c460a4f4c8c5/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParser\.java — [before](https://github.com/apache/pinot/blob/15a8f16b38130e2ea48287382b68aa0095dd626a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParser.java) · [after](https://github.com/apache/pinot/blob/54de3a78af71176c087e685c0e55c460a4f4c8c5/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/DataManipulationStatementParser.java)
- F3: pinot\-common/src/main/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatement\.java — [after](https://github.com/apache/pinot/blob/54de3a78af71176c087e685c0e55c460a4f4c8c5/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/DeleteSegmentStatement.java)
- F6: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutor\.java — [after](https://github.com/apache/pinot/blob/54de3a78af71176c087e685c0e55c460a4f4c8c5/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskExecutor.java)
- F8: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskGenerator\.java — [after](https://github.com/apache/pinot/blob/54de3a78af71176c087e685c0e55c460a4f4c8c5/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentdeletion/SegmentDeletionTaskGenerator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjE1YThmMTZiMzgxMzBlMmVhNDgyODczODJiNjhhYTAwOTVkZDYyNmEiLCJjb250ZXh0X2hhc2giOiI1OTI0ZGJkZDAzNjVmZmEzNGMyNjZjNjQ4NjZlYmYwNzk3N2FiYjg4NjBiNWE3YWEyZjYwZWJjYzJiYzY0NWI0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzg1MzMzLCJoZWFkX3NoYSI6IjU0ZGUzYTc4YWY3MTE3NmMwODdlNjg1YzBlNTVjNDYwYTRmNGM4YzUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxNWE4ZjE2YjM4MTMwZTJlYTQ4Mjg3MzgyYjY4YWEwMDk1ZGQ2MjZhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 39548419f999145add0ea1106845005df2166974d157e940a75bb65bf703874b -->
<!-- pinot-pr-flow:end -->

**This PR is a work in progress.**   

# Motivation

This PR was motivated by a GitHub issue: 
https://github.com/apache/pinot/issues/13476

# Modifications

- add class: DeleteSegmentStatement
- new logic in CalciteSqlParser
- new logic DataManipulationStatementParser

# DeleteSegmentStatement class

DeleteSegmentStatement implements Pinot's DataManipulationStatement interface.

This class uses ExecutionType.MINION 

# Feedback requested:

- is ExecutionType.MINION the correct choice for DeleteSegmentStatement?  The only other choice is ExecutionType.HTTP.  I reviewed the source tree and I could not find any Pinot statements that use ExecutionType.HTTP

- What is the correct way to delete segments?   I have not worked with segments before and I could use some guidance.  

- Based on my current understanding, it looks like I need to add behavior to the "executeTask" method in SegmentDeletionTaskExecutor.java.  I left a "TODO" comment in this file to indicate that the implementation is incomplete

# Testing

- added DeleteSegmentStatementTest.java
- added DataManipulationStatementParserTest.java
- added SegmentDeletionMinionClusterIntegrationTest.java
- updated CalciteSqlCompilerTest.java


# Supporting document

This Google Doc has additional information about Pinot SQL endpoints and segment deletion:

https://docs.google.com/document/d/1bsg3QKeZiXiFh2__tDkor-v0eDw0QBKuPZiK3DWg_04/edit?usp=sharing
