### PR TITLE
Set maven.compiler flags explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
     <jdk.version>11</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <!-- Setting maven.compiler flags to the jdk version. These can be used by maven plugins like maven-javadoc-plugin -->
+    <maven.compiler.release>${jdk.version}</maven.compiler.release>
+    <maven.compiler.source>${jdk.version}</maven.compiler.source>
+    <maven.compiler.target>${jdk.version}</maven.compiler.target>
+
     <!-- Configuration for unit/integration tests
       Property for running integration tests with profiles
       at the command line, where you do:

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <jdk.version>11</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <!-- Setting maven.compiler flags to the jdk version. These can be used by maven plugins like maven-javadoc-plugin -->
+    <!-- Setting maven.compiler flags to the jdk version. These are used by maven plugins like maven-javadoc-plugin -->
     <maven.compiler.release>${jdk.version}</maven.compiler.release>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>


### PR DESCRIPTION
Ran into another issue while doing 1.2.0 Release.

### What was the error?

The error came on running `release:prepare`. There were a bunch of errors like the following. These were coming from the. `maven-javadoc-plugin`, which for some reason was using source Java version as 7:

```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.7.0:jar (attach-javadocs) on project pinot-spi: MavenReportException: Error while generating Javadoc:
[INFO] [ERROR] Exit code: 1
[INFO] [ERROR] /root/pinot-release/pinot/target/checkout/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java:78: error: lambda expressions are not supported in -source 7
[INFO] [ERROR]       return () -> "noopMetricName";
[INFO] [ERROR]                 ^
[INFO] [ERROR]   (use -source 8 or higher to enable lambda expressions)
...
```

### Why is the Javadoc Plugin using source version as 7

This is because `maven-javadoc-plugin` is apparently now using the "release" flag for JDK 9 and above. This flag was introduced in `maven-javadoc-plugin:3.1.0` ([ref](https://github.com/apache/maven-javadoc-plugin/blob/a4f31fd0d5ed15297900ff42be62be4db17b3e27/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java#L822)). This is by default set to `maven.compiler.release`, which is set to 7 in Apache's POM ([ref](https://repository.apache.org/service/local/repo_groups/public/content/org/apache/apache/32/apache-32.pom))

### Why didn't this happen with Pinot 1.1.0 Release?

This is likely because of a version upgrade of `maven-javadoc-plugin`.

### How do we know this change actually fixes the issue?

Verified by cloning the `release-1.2.0-rc` tag, and running the following. The command fails but when I use the patch in this PR, it works:

```
$ mvn javadoc:javadoc -pl pinot-spi
```