### PR TITLE
add routing policy in query errmsg upon unavailable segments for a bit more context

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -844,14 +844,14 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   static String addRoutingPolicyInErrMsg(String errorMessage, String realtimeRoutingPolicy,
       String offlineRoutingPolicy) {
     if (realtimeRoutingPolicy != null && offlineRoutingPolicy != null) {
-      return String.format("%s, with routing policy: %s [realtime], %s [offline]", errorMessage, realtimeRoutingPolicy,
-          offlineRoutingPolicy);
+      return errorMessage + ", with routing policy: " + realtimeRoutingPolicy + " [realtime], " + offlineRoutingPolicy
+          + " [offline]";
     }
     if (realtimeRoutingPolicy != null) {
-      return String.format("%s, with routing policy: %s [realtime]", errorMessage, realtimeRoutingPolicy);
+      return errorMessage + ", with routing policy: " + realtimeRoutingPolicy + " [realtime]";
     }
     if (offlineRoutingPolicy != null) {
-      return String.format("%s, with routing policy: %s [offline]", errorMessage, offlineRoutingPolicy);
+      return errorMessage + ", with routing policy: " + offlineRoutingPolicy + " [offline]";
     }
     return errorMessage;
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
@@ -223,4 +223,15 @@ public class BaseSingleStageBrokerRequestHandlerTest {
     Assert.assertEquals(servers.iterator().next().getAdminEndpoint(), "http://server01:8097");
     latch.countDown();
   }
+
+  @Test
+  public void testAddRoutingPolicyInErrMsg() {
+    Assert.assertEquals(BaseSingleStageBrokerRequestHandler.addRoutingPolicyInErrMsg("error1", null, null), "error1");
+    Assert.assertEquals(BaseSingleStageBrokerRequestHandler.addRoutingPolicyInErrMsg("error1", "rt_rp", null),
+        "error1, with routing policy: rt_rp [realtime]");
+    Assert.assertEquals(BaseSingleStageBrokerRequestHandler.addRoutingPolicyInErrMsg("error1", null, "off_rp"),
+        "error1, with routing policy: off_rp [offline]");
+    Assert.assertEquals(BaseSingleStageBrokerRequestHandler.addRoutingPolicyInErrMsg("error1", "rt_rp", "off_rp"),
+        "error1, with routing policy: rt_rp [realtime], off_rp [offline]");
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
@@ -29,6 +29,7 @@ public class RoutingConfig extends BaseJsonConfig {
   public static final String PARTITION_SEGMENT_PRUNER_TYPE = "partition";
   public static final String TIME_SEGMENT_PRUNER_TYPE = "time";
   public static final String EMPTY_SEGMENT_PRUNER_TYPE = "empty";
+  public static final String DEFAULT_INSTANCE_SELECTOR_TYPE = "balanced";
   public static final String REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "replicaGroup";
   public static final String STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "strictReplicaGroup";
   public static final String MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE = "multiStageReplicaGroup";


### PR DESCRIPTION
When using strictReplicaGroup routing policy, the error msg may contain a huge number of segments that are unavailable. The segments are not really down but treated as unavailable by strictReplicaGroup policy, because all segments in a replica group are skipped if any one segment is unavailable in that group.

This PR adds the routing policy in query error msg when there are unavailable segments, to help reduce the confusion and triage the issue faster.
