### PR TITLE
Change STREAM_DATA_LOSS to a gauge from a meter.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -51,6 +51,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   NETTY_POOLED_USED_HEAP_MEMORY("bytes", true),
   NETTY_POOLED_ARENAS_DIRECT("arenas", true),
   NETTY_POOLED_ARENAS_HEAP("arenas", true),
+  STREAM_DATA_LOSS("streamDataLoss", false),
 
   /**
    * The size of the small cache.

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -118,7 +118,6 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
   LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
-  STREAM_DATA_LOSS("streamDataLoss", false),
 
   // Multi-stage
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -951,7 +951,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private void reportDataLoss(MessageBatch messageBatch) {
     if (messageBatch.hasDataLoss()) {
-      _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.STREAM_DATA_LOSS, 1L);
+      _serverMetrics.setValueOfTableGauge(_tableStreamName, ServerGauge.STREAM_DATA_LOSS, 1L);
       String message = String.format("Message loss detected in stream partition: %s for table: %s startOffset: %s "
               + "batchFirstOffset: %s", _partitionGroupId, _tableNameWithType, _startOffset,
           messageBatch.getFirstMessageOffset());
@@ -1197,6 +1197,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private void cleanupMetrics() {
     _serverMetrics.removeTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING);
+    _serverMetrics.removeTableGauge(_clientId, ServerGauge.STREAM_DATA_LOSS);
   }
 
   protected void hold()


### PR DESCRIPTION
STREAM_DATA_LOSS was added to notify that there was a gap in a real time stream. It is a boolean where 1 denotes that a gap and therefore a data loss was detected. The only solution is recreate the real time table.

The metric was wrongly defined as a Meter. This change fixes the code to create the metric as a Gauge similar to LLC_PARTITION_CONSUMING. Moreover, the metric is also deleted during clean up. 

tags: bug-fix, observability  
