### PR TITLE
Optimize NullableSingleInputAggregationFunction when entire block is null

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
@@ -81,7 +81,8 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
       return;
     }
 
-    if (roaringBitmap.getCardinality() < length) {
+    // Skip if entire block is null
+    if (!roaringBitmap.contains(0, length)) {
       forEachNotNull(length, roaringBitmap.getIntIterator(), consumer);
     }
   }
@@ -122,7 +123,8 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
   public <A> A foldNotNull(int length, @Nullable RoaringBitmap roaringBitmap, A initialAcum, Reducer<A> reducer) {
     IntIterator intIterator = roaringBitmap == null ? null : roaringBitmap.getIntIterator();
 
-    if (_nullHandlingEnabled && roaringBitmap != null && roaringBitmap.getCardinality() >= length) {
+    // Exit early if entire block is null
+    if (_nullHandlingEnabled && roaringBitmap != null && roaringBitmap.contains(0, length)) {
       return initialAcum;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
@@ -121,13 +121,12 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
    * @param <A> The type of the accumulator
    */
   public <A> A foldNotNull(int length, @Nullable RoaringBitmap roaringBitmap, A initialAcum, Reducer<A> reducer) {
-    IntIterator intIterator = roaringBitmap == null ? null : roaringBitmap.getIntIterator();
-
     // Exit early if entire block is null
     if (_nullHandlingEnabled && roaringBitmap != null && roaringBitmap.contains(0, length)) {
       return initialAcum;
     }
 
+    IntIterator intIterator = roaringBitmap == null ? null : roaringBitmap.getIntIterator();
     return foldNotNull(length, intIterator, initialAcum, reducer);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
@@ -81,7 +81,9 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
       return;
     }
 
-    forEachNotNull(length, roaringBitmap.getIntIterator(), consumer);
+    if (roaringBitmap.getCardinality() < length) {
+      forEachNotNull(length, roaringBitmap.getIntIterator(), consumer);
+    }
   }
 
   /**
@@ -119,6 +121,11 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
    */
   public <A> A foldNotNull(int length, @Nullable RoaringBitmap roaringBitmap, A initialAcum, Reducer<A> reducer) {
     IntIterator intIterator = roaringBitmap == null ? null : roaringBitmap.getIntIterator();
+
+    if (_nullHandlingEnabled && roaringBitmap != null && roaringBitmap.getCardinality() >= length) {
+      return initialAcum;
+    }
+
     return foldNotNull(length, intIterator, initialAcum, reducer);
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkModeAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkModeAggregation.java
@@ -58,11 +58,11 @@ public class BenchmarkModeAggregation extends AbstractAggregationFunctionBenchma
   @Param({"100", "50", "0"})
   public int _nullHandlingEnabledPerCent;
   private boolean _nullHandlingEnabled;
-  @Param({"2", "4", "8", "16", "32", "64", "128"})
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
   protected int _nullPeriod;
   private final Random _segmentNullRandomGenerator = new Random(42);
-  private double _modeIgnoringNull;
-  private double _modeNullAware;
+  private Double _modeIgnoringNull;
+  private Double _modeNullAware;
   private final int _numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
 
   public static void main(String[] args)
@@ -122,11 +122,15 @@ public class BenchmarkModeAggregation extends AbstractAggregationFunctionBenchma
         .get()
         .getKey()
         .doubleValue();
-    _modeNullAware = nullAwareDistribution.entrySet().stream()
-        .max(Comparator.comparingInt(Map.Entry::getValue))
-        .get()
-        .getKey()
-        .doubleValue();
+    if (nullAwareDistribution.isEmpty()) {
+      _modeNullAware = null;
+    } else {
+      _modeNullAware = nullAwareDistribution.entrySet().stream()
+              .max(Comparator.comparingInt(Map.Entry::getValue))
+              .get()
+              .getKey()
+              .doubleValue();
+    }
   }
 
   @Override


### PR DESCRIPTION
- Currently, if null handling is enabled and any aggregation function extending `NullableSingleInputAggregationFunction` encounters a block where every value is `null`, it will unnecessarily iterate through every entry in the null bitmap with a check to see whether any non-null values were encountered in each iteration.
- Instead, we can skip over this completely based on the null bitmap's cardinality. This optimization already exists in some of the other aggregation functions that don't currently extend `NullableSingleInputAggregationFunction` - 

https://github.com/apache/pinot/blob/0f2dcb770dca414b02dc4d495d4b4458fa2e91ec/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java#L135

https://github.com/apache/pinot/blob/0f2dcb770dca414b02dc4d495d4b4458fa2e91ec/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java#L102
- Some of the existing unit tests such as `ModeAggregationFunctionTest` and `AbstractPercentileAggregationFunctionTest` already provide coverage for this scenario.