### PR TITLE
Support madvise for MmapMemory

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -170,14 +170,9 @@ public class MmapMemory implements Memory {
     }
 
     protected void madvise(long size) {
-      String defaultAdvice = System.getenv("PINOT_MMAP_ADVICE");
-      if (defaultAdvice != null) {
-        try {
-          int advice = Integer.parseInt(defaultAdvice);
-          madvise(size, advice);
-        } catch (NumberFormatException ignored) {
-          LOGGER.warn("Invalid value specified for PINOT_MMAP_ADVICE. Expects a posix compatible integer");
-        }
+      int defaultAdvice = MmapMemoryConfig.getDefaultAdvice();
+      if (defaultAdvice >= 0) {
+        madvise(size, defaultAdvice);
       }
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -165,7 +165,20 @@ public class MmapMemory implements Memory {
      */
     protected void madvise(long size, int advice) {
       if (LIB_C != null) {
-        LIB_C.posix_madvise(_address, size, advice);
+        int errno = LIB_C.posix_madvise(_address, size, advice);
+        switch (errno) {
+          case 0:
+            // 0 indicates a successful call
+            break;
+          case 22:
+            LOGGER.warn("posix_madvise failed with EINVAL, either addr is not aligned or advice was invalid");
+            break;
+          case 12:
+            LOGGER.warn("posix_madvise failed with ENOMEM, indicating a bad address or size");
+            break;
+          default:
+            LOGGER.warn("posix_madvise returned an unknown error code: {}", errno);
+        }
       }
     }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -132,7 +132,7 @@ public class MmapMemory implements Memory {
       try {
         libC = LibraryLoader.create(LibC.class).failImmediately().load("c");
       } catch (Throwable ignored) {
-        LOGGER.info("Could not load JNR C Library, madvise will not be used for mmap memory.");
+        LOGGER.warn("Could not load JNR C Library, madvise will not be used for mmap memory.");
       }
       LIB_C = libC;
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -178,6 +178,7 @@ public class MmapMemory implements Memory {
             break;
           default:
             LOGGER.warn("posix_madvise returned an unknown error code: {}", errno);
+            break;
         }
       }
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemory.java
@@ -171,9 +171,7 @@ public class MmapMemory implements Memory {
 
     protected void madvise(long size) {
       String defaultAdvice = System.getenv("PINOT_MMAP_ADVICE");
-      if (defaultAdvice == null) {
-        madvise(size, LibC.POSIX_MADV_RANDOM);
-      } else {
+      if (defaultAdvice != null) {
         try {
           int advice = Integer.parseInt(defaultAdvice);
           madvise(size, advice);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemoryConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemoryConfig.java
@@ -25,8 +25,8 @@ import org.apache.commons.lang3.EnumUtils;
  * Simple singleton config for managing advanced mmap configurations
  */
 public class MmapMemoryConfig {
-  private MmapMemoryConfig() {}
-  private static final MmapMemoryConfig config = new MmapMemoryConfig();
+  private MmapMemoryConfig() { }
+  private static final MmapMemoryConfig INSTANCE = new MmapMemoryConfig();
 
   enum Advice {
     NORMAL(MmapMemory.LibC.POSIX_MADV_NORMAL),
@@ -57,7 +57,7 @@ public class MmapMemoryConfig {
   private int _defaultAdvice = -1;
 
   public static int getDefaultAdvice() {
-    return config._defaultAdvice;
+    return INSTANCE._defaultAdvice;
   }
 
   public static void setDefaultAdvice(int advice) {
@@ -66,7 +66,7 @@ public class MmapMemoryConfig {
         "Default advice for mmap buffers must be posix_madvise compatible (0-4): %d",
         advice
     );
-    config._defaultAdvice = advice;
+    INSTANCE._defaultAdvice = advice;
   }
 
   public static void setDefaultAdvice(String adviceString) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemoryConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/unsafe/MmapMemoryConfig.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.memory.unsafe;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.EnumUtils;
+
+/**
+ * Simple singleton config for managing advanced mmap configurations
+ */
+public class MmapMemoryConfig {
+  private MmapMemoryConfig() {}
+  private static final MmapMemoryConfig config = new MmapMemoryConfig();
+
+  enum Advice {
+    NORMAL(MmapMemory.LibC.POSIX_MADV_NORMAL),
+    RANDOM(MmapMemory.LibC.POSIX_MADV_RANDOM),
+    SEQUENTIAL(MmapMemory.LibC.POSIX_MADV_SEQUENTIAL),
+    WILL_NEED(MmapMemory.LibC.POSIX_MADV_WILLNEED),
+    DONT_NEED(MmapMemory.LibC.POSIX_MADV_DONTNEED);
+
+    private final int _advice;
+
+    Advice(int advice) {
+      _advice = advice;
+    }
+
+    /**
+     *  Get posix-compatible advice integer
+     */
+    public int getAdvice() {
+      return _advice;
+    }
+  }
+
+  /**
+   * Advice to use by default after calling mmap on a region of a file.
+   * Notably this is expected to be an integer corresponding to advice
+   * supported by posix_madvise()
+   */
+  private int _defaultAdvice = -1;
+
+  public static int getDefaultAdvice() {
+    return config._defaultAdvice;
+  }
+
+  public static void setDefaultAdvice(int advice) {
+    Preconditions.checkArgument(
+        advice >= 0 && advice <= 4,
+        "Default advice for mmap buffers must be posix_madvise compatible (0-4): %d",
+        advice
+    );
+    config._defaultAdvice = advice;
+  }
+
+  public static void setDefaultAdvice(String adviceString) {
+    Preconditions.checkArgument(
+      EnumUtils.isValidEnum(Advice.class, adviceString),
+      "Default advice for mmap buffers must match a posix_madvise compatible option: %s",
+      adviceString
+    );
+
+    setDefaultAdvice(Advice.valueOf(adviceString).getAdvice());
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -75,6 +75,7 @@ import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshManager;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.segment.spi.memory.unsafe.MmapMemoryConfig;
 import org.apache.pinot.server.access.AccessControlFactory;
 import org.apache.pinot.server.api.AdminApiApplication;
 import org.apache.pinot.server.conf.ServerConf;
@@ -201,6 +202,12 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     // Initialize Pinot Environment Provider
     _pinotEnvironmentProvider = initializePinotEnvironmentProvider();
+
+    // Set instance-level mmap advice defaults
+    String defaultMmapAdvice = _serverConf.getProperty(Server.CONFIG_OF_MMAP_DEFAULT_ADVICE);
+    if (defaultMmapAdvice != null) {
+      MmapMemoryConfig.setDefaultAdvice(defaultMmapAdvice);
+    }
 
     // Initialize the data buffer factory
     PinotDataBuffer.loadDefaultFactory(serverConf);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -653,6 +653,7 @@ public class CommonConstants {
     public static final double DEFAULT_SERVER_CONSUMPTION_RATE_LIMIT = 0.0;
 
     public static final String DEFAULT_READ_MODE = "mmap";
+    public static final String CONFIG_OF_MMAP_DEFAULT_ADVICE = "pinot.server.mmap.advice.default";
     // Whether to reload consuming segment on scheme update
     public static final boolean DEFAULT_RELOAD_CONSUMING_SEGMENT = true;
     public static final String DEFAULT_INSTANCE_BASE_DIR =


### PR DESCRIPTION
Fixes #12166 

### Background

By default in linux "mmap" uses the device's read_ahead_kb to determine how many pages to read ahead:

```bash
$ cat /sys/block/sda/queue/read_ahead_kb
128
```

This is useful because many file access patterns are sequential and different filesystems or devices may perform better with different io sizes -- for example comparing fast nvme devices to network attached disks.

However for cases of non-sequential access, having this read-ahead can pollute the page cache causing substantial unnecessary paging from disk.

madvise gives advice on how applications will access pages -- 
https://man7.org/linux/man-pages/man3/posix_madvise.3.html
https://man7.org/linux/man-pages/man2/madvise.2.html

The alternative is to override the read_ahead value at a block device level, which may often not be feasible + sacrifices potential to benefit from read_ahead for sequential workloads.

### Discussing Pinot Access Patterns

We mostly read memory with a few patterns from my experience:

* Direct access by index (for example fixed-bit values)
* Binary search of sorted data
* Sequential scan of data

For example, consider applying a simple equality filter with inverted index:
1. Search for the value in the sorted dictionary
2. Find the corresponding bitmap locations in the offset map
3. Read the inverted index

Since pages needed for this are likely to be sufficiently far apart, MADV_RANDOM makes the most sense to avoid pollution from read ahead.

On the other hand, FULL_SCAN would read the full forward index sequentially to find matching docs. This would benefit from MADV_NORMAL or MADV_SEQUENTIAL to both potentially batch io and (for SEQUENTIAL) potentially hint that read pages may not be needed again soon.

Optimizing based on either the index type or operation may eventually be beneficial in the future if we continue to use mmap, however is substantially complex.

From our experience of setting READ_AHEAD_KB of the device to 0 (rolled out to all hosts we operate with fast ssd disks), we saw no performance degradation for any usecases and found better performance in a few cases where the read ahead substantially increased latency. We did not roll this config out to non-ssd disks as this would have meant changing the value for the os disk, which we wanted to avoid...

Since we have a fairly wide variety of usecases at Linkedin, this indicates to me that using a default value of MADV_RANDOM _likely_ makes the most sense.

This is left configurable though -- particularly users on network storage/ssd or other "slow" mediums and having largely sequential workloads might benefit from a different advice.

### Madvise in java

Unfortunately java does not expose madvise since it is a linux/posix concept. Thus some native code is needed.

We already depend on https://github.com/jnr/jnr-ffi which makes it very easy to load native libraries.

### Platform Specifics

Found that this works fine on Mac and Linux + calls madvise as expected.
The code should be written in a way that can be compiled on Windows/incompatible systems but would not be used + MmapMemory would not be supported anyways (and would fail sooner)

### TODO's

- [ ] Will run some benchmarking to show difference in performance (likely this would be usecase/setup dependent though since the disk performance and page cache size available would matter substantially)
- [x] Consider if this way to add config is right (probably not), I just copied this usage https://github.com/apache/pinot/blob/95a526e29cb1cecc6993113ab39aa3709edda83e/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java#L168
- [ ] Double check things work fine on windows and if jars are compatible built from mac and used on linux/windows/etc
