### PR TITLE
Pull some dependencies to root POM

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -310,7 +310,6 @@
     <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
-      <version>0.4</version>
     </dependency>
     <dependency>
       <groupId>com.github.seancfoley</groupId>
@@ -327,7 +326,6 @@
     <dependency>
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
-      <version>1.7</version>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/pinot-connectors/pinot-spark-2-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-2-connector/pom.xml
@@ -33,7 +33,6 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <spark.version>2.4.8</spark.version>
-    <paranamer.version>2.8</paranamer.version>
     <scalaxml.version>2.3.0</scalaxml.version>
     <scalatest.version>3.2.18</scalatest.version>
     <shadeBase>org.apache.pinot.\$internal</shadeBase>
@@ -66,10 +65,6 @@
             <exclusion>
               <groupId>org.apache.curator</groupId>
               <artifactId>curator-recipes</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>com.thoughtworks.paranamer</groupId>
-              <artifactId>paranamer</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.scala-lang.modules</groupId>

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -55,10 +55,6 @@
               <artifactId>curator-recipes</artifactId>
             </exclusion>
             <exclusion>
-              <groupId>com.thoughtworks.paranamer</groupId>
-              <artifactId>paranamer</artifactId>
-            </exclusion>
-            <exclusion>
               <groupId>org.scala-lang.modules</groupId>
               <artifactId>scala-xml_${scala.compat.version}</artifactId>
             </exclusion>

--- a/pinot-connectors/pinot-spark-common/pom.xml
+++ b/pinot-connectors/pinot-spark-common/pom.xml
@@ -33,7 +33,6 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <circe.version>0.14.9</circe.version>
-    <paranameter.version>2.8</paranameter.version>
     <scalaxml.version>2.3.0</scalaxml.version>
     <scalatest.version>3.2.18</scalatest.version>
   </properties>
@@ -46,18 +45,9 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>com.thoughtworks.paranamer</groupId>
-          <artifactId>paranamer</artifactId>
-          <version>${paranameter.version}</version>
-        </dependency>
-        <dependency>
           <groupId>com.fasterxml.jackson.module</groupId>
           <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
           <exclusions>
-            <exclusion>
-              <groupId>com.thoughtworks.paranamer</groupId>
-              <artifactId>paranamer</artifactId>
-            </exclusion>
             <exclusion>
               <groupId>org.scala-lang</groupId>
               <artifactId>scala-library</artifactId>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <lucene.version>9.11.1</lucene.version>
     <reflections.version>0.10.2</reflections.version>
     <dynatrace.hash4j.version>0.18.0</dynatrace.hash4j.version>
+    <yammer-metrics.version>2.2.0</yammer-metrics.version>
     <!-- helix-core, spark-core use libraries from io.dropwizard.metrics -->
     <dropwizard-metrics.version>4.2.26</dropwizard-metrics.version>
     <snappy-java.version>1.1.10.6</snappy-java.version>
@@ -185,6 +186,7 @@
     <janino.version>3.1.12</janino.version>
     <woodstox.version>7.0.0</woodstox.version>
     <sslcontext.kickstart.version>8.3.6</sslcontext.kickstart.version>
+    <jbcrypt.version>0.4</jbcrypt.version>
 
     <confluent.version>7.7.0</confluent.version>
     <pulsar.version>3.3.1</pulsar.version>
@@ -230,6 +232,7 @@
     <grpc.version>1.66.0</grpc.version>
     <google.cloud.libraries.version>26.43.0</google.cloud.libraries.version>
     <google.auto-service.version>1.1.1</google.auto-service.version>
+    <google.re2j.version>1.7</google.re2j.version>
     <google.errorprone.version>2.29.2</google.errorprone.version>
     <google.j2objc.version>3.0.0</google.j2objc.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
@@ -251,6 +254,7 @@
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <aircompressor.version>0.27</aircompressor.version>
     <jna.version>5.14.0</jna.version>
+    <paranamer.version>2.8</paranamer.version>
 
     <!-- Test Libraries -->
     <testng.version>7.10.2</testng.version>
@@ -894,11 +898,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.paranamer</groupId>
-        <artifactId>paranamer</artifactId>
-        <version>2.8</version>
-      </dependency>
 
       <!-- Jackson -->
       <dependency>
@@ -1092,6 +1091,11 @@
         <artifactId>auto-service</artifactId>
         <version>${google.auto-service.version}</version>
         <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.re2j</groupId>
+        <artifactId>re2j</artifactId>
+        <version>${google.re2j.version}</version>
       </dependency>
       <!-- Solve the dependency converge issue between guava and calcite-core -->
       <dependency>
@@ -1416,6 +1420,11 @@
 
       <!-- Metrics -->
       <dependency>
+        <groupId>com.yammer.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${yammer-metrics.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${dropwizard-metrics.version}</version>
@@ -1680,6 +1689,11 @@
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.paranamer</groupId>
+        <artifactId>paranamer</artifactId>
+        <version>${paranamer.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.yscope.clp</groupId>
@@ -1807,6 +1821,11 @@
         <groupId>io.github.hakky54</groupId>
         <artifactId>sslcontext-kickstart-for-netty</artifactId>
         <version>${sslcontext.kickstart.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mindrot</groupId>
+        <artifactId>jbcrypt</artifactId>
+        <version>${jbcrypt.version}</version>
       </dependency>
 
       <!-- Bouncy Castle libraries are used by Kafka and Pulsar plugins -->


### PR DESCRIPTION
The following dependencies are pulled up to be managed in root POM:
- com.google.re2j:re2j
- org.midrot:jbcrypt
- com.yammer.metrics:metrics-core
- com.thoughtworks.paranamer:paranamer (already in POM, remove the redundant override)