### PR TITLE
changing sdk version due to issue with the new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.0</audienceannotations.version>
     <clp-ffi.version>0.4.4</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.26.21</aws.sdk.version>
+    <aws.sdk.version>2.26.13</aws.sdk.version>
     <joda-time.version>2.12.7</joda-time.version>
     <janino.version>3.1.12</janino.version>
     <testng.version>7.10.2</testng.version>


### PR DESCRIPTION
## Context
An automatic upgrade in the aws version has led to ClassNotFoundException being thrown. Details: https://github.com/aws/aws-sdk-java-v2/issues/5127

Scope of the PR:
1. This PR aims to bring back the version to previous stable version. 