### PR TITLE
Fix potential int overflow issue for memory allocation of indices in segment-local module

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
@@ -43,10 +43,10 @@ public class FixedByteSingleValueMultiColumnReaderWriter implements Closeable {
 
   private final int[] _columnSizesInBytes;
   private final PinotDataBufferMemoryManager _memoryManager;
-  private String _allocationContext;
+  private final String _allocationContext;
   private final long _chunkSizeInBytes;
   private int _capacityInRows;
-  private int _numColumns;
+  private final int _numColumns;
 
   /**
    * Constructor for the class.
@@ -74,7 +74,7 @@ public class FixedByteSingleValueMultiColumnReaderWriter implements Closeable {
     }
 
     _numColumns = _columnSizesInBytes.length;
-    _chunkSizeInBytes = rowSizeInBytes * numRowsPerChunk;
+    _chunkSizeInBytes = (long) rowSizeInBytes * numRowsPerChunk;
   }
 
   public int getInt(int row, int column) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkForwardIndexWriter.java
@@ -49,7 +49,7 @@ public class FixedByteChunkForwardIndexWriter extends BaseChunkForwardIndexWrite
       int numDocsPerChunk, int sizeOfEntry, int writerVersion)
       throws IOException {
     super(file, compressionType, totalDocs, normalizeDocsPerChunk(writerVersion, numDocsPerChunk),
-        (sizeOfEntry * normalizeDocsPerChunk(writerVersion, numDocsPerChunk)), sizeOfEntry, writerVersion, true);
+        (long) sizeOfEntry * normalizeDocsPerChunk(writerVersion, numDocsPerChunk), sizeOfEntry, writerVersion, true);
     _chunkDataOffset = 0;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -420,7 +420,7 @@ public abstract class BaseOffHeapMutableDictionary implements MutableDictionary 
     ValueToDictId valueToDictId = _valueToDict;
     long size = 0;
     for (IntBuffer iBuf : valueToDictId._iBufList) {
-      size = size + iBuf.capacity() * Integer.BYTES;
+      size = size + (long) iBuf.capacity() * Integer.BYTES;
     }
     return size;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -82,9 +82,6 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     }
     _numRowsPerChunk = numRowsPerChunk;
     _chunkSizeInBytes = (long) numRowsPerChunk * _valueSizeInBytes;
-    Preconditions.checkState(_chunkSizeInBytes < Integer.MAX_VALUE,
-        "Chunk size is too large: %s (numRowsPerChunk: %s, valueSizeInBytes: %s)", _chunkSizeInBytes, numRowsPerChunk,
-        _valueSizeInBytes);
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
     addBuffer();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -81,7 +81,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
       _valueSizeInBytes = storedType.size();
     }
     _numRowsPerChunk = numRowsPerChunk;
-    _chunkSizeInBytes = numRowsPerChunk * _valueSizeInBytes;
+    _chunkSizeInBytes = (long) numRowsPerChunk * _valueSizeInBytes;
+    Preconditions.checkState(_chunkSizeInBytes < Integer.MAX_VALUE,
+        "Chunk size is too large: %s (numRowsPerChunk: %s, valueSizeInBytes: %s)", _chunkSizeInBytes, numRowsPerChunk,
+        _valueSizeInBytes);
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
     addBuffer();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
@@ -347,7 +347,7 @@ public final class RangeIndexCreator implements CombinedInvertedIndexCreator {
         Number rangeStart = _numberValueBuffer.get(range.getLeft());
         writeNumberToHeader(header, rangeStart);
       }
-      bytesWritten += ranges.size() * _valueType.size(); // Range start values
+      bytesWritten += (long) ranges.size() * _valueType.size(); // Range start values
 
       Number lastRangeEnd = _numberValueBuffer.get(ranges.get(ranges.size() - 1).getRight());
       writeNumberToHeader(header, lastRangeEnd);
@@ -355,7 +355,7 @@ public final class RangeIndexCreator implements CombinedInvertedIndexCreator {
 
       //compute the offset where the bitmap for the first range would be written
       //bitmap start offset for each range, one extra to make it easy to get the length for last one.
-      long bitmapOffsetHeaderSize = (ranges.size() + 1) * Long.BYTES;
+      long bitmapOffsetHeaderSize = (long) (ranges.size() + 1) * Long.BYTES;
 
       long bitmapOffset = bytesWritten + bitmapOffsetHeaderSize;
       header.writeLong(bitmapOffset);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
@@ -241,10 +241,10 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
 
   protected long getChunkPositionAndRecordRanges(int chunkId, List<ByteRange> ranges) {
     if (_headerEntryChunkOffsetSize == Integer.BYTES) {
-      ranges.add(new ByteRange(_dataHeaderStart + chunkId * _headerEntryChunkOffsetSize, Integer.BYTES));
+      ranges.add(new ByteRange(_dataHeaderStart + (long) chunkId * _headerEntryChunkOffsetSize, Integer.BYTES));
       return _dataHeader.getInt(chunkId * _headerEntryChunkOffsetSize);
     } else {
-      ranges.add(new ByteRange(_dataHeaderStart + chunkId * _headerEntryChunkOffsetSize, Long.BYTES));
+      ranges.add(new ByteRange(_dataHeaderStart + (long) chunkId * _headerEntryChunkOffsetSize, Long.BYTES));
       return _dataHeader.getLong(chunkId * _headerEntryChunkOffsetSize);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -68,7 +68,7 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
     _numValues = numValues;
     _numDocsPerChunk = (int) (Math.ceil((float) PREFERRED_NUM_VALUES_PER_CHUNK / (numValues / numDocs)));
     int numChunks = (numDocs + _numDocsPerChunk - 1) / _numDocsPerChunk;
-    long endOffset = numChunks * Integer.BYTES;
+    long endOffset = (long) numChunks * Integer.BYTES;
     _bitmapReaderStartOffset = endOffset;
     _chunkOffsetReader = new FixedByteValueReaderWriter(dataBuffer.view(0L, endOffset));
     int bitmapSize = (numValues + Byte.SIZE - 1) / Byte.SIZE;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
@@ -99,7 +99,8 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
 
     // These offsets are offset in the data buffer
     long chunkStartOffset = getChunkPosition(chunkId);
-    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
+    long valueStartOffset =
+        chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
     long valueEndOffset = getValueEndOffset(chunkId, chunkRowId, chunkStartOffset);
 
     int length = (int) (valueEndOffset - valueStartOffset);
@@ -152,7 +153,8 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
 
     // These offsets are offset in the data buffer
     long chunkStartOffset = getChunkPosition(chunkId);
-    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
+    long valueStartOffset =
+        chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
     long valueEndOffset = getValueEndOffset(chunkId, chunkRowId, chunkStartOffset);
 
     byte[] bytes = new byte[(int) (valueEndOffset - valueStartOffset)];

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
@@ -99,7 +99,7 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
 
     // These offsets are offset in the data buffer
     long chunkStartOffset = getChunkPosition(chunkId);
-    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + chunkRowId * ROW_OFFSET_SIZE);
+    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
     long valueEndOffset = getValueEndOffset(chunkId, chunkRowId, chunkStartOffset);
 
     int length = (int) (valueEndOffset - valueStartOffset);
@@ -152,7 +152,7 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
 
     // These offsets are offset in the data buffer
     long chunkStartOffset = getChunkPosition(chunkId);
-    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + chunkRowId * ROW_OFFSET_SIZE);
+    long valueStartOffset = chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) chunkRowId * ROW_OFFSET_SIZE);
     long valueEndOffset = getValueEndOffset(chunkId, chunkRowId, chunkStartOffset);
 
     byte[] bytes = new byte[(int) (valueEndOffset - valueStartOffset)];
@@ -188,7 +188,7 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
         // Last row in the last chunk
         return _dataBuffer.size();
       } else {
-        int valueEndOffsetInChunk = _dataBuffer.getInt(chunkStartOffset + (chunkRowId + 1) * ROW_OFFSET_SIZE);
+        int valueEndOffsetInChunk = _dataBuffer.getInt(chunkStartOffset + (long) (chunkRowId + 1) * ROW_OFFSET_SIZE);
         if (valueEndOffsetInChunk == 0) {
           // Last row in the last chunk (chunk is incomplete, which stores 0 as the offset for the absent rows)
           return _dataBuffer.size();
@@ -201,7 +201,7 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
         // Last row in the chunk
         return getChunkPosition(chunkId + 1);
       } else {
-        return chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (chunkRowId + 1) * ROW_OFFSET_SIZE);
+        return chunkStartOffset + _dataBuffer.getInt(chunkStartOffset + (long) (chunkRowId + 1) * ROW_OFFSET_SIZE);
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/sorted/SortedIndexReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/sorted/SortedIndexReaderImpl.java
@@ -36,7 +36,7 @@ public class SortedIndexReaderImpl implements SortedIndexReader<SortedIndexReade
 
   public SortedIndexReaderImpl(PinotDataBuffer dataBuffer, int cardinality) {
     // 2 values per dictionary id
-    Preconditions.checkState(dataBuffer.size() == 2 * cardinality * Integer.BYTES);
+    Preconditions.checkState(dataBuffer.size() == 2L * cardinality * Integer.BYTES);
     _reader = new FixedByteValueReaderWriter(dataBuffer);
     _cardinality = cardinality;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -172,7 +172,7 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   int getDimensionValue(int docId, int dimensionId)
       throws IOException {
     ensureBufferReadable(docId);
-    return _starTreeRecordBuffer.getInt(_starTreeRecordOffsets.get(docId) + dimensionId * Integer.BYTES);
+    return _starTreeRecordBuffer.getInt(_starTreeRecordOffsets.get(docId) + (long) dimensionId * Integer.BYTES);
   }
 
   private void ensureBufferReadable(int docId)
@@ -219,8 +219,8 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
         long offset1 = (long) sortedDocIds[i1] * _numDimensions * Integer.BYTES;
         long offset2 = (long) sortedDocIds[i2] * _numDimensions * Integer.BYTES;
         for (int i = 0; i < _numDimensions; i++) {
-          int dimension1 = dataBuffer.getInt(offset1 + i * Integer.BYTES);
-          int dimension2 = dataBuffer.getInt(offset2 + i * Integer.BYTES);
+          int dimension1 = dataBuffer.getInt(offset1 + (long) i * Integer.BYTES);
+          int dimension2 = dataBuffer.getInt(offset2 + (long) i * Integer.BYTES);
           if (dimension1 != dimension2) {
             return dimension1 - dimension2;
           }
@@ -282,8 +282,8 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       long offset1 = _starTreeRecordOffsets.get(sortedDocIds[i1]);
       long offset2 = _starTreeRecordOffsets.get(sortedDocIds[i2]);
       for (int i = dimensionId + 1; i < _numDimensions; i++) {
-        int dimension1 = _starTreeRecordBuffer.getInt(offset1 + i * Integer.BYTES);
-        int dimension2 = _starTreeRecordBuffer.getInt(offset2 + i * Integer.BYTES);
+        int dimension1 = _starTreeRecordBuffer.getInt(offset1 + (long) i * Integer.BYTES);
+        int dimension2 = _starTreeRecordBuffer.getInt(offset2 + (long) i * Integer.BYTES);
         if (dimension1 != dimension2) {
           return dimension1 - dimension2;
         }


### PR DESCRIPTION
Memory allocation for FixedByteSVMutableForwardIndex with large segment size throws the following exception because of int overflow:
```
Caused by: java.lang.IllegalArgumentException: Illegal memory allocation -4 for segment TestTable__2__18__20240727T1658Z column TestTable__2__18__20240727T1658Z:action.sv.unsorted.fwd
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[com.google.guava.guava-33.1.0-jre.jar:?]
        at org.apache.pinot.segment.local.io.readerwriter.RealtimeIndexOffHeapMemoryManager.allocate(RealtimeIndexOffHeapMemoryManager.java:78) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex.addBuffer(FixedByteSVMutableForwardIndex.java:244) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex.<init>(FixedByteSVMutableForwardIndex.java:87) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex.<init>(FixedByteSVMutableForwardIndex.java:92) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType.createMutableIndex(ForwardIndexType.java:309) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType.createMutableIndex(ForwardIndexType.java:67) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl.addMutableIndex(MutableSegmentImpl.java:412) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl.<init>(MutableSegmentImpl.java:346) ~[org.apache.pinot.pinot-segment-local-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.<init>(RealtimeSegmentDataManager.java:1614) ~[org.apache.pinot.pinot-core-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
        at org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager.doAddConsumingSegment(RealtimeTableDataManager.java:494) ~[org.apache.pinot.pinot-core-1.2.0-dev-1372.jar:1.2.0-dev-1372-d1cf4859df5749da8115e00b5055f47185b8c4b2]
```
-4 is because of int overflow for multiplication of `numRowsPerChunk * _valueSizeInBytes (2^31-1 * 4)` in which both variables are int.

This PR fixes this issue in this class and also other places in segment-local module.