### PR TITLE
Fix mvn javadoc:javadoc goal for Pinot Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2050,6 +2050,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <!-- Default configuration for all reports -->
+          <excludePackageNames>protobuf.grpc-java.org.apache.pinot.common.proto</excludePackageNames>
         </configuration>
         <executions>
           <execution>
@@ -2455,6 +2456,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <!-- Default configuration for all reports -->
+          <excludePackageNames>protobuf.grpc-java.org.apache.pinot.common.proto</excludePackageNames>
+        </configuration>
         <reportSets>
           <reportSet>
             <id>non-aggregate</id>


### PR DESCRIPTION
Context in #13718.

Tested by running across the entire project `mvn javadoc:javadoc` and it completes finally.