### PR TITLE
[minor] Use ByteString.EMPTY to Prevent Protobuf Version Pin to >3.19

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufCodeGenMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufCodeGenMessageDecoderTest.java
@@ -234,8 +234,8 @@ public class ProtoBufCodeGenMessageDecoderTest {
         new Object[] {FLOAT_FIELD, 0f, 0f},
         new Object[] {NULLABLE_FLOAT_FIELD, 0f, 0f},
 
-        new Object[] {BYTES_FIELD, ByteString.empty(), new byte[] {}},
-        new Object[] {NULLABLE_BYTES_FIELD, ByteString.empty(), new byte[] {}},
+        new Object[] {BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
+        new Object[] {NULLABLE_BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
 
         new Object[] {BOOL_FIELD, false, "false"},
         new Object[] {NULLABLE_BOOL_FIELD, false, "false"}

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorLowLevelTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorLowLevelTest.java
@@ -163,8 +163,8 @@ public class ProtoBufRecordExtractorLowLevelTest {
         new Object[] {FLOAT_FIELD, 0f, 0f},
         new Object[] {NULLABLE_FLOAT_FIELD, 0f, 0f},
 
-        new Object[] {BYTES_FIELD, ByteString.empty(), new byte[] {}},
-        new Object[] {NULLABLE_BYTES_FIELD, ByteString.empty(), new byte[] {}},
+        new Object[] {BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
+        new Object[] {NULLABLE_BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
 
         new Object[] {BOOL_FIELD, false, "false"},
         new Object[] {NULLABLE_BOOL_FIELD, false, "false"}


### PR DESCRIPTION
`ByteString.empty()` was added in `3.20.0`. `ByteString.EMPTY` should be equivalent and will allow lower protobuf versions to be used.