### PR TITLE
refine a few logs and checks for upsert

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -383,17 +383,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         && _tableUpsertMetadataManager.getUpsertMode() == UpsertConfig.Mode.PARTIAL;
   }
 
-  private boolean isUpsertPreloadEnabled() {
-    UpsertConfig upsertConfig = _tableConfig.getUpsertConfig();
-    return _tableUpsertMetadataManager != null && _segmentPreloadExecutor != null && upsertConfig != null
-        && upsertConfig.isEnableSnapshot() && upsertConfig.isEnablePreload();
-  }
-
   /**
-   * Handles upsert preload, and returns whether the upsert preload is enabled.
+   * Handles upsert preload if the upsert preload is enabled.
    */
   private void handleUpsertPreload(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig) {
-    if (!isUpsertPreloadEnabled()) {
+    if (_tableUpsertMetadataManager == null || !_tableUpsertMetadataManager.isEnablePreload()) {
       return;
     }
     String segmentName = zkMetadata.getSegmentName();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -162,7 +162,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _partialUpsertHandler = context.getPartialUpsertHandler();
     _enableSnapshot = context.isSnapshotEnabled();
     _snapshotLock = _enableSnapshot ? new ReentrantReadWriteLock() : null;
-    _isPreloading = _enableSnapshot && context.isPreloadEnabled();
+    _isPreloading = context.isPreloadEnabled();
     _metadataTTL = context.getMetadataTTL();
     _deletedKeysTTL = context.getDeletedKeysTTL();
     _tableIndexDir = context.getTableIndexDir();
@@ -933,6 +933,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     int numImmutableSegments = 0;
     int numConsumingSegments = 0;
+    int numUnchangedSegments = 0;
     // The segments without validDocIds snapshots should take their snapshots at last. So that when there is failure
     // to take snapshots, the validDocIds snapshot on disk still keep track of an exclusive set of valid docs across
     // segments. Because the valid docs as tracked by the existing validDocIds snapshots can only get less. That no
@@ -945,6 +946,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
       if (!_updatedSegmentsSinceLastSnapshot.contains(segment)) {
         // if no updates since last snapshot then skip
+        numUnchangedSegments++;
         continue;
       }
       try {
@@ -976,7 +978,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         ServerGauge.UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT, numImmutableSegments);
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
         ServerGauge.UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT, numPrimaryKeysInSnapshot);
-    int numMissedSegments = numTrackedSegments - numImmutableSegments - numConsumingSegments;
+    int numMissedSegments = numTrackedSegments - numImmutableSegments - numConsumingSegments - numUnchangedSegments;
     if (numMissedSegments > 0) {
       _serverMetrics.addMeteredTableValue(_tableNameWithType, String.valueOf(_partitionId),
           ServerMeter.UPSERT_MISSED_VALID_DOC_ID_SNAPSHOT_COUNT, numMissedSegments);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -41,6 +41,8 @@ public interface TableUpsertMetadataManager extends Closeable {
 
   UpsertConfig.Mode getUpsertMode();
 
+  boolean isEnablePreload();
+
   /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */


### PR DESCRIPTION
Unify the check of whether to enable preload, which considers the existence of preload executor as well. If snapshot+preload flags are set but not configure the preload executor, the _isPreloading flag is initialized incorrectly.

Also refined the log/metrics of `numMissedSegments` which didn't exclude the segments not changed, thus kept printing missing segments.