### PR TITLE
Fix literal type handling in LiteralValueExtractor

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
@@ -67,7 +67,7 @@ public class GapfillFilterHandler implements ValueExtractorFactory {
     expression = GapfillUtils.stripGapfill(expression);
     if (expression.getType() == ExpressionContext.Type.LITERAL) {
       // Literal
-      return new LiteralValueExtractor(expression.getLiteral().getStringValue());
+      return new LiteralValueExtractor(expression.getLiteral());
     }
 
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
@@ -108,7 +108,7 @@ public class PostAggregationHandler implements ValueExtractorFactory {
   public ValueExtractor getValueExtractor(ExpressionContext expression) {
     if (expression.getType() == ExpressionContext.Type.LITERAL) {
       // Literal
-      return new LiteralValueExtractor(expression.getLiteral().getStringValue());
+      return new LiteralValueExtractor(expression.getLiteral());
     }
     if (_numGroupByExpressions > 0) {
       Integer groupByExpressionIndex = _groupByExpressionIndexMap.get(expression);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/LiteralValueExtractor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/LiteralValueExtractor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.reduce.filter;
 
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
 
@@ -25,24 +26,26 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
  * Value extractor for a literal.
  */
 public class LiteralValueExtractor implements ValueExtractor {
-  private final String _literal;
+  private final LiteralContext _literal;
 
-  public LiteralValueExtractor(String literal) {
+  public LiteralValueExtractor(LiteralContext literal) {
     _literal = literal;
   }
 
   @Override
   public String getColumnName() {
-    return '\'' + _literal + '\'';
+    return '\'' + _literal.getStringValue() + '\'';
   }
 
   @Override
   public ColumnDataType getColumnDataType() {
-    return ColumnDataType.STRING;
+    ColumnDataType columnDataType = ColumnDataType.fromDataType(_literal.getType(), _literal.isSingleValue());
+    // Handle unrecognized result class with STRING
+    return columnDataType == ColumnDataType.UNKNOWN ? ColumnDataType.STRING : columnDataType;
   }
 
   @Override
   public Object extract(Object[] row) {
-    return _literal;
+    return _literal.getValue();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/LiteralValueExtractor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/LiteralValueExtractor.java
@@ -34,7 +34,7 @@ public class LiteralValueExtractor implements ValueExtractor {
 
   @Override
   public String getColumnName() {
-    return '\'' + _literal.getStringValue() + '\'';
+    return _literal.toString();
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/PostAggregationHandlerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/PostAggregationHandlerTest.java
@@ -120,4 +120,22 @@ public class PostAggregationHandlerTest {
       assertEquals(handler.getResult(new Object[]{6, 7L, 8.0, 9.0, 10.0}), new Object[]{5.5, 7L});
     }
   }
+
+  @Test
+  public void testLiteralTypeHandling() {
+    QueryContext queryContext = QueryContextConverterUtils
+        .getQueryContext("SELECT COUNT(*), 1 FROM testTable GROUP BY d1");
+    DataSchema dataSchema =
+        new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.LONG});
+    PostAggregationHandler postAggregationHandler = new PostAggregationHandler(queryContext, dataSchema);
+
+    assertEquals(postAggregationHandler.getResultDataSchema().getColumnDataTypes(),
+        new ColumnDataType[]{ColumnDataType.LONG, ColumnDataType.INT});
+
+    queryContext = QueryContextConverterUtils
+        .getQueryContext("SELECT COUNT(*), '1' FROM testTable GROUP BY d1");
+    postAggregationHandler = new PostAggregationHandler(queryContext, dataSchema);
+    assertEquals(postAggregationHandler.getResultDataSchema().getColumnDataTypes(),
+        new ColumnDataType[]{ColumnDataType.LONG, ColumnDataType.STRING});
+  }
 }


### PR DESCRIPTION
- The `LiteralValueExtractor` is currently hardcoded to only handle string literals and all call sites convert literals to strings before creating a `LiteralValueExtractor`.
- This causes issues when using argument type based scalar function lookup in `PostAggregationFunction` (see https://github.com/apache/pinot/pull/13711#issuecomment-2258219043 for instance).
- This patch updates the `LiteralValueExtractor` class to handle literals of all types appropriately.