### PR TITLE
Minor LICENSE-binary Corrections for 1.2.0 Release

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -361,10 +361,10 @@ io.opencensus:opencensus-proto:0.2.0
 io.opentelemetry:opentelemetry-api-incubator:1.37.0-alpha
 io.opentelemetry:opentelemetry-api:1.37.0
 io.opentelemetry:opentelemetry-context:1.37.0
-io.perfmark:perfmark-api:0.27.0
+io.perfmark:perfmark-api:0.26.0
 io.projectreactor.netty:reactor-netty-core:1.0.45
 io.projectreactor.netty:reactor-netty-http:1.0.45
-io.projectreactor:reactor-core:3.4.48
+io.projectreactor:reactor-core:3.4.38
 io.swagger.core.v3:swagger-annotations:2.1.10
 io.swagger:swagger-annotations:1.6.14
 io.swagger:swagger-core:1.6.14
@@ -503,7 +503,7 @@ org.jetbrains.kotlin:kotlin-stdlib-common:1.9.24
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.24
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24
-org.jetbrains:annotations:17.0
+org.jetbrains:annotations:17.0.0
 org.locationtech.proj4j:proj4j:1.2.2
 org.lz4:lz4-java:1.8.0
 org.objenesis:objenesis:2.1
@@ -583,7 +583,6 @@ net.sf.jopt-simple:jopt-simple:5.0.4
 net.sourceforge.argparse4j:argparse4j:0.7.0
 org.checkerframework:checker-qual:3.44.0
 org.codehaus.mojo:animal-sniffer-annotations:1.23
-org.projectlombok:lombok:1.18.30
 org.reactivestreams:reactive-streams:1.0.4
 org.slf4j:slf4j-api:2.0.13
 org.slf4j:slf4j-reload4j:1.7.36
@@ -628,7 +627,7 @@ Common Development and Distribution License (CDDL) 1.0
 (see licenses/LICENSE-cddl-1.0.txt)
 
 com.sun.activation:javax.activation:1.2.0
-org.glassfish.jersey.containers:jersey-container-servlet-core:2.39
+org.glassfish.jersey.containers:jersey-container-servlet-core:2.42
 
 
 Common Development and Distribution License (CDDL) 1.1
@@ -637,7 +636,7 @@ Common Development and Distribution License (CDDL) 1.1
 
 com.github.pjfanning:jersey-json:1.20
 com.sun.xml.bind:jaxb-impl:2.2.3-1
-javax.activation:activation-api:1.2.0
+javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.servlet:javax.servlet-api:4.0.1
 javax.xml.bind:jaxb-api:2.3.1


### PR DESCRIPTION
I was re-doing the license/notice steps after cherry-picking #13548 and found that there were minor errors.

No changes to notice file.