### PR TITLE
Experiment trying to add error-prone and null away

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotResultSet.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotResultSet.java
@@ -288,7 +288,7 @@ public class PinotResultSet extends AbstractBaseResultSet {
   public short getShort(int columnIndex)
       throws SQLException {
     Integer value = getInt(columnIndex);
-    return value == null ? null : value.shortValue();
+    return value.shortValue();
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseResultSet.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseResultSet.java
@@ -260,7 +260,7 @@ public abstract class AbstractBaseResultSet implements ResultSet {
   @Override
   public short getShort(String columnLabel)
       throws SQLException {
-    return getShort(columnLabel);
+    return getShort(findColumn(columnLabel));
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -37,6 +37,7 @@ public class FunctionUtils {
   }
 
   // Types allowed as the function parameter (in the function signature) for type conversion
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<Class<?>, PinotDataType> PARAMETER_TYPE_MAP = new HashMap<>() {{
     put(int.class, PinotDataType.INTEGER);
     put(Integer.class, PinotDataType.INTEGER);
@@ -61,6 +62,7 @@ public class FunctionUtils {
   }};
 
   // Types allowed as the function argument (actual value passed into the function) for type conversion
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<Class<?>, PinotDataType> ARGUMENT_TYPE_MAP = new HashMap<>() {{
     put(Byte.class, PinotDataType.BYTE);
     put(Boolean.class, PinotDataType.BOOLEAN);
@@ -87,6 +89,7 @@ public class FunctionUtils {
     put(Object[].class, PinotDataType.OBJECT_ARRAY);
   }};
 
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<Class<?>, DataType> DATA_TYPE_MAP = new HashMap<>() {{
     put(int.class, DataType.INT);
     put(Integer.class, DataType.INT);
@@ -109,6 +112,7 @@ public class FunctionUtils {
     put(String[].class, DataType.STRING);
   }};
 
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<Class<?>, ColumnDataType> COLUMN_DATA_TYPE_MAP = new HashMap<>() {{
     put(int.class, ColumnDataType.INT);
     put(Integer.class, ColumnDataType.INT);

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
@@ -77,7 +77,8 @@ public class OrderByExpressionContext {
       return false;
     }
     OrderByExpressionContext that = (OrderByExpressionContext) o;
-    return Objects.equals(_expression, that._expression) && _isAsc == that._isAsc && _isNullsLast == that._isNullsLast;
+    return Objects.equals(_expression, that._expression) && Objects.equals(_isAsc, that._isAsc)
+        && Objects.equals(_isNullsLast, that._isNullsLast);
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/tier/TimeBasedTierSegmentSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/tier/TimeBasedTierSegmentSelector.java
@@ -54,7 +54,7 @@ public class TimeBasedTierSegmentSelector implements TierSegmentSelector {
     SegmentZKMetadata segmentZKMetadata =
         ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), tableNameWithType, segmentName);
     Preconditions
-        .checkNotNull(segmentZKMetadata, "Could not find zk metadata for segment: {} of table: {}", segmentName,
+        .checkNotNull(segmentZKMetadata, "Could not find zk metadata for segment: %s of table: %s", segmentName,
             tableNameWithType);
 
     // don't try to move consuming segments

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPolygonFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPolygonFunction.java
@@ -58,7 +58,7 @@ public class StPolygonFunction extends ConstructFromTextFunction {
         Preconditions.checkArgument(geometry instanceof Polygon, "The geometry object must be polygon");
         _results[i] = GeometrySerializer.serialize(geometry);
       } catch (ParseException e) {
-        new RuntimeException(String.format("Failed to parse geometry from string: %s", argumentValues[i]));
+        throw new RuntimeException(String.format("Failed to parse geometry from string: %s", argumentValues[i]));
       }
     }
     return _results;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -119,7 +119,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     _numGroupsLimit = queryExecutorConfig.getProperty(NUM_GROUPS_LIMIT_KEY, DEFAULT_NUM_GROUPS_LIMIT);
     Preconditions.checkState(_maxInitialResultHolderCapacity <= _numGroupsLimit,
-        "Invalid configuration: maxInitialResultHolderCapacity: %d must be smaller or equal to numGroupsLimit: %d",
+        "Invalid configuration: maxInitialResultHolderCapacity: %s must be smaller or equal to numGroupsLimit: %s",
         _maxInitialResultHolderCapacity, _numGroupsLimit);
     _minSegmentGroupTrimSize =
         queryExecutorConfig.getProperty(MIN_SEGMENT_GROUP_TRIM_SIZE_KEY, DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE);
@@ -127,7 +127,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         queryExecutorConfig.getProperty(MIN_SERVER_GROUP_TRIM_SIZE_KEY, DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE);
     _groupByTrimThreshold = queryExecutorConfig.getProperty(GROUPBY_TRIM_THRESHOLD_KEY, DEFAULT_GROUPBY_TRIM_THRESHOLD);
     Preconditions.checkState(_groupByTrimThreshold > 0,
-        "Invalid configurable: groupByTrimThreshold: %d must be positive", _groupByTrimThreshold);
+        "Invalid configurable: groupByTrimThreshold: %s must be positive", _groupByTrimThreshold);
     LOGGER.info("Initialized plan maker with maxExecutionThreads: {}, maxInitialResultHolderCapacity: {}, "
             + "numGroupsLimit: {}, minSegmentGroupTrimSize: {}, minServerGroupTrimSize: {}, groupByTrimThreshold: {}",
         _maxExecutionThreads, _maxInitialResultHolderCapacity, _numGroupsLimit, _minSegmentGroupTrimSize,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -184,7 +184,7 @@ public class AggregationFunctionFactory {
           double percentile = arguments.get(1).getLiteral().getDoubleValue();
           Preconditions.checkArgument(percentile >= 0 && percentile <= 100, "Invalid percentile: %s", percentile);
           int compressionFactor = arguments.get(2).getLiteral().getIntValue();
-          Preconditions.checkArgument(compressionFactor >= 0, "Invalid compressionFactor: %d", compressionFactor);
+          Preconditions.checkArgument(compressionFactor >= 0, "Invalid compressionFactor: %s", compressionFactor);
           if (remainingFunctionName.equals("TDIGEST")) {
             // PercentileTDigest
             return new PercentileTDigestAggregationFunction(firstArgument, percentile, compressionFactor,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -97,7 +97,7 @@ public class DistinctCountCPCSketchAggregationFunction
     if (arguments.size() == 2) {
       ExpressionContext secondArgument = arguments.get(1);
       Preconditions.checkArgument(secondArgument.getType() == ExpressionContext.Type.LITERAL,
-          "CPC Sketch Aggregation Function expects the second argument to be a literal (parameters)," + " but got: ",
+          "CPC Sketch Aggregation Function expects the second argument to be a literal (parameters), but got: %s",
           secondArgument.getType());
 
       if (secondArgument.getLiteral().getType() == FieldSpec.DataType.STRING) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -117,7 +117,7 @@ public class IntegerTupleSketchAggregationFunction
     if (arguments.size() == 2) {
       ExpressionContext secondArgument = arguments.get(1);
       Preconditions.checkArgument(secondArgument.getType() == ExpressionContext.Type.LITERAL,
-          "Tuple Sketch Aggregation Function expects the second argument to be a literal (parameters)," + " but got: ",
+          "Tuple Sketch Aggregation Function expects the second argument to be a literal (parameters), but got: %s",
           secondArgument.getType());
 
       if (secondArgument.getLiteral().getType() == FieldSpec.DataType.STRING) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
@@ -486,6 +486,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
    * @return Literal value converted into either an alias name or an SQL string. BYTE, STRING, and BINARY values are
    * delimited by quotes in SQL and everything is delimited by quotes for use in alias.
    * */
+  @SuppressWarnings("ArrayToString") // Ignoring, but probably we will need to fix it
   private static String getLiteralSQL(Literal literal, boolean aliasing) {
     StringBuffer result = new StringBuffer();
     result.append(aliasing ? "'" : "");

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
@@ -118,7 +118,7 @@ public abstract class PriorityScheduler extends QueryScheduler {
             request.setResultFuture(queryFutureTask);
             request.getSchedulerGroup().startQuery();
             queryRequest.getTimerContext().getPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT).stopAndRecord();
-            _resourceManager.getQueryRunners().submit(queryFutureTask);
+            ListenableFuture<?> unused = _resourceManager.getQueryRunners().submit(queryFutureTask);
           } catch (Throwable t) {
             LOGGER.error(
                 "Error in scheduler thread. This is indicative of a bug. Please report this. Server will continue "

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
@@ -45,6 +45,7 @@ public class FCFSQueryScheduler extends QueryScheduler {
   }
 
   @Override
+  @SuppressWarnings("CheckReturnValue")
   public ListenableFuture<byte[]> submit(ServerQueryRequest queryRequest) {
     if (!_isRunning) {
       return immediateErrorResponse(queryRequest, QueryException.SERVER_SCHEDULER_DOWN_ERROR);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
@@ -38,6 +38,7 @@ public class UnboundedResourceManager extends ResourceManager {
   public QueryExecutorService getExecutorService(ServerQueryRequest query, SchedulerGroupAccountant accountant) {
     return new QueryExecutorService() {
       @Override
+      @SuppressWarnings("CheckReturnValue")
       public void execute(Runnable command) {
         _queryWorkers.submit(command);
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PhysicalExplainPlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PhysicalExplainPlanVisitor.java
@@ -239,7 +239,7 @@ public class PhysicalExplainPlanVisitor implements PlanNodeVisitor<StringBuilder
         .append(_dispatchableSubPlan.getQueryStageList()
             .get(node.getStageId())
             .getWorkerIdToSegmentsMap()
-            .get(context._host))
+            .get(context._workerId))
         .append('\n');
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -290,7 +290,7 @@ public class WorkerManager {
             serverInstanceToSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
         // TODO: support optional segments for multi-stage engine.
         Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue().getLeft()) == null,
-            "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
+            "Entry for server %s and table type: %s already exist!", serverEntry.getKey(), tableType);
       }
 
       // attach unavailable segments to metadata

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/SerializedFrequentLongsSketch.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/SerializedFrequentLongsSketch.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import org.apache.datasketches.frequencies.LongsSketch;
 
 
+@SuppressWarnings("ComparableType") // Ignored, but it should be fixed
 public class SerializedFrequentLongsSketch implements Comparable<LongsSketch> {
   private final LongsSketch _sketch;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/SerializedFrequentStringsSketch.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/SerializedFrequentStringsSketch.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import org.apache.datasketches.common.ArrayOfStringsSerDe;
 import org.apache.datasketches.frequencies.ItemsSketch;
 
+@SuppressWarnings("ComparableType") // Ignored, but it should be fixed
 public class SerializedFrequentStringsSketch implements Comparable<ItemsSketch<String>> {
   private final ItemsSketch<String> _sketch;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVForwardIndexWriter.java
@@ -84,8 +84,8 @@ public class FixedBitMVForwardIndexWriter implements Closeable {
     _rawDataSize = ((long) totalNumValues * numBitsPerValue + 7) / 8;
     _totalSize = _chunkOffsetHeaderSize + _bitsetSize + _rawDataSize;
     Preconditions
-        .checkState(_totalSize > 0 && _totalSize < Integer.MAX_VALUE, "Total size can not exceed 2GB for file: ",
-            file.toString());
+        .checkState(_totalSize > 0 && _totalSize < Integer.MAX_VALUE, "Total size can not exceed 2GB for file: %s",
+            file);
     // Backward-compatible: index file is always big-endian
     _indexDataBuffer =
         PinotDataBuffer.mapFile(file, false, 0, _totalSize, ByteOrder.BIG_ENDIAN, getClass().getSimpleName());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOnHeapMutableDictionary.java
@@ -202,11 +202,6 @@ public class BigDecimalOnHeapMutableDictionary extends BaseOnHeapMutableDictiona
     return getBigDecimalValue(dictId).toPlainString();
   }
 
-  @Override
-  public byte[] getBytesValue(int dictId) {
-    return getBytesValue(dictId);
-  }
-
   private void updateMinMax(BigDecimal value) {
     if (_min == null) {
       _min = value;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
@@ -179,7 +179,7 @@ public class SchemaConformingTransformer implements RecordTransformer {
     Preconditions.checkState(null != fieldSpec, "Field '%s' doesn't exist in schema", extrasFieldName);
     DataType fieldDataType = fieldSpec.getDataType();
     Preconditions.checkState(DataType.JSON == fieldDataType || DataType.STRING == fieldDataType,
-        "Field '%s' has unsupported type %s", fieldDataType.toString());
+        "Field '%s' has unsupported type %s", fieldSpec.getFieldType(), fieldDataType);
     return fieldDataType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/nullvalue/NullValueVectorCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/nullvalue/NullValueVectorCreator.java
@@ -66,6 +66,7 @@ public class NullValueVectorCreator implements IndexCreator {
     _bitmapWriter.add(docId);
   }
 
+  @Override
   public void seal()
       throws IOException {
     // Create null value vector file only if the bitmap is not empty

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -110,8 +111,8 @@ public class HnswVectorIndexReader implements VectorIndexReader {
       _indexSearcher.search(knnFloatVectorQuery, docIDCollector);
       return docIds;
     } catch (Exception e) {
-      String msg =
-          "Caught exception while searching the HNSW index for column:" + _column + ", search query:" + searchQuery;
+      String msg = "Caught exception while searching the HNSW index for column:" + _column + ", search query:"
+          + Arrays.toString(searchQuery);
       throw new RuntimeException(msg, e);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -374,7 +374,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       return;
     }
     Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
-        "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
+        "Got unsupported segment implementation: %s for segment: %s, table: %s", segment.getClass(), segmentName,
         _tableNameWithType);
     ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
 
@@ -470,7 +470,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         segmentName, _tableNameWithType);
     // Note that EmptyIndexSegment should not reach here either, as it doesn't have validDocIds snapshot.
     Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
-        "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
+        "Got unsupported segment implementation: %s for segment: %s, table: %s", segment.getClass(), segmentName,
         _tableNameWithType);
     if (!startOperation()) {
       _logger.info("Skip preloading segment: {} because metadata manager is already stopped", segmentName);
@@ -665,7 +665,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected void doReplaceSegment(ImmutableSegment segment, IndexSegment oldSegment) {
     String segmentName = segment.getSegmentName();
     Preconditions.checkArgument(segmentName.equals(oldSegment.getSegmentName()),
-        "Cannot replace segment with different name for table: {}, old segment: {}, new segment: {}",
+        "Cannot replace segment with different name for table: %s, old segment: %s, new segment: %s",
         _tableNameWithType, oldSegment.getSegmentName(), segmentName);
     _logger.info("Replacing {} segment: {}, current primary key count: {}",
         oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, getNumPrimaryKeys());
@@ -712,7 +712,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         oldSegment.getValidDocIds() != null ? oldSegment.getValidDocIds().getMutableRoaringBitmap() : null;
     if (recordInfoIterator != null) {
       Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
-          "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
+          "Got unsupported segment implementation: %s for segment: %s, table: %s", segment.getClass(), segmentName,
           _tableNameWithType);
       if (validDocIds == null) {
         validDocIds = new ThreadSafeMutableRoaringBitmap();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
@@ -219,6 +219,7 @@ public class UpsertUtils {
       }
     }
 
+    @Override
     public Comparable getComparisonValue(int docId) {
       Comparable[] comparisonColumns = new Comparable[_comparisonColumnReaders.length];
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -273,6 +273,7 @@ public final class TableConfigUtils {
    * - Valid segmentPushType
    * - Valid retentionTimeUnit
    */
+  @SuppressWarnings("ReturnValueIgnored")
   private static void validateRetentionConfig(TableConfig tableConfig) {
     SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
     String tableName = tableConfig.getTableName();
@@ -860,7 +861,7 @@ public final class TableConfigUtils {
 
     Preconditions.checkState(
         tableConfig.getInstanceAssignmentConfigMap() == null || !tableConfig.getInstanceAssignmentConfigMap()
-            .containsKey(InstancePartitionsType.COMPLETED),
+            .containsKey(InstancePartitionsType.COMPLETED.toString()),
         "InstanceAssignmentConfig for COMPLETED is not allowed for upsert tables");
     validateAggregateMetricsForUpsertConfig(tableConfig);
     validateTTLForUpsertConfig(tableConfig, schema);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/mutablefst/MutableFSTImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/mutablefst/MutableFSTImpl.java
@@ -62,10 +62,6 @@ public class MutableFSTImpl implements MutableFST {
     _start = start;
   }
 
-  public MutableState newStartState() {
-    return newStartState();
-  }
-
   public MutableArc addArc(MutableState startState, int outputSymbol, MutableState endState) {
     MutableArc newArc = new MutableArc(outputSymbol, endState);
     startState.addArc(newArc);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferPinotBufferFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferPinotBufferFactory.java
@@ -44,7 +44,7 @@ public class ByteBufferPinotBufferFactory implements PinotBufferFactory {
   public PinotDataBuffer mapFile(File file, boolean readOnly, long offset, long size, ByteOrder byteOrder)
       throws IOException {
     Preconditions.checkArgument(size <= Integer.MAX_VALUE,
-        "Trying to allocate {} bytes when max is {}", size, Integer.MAX_VALUE);
+        "Trying to allocate %s bytes when max is %s", size, Integer.MAX_VALUE);
     return PinotByteBuffer.mapFile(file, readOnly, offset, (int) size, byteOrder);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/BoundedColumnValuePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/BoundedColumnValuePartitionFunction.java
@@ -50,7 +50,7 @@ public class BoundedColumnValuePartitionFunction implements PartitionFunction {
 
   public BoundedColumnValuePartitionFunction(int numPartitions, Map<String, String> functionConfig) {
     Preconditions.checkArgument(functionConfig != null && functionConfig.size() > 0,
-        "'functionConfig' should be present, specified", functionConfig);
+        "'functionConfig' should be present, specified %s", functionConfig);
     Preconditions.checkState(functionConfig.get(COLUMN_VALUES) != null, "columnValues must be configured");
     Preconditions.checkState(functionConfig.get(COLUMN_VALUES_DELIMITER) != null,
         "'columnValuesDelimiter' must be configured");

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
@@ -37,7 +37,7 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
    * @param numPartitions Number of partitions
    */
   public ByteArrayPartitionFunction(int numPartitions) {
-    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified", numPartitions);
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified %s", numPartitions);
     _numPartitions = numPartitions;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
@@ -32,7 +32,7 @@ public class HashCodePartitionFunction implements PartitionFunction {
   private final int _numPartitions;
 
   public HashCodePartitionFunction(int numPartitions) {
-    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified", numPartitions);
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified %s", numPartitions);
     _numPartitions = numPartitions;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
@@ -37,7 +37,7 @@ public class ModuloPartitionFunction implements PartitionFunction {
    * @param numPartitions Number of partitions.
    */
   public ModuloPartitionFunction(int numPartitions) {
-    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified", numPartitions);
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0, specified %s", numPartitions);
     _numPartitions = numPartitions;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -39,6 +39,7 @@ public class PinotFSFactory {
   public static final String LOCAL_PINOT_FS_SCHEME = "file";
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotFSFactory.class);
   private static final String CLASS = "class";
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<String, PinotFS> PINOT_FS_MAP = new HashMap<String, PinotFS>() {
     {
       put(LOCAL_PINOT_FS_SCHEME, new NoClosePinotFS(new LocalPinotFS()));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -36,7 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+@SuppressWarnings("DoubleBraceInitialization")
 public class PluginManager {
 
   public static final String PLUGINS_DIR_PROPERTY_NAME = "plugins.dir";

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncherTest.java
@@ -33,6 +33,7 @@ public class IngestionJobLauncherTest {
   private Map<String, String> _defaultEnvironmentValues;
 
   @BeforeMethod
+  @SuppressWarnings("DoubleBraceInitialization")
   public void setup() {
     _defaultEnvironmentValues = new HashMap<String, String>() {{
       put("year", "2022");

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
@@ -99,7 +99,7 @@ public class TimestampUtilsTest {
 
     // ISO8601 with milliseconds and various timezones
     assertEquals(TimestampUtils.toTimestamp("2024-07-12T15:32:36.123Z"),
-        Timestamp.from(ZonedDateTime.of(2024, 7, 12, 15, 32, 36, 123000000, ZoneId.of("Z")).toInstant()));
+        Timestamp.from(ZonedDateTime.of(2024, 7, 12, 15, 32, 36, 123000000, ZoneOffset.UTC).toInstant()));
     assertEquals(TimestampUtils.toTimestamp("2024-07-12T15:32:36.123+01:30"),
         Timestamp.from(ZonedDateTime.of(2024, 7, 12, 15, 32, 36, 123000000, ZoneId.of("+01:30")).toInstant()));
     assertEquals(TimestampUtils.toTimestamp("2024-07-12T15:32:36.123-08:00"),

--- a/pom.xml
+++ b/pom.xml
@@ -890,6 +890,7 @@
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
         <version>${google.auto-service.version}</version>
+        <scope>provided</scope>
         <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
       </dependency>
       <!-- Solve the dependency converge issue between guava and calcite-core -->
@@ -1894,6 +1895,42 @@
             <target>${jdk.version}</target>
             <fork>true</fork>
             <encoding>${project.build.sourceEncoding}</encoding>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${google.errorprone.version}</version>
+              </path>
+              <path>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${google.auto-service.version}</version>
+              </path>
+              <path>
+                <groupId>org.immutables</groupId>
+                <artifactId>value-annotations</artifactId>
+                <version>${immutables.version}</version>
+              </path>
+              <path>
+                <groupId>com.uber.nullaway</groupId>
+                <artifactId>nullaway</artifactId>
+                <version>0.10.15</version>
+              </path>
+            </annotationProcessorPaths>
+            <compilerArgs>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+              <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+              <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              <arg>-XDcompilePolicy=simple</arg>
+              <arg>-Xplugin:ErrorProne -XepOpt:NullAway:AnnotatedPackages=org.apache.pinot</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This PR is an attempt to add error-prone static checker to be able to detect issues in the code.

This is not ready to merge given in only fixed some of the errors detected (36 files so far). I just fixed the more problematic errors. Several more warnings (including null handling) were reported.

Some errors are clearly problematic in production, including some infinite recursions while other are just informative (ie there are ton of cases where we call Preconditions with {} instead of %s, which means the message will not contain the argument).