### PR TITLE
Switch maven-source-plugin to jar-no-fork: 1.2.0 Release Failure Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1728,7 +1728,7 @@
             <execution>
               <id>attach-sources</id>
               <goals>
-                <goal>jar</goal>
+                <goal>jar-no-fork</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
Context in #13707.

Also, the following two links back that using jar-no-fork is ideal

https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html
https://stackoverflow.com/questions/10567551/difference-between-maven-source-plugin-jar-and-jar-no-fork-goal

I'll cherry-pick this to `release-1.2.0-rc` branch and try the release again.