### PR TITLE
Fix filtered aggregate with ordering

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -91,10 +91,9 @@ public class QueryContext {
 
   // Pre-calculate the aggregation functions and columns for the query so that it can be shared across all the segments
   private AggregationFunction[] _aggregationFunctions;
-  private Map<FunctionContext, Integer> _aggregationFunctionIndexMap;
-  private boolean _hasFilteredAggregations;
   private List<Pair<AggregationFunction, FilterContext>> _filteredAggregationFunctions;
   private Map<Pair<FunctionContext, FilterContext>, Integer> _filteredAggregationsIndexMap;
+  private boolean _hasFilteredAggregations;
   private Set<String> _columns;
 
   // Other properties to be shared across all the segments
@@ -273,28 +272,19 @@ public class QueryContext {
   }
 
   /**
-   * Returns the filtered aggregation expressions for the query.
-   */
-  public boolean hasFilteredAggregations() {
-    return _hasFilteredAggregations;
-  }
-
-  /**
-   * Returns a map from the AGGREGATION FunctionContext to the index of the corresponding AggregationFunction in the
-   * aggregation functions array.
-   */
-  @Nullable
-  public Map<FunctionContext, Integer> getAggregationFunctionIndexMap() {
-    return _aggregationFunctionIndexMap;
-  }
-
-  /**
    * Returns a map from the filtered aggregation (pair of AGGREGATION FunctionContext and FILTER FilterContext) to the
    * index of corresponding AggregationFunction in the aggregation functions array.
    */
   @Nullable
   public Map<Pair<FunctionContext, FilterContext>, Integer> getFilteredAggregationsIndexMap() {
     return _filteredAggregationsIndexMap;
+  }
+
+  /**
+   * Returns the filtered aggregation expressions for the query.
+   */
+  public boolean hasFilteredAggregations() {
+    return _hasFilteredAggregations;
   }
 
   /**
@@ -619,12 +609,7 @@ public class QueryContext {
         for (int i = 0; i < numAggregations; i++) {
           aggregationFunctions[i] = filteredAggregationFunctions.get(i).getLeft();
         }
-        Map<FunctionContext, Integer> aggregationFunctionIndexMap = new HashMap<>();
-        for (Map.Entry<Pair<FunctionContext, FilterContext>, Integer> entry : filteredAggregationsIndexMap.entrySet()) {
-          aggregationFunctionIndexMap.put(entry.getKey().getLeft(), entry.getValue());
-        }
         queryContext._aggregationFunctions = aggregationFunctions;
-        queryContext._aggregationFunctionIndexMap = aggregationFunctionIndexMap;
         queryContext._filteredAggregationFunctions = filteredAggregationFunctions;
         queryContext._filteredAggregationsIndexMap = filteredAggregationsIndexMap;
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -480,21 +480,21 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(aggregationFunctions[3].getResultColumnName(), "sum(col4)");
       assertEquals(aggregationFunctions[4].getResultColumnName(), "max(col4)");
       assertEquals(aggregationFunctions[5].getResultColumnName(), "max(col1)");
-      Map<FunctionContext, Integer> aggregationFunctionIndexMap = queryContext.getAggregationFunctionIndexMap();
-      assertNotNull(aggregationFunctionIndexMap);
-      assertEquals(aggregationFunctionIndexMap.size(), 6);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
-          Collections.singletonList(ExpressionContext.forIdentifier("col1")))), 0);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
-          Collections.singletonList(ExpressionContext.forIdentifier("col2")))), 1);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "min",
-          Collections.singletonList(ExpressionContext.forIdentifier("col2")))), 2);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
-          Collections.singletonList(ExpressionContext.forIdentifier("col4")))), 3);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
-          Collections.singletonList(ExpressionContext.forIdentifier("col4")))), 4);
-      assertEquals((int) aggregationFunctionIndexMap.get(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
-          Collections.singletonList(ExpressionContext.forIdentifier("col1")))), 5);
+      Map<Pair<FunctionContext, FilterContext>, Integer> indexMap = queryContext.getFilteredAggregationsIndexMap();
+      assertNotNull(indexMap);
+      assertEquals(indexMap.size(), 6);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+          Collections.singletonList(ExpressionContext.forIdentifier("col1"))), null)), 0);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col2"))), null)), 1);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "min",
+          Collections.singletonList(ExpressionContext.forIdentifier("col2"))), null)), 2);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
+          Collections.singletonList(ExpressionContext.forIdentifier("col4"))), null)), 3);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col4"))), null)), 4);
+      assertEquals((int) indexMap.get(Pair.of(new FunctionContext(FunctionContext.Type.AGGREGATION, "max",
+          Collections.singletonList(ExpressionContext.forIdentifier("col1"))), null)), 5);
     }
 
     // DistinctCountThetaSketch (string literal and escape quote)
@@ -540,21 +540,10 @@ public class BrokerRequestToQueryContextConverterTest {
       assertTrue(filteredAggregationFunctions.get(1).getLeft() instanceof CountAggregationFunction);
       assertEquals(filteredAggregationFunctions.get(1).getRight().toString(), "foo < '6'");
 
-      Map<FunctionContext, Integer> aggregationIndexMap = queryContext.getAggregationFunctionIndexMap();
-      assertNotNull(aggregationIndexMap);
-      assertEquals(aggregationIndexMap.size(), 1);
-      for (Map.Entry<FunctionContext, Integer> entry : aggregationIndexMap.entrySet()) {
-        FunctionContext aggregation = entry.getKey();
-        int index = entry.getValue();
-        assertEquals(aggregation.toString(), "count(*)");
-        assertTrue(index == 0 || index == 1);
-      }
-
-      Map<Pair<FunctionContext, FilterContext>, Integer> filteredAggregationsIndexMap =
-          queryContext.getFilteredAggregationsIndexMap();
-      assertNotNull(filteredAggregationsIndexMap);
-      assertEquals(filteredAggregationsIndexMap.size(), 2);
-      for (Map.Entry<Pair<FunctionContext, FilterContext>, Integer> entry : filteredAggregationsIndexMap.entrySet()) {
+      Map<Pair<FunctionContext, FilterContext>, Integer> indexMap = queryContext.getFilteredAggregationsIndexMap();
+      assertNotNull(indexMap);
+      assertEquals(indexMap.size(), 2);
+      for (Map.Entry<Pair<FunctionContext, FilterContext>, Integer> entry : indexMap.entrySet()) {
         Pair<FunctionContext, FilterContext> pair = entry.getKey();
         FunctionContext aggregation = pair.getLeft();
         FilterContext filter = pair.getRight();
@@ -600,32 +589,10 @@ public class BrokerRequestToQueryContextConverterTest {
       assertTrue(filteredAggregationFunctions.get(3).getLeft() instanceof MinAggregationFunction);
       assertEquals(filteredAggregationFunctions.get(3).getRight().toString(), "salary > '50000'");
 
-      Map<FunctionContext, Integer> aggregationIndexMap = queryContext.getAggregationFunctionIndexMap();
-      assertNotNull(aggregationIndexMap);
-      assertEquals(aggregationIndexMap.size(), 2);
-      for (Map.Entry<FunctionContext, Integer> entry : aggregationIndexMap.entrySet()) {
-        FunctionContext aggregation = entry.getKey();
-        int index = entry.getValue();
-        switch (index) {
-          case 0:
-          case 1:
-            assertEquals(aggregation.toString(), "sum(salary)");
-            break;
-          case 2:
-          case 3:
-            assertEquals(aggregation.toString(), "min(salary)");
-            break;
-          default:
-            fail();
-            break;
-        }
-      }
-
-      Map<Pair<FunctionContext, FilterContext>, Integer> filteredAggregationsIndexMap =
-          queryContext.getFilteredAggregationsIndexMap();
-      assertNotNull(filteredAggregationsIndexMap);
-      assertEquals(filteredAggregationsIndexMap.size(), 4);
-      for (Map.Entry<Pair<FunctionContext, FilterContext>, Integer> entry : filteredAggregationsIndexMap.entrySet()) {
+      Map<Pair<FunctionContext, FilterContext>, Integer> indexMap = queryContext.getFilteredAggregationsIndexMap();
+      assertNotNull(indexMap);
+      assertEquals(indexMap.size(), 4);
+      for (Map.Entry<Pair<FunctionContext, FilterContext>, Integer> entry : indexMap.entrySet()) {
         Pair<FunctionContext, FilterContext> pair = entry.getKey();
         FunctionContext aggregation = pair.getLeft();
         FilterContext filter = pair.getRight();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -135,14 +135,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       new StarTreeIndexConfig(Collections.singletonList("DestState"), null,
           Collections.singletonList(AggregationFunctionColumnPair.COUNT_STAR.toColumnName()), null, 100);
   private static final String TEST_STAR_TREE_QUERY_2 = "SELECT COUNT(*) FROM mytable WHERE DestState = 'CA'";
-  private static final String TEST_STAR_TREE_QUERY_FILTERED_AGG =
-      "SELECT COUNT(*), COUNT(*) FILTER (WHERE Carrier = 'UA') FROM mytable WHERE DestState = 'CA'";
-  // This query contains a filtered aggregation which cannot be solved with startree, but the COUNT(*) still should be
-  private static final String TEST_STAR_TREE_QUERY_FILTERED_AGG_MIXED =
-      "SELECT COUNT(*), AVG(ArrDelay) FILTER (WHERE Carrier = 'UA') FROM mytable WHERE DestState = 'CA'";
-  private static final StarTreeIndexConfig STAR_TREE_INDEX_CONFIG_3 =
-      new StarTreeIndexConfig(List.of("Carrier", "DestState"), null,
-          Collections.singletonList(AggregationFunctionColumnPair.COUNT_STAR.toColumnName()), null, 100);
 
   // For default columns test
   private static final String TEST_EXTRA_COLUMNS_QUERY = "SELECT COUNT(*) FROM mytable WHERE NewAddedIntMetric = 1";
@@ -3460,6 +3452,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     testQuery("SELECT Origin, SUM(ArrDelay) FROM mytable GROUP BY Origin LIMIT 0");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilteredAggregationWithGroupByOrdering(boolean useMultiStageQueryEngine)
+    throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    // Test the ordering is correctly applied to the correct aggregation (the one without FILTER clause)
+    testQuery("SELECT DestCityName, COUNT(*) AS c1, COUNT(*) FILTER (WHERE AirTime = 0) AS c2 FROM mytable "
+        + "GROUP BY DestCityName ORDER BY c1 DESC LIMIT 10");
   }
 
   private String buildSkipIndexesOption(String columnsAndIndexes) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3460,6 +3460,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
 
     // Test the ordering is correctly applied to the correct aggregation (the one without FILTER clause)
+    // See https://github.com/apache/pinot/pull/13784
     testQuery("SELECT DestCityName, COUNT(*) AS c1, COUNT(*) FILTER (WHERE AirTime = 0) AS c2 FROM mytable "
         + "GROUP BY DestCityName ORDER BY c1 DESC LIMIT 10");
   }


### PR DESCRIPTION
Fix #13749 

For filtered aggregate group-by queries, when there are mixed same aggregate with and without filter, and the ordering is applied to the aggregate without filter, we might get wrong result because we read the index of the aggregate from a map without filter info.
E.g. for this query: `SELECT DestCityName, COUNT(*) AS c1, COUNT(*) FILTER (WHERE AirTime = 0) AS c2 FROM mytable GROUP BY DestCityName ORDER BY c1 DESC LIMIT 10`, it might end up mistakenly ordering on `c2` column.
The fix is to remove the map of aggregate index without the filter info and always use the one with filter info.