### PR TITLE
Clean docker build cache after in vulnerability check github action job

### DIFF
--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -40,4 +40,8 @@ docker build \
     --tag ${DOCKER_IMAGE_NAME}:${PINOT_SHA} \
     .
 
+docker builder prune -a -f
+
+docker image prune -f
+
 docker image ls


### PR DESCRIPTION
Clean docker build cache after in vulnerability check github action job
Freed about 12gb building cache for next task run.