### PR TITLE
Log when table to broker list map is refreshed

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
@@ -34,12 +34,15 @@ import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
 import org.apache.pinot.client.utils.BrokerSelectorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Maintains a mapping between table name and list of brokers
  */
 public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicBrokerSelector.class);
   private static final Random RANDOM = new Random();
 
   private final AtomicReference<Map<String, List<String>>> _tableToBrokerListMapRef = new AtomicReference<>();
@@ -84,6 +87,7 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
       brokerSet.addAll(brokerList);
     }
     _allBrokerListRef.set(new ArrayList<>(brokerSet));
+    LOGGER.info("Refreshed table to broker list map: {}", _tableToBrokerListMapRef.get());
   }
 
   @Nullable


### PR DESCRIPTION
When a broker is added, removed or dies in a cluster, the DynamicBrokerSelector refreshes the table to broker list map. Adding log to find out when this map is refreshed to help troubleshoot delay in updating this map.

`observability`