### PR TITLE
Add broker API to run a query on both query engines and compare results

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
@@ -129,8 +129,8 @@ public class PinotClientRequestTest {
     when(request.getRequestURL()).thenReturn(new StringBuilder());
     when(_requestHandler.handleRequest(any(), any(), any(), any(), any()))
         .thenReturn(BrokerResponseNative.EMPTY_RESULT);
-    _pinotClientRequest.processSqlQueryWithBothEnginesAndCompareResults("{\"v1sql\": \"SELECT v1 FROM mytable\","
-            + "\"v2sql\": \"SELECT v2 FROM mytable\"}", asyncResponse, request, null);
+    _pinotClientRequest.processSqlQueryWithBothEnginesAndCompareResults("{\"sqlV1\": \"SELECT v1 FROM mytable\","
+            + "\"sqlV2\": \"SELECT v2 FROM mytable\"}", asyncResponse, request, null);
 
     ArgumentCaptor<JsonNode> requestCaptor = ArgumentCaptor.forClass(JsonNode.class);
     verify(_requestHandler, times(2)).handleRequest(requestCaptor.capture(), any(), any(), any(), any());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -370,8 +370,8 @@ public class CommonConstants {
 
     public static class Request {
       public static final String SQL = "sql";
-      public static final String V1SQL = "v1sql";
-      public static final String V2SQL = "v2sql";
+      public static final String SQL_V1 = "sqlV1";
+      public static final String SQL_V2 = "sqlV2";
       public static final String TRACE = "trace";
       public static final String QUERY_OPTIONS = "queryOptions";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -370,6 +370,8 @@ public class CommonConstants {
 
     public static class Request {
       public static final String SQL = "sql";
+      public static final String V1SQL = "v1sql";
+      public static final String V2SQL = "v2sql";
       public static final String TRACE = "trace";
       public static final String QUERY_OPTIONS = "queryOptions";
 


### PR DESCRIPTION
- This patch adds a broker API to run a query on both the single stage and the multi stage query engines and compare the results. It complements the migration metric added in https://github.com/apache/pinot/pull/13628 in order to assist users that want to migrate from the v1 query engine to the v2 query engine.
- This tool is a more "active" way of checking queries than the "passive" metric that only checks whether the v1 queries being run are compilable in v2.
- Here, the query is actually run on both the query engines and the results are compared. Any differences such as a mismatch in the number of result rows, types of result columns etc. are explicitly called out to the user.