### PR TITLE
Fix flaky gauge value issue

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -451,7 +451,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     setValueOfGauge(value, gaugeName);
   }
 
-  private void setValueOfGauge(long value, String gaugeName) {
+  protected void setValueOfGauge(long value, String gaugeName) {
     AtomicLong gaugeValue = _gaugeValues.get(gaugeName);
     if (gaugeValue == null) {
       synchronized (_gaugeValues) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -787,8 +787,10 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param gaugeName gauge name
    */
   public void removeGauge(final String gaugeName) {
-    _gaugeValues.remove(gaugeName);
-    removeGaugeFromMetricRegistry(gaugeName);
+    synchronized (_gaugeValues) {
+      _gaugeValues.remove(gaugeName);
+      removeGaugeFromMetricRegistry(gaugeName);
+    }
   }
 
   public void removeTableMeter(final String tableName, final M meter) {


### PR DESCRIPTION
Fix for #13629 

Currently, we maintain a map `_gaugeValues` in the `AbstractMetrics` class for gauge values. When adding a new gauge, we lock the entire operation of adding the gauge to the `_gaugeValues` map and the `metricsRegistry` factory simultaneously ([Ref](https://github.com/apache/pinot/blob/15a8f16b38130e2ea48287382b68aa0095dd626a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java#L457-L461)). However, there was a bug where the removal was not done under a lock. This led to a race condition when `removeGauge` and `setValueOfGauge` were called almost simultaneously. This could result in a scenario where the gauge is removed from the `_gaugeValues` map, then `setValueOfGauge` takes a lock on the map, adds it back to `_gaugeValues`, and registers it with `_metricsRegistry`, but then `removeFromMetricsRegistry` from the `removeGauge` method kicks in, removing it from `_metricsRegistry`.

This was specifically caught in our scenario by the way we have implemented our `_metricsRegistry`. We have a thread where we loop through all the gauges every 10 seconds and emit the value. In our scenario, `_metricsRegistry` was missing the gauge altogether because of the above race condition.
