### PR TITLE
Fail multi-stage client queries in the broker if multi-stage engine is disabled

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -88,10 +88,15 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
         return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
       }
     }
-    if (_multiStageBrokerRequestHandler != null && QueryOptionsUtils.isUseMultistageEngine(
-        sqlNodeAndOptions.getOptions())) {
-      return _multiStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
-          requestContext, httpHeaders);
+
+    if (QueryOptionsUtils.isUseMultistageEngine(sqlNodeAndOptions.getOptions())) {
+      if (_multiStageBrokerRequestHandler != null) {
+        return _multiStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
+            requestContext, httpHeaders);
+      } else {
+        return new BrokerResponseNative(QueryException.getException(QueryException.INTERNAL_ERROR,
+            "V2 Multi-Stage query engine not enabled."));
+      }
     } else {
       return _singleStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
           requestContext, httpHeaders);


### PR DESCRIPTION
- Users can use the multi-stage query engine via query options (https://docs.pinot.apache.org/developers/advanced/v2-multi-stage-query-engine) or the (currently undocumented) broker API endpoints `GET /query` and `POST /query` (https://github.com/apache/pinot/pull/11341).
- Currently, if the multi-stage engine is disabled via the config `pinot.multistage.engine.enabled` and users issue a broker query request indicating that the multi-stage engine should be used, the query doesn't fail and instead falls back to using the single-stage engine.
- This can lead to a confusing user experience. Also, in the controller's SQL query API, we return an error in this scenario - https://github.com/apache/pinot/blob/dd8a6477c22e761a2a6dc3264b9c2a86c94427fd/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java#L173-L180
- This patch updates the broker behavior to match the controller behavior when the multi-stage engine is disabled in order to improve and unify the UX.