### PR TITLE
Improve logging in SegmentPreProcessor::needProcess

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -72,13 +72,17 @@ public class ColumnMinMaxValueGenerator {
     _columnMinMaxValueGeneratorMode = columnMinMaxValueGeneratorMode;
   }
 
-  public boolean needAddColumnMinMaxValue() {
+  /**
+   * Returns the list of columns that need min/max values to be updated
+   */
+  public List<String> columnMinMaxValueUpdates() {
+    List<String> columns = new ArrayList<>();
     for (String column : getColumnsToAddMinMaxValue()) {
       if (needAddColumnMinMaxValueForColumn(column)) {
-        return true;
+        columns.add(column);
       }
     }
-    return false;
+    return columns;
   }
 
   public void addColumnMinMaxValue()


### PR DESCRIPTION
- The current logs indicating that a segment needs to be reprocessed for some reason don't include the name of the segment. This can make debugging tricky when a large number of segments are being reloaded.
- The min/max value updates log doesn't include the names of the columns where such updates are required.
- This patch fixes both the above issues.