### PR TITLE
Improve null handling performance for nullable single input aggregation functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -58,4 +58,9 @@ public class Key {
   public int hashCode() {
     return Arrays.hashCode(_values);
   }
+
+  @Override
+  public String toString() {
+    return Arrays.toString(_values);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -64,4 +64,9 @@ public class Record {
   public int hashCode() {
     return Arrays.hashCode(_values);
   }
+
+  @Override
+  public String toString() {
+    return Arrays.toString(_values);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -31,20 +31,17 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.local.customobject.AvgPair;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.roaringbitmap.RoaringBitmap;
 
 
-public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<AvgPair, Double> {
+public class AvgAggregationFunction extends NullableSingleInputAggregationFunction<AvgPair, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
-  private final boolean _nullHandlingEnabled;
 
   public AvgAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "AVG"), nullHandlingEnabled);
   }
 
   protected AvgAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -66,73 +63,37 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap != null && !nullBitmap.isEmpty()) {
-        aggregateNullHandlingEnabled(length, aggregationResultHolder, blockValSet, nullBitmap);
-        return;
-      }
-    }
 
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
-      double sum = 0.0;
-      for (int i = 0; i < length; i++) {
-        sum += doubleValues[i];
+      AvgPair avgPair = new AvgPair();
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          avgPair.apply(doubleValues[i], 1);
+        }
+      });
+      // Only set the aggregation result when there is at least one non-null input value
+      if (avgPair.getCount() != 0) {
+        updateAggregationResult(aggregationResultHolder, avgPair.getSum(), avgPair.getCount());
       }
-      setAggregationResult(aggregationResultHolder, sum, length);
     } else {
       // Serialized AvgPair
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      double sum = 0.0;
-      long count = 0L;
-      for (int i = 0; i < length; i++) {
-        AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-        sum += value.getSum();
-        count += value.getCount();
-      }
-      setAggregationResult(aggregationResultHolder, sum, count);
-    }
-  }
-
-  private void aggregateNullHandlingEnabled(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    if (blockValSet.getValueType() != DataType.BYTES) {
-      double[] doubleValues = blockValSet.getDoubleValuesSV();
-      if (nullBitmap.getCardinality() < length) {
-        double sum = 0.0;
-        long count = 0L;
-        // TODO: need to update the for-loop terminating condition to: i < length & i < doubleValues.length?
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            sum += doubleValues[i];
-            count++;
-          }
+      AvgPair avgPair = new AvgPair();
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
+          avgPair.apply(value);
         }
-        setAggregationResult(aggregationResultHolder, sum, count);
-      }
-      // Note: when all input values re null (nullBitmap.getCardinality() == values.length), avg is null. As a result,
-      // we don't call setAggregationResult.
-    } else {
-      // Serialized AvgPair
-      byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      if (nullBitmap.getCardinality() < length) {
-        double sum = 0.0;
-        long count = 0L;
-        // TODO: need to update the for-loop terminating condition to: i < length & i < bytesValues.length?
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            AvgPair value = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-            sum += value.getSum();
-            count += value.getCount();
-          }
-        }
-        setAggregationResult(aggregationResultHolder, sum, count);
+      });
+      // Only set the aggregation result when there is at least one non-null input value
+      if (avgPair.getCount() != 0) {
+        updateAggregationResult(aggregationResultHolder, avgPair.getSum(), avgPair.getCount());
       }
     }
   }
 
-  protected void setAggregationResult(AggregationResultHolder aggregationResultHolder, double sum, long count) {
+  protected void updateAggregationResult(AggregationResultHolder aggregationResultHolder, double sum, long count) {
     AvgPair avgPair = aggregationResultHolder.getResult();
     if (avgPair == null) {
       aggregationResultHolder.setValue(new AvgPair(sum, count));
@@ -145,55 +106,23 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap != null && !nullBitmap.isEmpty()) {
-        aggregateGroupBySVNullHandlingEnabled(length, groupKeyArray, groupByResultHolder, blockValSet, nullBitmap);
-        return;
-      }
-    }
 
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
-      for (int i = 0; i < length; i++) {
-        setGroupByResult(groupKeyArray[i], groupByResultHolder, doubleValues[i], 1L);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          updateGroupByResult(groupKeyArray[i], groupByResultHolder, doubleValues[i], 1L);
+        }
+      });
     } else {
       // Serialized AvgPair
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      for (int i = 0; i < length; i++) {
-        AvgPair avgPair = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-        setGroupByResult(groupKeyArray[i], groupByResultHolder, avgPair.getSum(), avgPair.getCount());
-      }
-    }
-  }
-
-  private void aggregateGroupBySVNullHandlingEnabled(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    if (blockValSet.getValueType() != DataType.BYTES) {
-      double[] doubleValues = blockValSet.getDoubleValuesSV();
-      // TODO: need to update the for-loop terminating condition to: i < length & i < valueArray.length?
-      if (nullBitmap.getCardinality() < length) {
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            int groupKey = groupKeyArray[i];
-            setGroupByResult(groupKey, groupByResultHolder, doubleValues[i], 1L);
-          }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          AvgPair avgPair = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
+          updateGroupByResult(groupKeyArray[i], groupByResultHolder, avgPair.getSum(), avgPair.getCount());
         }
-      }
-    } else {
-      // Serialized AvgPair
-      byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      // TODO: need to update the for-loop terminating condition to: i < length & i < valueArray.length?
-      if (nullBitmap.getCardinality() < length) {
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            int groupKey = groupKeyArray[i];
-            AvgPair avgPair = ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(bytesValues[i]);
-            setGroupByResult(groupKey, groupByResultHolder, avgPair.getSum(), avgPair.getCount());
-          }
-        }
-      }
+      });
     }
   }
 
@@ -207,7 +136,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
       for (int i = 0; i < length; i++) {
         double value = doubleValues[i];
         for (int groupKey : groupKeysArray[i]) {
-          setGroupByResult(groupKey, groupByResultHolder, value, 1L);
+          updateGroupByResult(groupKey, groupByResultHolder, value, 1L);
         }
       }
     } else {
@@ -218,13 +147,13 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
         double sum = avgPair.getSum();
         long count = avgPair.getCount();
         for (int groupKey : groupKeysArray[i]) {
-          setGroupByResult(groupKey, groupByResultHolder, sum, count);
+          updateGroupByResult(groupKey, groupByResultHolder, sum, count);
         }
       }
     }
   }
 
-  protected void setGroupByResult(int groupKey, GroupByResultHolder groupByResultHolder, double sum, long count) {
+  protected void updateGroupByResult(int groupKey, GroupByResultHolder groupByResultHolder, double sum, long count) {
     AvgPair avgPair = groupByResultHolder.getResult(groupKey);
     if (avgPair == null) {
       groupByResultHolder.setValueForKey(groupKey, new AvgPair(sum, count));
@@ -237,7 +166,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
   public AvgPair extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     AvgPair avgPair = aggregationResultHolder.getResult();
     if (avgPair == null) {
-      return _nullHandlingEnabled ? null : new AvgPair(0.0, 0L);
+      return _nullHandlingEnabled ? null : new AvgPair();
     }
     return avgPair;
   }
@@ -246,7 +175,7 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
   public AvgPair extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     AvgPair avgPair = groupByResultHolder.getResult(groupKey);
     if (avgPair == null) {
-      return _nullHandlingEnabled ? null : new AvgPair(0.0, 0L);
+      return _nullHandlingEnabled ? null : new AvgPair();
     }
     return avgPair;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -51,7 +51,7 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
       }
       count += values.length;
     }
-    setAggregationResult(aggregationResultHolder, sum, count);
+    updateAggregationResult(aggregationResultHolder, sum, count);
   }
 
   @Override
@@ -81,6 +81,6 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
       sum += value;
     }
     long count = values.length;
-    setGroupByResult(groupKey, groupByResultHolder, sum, count);
+    updateGroupByResult(groupKey, groupByResultHolder, sum, count);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -33,27 +33,26 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class CountAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
+public class CountAggregationFunction extends NullableSingleInputAggregationFunction<Long, Long> {
   private static final String COUNT_STAR_RESULT_COLUMN_NAME = "count(*)";
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
   // Special expression used by star-tree to pass in BlockValSet
   private static final ExpressionContext STAR_TREE_COUNT_STAR_EXPRESSION =
       ExpressionContext.forIdentifier(AggregationFunctionColumnPair.STAR);
 
-  private final boolean _nullHandlingEnabled;
 
   public CountAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    this(verifySingleArgument(arguments, "COUNT"), nullHandlingEnabled);
-  }
-
-  protected CountAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
     // Consider null values only when null handling is enabled and function is not COUNT(*)
     // Note COUNT on any literal gives same result as COUNT(*)
     // So allow for identifiers that are not * and functions, disable for literals and *
-    _nullHandlingEnabled = nullHandlingEnabled && (
-        (expression.getType() == ExpressionContext.Type.IDENTIFIER && !expression.getIdentifier().equals("*")) || (
-            expression.getType() == ExpressionContext.Type.FUNCTION));
+    this(verifySingleArgument(arguments, "COUNT"), nullHandlingEnabled
+        && ((arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
+            && !arguments.get(0).getIdentifier().equals("*"))
+            || (arguments.get(0).getType() == ExpressionContext.Type.FUNCTION)));
+  }
+
+  protected CountAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -126,23 +125,13 @@ public class CountAggregationFunction extends BaseSingleInputAggregationFunction
       //     0 |   1
       assert blockValSetMap.size() == 1;
       BlockValSet blockValSet = blockValSetMap.values().iterator().next();
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap != null && !nullBitmap.isEmpty()) {
-        if (nullBitmap.getCardinality() == length) {
-          return;
-        }
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            int groupKey = groupKeyArray[i];
-            groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);
-          }
-        }
-      } else {
-        for (int i = 0; i < length; i++) {
+
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
           int groupKey = groupKeyArray[i];
           groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);
         }
-      }
+      });
     } else {
       // Star-tree pre-aggregated values
       long[] valueArray = blockValSetMap.get(STAR_TREE_COUNT_STAR_EXPRESSION).getLongValuesSV();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -31,20 +31,17 @@ import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.roaringbitmap.RoaringBitmap;
 
 
-public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
+public class MaxAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
-  private final boolean _nullHandlingEnabled;
 
   public MaxAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "MAX"), nullHandlingEnabled);
   }
 
   protected MaxAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -72,61 +69,77 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      // TODO: avoid the null bitmap check when it is null or empty for better performance.
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      aggregateNullHandlingEnabled(length, aggregationResultHolder, blockValSet, nullBitmap);
-      return;
-    }
 
     switch (blockValSet.getValueType().getStoredType()) {
       case INT: {
         int[] values = blockValSet.getIntValuesSV();
-        int max = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          max = Math.max(values[i], max);
-        }
-        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
+
+        Integer max = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          int innerMax = values[from];
+          for (int i = from; i < to; i++) {
+            innerMax = Math.max(innerMax, values[i]);
+          }
+          return acum == null ? innerMax : Math.max(acum, innerMax);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, max);
         break;
       }
       case LONG: {
         long[] values = blockValSet.getLongValuesSV();
-        long max = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          max = Math.max(values[i], max);
-        }
-        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
+
+        Long max = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          long innerMax = values[from];
+          for (int i = from; i < to; i++) {
+            innerMax = Math.max(innerMax, values[i]);
+          }
+          return acum == null ? innerMax : Math.max(acum, innerMax);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, max);
         break;
       }
       case FLOAT: {
         float[] values = blockValSet.getFloatValuesSV();
-        float max = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          max = Math.max(values[i], max);
-        }
-        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
+
+        Float max = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          float innerMax = values[from];
+          for (int i = from; i < to; i++) {
+            innerMax = Math.max(innerMax, values[i]);
+          }
+          return acum == null ? innerMax : Math.max(acum, innerMax);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, max);
         break;
       }
       case DOUBLE: {
         double[] values = blockValSet.getDoubleValuesSV();
-        double max = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          max = Math.max(values[i], max);
-        }
-        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
+
+        Double max = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerMax = values[from];
+          for (int i = from; i < to; i++) {
+            innerMax = Math.max(innerMax, values[i]);
+          }
+          return acum == null ? innerMax : Math.max(acum, innerMax);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, max);
         break;
       }
       case BIG_DECIMAL: {
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-        BigDecimal max = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          max = values[i].max(max);
-        }
+
+        BigDecimal max = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+          BigDecimal innerMax = values[from];
+          for (int i = from; i < to; i++) {
+            innerMax = innerMax.max(values[i]);
+          }
+          return acum == null ? innerMax : acum.max(innerMax);
+        });
+
         // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-        aggregationResultHolder.setValue(Math.max(max.doubleValue(), aggregationResultHolder.getDoubleResult()));
+        updateAggregationResultHolder(aggregationResultHolder, max);
         break;
       }
       default:
@@ -134,117 +147,42 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
     }
   }
 
-  private void aggregateNullHandlingEnabled(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    switch (blockValSet.getValueType().getStoredType()) {
-      case INT: {
-        if (nullBitmap.getCardinality() < length) {
-          int[] values = blockValSet.getIntValuesSV();
-          int max = Integer.MIN_VALUE;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              max = Math.max(values[i], max);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, max);
-        }
-        // Note: when all input values re null (nullBitmap.getCardinality() == values.length), max is null. As a result,
-        // we don't update the value of aggregationResultHolder.
-        break;
+  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number max) {
+    if (max != null) {
+      if (_nullHandlingEnabled) {
+        Double otherMax = aggregationResultHolder.getResult();
+        aggregationResultHolder.setValue(otherMax == null ? max.doubleValue() : Math.max(max.doubleValue(), otherMax));
+      } else {
+        double otherMax = aggregationResultHolder.getDoubleResult();
+        aggregationResultHolder.setValue(Math.max(max.doubleValue(), otherMax));
       }
-      case LONG: {
-        if (nullBitmap.getCardinality() < length) {
-          long[] values = blockValSet.getLongValuesSV();
-          long max = Long.MIN_VALUE;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              max = Math.max(values[i], max);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, max);
-        }
-        break;
-      }
-      case FLOAT: {
-        if (nullBitmap.getCardinality() < length) {
-          float[] values = blockValSet.getFloatValuesSV();
-          float max = Float.NEGATIVE_INFINITY;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              max = Math.max(values[i], max);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, max);
-        }
-        break;
-      }
-      case DOUBLE: {
-        if (nullBitmap.getCardinality() < length) {
-          double[] values = blockValSet.getDoubleValuesSV();
-          double max = Double.NEGATIVE_INFINITY;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              max = Math.max(values[i], max);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, max);
-        }
-        break;
-      }
-      case BIG_DECIMAL: {
-        if (nullBitmap.getCardinality() < length) {
-          BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-          BigDecimal max = null;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              max = max == null ? values[i] : values[i].max(max);
-            }
-          }
-          // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-          assert max != null;
-          updateAggregationResultHolder(aggregationResultHolder, max.doubleValue());
-        }
-        break;
-      }
-      default:
-        throw new IllegalStateException("Cannot compute max for non-numeric type: " + blockValSet.getValueType());
     }
-  }
-
-  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, double max) {
-    Double otherMax = aggregationResultHolder.getResult();
-    aggregationResultHolder.setValue(otherMax == null ? max : Math.max(max, otherMax));
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[] valueArray = blockValSet.getDoubleValuesSV();
+
     if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      if (nullBitmap.getCardinality() < length) {
-        double[] valueArray = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
           double value = valueArray[i];
           int groupKey = groupKeyArray[i];
           Double result = groupByResultHolder.getResult(groupKey);
-          if (!nullBitmap.contains(i) && (result == null || value > result)) {
+          if (result == null || value > result) {
             groupByResultHolder.setValueForKey(groupKey, value);
           }
         }
-      }
-      return;
-    }
-
-    double[] valueArray = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      int groupKey = groupKeyArray[i];
-      if (value > groupByResultHolder.getDoubleResult(groupKey)) {
-        groupByResultHolder.setValueForKey(groupKey, value);
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        double value = valueArray[i];
+        int groupKey = groupKeyArray[i];
+        if (value > groupByResultHolder.getDoubleResult(groupKey)) {
+          groupByResultHolder.setValueForKey(groupKey, value);
+        }
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -130,7 +130,7 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
       case BIG_DECIMAL: {
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
 
-        BigDecimal max = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+        BigDecimal max = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
           BigDecimal innerMax = values[from];
           for (int i = from; i < to; i++) {
             innerMax = innerMax.max(values[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -130,7 +130,7 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
       case BIG_DECIMAL: {
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
 
-        BigDecimal min = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+        BigDecimal min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
           BigDecimal innerMin = values[from];
           for (int i = from; i < to; i++) {
             innerMin = innerMin.min(values[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -31,20 +31,17 @@ import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.roaringbitmap.RoaringBitmap;
 
 
-public class MinAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
+public class MinAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
-  private final boolean _nullHandlingEnabled;
 
   public MinAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "MIN"), nullHandlingEnabled);
   }
 
   protected MinAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -72,60 +69,77 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      aggregateNullHandlingEnabled(length, aggregationResultHolder, blockValSet, nullBitmap);
-      return;
-    }
 
     switch (blockValSet.getValueType().getStoredType()) {
       case INT: {
         int[] values = blockValSet.getIntValuesSV();
-        int min = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          min = Math.min(values[i], min);
-        }
-        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+
+        Integer min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          int innerMin = values[from];
+          for (int i = from; i < to; i++) {
+            innerMin = Math.min(innerMin, values[i]);
+          }
+          return acum == null ? innerMin : Math.min(acum, innerMin);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, min);
         break;
       }
       case LONG: {
         long[] values = blockValSet.getLongValuesSV();
-        long min = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          min = Math.min(values[i], min);
-        }
-        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+
+        Long min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          long innerMin = values[from];
+          for (int i = from; i < to; i++) {
+            innerMin = Math.min(innerMin, values[i]);
+          }
+          return acum == null ? innerMin : Math.min(acum, innerMin);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, min);
         break;
       }
       case FLOAT: {
         float[] values = blockValSet.getFloatValuesSV();
-        float min = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          min = Math.min(values[i], min);
-        }
-        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+
+        Float min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          float innerMin = values[from];
+          for (int i = from; i < to; i++) {
+            innerMin = Math.min(innerMin, values[i]);
+          }
+          return acum == null ? innerMin : Math.min(acum, innerMin);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, min);
         break;
       }
       case DOUBLE: {
         double[] values = blockValSet.getDoubleValuesSV();
-        double min = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          min = Math.min(values[i], min);
-        }
-        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+
+        Double min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerMin = values[from];
+          for (int i = from; i < to; i++) {
+            innerMin = Math.min(innerMin, values[i]);
+          }
+          return acum == null ? innerMin : Math.min(acum, innerMin);
+        });
+
+        updateAggregationResultHolder(aggregationResultHolder, min);
         break;
       }
       case BIG_DECIMAL: {
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-        BigDecimal min = values[0];
-        for (int i = 0; i < length & i < values.length; i++) {
-          min = values[i].min(min);
-        }
+
+        BigDecimal min = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+          BigDecimal innerMin = values[from];
+          for (int i = from; i < to; i++) {
+            innerMin = innerMin.min(values[i]);
+          }
+          return acum == null ? innerMin : acum.min(innerMin);
+        });
+
         // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-        aggregationResultHolder.setValue(Math.min(min.doubleValue(), aggregationResultHolder.getDoubleResult()));
+        updateAggregationResultHolder(aggregationResultHolder, min);
         break;
       }
       default:
@@ -133,117 +147,42 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
     }
   }
 
-  private void aggregateNullHandlingEnabled(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    switch (blockValSet.getValueType().getStoredType()) {
-      case INT: {
-        if (nullBitmap.getCardinality() < length) {
-          int[] values = blockValSet.getIntValuesSV();
-          int min = Integer.MAX_VALUE;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              min = Math.min(values[i], min);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, min);
-        }
-        // Note: when all input values re null (nullBitmap.getCardinality() == values.length), min is null. As a result,
-        // we don't update the value of aggregationResultHolder.
-        break;
+  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number min) {
+    if (min != null) {
+      if (_nullHandlingEnabled) {
+        Double otherMin = aggregationResultHolder.getResult();
+        aggregationResultHolder.setValue(otherMin == null ? min.doubleValue() : Math.min(min.doubleValue(), otherMin));
+      } else {
+        double otherMin = aggregationResultHolder.getDoubleResult();
+        aggregationResultHolder.setValue(Math.min(min.doubleValue(), otherMin));
       }
-      case LONG: {
-        if (nullBitmap.getCardinality() < length) {
-          long[] values = blockValSet.getLongValuesSV();
-          long min = Long.MAX_VALUE;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              min = Math.min(values[i], min);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, min);
-        }
-        break;
-      }
-      case FLOAT: {
-        if (nullBitmap.getCardinality() < length) {
-          float[] values = blockValSet.getFloatValuesSV();
-          float min = Float.POSITIVE_INFINITY;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              min = Math.min(values[i], min);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, min);
-        }
-        break;
-      }
-      case DOUBLE: {
-        if (nullBitmap.getCardinality() < length) {
-          double[] values = blockValSet.getDoubleValuesSV();
-          double min = Double.POSITIVE_INFINITY;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              min = Math.min(values[i], min);
-            }
-          }
-          updateAggregationResultHolder(aggregationResultHolder, min);
-        }
-        break;
-      }
-      case BIG_DECIMAL: {
-        if (nullBitmap.getCardinality() < length) {
-          BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-          BigDecimal min = null;
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              min = min == null ? values[i] : values[i].min(min);
-            }
-          }
-          assert min != null;
-          // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-          updateAggregationResultHolder(aggregationResultHolder, min.doubleValue());
-        }
-        break;
-      }
-      default:
-        throw new IllegalStateException("Cannot compute min for non-numeric type: " + blockValSet.getValueType());
     }
-  }
-
-  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, double min) {
-    Double otherMin = aggregationResultHolder.getResult();
-    aggregationResultHolder.setValue(otherMin == null ? min : Math.min(min, otherMin));
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[] valueArray = blockValSet.getDoubleValuesSV();
+
     if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      if (nullBitmap.getCardinality() < length) {
-        double[] valueArray = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
           double value = valueArray[i];
           int groupKey = groupKeyArray[i];
           Double result = groupByResultHolder.getResult(groupKey);
-          if (!nullBitmap.contains(i) && (result == null || value < result)) {
+          if (result == null || value < result) {
             groupByResultHolder.setValueForKey(groupKey, value);
           }
         }
-      }
-      return;
-    }
-
-    double[] valueArray = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      int groupKey = groupKeyArray[i];
-      if (value < groupByResultHolder.getDoubleResult(groupKey)) {
-        groupByResultHolder.setValueForKey(groupKey, value);
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        double value = valueArray[i];
+        int groupKey = groupKeyArray[i];
+        if (value < groupByResultHolder.getDoubleResult(groupKey)) {
+          groupByResultHolder.setValueForKey(groupKey, value);
+        }
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
@@ -114,7 +114,7 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
    * @param <A> The type of the accumulator
    */
   public <A> A foldNotNull(int length, BlockValSet blockValSet, A initialAcum, Reducer<A> reducer) {
-    return foldNotNull(length, blockValSet.getNullBitmap(), initialAcum, reducer);
+    return foldNotNull(length, _nullHandlingEnabled ? blockValSet.getNullBitmap() : null, initialAcum, reducer);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/NullableSingleInputAggregationFunction.java
@@ -107,7 +107,9 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
   }
 
   /**
-   * Folds over the non-null ranges of the blockValSet using the reducer.
+   * Folds over the non-null ranges of the blockValSet using the reducer. Returns {@code initialAcum} if the entire
+   * block is null.
+   *
    * @param initialAcum the initial value of the accumulator
    * @param <A> The type of the accumulator
    */
@@ -116,7 +118,8 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
   }
 
   /**
-   * Folds over the non-null ranges of the blockValSet using the reducer.
+   * Folds over the non-null ranges of the blockValSet using the reducer. Returns {@code initialAcum} if the entire
+   * block is null.
    * @param initialAcum the initial value of the accumulator
    * @param <A> The type of the accumulator
    */
@@ -139,6 +142,11 @@ public abstract class NullableSingleInputAggregationFunction<I, F extends Compar
    */
   public <A> A foldNotNull(int length, @Nullable IntIterator nullIndexIterator, A initialAcum, Reducer<A> reducer) {
     A acum = initialAcum;
+
+    if (length == 0) {
+      return acum;
+    }
+
     if (!_nullHandlingEnabled || nullIndexIterator == null || !nullIndexIterator.hasNext()) {
       return reducer.apply(initialAcum, 0, length);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -31,20 +31,17 @@ import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.roaringbitmap.RoaringBitmap;
 
 
-public class SumAggregationFunction extends BaseSingleInputAggregationFunction<Double, Double> {
+public class SumAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
   private static final double DEFAULT_VALUE = 0.0;
-  private final boolean _nullHandlingEnabled;
 
   public SumAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "SUM"), nullHandlingEnabled);
   }
 
   protected SumAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -72,170 +69,112 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      aggregateNullHandlingEnabled(length, aggregationResultHolder, blockValSet, nullBitmap);
-      return;
-    }
 
-    double sum = aggregationResultHolder.getDoubleResult();
+    Double sum;
     switch (blockValSet.getValueType().getStoredType()) {
       case INT: {
         int[] values = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length & i < values.length; i++) {
-          sum += values[i];
-        }
+
+        sum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerSum = 0;
+          for (int i = from; i < to; i++) {
+            innerSum += values[i];
+          }
+          return acum == null ? innerSum : acum + innerSum;
+        });
+
         break;
       }
       case LONG: {
         long[] values = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length & i < values.length; i++) {
-          sum += values[i];
-        }
+
+        sum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerSum = 0;
+          for (int i = from; i < to; i++) {
+            innerSum += values[i];
+          }
+          return acum == null ? innerSum : acum + innerSum;
+        });
+
         break;
       }
       case FLOAT: {
         float[] values = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length & i < values.length; i++) {
-          sum += values[i];
-        }
+
+        sum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerSum = 0;
+          for (int i = from; i < to; i++) {
+            innerSum += values[i];
+          }
+          return acum == null ? innerSum : acum + innerSum;
+        });
+
         break;
       }
       case DOUBLE: {
         double[] values = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length & i < values.length; i++) {
-          sum += values[i];
-        }
+
+        sum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          double innerSum = 0;
+          for (int i = from; i < to; i++) {
+            innerSum += values[i];
+          }
+          return acum == null ? innerSum : acum + innerSum;
+        });
+
         break;
       }
       case BIG_DECIMAL: {
-        BigDecimal decimalSum = BigDecimal.valueOf(sum);
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-        for (int i = 0; i < length & i < values.length; i++) {
-          decimalSum = decimalSum.add(values[i]);
-        }
+
+        BigDecimal decimalSum = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+          BigDecimal innerSum = BigDecimal.ZERO;
+          for (int i = from; i < to; i++) {
+            innerSum = innerSum.add(values[i]);
+          }
+          return acum == null ? innerSum : acum.add(innerSum);
+        });
         // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-        sum = decimalSum.doubleValue();
+        sum = decimalSum == null ? null : decimalSum.doubleValue();
         break;
       }
       default:
         throw new IllegalStateException("Cannot compute sum for non-numeric type: " + blockValSet.getValueType());
     }
-    aggregationResultHolder.setValue(sum);
+    updateAggregationResultHolder(aggregationResultHolder, sum);
   }
 
-  private void aggregateNullHandlingEnabled(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    double sum = 0;
-    switch (blockValSet.getValueType().getStoredType()) {
-      case INT: {
-        if (nullBitmap.getCardinality() < length) {
-          int[] values = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              sum += values[i];
-            }
-          }
-          setAggregationResultHolder(aggregationResultHolder, sum);
-        }
-        break;
+  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Double sum) {
+    if (sum != null) {
+      if (_nullHandlingEnabled) {
+        Double otherSum = aggregationResultHolder.getResult();
+        aggregationResultHolder.setValue(otherSum == null ? sum : sum + otherSum);
+      } else {
+        double otherSum = aggregationResultHolder.getDoubleResult();
+        aggregationResultHolder.setValue(sum + otherSum);
       }
-      case LONG: {
-        if (nullBitmap.getCardinality() < length) {
-          long[] values = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              sum += values[i];
-            }
-          }
-          setAggregationResultHolder(aggregationResultHolder, sum);
-        }
-        break;
-      }
-      case FLOAT: {
-        if (nullBitmap.getCardinality() < length) {
-          float[] values = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              sum += values[i];
-            }
-          }
-          setAggregationResultHolder(aggregationResultHolder, sum);
-        }
-        break;
-      }
-      case DOUBLE: {
-        if (nullBitmap.getCardinality() < length) {
-          double[] values = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              sum += values[i];
-            }
-          }
-          setAggregationResultHolder(aggregationResultHolder, sum);
-        }
-        break;
-      }
-      case BIG_DECIMAL: {
-        if (nullBitmap.getCardinality() < length) {
-          BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
-          BigDecimal decimalSum = BigDecimal.valueOf(sum);
-          for (int i = 0; i < length & i < values.length; i++) {
-            if (!nullBitmap.contains(i)) {
-              decimalSum = decimalSum.add(values[i]);
-            }
-          }
-          // TODO: even though the source data has BIG_DECIMAL type, we still only support double precision.
-          setAggregationResultHolder(aggregationResultHolder, decimalSum.doubleValue());
-        }
-        break;
-      }
-      default:
-        throw new IllegalStateException("Cannot compute sum for non-numeric type: " + blockValSet.getValueType());
     }
-  }
-
-  private void setAggregationResultHolder(AggregationResultHolder aggregationResultHolder, double sum) {
-    Double otherSum = aggregationResultHolder.getResult();
-    aggregationResultHolder.setValue(otherSum == null ? sum : sum + otherSum);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
-      if (nullBitmap == null) {
-        nullBitmap = new RoaringBitmap();
-      }
-      if (nullBitmap.getCardinality() < length) {
-        double[] valueArray = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          if (!nullBitmap.contains(i)) {
-            int groupKey = groupKeyArray[i];
-            Double result = groupByResultHolder.getResult(groupKey);
-            groupByResultHolder.setValueForKey(groupKey, result == null ? valueArray[i] : result + valueArray[i]);
-            // In presto:
-            // SELECT sum (cast(id AS DOUBLE)) as sum,  min(id) as min, max(id) as max, key FROM (VALUES (null, 1),
-            // (null, 2)) AS t(id, key)  GROUP BY key ORDER BY max DESC;
-            // sum  | min  | max  | key
-            //------+------+------+-----
-            // NULL | NULL | NULL |   2
-            // NULL | NULL | NULL |   1
-          }
-        }
-      }
-      return;
-    }
-
     double[] valueArray = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int groupKey = groupKeyArray[i];
+          Double result = groupByResultHolder.getResult(groupKey);
+          groupByResultHolder.setValueForKey(groupKey, result == null ? valueArray[i] : result + valueArray[i]);
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        int groupKey = groupKeyArray[i];
+        groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -127,7 +127,7 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
       case BIG_DECIMAL: {
         BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
 
-        BigDecimal decimalSum = foldNotNull(length, blockValSet.getNullBitmap(), null, (acum, from, to) -> {
+        BigDecimal decimalSum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
           BigDecimal innerSum = BigDecimal.ZERO;
           for (int i = from; i < to; i++) {
             innerSum = innerSum.add(values[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
@@ -19,12 +19,12 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongOpenHashSet> {
@@ -34,26 +34,17 @@ public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongO
   }
 
   @Override
-  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     long[] value = blockValSet.getLongValuesSV();
     LongOpenHashSet valueArray = new LongOpenHashSet(length);
-    for (int i = 0; i < length; i++) {
-      valueArray.add(value[i]);
-    }
-    aggregationResultHolder.setValue(valueArray);
-  }
 
-  @Override
-  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    long[] value = blockValSet.getLongValuesSV();
-    LongOpenHashSet valueArray = new LongOpenHashSet(length);
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         valueArray.add(value[i]);
       }
-    }
+    });
     aggregationResultHolder.setValue(valueArray);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.Arrays;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<ObjectOpenHashSet<String>> {
@@ -33,23 +33,12 @@ public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<O
   }
 
   @Override
-  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
-    ObjectOpenHashSet<String> valueArray = new ObjectOpenHashSet<>(length);
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     String[] value = blockValSet.getStringValuesSV();
-    valueArray.addAll(Arrays.asList(value));
-    aggregationResultHolder.setValue(valueArray);
-  }
-
-  @Override
-  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
     ObjectOpenHashSet<String> valueArray = new ObjectOpenHashSet<>(length);
-    String[] value = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
-        valueArray.add(value[i]);
-      }
-    }
+    forEachNotNull(length, blockValSet, (from, to) -> valueArray.addAll(Arrays.asList(value).subList(from, to)));
     aggregationResultHolder.setValue(valueArray);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggFloatFunction extends BaseArrayAggFloatFunction<FloatArrayList> {
@@ -32,30 +32,21 @@ public class ArrayAggFloatFunction extends BaseArrayAggFloatFunction<FloatArrayL
   }
 
   @Override
-  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
-    FloatArrayList valueArray = new FloatArrayList(length);
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     float[] value = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      valueArray.add(value[i]);
-    }
-    aggregationResultHolder.setValue(valueArray);
-  }
+    FloatArrayList valueArray = new FloatArrayList(length);
 
-  @Override
-  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    FloatArrayList valueArray = new FloatArrayList(length);
-    float[] value = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         valueArray.add(value[i]);
       }
-    }
+    });
     aggregationResultHolder.setValue(valueArray);
   }
 
   @Override
-
   protected void setGroupByResult(GroupByResultHolder resultHolder, int groupKey, float value) {
     FloatArrayList valueArray = resultHolder.getResult(groupKey);
     if (valueArray == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggStringFunction extends BaseArrayAggStringFunction<ObjectArrayList<String>> {
@@ -33,23 +33,12 @@ public class ArrayAggStringFunction extends BaseArrayAggStringFunction<ObjectArr
   }
 
   @Override
-  protected void aggregateArray(int length, AggregationResultHolder aggregationResultHolder, BlockValSet blockValSet) {
-    ObjectArrayList<String> valueArray = new ObjectArrayList<>(length);
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     String[] value = blockValSet.getStringValuesSV();
-    valueArray.addAll(Arrays.asList(value));
-    aggregationResultHolder.setValue(valueArray);
-  }
-
-  @Override
-  protected void aggregateArrayWithNull(int length, AggregationResultHolder aggregationResultHolder,
-      BlockValSet blockValSet, RoaringBitmap nullBitmap) {
     ObjectArrayList<String> valueArray = new ObjectArrayList<>(length);
-    String[] value = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
-        valueArray.add(value[i]);
-      }
-    }
+    forEachNotNull(length, blockValSet, (from, to) -> valueArray.addAll(Arrays.asList(value).subList(from, to)));
     aggregationResultHolder.setValue(valueArray);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.doubles.AbstractDoubleCollection;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggDoubleFunction<I extends AbstractDoubleCollection>
@@ -36,47 +36,32 @@ public abstract class BaseArrayAggDoubleFunction<I extends AbstractDoubleCollect
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, double value);
 
   @Override
-  protected void aggregateArrayGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     double[] values = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupBySVWithNull(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    double[] values = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
       }
-    }
+    });
   }
 
   @Override
-  protected void aggregateArrayGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     double[] values = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      for (int groupKey : groupKeysArray[i]) {
-        setGroupByResult(groupByResultHolder, groupKey, values[i]);
-      }
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupByMVWithNull(int length, int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    double[] values = blockValSet.getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
-        for (int groupKey : groupKeysArray[i]) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        int[] groupKeys = groupKeysArray[i];
+        for (int groupKey : groupKeys) {
           setGroupByResult(groupByResultHolder, groupKey, values[i]);
         }
       }
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.floats.AbstractFloatCollection;
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggFloatFunction<I extends AbstractFloatCollection>
@@ -36,47 +36,32 @@ public abstract class BaseArrayAggFloatFunction<I extends AbstractFloatCollectio
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, float value);
 
   @Override
-  protected void aggregateArrayGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     float[] values = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupBySVWithNull(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    float[] values = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
       }
-    }
+    });
   }
 
   @Override
-  protected void aggregateArrayGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     float[] values = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      for (int groupKey : groupKeysArray[i]) {
-        setGroupByResult(groupByResultHolder, groupKey, values[i]);
-      }
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupByMVWithNull(int length, int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    float[] values = blockValSet.getFloatValuesSV();
-    for (int i = 0; i < length; i++) {
-      for (int groupKey : groupKeysArray[i]) {
-        if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        int[] groupKeys = groupKeysArray[i];
+        for (int groupKey : groupKeys) {
           setGroupByResult(groupByResultHolder, groupKey, values[i]);
         }
       }
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
@@ -20,11 +20,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.longs.AbstractLongCollection;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggLongFunction<I extends AbstractLongCollection>
@@ -37,49 +37,32 @@ public abstract class BaseArrayAggLongFunction<I extends AbstractLongCollection>
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, long value);
 
   @Override
-  protected void aggregateArrayGroupBySV(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet) {
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     long[] values = blockValSet.getLongValuesSV();
-    for (int i = 0; i < length; i++) {
-      setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupBySVWithNull(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    long[] values = blockValSet.getLongValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
       }
-    }
+    });
   }
 
   @Override
-  protected void aggregateArrayGroupByMV(int length, int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet) {
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     long[] values = blockValSet.getLongValuesSV();
-    for (int i = 0; i < length; i++) {
-      int[] groupKeys = groupKeysArray[i];
-      for (int groupKey : groupKeys) {
-        setGroupByResult(groupByResultHolder, groupKey, values[i]);
-      }
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupByMVWithNull(int length, int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    long[] values = blockValSet.getLongValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         int[] groupKeys = groupKeysArray[i];
         for (int groupKey : groupKeys) {
           setGroupByResult(groupByResultHolder, groupKey, values[i]);
         }
       }
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
@@ -21,11 +21,11 @@ package org.apache.pinot.core.query.aggregation.function.array;
 import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectIterators;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollection<String>>
@@ -37,47 +37,32 @@ public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollect
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, String value);
 
   @Override
-  protected void aggregateArrayGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     String[] values = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupBySVWithNull(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    String[] values = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
         setGroupByResult(groupByResultHolder, groupKeyArray[i], values[i]);
       }
-    }
+    });
   }
 
   @Override
-  protected void aggregateArrayGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet) {
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
     String[] values = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      for (int groupKey : groupKeysArray[i]) {
-        setGroupByResult(groupByResultHolder, groupKey, values[i]);
-      }
-    }
-  }
 
-  @Override
-  protected void aggregateArrayGroupByMVWithNull(int length, int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, RoaringBitmap nullBitmap) {
-    String[] values = blockValSet.getStringValuesSV();
-    for (int i = 0; i < length; i++) {
-      if (!nullBitmap.contains(i)) {
-        for (int groupKey : groupKeysArray[i]) {
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        int[] groupKeys = groupKeysArray[i];
+        for (int groupKey : groupKeys) {
           setGroupByResult(groupByResultHolder, groupKey, values[i]);
         }
       }
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ArrayAggFunctionTest.java
@@ -1,0 +1,661 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+
+public class ArrayAggFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  void aggregationAllNullsWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
+        .thenResultIs(new Object[]{new int[]{Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE,
+            Integer.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationAllNullsWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+        .thenResultIs(new Object[]{new long[0]});
+  }
+
+  @Test
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', arrayagg(myField, 'FLOAT') from testTable group by 'literal'")
+        .thenResultIs(new Object[]{"literal", new float[]{Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY,
+            Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}});
+  }
+
+  @Test
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', arrayagg(myField, 'DOUBLE') from testTable group by 'literal'")
+        .thenResultIs(new Object[]{"literal", new double[0]});
+  }
+
+  @Test
+  void aggregationIntWithNullHandlingDisabled() {
+    // Use repeated segment values because order of processing across segments isn't deterministic and not relevant
+    // to this test
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
+        .thenResultIs(new Object[]{new int[]{1, Integer.MIN_VALUE, 2, 1, Integer.MIN_VALUE, 2}});
+  }
+
+  @Test
+  void aggregationIntWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).whenQuery("select arrayagg(myField, 'INT') from testTable")
+        .thenResultIs(new Object[]{new int[]{1, 2, 1, 2}});
+  }
+
+  @Test
+  void aggregationDistinctIntWithNullHandlingDisabled() {
+    // Use a single value in the segment because ordering is currently not deterministic due to the use of a hashset in
+    // distinct array agg
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'INT', true) from testTable")
+        .thenResultIs(new Object[]{new int[]{Integer.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationDistinctIntWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "1"
+        ).whenQuery("select arrayagg(myField, 'INT', true) from testTable")
+        .thenResultIs(new Object[]{new int[]{1}});
+  }
+
+  @Test
+  void aggregationGroupBySVIntWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'INT') from testTable group by myField")
+        .thenResultIs(new Object[]{1, new int[]{1, 1}}, new Object[]{2, new int[]{2, 2}},
+            new Object[]{Integer.MIN_VALUE, new int[]{Integer.MIN_VALUE, Integer.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationGroupBySVIntWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'INT') from testTable group by myField")
+        .thenResultIs(new Object[]{1, new int[]{1, 1}}, new Object[]{2, new int[]{2, 2}},
+            new Object[]{null, new int[0]});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVIntWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'INT', true) from testTable group by myField")
+        .thenResultIs(new Object[]{1, new int[]{1}}, new Object[]{2, new int[]{2}},
+            new Object[]{Integer.MIN_VALUE, new int[]{Integer.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVIntWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.INT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'INT', true) from testTable group by myField")
+        .thenResultIs(new Object[]{1, new int[]{1}}, new Object[]{2, new int[]{2}},
+            new Object[]{null, new int[0]});
+  }
+
+  @Test
+  void aggregationLongWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+        .thenResultIs(new Object[]{new long[]{1, Long.MIN_VALUE, 2, 1, Long.MIN_VALUE, 2}});
+  }
+
+  @Test
+  void aggregationLongWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).whenQuery("select arrayagg(myField, 'LONG') from testTable")
+        .thenResultIs(new Object[]{new long[]{1, 2, 1, 2}});
+  }
+
+  @Test
+  void aggregationDistinctLongWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
+        .thenResultIs(new Object[]{new long[]{Long.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationDistinctLongWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "1"
+        ).whenQuery("select arrayagg(myField, 'LONG', true) from testTable")
+        .thenResultIs(new Object[]{new long[]{1}});
+  }
+
+  @Test
+  void aggregationGroupBySVLongWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'LONG') from testTable group by myField")
+        .thenResultIs(new Object[]{1L, new long[]{1, 1}}, new Object[]{2L, new long[]{2, 2}},
+            new Object[]{Long.MIN_VALUE, new long[]{Long.MIN_VALUE, Long.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationGroupBySVLongWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'LONG') from testTable group by myField")
+        .thenResultIs(new Object[]{1L, new long[]{1, 1}}, new Object[]{2L, new long[]{2, 2}},
+            new Object[]{null, new long[0]});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVLongWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'LONG', true) from testTable group by myField")
+        .thenResultIs(new Object[]{1L, new long[]{1}}, new Object[]{2L, new long[]{2}},
+            new Object[]{Long.MIN_VALUE, new long[]{Long.MIN_VALUE}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVLongWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.LONG).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).andOnSecondInstance("myField",
+            "1",
+            "2",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'LONG', true) from testTable group by myField")
+        .thenResultIs(new Object[]{1L, new long[]{1}}, new Object[]{2L, new long[]{2}},
+            new Object[]{null, new long[0]});
+  }
+
+  @Test
+  void aggregationFloatWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
+        .thenResultIs(new Object[]{new float[]{1.0f, Float.NEGATIVE_INFINITY, 2.0f, 1.0f, Float.NEGATIVE_INFINITY,
+            2.0f}});
+  }
+
+  @Test
+  void aggregationFloatWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).whenQuery("select arrayagg(myField, 'FLOAT') from testTable")
+        .thenResultIs(new Object[]{new float[]{1.0f, 2.0f, 1.0f, 2.0f}});
+  }
+
+  @Test
+  void aggregationDistinctFloatWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
+        .thenResultIs(new Object[]{new float[]{Float.NEGATIVE_INFINITY}});
+  }
+
+  @Test
+  void aggregationDistinctFloatWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "1.0"
+        ).whenQuery("select arrayagg(myField, 'FLOAT', true) from testTable")
+        .thenResultIs(new Object[]{new float[]{1.0f}});
+  }
+
+  @Test
+  void aggregationGroupBySVFloatWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'FLOAT') from testTable group by myField")
+        .thenResultIs(new Object[]{Float.NEGATIVE_INFINITY,
+                new float[]{Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}},
+            new Object[]{1.0f, new float[]{1.0f, 1.0f}}, new Object[]{2.0f, new float[]{2.0f, 2.0f}});
+  }
+
+  @Test
+  void aggregationGroupBySVFloatWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0"
+        ).whenQuery("select myField, arrayagg(myField, 'FLOAT') from testTable group by myField")
+        .thenResultIs(new Object[]{null, new float[0]}, new Object[]{1.0f, new float[]{1.0f, 1.0f}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVFloatWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'FLOAT', true) from testTable group by myField")
+        .thenResultIs(new Object[]{Float.NEGATIVE_INFINITY, new float[]{Float.NEGATIVE_INFINITY}},
+            new Object[]{1.0f, new float[]{1.0f}}, new Object[]{2.0f, new float[]{2.0f}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVFloatWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.FLOAT).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0"
+        ).whenQuery("select myField, arrayagg(myField, 'FLOAT', true) from testTable group by myField")
+        .thenResultIs(new Object[]{null, new float[0]}, new Object[]{1.0f, new float[]{1.0f}});
+  }
+
+  @Test
+  void aggregationDoubleWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
+        .thenResultIs(new Object[]{new double[]{1.0, Double.NEGATIVE_INFINITY, 2.0, 1.0, Double.NEGATIVE_INFINITY,
+            2.0}});
+  }
+
+  @Test
+  void aggregationDoubleWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "1.0",
+            "null",
+            "2.0"
+        ).whenQuery("select arrayagg(myField, 'DOUBLE') from testTable")
+        .thenResultIs(new Object[]{new double[]{1.0, 2.0, 1.0, 2.0}});
+  }
+
+  @Test
+  void aggregationDistinctDoubleWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
+        .thenResultIs(new Object[]{new double[]{Double.NEGATIVE_INFINITY}});
+  }
+
+  @Test
+  void aggregationDistinctDoubleWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "1.0",
+            "null",
+            "1.0"
+        ).whenQuery("select arrayagg(myField, 'DOUBLE', true) from testTable")
+        .thenResultIs(new Object[]{new double[]{1.0}});
+  }
+
+  @Test
+  void aggregationGroupBySVDoubleWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'DOUBLE') from testTable group by myField")
+        .thenResultIs(new Object[]{Double.NEGATIVE_INFINITY, new double[]{Double.NEGATIVE_INFINITY,
+                Double.NEGATIVE_INFINITY}}, new Object[]{1.0, new double[]{1.0, 1.0}},
+            new Object[]{2.0, new double[]{2.0, 2.0}});
+  }
+
+  @Test
+  void aggregationGroupBySVDoubleWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'DOUBLE') from testTable group by myField")
+        .thenResultIs(new Object[]{null, new double[0]}, new Object[]{1.0, new double[]{1.0, 1.0}},
+            new Object[]{2.0, new double[]{2.0, 2.0}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVDoubleWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'DOUBLE', true) from testTable group by myField")
+        .thenResultIs(new Object[]{Double.NEGATIVE_INFINITY, new double[]{Double.NEGATIVE_INFINITY}},
+            new Object[]{1.0, new double[]{1.0}}, new Object[]{2.0, new double[]{2.0}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVDoubleWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.DOUBLE).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1.0",
+            "2.0"
+        ).whenQuery("select myField, arrayagg(myField, 'DOUBLE', true) from testTable group by myField")
+        .thenResultIs(new Object[]{null, new double[0]}, new Object[]{1.0, new double[]{1.0}},
+            new Object[]{2.0, new double[]{2.0}});
+  }
+
+  @Test
+  void aggregationStringWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "a",
+            "null",
+            "b"
+        ).andOnSecondInstance("myField",
+            "a",
+            "null",
+            "b"
+        ).whenQuery("select arrayagg(myField, 'STRING') from testTable")
+        .thenResultIs(new Object[]{new String[]{"a", "null", "b", "a", "null", "b"}});
+  }
+
+  @Test
+  void aggregationStringWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "a",
+            "null",
+            "b"
+        ).andOnSecondInstance("myField",
+            "a",
+            "null",
+            "b"
+        ).whenQuery("select arrayagg(myField, 'STRING') from testTable")
+        .thenResultIs(new Object[]{new String[]{"a", "b", "a", "b"}});
+  }
+
+  @Test
+  void aggregationDistinctStringWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
+        .thenResultIs(new Object[]{new String[]{"null"}});
+  }
+
+  @Test
+  void aggregationDistinctStringWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "a",
+            "null",
+            "a"
+        ).whenQuery("select arrayagg(myField, 'STRING', true) from testTable")
+        .thenResultIs(new Object[]{new String[]{"a"}});
+  }
+
+  @Test
+  void aggregationGroupBySVStringWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).andOnSecondInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'STRING') from testTable group by myField")
+        .thenResultIs(new Object[]{"a", new String[]{"a", "a"}}, new Object[]{"b", new String[]{"b", "b"}},
+            new Object[]{"null", new String[]{"null", "null"}});
+  }
+
+  @Test
+  void aggregationGroupBySVStringWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).andOnSecondInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'STRING') from testTable group by myField")
+        .thenResultIs(new Object[]{"a", new String[]{"a", "a"}}, new Object[]{"b", new String[]{"b", "b"}},
+            new Object[]{null, new String[0]});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVStringWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).andOnSecondInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'STRING', true) from testTable group by myField")
+        .thenResultIs(new Object[]{"a", new String[]{"a"}}, new Object[]{"b", new String[]{"b"}},
+            new Object[]{"null", new String[]{"null"}});
+  }
+
+  @Test
+  void aggregationDistinctGroupBySVStringWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.STRING).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).andOnSecondInstance("myField",
+            "a",
+            "b",
+            "null"
+        ).whenQuery("select myField, arrayagg(myField, 'STRING', true) from testTable group by myField")
+        .thenResultIs(new Object[]{"a", new String[]{"a"}}, new Object[]{"b", new String[]{"b"}},
+            new Object[]{null, new String[0]});
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select avg(myField) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select avg(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "7",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "3"
+        ).whenQuery("select avg(myField) from testTable")
+        .thenResultIs("DOUBLE", "3");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "7",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "3"
+        ).whenQuery("select avg(myField) from testTable")
+        .thenResultIs("DOUBLE", "5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "7",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "3"
+        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 3");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "7",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "3"
+        ).whenQuery("select 'literal', avg(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 5");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/BooleanAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/BooleanAggregationFunctionTest.java
@@ -1,0 +1,178 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+
+public class BooleanAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  void aggregationAllNullsWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select bool_or(myField) from testTable")
+        .thenResultIs("BOOLEAN", "false");
+  }
+
+  @Test
+  void aggregationAllNullsWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select bool_and(myField) from testTable")
+        .thenResultIs("BOOLEAN", "null");
+  }
+
+  @Test
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | false");
+  }
+
+  @Test
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | null");
+  }
+
+  @Test
+  void andAggregationWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "true"
+        ).whenQuery("select bool_and(myField) from testTable")
+        .thenResultIs("BOOLEAN", "false");
+  }
+
+  @Test
+  void andAggregationWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select bool_and(myField) from testTable")
+        .thenResultIs("BOOLEAN", "true");
+  }
+
+  @Test
+  void andAggregationGroupBySVWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "true"
+        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | false");
+  }
+
+  @Test
+  void andAggregationGroupBySVWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', bool_and(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | true");
+  }
+
+  @Test
+  void orAggregationWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "false"
+        ).andOnSecondInstance("myField",
+            "null",
+            "false"
+        ).whenQuery("select bool_or(myField) from testTable")
+        .thenResultIs("BOOLEAN", "false");
+  }
+
+  @Test
+  void orAggregationWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select bool_or(myField) from testTable")
+        .thenResultIs("BOOLEAN", "true");
+  }
+
+  @Test
+  void orAggregationGroupBySVWithNullHandlingDisabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "true"
+        ).andOnSecondInstance("myField",
+            "null",
+            "true"
+        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | true");
+  }
+
+  @Test
+  void orAggregationGroupBySVWithNullHandlingEnabled() {
+    new DataTypeScenario(FieldSpec.DataType.BOOLEAN).getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "false"
+        ).andOnSecondInstance("myField",
+            "null",
+            "false"
+        ).whenQuery("select 'literal', bool_or(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | BOOLEAN", "literal | false");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -30,7 +31,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void list() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             new Object[] {1}
         )
@@ -50,7 +51,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void listNullHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             new Object[] {1}
         )
@@ -70,7 +71,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countNullWhenHandlingDisabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             "myField",
             "1"
@@ -93,7 +94,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countNullWhenHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             "myField",
             "1"
@@ -116,7 +117,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countStarNullWhenHandlingDisabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(false)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             "myField",
             "1"
@@ -138,7 +139,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
   public void countStarNullWhenHandlingEnabled() {
     FluentQueryTest.withBaseDir(_baseDir)
         .withNullHandling(true)
-        .givenTable(SINGLE_FIELD_NULLABLE_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
         .onFirstInstance(
             "myField",
             "1"
@@ -153,6 +154,55 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             "1    | 1",
             "2    | 1",
             "null | 1"
-        );;
+        );
+  }
+
+  @Test(dataProvider = "nullHandlingEnabled")
+  public void countStarWithoutGroupBy(boolean nullHandlingEnabled) {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandlingEnabled)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            "myField",
+            "1",
+            "2",
+            "null"
+        )
+        .andOnSecondInstance(
+            "myField",
+            "null",
+            "null"
+        )
+        .whenQuery("select COUNT(*) from testTable")
+        // COUNT(*) result should be the same regardless of whether null handling is enabled or not
+        .thenResultIs("LONG", "5");
+  }
+
+  @Test(dataProvider = "nullHandlingEnabled")
+  public void countLiteralWithoutGroupBy(boolean nullHandlingEnabled) {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandlingEnabled)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            "myField",
+            "1",
+            "2",
+            "null"
+        )
+        .andOnSecondInstance(
+            "myField",
+            "null",
+            "null"
+        )
+        .whenQuery("select COUNT('literal') from testTable")
+        // COUNT(*) result should be the same regardless of whether null handling is enabled or not
+        .thenResultIs("LONG", "5");
+  }
+
+  @DataProvider(name = "nullHandlingEnabled")
+  public Object[][] nullHandlingEnabled() {
+    return new Object[][]{
+        {false}, {true}
+    };
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
@@ -1,0 +1,281 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class DistinctAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select count(distinct myField) from testTable")
+        .thenResultIs("INTEGER", "1");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select count(distinct myField) from testTable")
+        .thenResultIs("INTEGER", "0");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | INTEGER", "literal | 1");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | INTEGER", "literal | 0");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select count(distinct myField) from testTable")
+        .thenResultIs("INTEGER", "3");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select count(distinct myField) from testTable")
+        .thenResultIs("INTEGER", "2");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctCountAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "3",
+            "2"
+        ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | INTEGER", "literal | 3");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctSumAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select sum(distinct myField) from testTable")
+        .thenResultIs("DOUBLE", addToDefaultNullValue(scenario.getDataType(), 3));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctSumAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select sum(distinct myField) from testTable")
+        .thenResultIs("DOUBLE", "3");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctSumAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "3",
+            "2"
+        ).whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | " + addToDefaultNullValue(scenario.getDataType(), 6));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctSumAggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "3",
+            "2"
+        ).whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 6");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctAvgAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "null",
+            "null"
+        ).whenQuery("select avg(distinct myField) from testTable")
+        .thenResultIs("DOUBLE", "1.0");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctAvgAggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "null",
+            "null"
+        ).whenQuery("select avg(distinct myField) from testTable")
+        .thenResultIs("DOUBLE", "1.5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctAvgAggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "3",
+            "2"
+        ).whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 1.5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctAvgAggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "2",
+            "3",
+            "2"
+        ).whenQuery("select 'literal', avg(distinct myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 2.0");
+  }
+
+  private String addToDefaultNullValue(FieldSpec.DataType dataType, int addend) {
+    switch (dataType) {
+      case INT:
+        return String.valueOf(FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT + addend);
+      case LONG:
+        return String.valueOf(FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_LONG + addend);
+      case FLOAT:
+        return String.valueOf(FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT + addend);
+      case DOUBLE:
+        return String.valueOf(FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE + addend);
+      default:
+        throw new IllegalArgumentException("Unsupported data type: " + dataType);
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunctionTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class MaxAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select max(myField) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select max(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).whenQuery("select max(myField) from testTable")
+        .thenResultIs("DOUBLE", "5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).whenQuery("select max(myField) from testTable")
+        .thenResultIs("DOUBLE", "5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 5");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "3",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', max(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 5");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunctionTest.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class MinAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select min(myField) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select min(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select min(myField) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select min(myField) from testTable")
+        .thenResultIs("DOUBLE", "2");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', min(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 3");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
@@ -20,7 +20,6 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import org.apache.pinot.common.utils.PinotDataType;
-import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,28 +30,11 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new Scenario(FieldSpec.DataType.INT),
-        new Scenario(FieldSpec.DataType.LONG),
-        new Scenario(FieldSpec.DataType.FLOAT),
-        new Scenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
     };
-  }
-
-  public class Scenario {
-    private final FieldSpec.DataType _dataType;
-
-    public Scenario(FieldSpec.DataType dataType) {
-      _dataType = dataType;
-    }
-
-    public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled) {
-      return givenSingleNullableFieldTable(_dataType, nullHandlingEnabled);
-    }
-
-    @Override
-    public String toString() {
-      return "Scenario{" + "dt=" + _dataType + '}';
-    }
   }
 
   String diffBetweenMinAnd9(FieldSpec.DataType dt) {
@@ -66,7 +48,7 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrWithoutNull(Scenario scenario) {
+  void aggrWithoutNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
         .onFirstInstance("myField",
             "null",
@@ -78,11 +60,11 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
             "null"
         )
         .whenQuery("select minmaxrange(myField) from testTable")
-        .thenResultIs("DOUBLE", diffBetweenMinAnd9(scenario._dataType));
+        .thenResultIs("DOUBLE", diffBetweenMinAnd9(scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrWithNull(Scenario scenario) {
+  void aggrWithNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
         .onFirstInstance("myField",
             "null",
@@ -97,7 +79,7 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrSvWithoutNull(Scenario scenario) {
+  void aggrSvWithoutNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
         .onFirstInstance("myField",
             "null",
@@ -108,11 +90,11 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
             "9",
             "null"
         ).whenQuery("select 'cte', minmaxrange(myField) from testTable group by 'cte'")
-        .thenResultIs("STRING | DOUBLE", "cte | " + diffBetweenMinAnd9(scenario._dataType));
+        .thenResultIs("STRING | DOUBLE", "cte | " + diffBetweenMinAnd9(scenario.getDataType()));
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrSvWithNull(Scenario scenario) {
+  void aggrSvWithNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(true)
         .onFirstInstance("myField",
             "null",
@@ -137,12 +119,12 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrSvSelfWithoutNull(Scenario scenario) {
-    PinotDataType pinotDataType = scenario._dataType == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario._dataType.name());
+  void aggrSvSelfWithoutNull(DataTypeScenario scenario) {
+    PinotDataType pinotDataType = scenario.getDataType() == FieldSpec.DataType.INT
+        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario.getDataType().name());
 
     Object defaultNullValue;
-    switch (scenario._dataType) {
+    switch (scenario.getDataType()) {
       case INT:
         defaultNullValue = Integer.MIN_VALUE;
         break;
@@ -156,7 +138,7 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
         defaultNullValue = Double.NEGATIVE_INFINITY;
         break;
       default:
-        throw new IllegalArgumentException("Unexpected scenario data type " + scenario._dataType);
+        throw new IllegalArgumentException("Unexpected scenario data type " + scenario.getDataType());
     }
 
     scenario.getDeclaringTable(false)
@@ -170,15 +152,15 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
             "2"
         ).whenQuery("select myField, minmaxrange(myField) from testTable group by myField order by myField")
         .thenResultIs(pinotDataType + " | DOUBLE",
-            defaultNullValue + " | " + aggrSvSelfWithoutNullResult(scenario._dataType),
+            defaultNullValue + " | " + aggrSvSelfWithoutNullResult(scenario.getDataType()),
             "1                   | 0",
             "2                   | 0");
   }
 
   @Test(dataProvider = "scenarios")
-  void aggrSvSelfWithNull(Scenario scenario) {
-    PinotDataType pinotDataType = scenario._dataType == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario._dataType.name());
+  void aggrSvSelfWithNull(DataTypeScenario scenario) {
+    PinotDataType pinotDataType = scenario.getDataType() == FieldSpec.DataType.INT
+        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario.getDataType().name());
 
     scenario.getDeclaringTable(true)
         .onFirstInstance("myField",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunctionTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class SumAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select sum(myField) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select sum(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "3",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select sum(myField) from testTable")
+        .thenResultIs("DOUBLE", "8");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).andOnSecondInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).whenQuery("select sum(myField) from testTable")
+        .thenResultIs("DOUBLE", "10");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 10");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', sum(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 8");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunctionTest.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class SumPrecisionAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select sumprecision(myField) from testTable")
+        .thenResultIs("STRING",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select sumprecision(myField) from testTable")
+        .thenResultIs("STRING", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "3",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select sumprecision(myField) from testTable")
+        .thenResultIs("STRING", getStringValueOfSum(8, scenario.getDataType()));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).andOnSecondInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).whenQuery("select sumprecision(myField) from testTable")
+        .thenResultIs("STRING", getStringValueOfSum(10, scenario.getDataType()));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | " + getStringValueOfSum(10, scenario.getDataType()));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', sumprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | " + getStringValueOfSum(8, scenario.getDataType()));
+  }
+
+  private String getStringValueOfSum(int sum, FieldSpec.DataType dataType) {
+    if (dataType == FieldSpec.DataType.FLOAT || dataType == FieldSpec.DataType.DOUBLE) {
+      return String.valueOf((double) sum);
+    } else {
+      return String.valueOf(sum);
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunctionTest.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.core.query.aggregation.utils.StatisticalAggregationFunctionUtils.calculateVariance;
+
+
+public class VarianceAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  private static final EnumSet<AggregationFunctionType> VARIANCE_FUNCTIONS = EnumSet.of(AggregationFunctionType.VARPOP,
+      AggregationFunctionType.VARSAMP, AggregationFunctionType.STDDEVPOP, AggregationFunctionType.STDDEVSAMP);
+
+  private static final Set<FieldSpec.DataType> DATA_TYPES = Set.of(FieldSpec.DataType.INT, FieldSpec.DataType.LONG,
+      FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE);
+
+  @DataProvider(name = "scenarios")
+  Object[][] scenarios() {
+    Object[][] scenarios = new Object[16][2];
+
+    int i = 0;
+    for (AggregationFunctionType functionType : VARIANCE_FUNCTIONS) {
+      for (FieldSpec.DataType dataType : DATA_TYPES) {
+        scenarios[i][0] = functionType;
+        scenarios[i][1] = new DataTypeScenario(dataType);
+        i++;
+      }
+    }
+
+    return scenarios;
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+        .thenResultIs("DOUBLE", "0.0");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(AggregationFunctionType functionType,
+      DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | 0.0");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(AggregationFunctionType functionType,
+      DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "3",
+            "6",
+            "null"
+        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0),
+            functionType)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "3",
+            "6",
+            "null"
+        ).whenQuery("select " + functionType.getName() + "(myField) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "3",
+            "6",
+            "null"
+        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + calculateVariance(List.of(1.0, 0.0, 2.0, 3.0, 6.0, 0.0), functionType));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(AggregationFunctionType functionType, DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "1",
+            "null",
+            "2"
+        ).andOnSecondInstance("myField",
+            "3",
+            "6",
+            "null"
+        ).whenQuery("select 'literal', " + functionType.getName() + "(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | DOUBLE", "literal | "
+            + calculateVariance(List.of(1.0, 2.0, 3.0, 6.0), functionType));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -77,6 +77,10 @@ public abstract class BaseQueriesTest {
   protected static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(2);
   protected static final BrokerMetrics BROKER_METRICS = mock(BrokerMetrics.class);
 
+  public final void shutdownExecutor() {
+    EXECUTOR_SERVICE.shutdownNow();
+  }
+
   @Language(value = "sql", prefix = "select * from table")
   protected abstract String getFilter();
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
@@ -102,6 +102,10 @@ public class FluentQueryTest {
       _extraQueryOptions = extraQueryOptions;
     }
 
+    public OnFirstInstance getFirstInstance() {
+      return new OnFirstInstance(_tableConfig, _schema, _baseDir, false, _baseQueriesTest, _extraQueryOptions);
+    }
+
     public OnFirstInstance onFirstInstance(String... content) {
       return new OnFirstInstance(_tableConfig, _schema, _baseDir, false, _baseQueriesTest, _extraQueryOptions)
           .andSegment(content);
@@ -220,6 +224,13 @@ public class FluentQueryTest {
       return this;
     }
 
+    public OnSecondInstance getSecondInstance() {
+      processSegments();
+      return new OnSecondInstance(
+          _tableConfig, _schema, _indexDir.getParentFile(), !_onSecondInstance, _baseQueriesTest, _extraQueryOptions
+      );
+    }
+
     public OnSecondInstance andOnSecondInstance(Object[]... content) {
       processSegments();
       return new OnSecondInstance(
@@ -232,6 +243,15 @@ public class FluentQueryTest {
       return new OnSecondInstance(
           _tableConfig, _schema, _indexDir.getParentFile(), !_onSecondInstance, _baseQueriesTest, _extraQueryOptions)
           .andSegment(content);
+    }
+
+    public OnFirstInstance prepareToQuery() {
+      processSegments();
+      return this;
+    }
+
+    public void tearDown() {
+      _baseQueriesTest.shutdownExecutor();
     }
   }
 
@@ -249,6 +269,15 @@ public class FluentQueryTest {
     public OnSecondInstance andSegment(String... tableText) {
       super.andSegment(tableText);
       return this;
+    }
+
+    public OnSecondInstance prepareToQuery() {
+      processSegments();
+      return this;
+    }
+
+    public void tearDown() {
+      _baseQueriesTest.shutdownExecutor();
     }
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/SyntheticBlockValSets.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/SyntheticBlockValSets.java
@@ -240,7 +240,7 @@ public class SyntheticBlockValSets {
 
     @Override
     public FieldSpec.DataType getValueType() {
-      return FieldSpec.DataType.LONG;
+      return FieldSpec.DataType.DOUBLE;
     }
 
     @Override

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationFunctionBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationFunctionBenchmark.java
@@ -30,7 +30,9 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.Blackhole;
 
-
+/**
+ * Base class for aggregation function benchmarks.
+ */
 public abstract class AbstractAggregationFunctionBenchmark {
 
   /**

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationFunctionBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationFunctionBenchmark.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.perf;
+package org.apache.pinot.perf.aggregation;
 
 import com.google.common.base.Preconditions;
 import java.util.Map;
@@ -70,11 +70,24 @@ public abstract class AbstractAggregationFunctionBenchmark {
   protected abstract Map<ExpressionContext, BlockValSet> getBlockValSetMap();
 
   /**
+   * Returns the comparable final result extracted from the aggregation result holder.
+   * <p>
+   * This method will be called in the benchmark method, so it must be fast.
+   */
+  protected Comparable extractFinalResult(AggregationResultHolder aggregationResultHolder) {
+    return getAggregationFunction().extractFinalResult(aggregationResultHolder.getResult());
+  }
+
+  /**
    * Verifies the final result of the aggregation function.
    *
    * This method will be called in the benchmark method, so it must be fast.
    */
   protected void verifyResult(Blackhole bh, Comparable finalResult, Object expectedResult) {
+    if (expectedResult == null) {
+      Preconditions.checkArgument(finalResult == null, "Expected final result to be null, actual: %s", finalResult);
+      return;
+    }
     Preconditions.checkState(finalResult.equals(expectedResult), "Result mismatch: expected: %s, actual: %s",
         expectedResult, finalResult);
     bh.consume(finalResult);
@@ -211,7 +224,7 @@ public abstract class AbstractAggregationFunctionBenchmark {
 
     getAggregationFunction().aggregate(DocIdSetPlanNode.MAX_DOC_PER_CALL, resultHolder, blockValSetMap);
 
-    Comparable finalResult = getAggregationFunction().extractFinalResult(resultHolder.getResult());
+    Comparable finalResult = extractFinalResult(resultHolder);
 
     verifyResult(bh, finalResult, getExpectedResult());
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationQueryBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/AbstractAggregationQueryBenchmark.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Base class for aggregation query benchmarks.
+ */
+public abstract class AbstractAggregationQueryBenchmark {
+
+  private File _baseDir;
+  private FluentQueryTest.OnSecondInstance _onSecondInstance;
+
+  protected void init(boolean nullHandlingEnabled) throws IOException {
+    _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    TableConfig tableConfig = createTableConfig();
+    Schema schema = createSchema();
+    List<List<Object[][]>> segmentsPerServer = createSegmentsPerServer();
+
+    FluentQueryTest.OnFirstInstance onFirstInstance =
+        FluentQueryTest.withBaseDir(_baseDir)
+            .withNullHandling(nullHandlingEnabled)
+            .givenTable(schema, tableConfig)
+            .getFirstInstance();
+
+    List<Object[][]> segmentsOnFirstServer = segmentsPerServer.get(0);
+    for (Object[][] segment : segmentsOnFirstServer) {
+      onFirstInstance.andSegment(segment);
+    }
+
+    FluentQueryTest.OnSecondInstance onSecondInstance = onFirstInstance.getSecondInstance();
+    List<Object[][]> segmentsOnSecondServer = segmentsPerServer.get(1);
+    for (Object[][] segment : segmentsOnSecondServer) {
+      onSecondInstance.andSegment(segment);
+    }
+    onSecondInstance.prepareToQuery();
+    _onSecondInstance = onSecondInstance;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    if (_baseDir != null) {
+      FileUtils.deleteDirectory(_baseDir);
+    }
+    _onSecondInstance.tearDown();
+  }
+
+  protected void executeQuery(String query, Blackhole bh) {
+    bh.consume(_onSecondInstance.whenQuery(query));
+  }
+
+  protected abstract Schema createSchema();
+
+  protected abstract TableConfig createTableConfig();
+
+  /**
+   * Returns a list of segments to be created on the servers. The first list is the list of segments to be
+   * created on the first server and the second list is the segments to be created on the second server.
+   */
+  protected abstract List<List<Object[][]>> createSegmentsPerServer();
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkAvgAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkAvgAggregation.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AvgAggregationFunction;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkAvgAggregation extends AbstractAggregationFunctionBenchmark.Stable {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+
+  @Param({"false", "true"})
+  private boolean _nullHandlingEnabled;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkAvgAggregation.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected AggregationFunction<?, ?> createAggregationFunction() {
+    return new AvgAggregationFunction(Collections.singletonList(EXPR), _nullHandlingEnabled);
+  }
+
+  @Override
+  protected AggregationResultHolder createResultHolder() {
+    return getAggregationFunction().createAggregationResultHolder();
+  }
+
+  @Override
+  protected Map<ExpressionContext, BlockValSet> createBlockValSetMap() {
+    Random valueRandom = new Random(420);
+    int numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+    RoaringBitmap nullBitmap = SyntheticNullBitmapFactories.Periodic.randomInPeriod(numDocs, _nullPeriod);
+    BlockValSet block = SyntheticBlockValSets.Double.create(numDocs, _nullHandlingEnabled ? nullBitmap : null,
+        valueRandom::nextDouble);
+    return Map.of(EXPR, block);
+  }
+
+  @Override
+  protected Object createExpectedResult(Map<ExpressionContext, BlockValSet> map) {
+    double sum = 0.0;
+    long count = 0;
+
+    BlockValSet blockValSet = getBlockValSetMap().get(EXPR);
+    double[] doubleValuesSV = blockValSet.getDoubleValuesSV();
+    RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+
+    for (int i = 0; i < doubleValuesSV.length; i++) {
+      if (nullBitmap != null && nullBitmap.contains(i)) {
+        continue;
+      }
+      sum += doubleValuesSV[i];
+      count++;
+    }
+
+    if (count != 0) {
+      return sum / count;
+    } else {
+      if (_nullHandlingEnabled) {
+        return null;
+      } else {
+        return Double.NEGATIVE_INFINITY;
+      }
+    }
+  }
+
+  @Override
+  protected void resetResultHolder(AggregationResultHolder resultHolder) {
+    resultHolder.setValue(null);
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountAggregation.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.DistinctCountAggregationFunction;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkDistinctCountAggregation extends AbstractAggregationFunctionBenchmark.Stable {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+
+  @Param({"false", "true"})
+  private boolean _nullHandlingEnabled;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkDistinctCountAggregation.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected AggregationFunction<?, ?> createAggregationFunction() {
+    return new DistinctCountAggregationFunction(Collections.singletonList(EXPR), _nullHandlingEnabled);
+  }
+
+  @Override
+  protected AggregationResultHolder createResultHolder() {
+    return getAggregationFunction().createAggregationResultHolder();
+  }
+
+  @Override
+  protected Map<ExpressionContext, BlockValSet> createBlockValSetMap() {
+    Random valueRandom = new Random(420);
+    int numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+    RoaringBitmap nullBitmap = SyntheticNullBitmapFactories.Periodic.randomInPeriod(numDocs, _nullPeriod);
+    BlockValSet block = SyntheticBlockValSets.Long.create(numDocs, _nullHandlingEnabled ? nullBitmap : null,
+        valueRandom::nextLong);
+    return Map.of(EXPR, block);
+  }
+
+  @Override
+  protected Object createExpectedResult(Map<ExpressionContext, BlockValSet> map) {
+    BlockValSet blockValSet = getBlockValSetMap().get(EXPR);
+    long[] longValuesSV = blockValSet.getLongValuesSV();
+    RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+
+    return (int) IntStream.range(0, longValuesSV.length)
+        .filter(i -> nullBitmap == null || !nullBitmap.contains(i))
+        .mapToLong(i -> longValuesSV[i])
+        .distinct()
+        .count();
+  }
+
+  @Override
+  protected void resetResultHolder(AggregationResultHolder resultHolder) {
+    resultHolder.setValue(null);
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkMinAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkMinAggregation.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.MinAggregationFunction;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkMinAggregation extends AbstractAggregationFunctionBenchmark.Stable {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+
+  @Param({"false", "true"})
+  private boolean _nullHandlingEnabled;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkMinAggregation.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected AggregationFunction<?, ?> createAggregationFunction() {
+    return new MinAggregationFunction(Collections.singletonList(EXPR), _nullHandlingEnabled);
+  }
+
+  @Override
+  protected AggregationResultHolder createResultHolder() {
+    return getAggregationFunction().createAggregationResultHolder();
+  }
+
+  @Override
+  protected Map<ExpressionContext, BlockValSet> createBlockValSetMap() {
+    Random valueRandom = new Random(420);
+    int numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+    RoaringBitmap nullBitmap = SyntheticNullBitmapFactories.Periodic.randomInPeriod(numDocs, _nullPeriod);
+    BlockValSet block = SyntheticBlockValSets.Double.create(numDocs, _nullHandlingEnabled ? nullBitmap : null,
+        valueRandom::nextInt);
+    return Map.of(EXPR, block);
+  }
+
+  @Override
+  protected Object createExpectedResult(Map<ExpressionContext, BlockValSet> map) {
+    Double min = null;
+    BlockValSet blockValSet = getBlockValSetMap().get(EXPR);
+    double[] doubleValuesSV = blockValSet.getDoubleValuesSV();
+    RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+
+    for (int i = 0; i < doubleValuesSV.length; i++) {
+      if (nullBitmap != null && nullBitmap.contains(i)) {
+        continue;
+      }
+      min = (min == null) ? doubleValuesSV[i] : Math.min(min, doubleValuesSV[i]);
+    }
+
+    return min;
+  }
+
+  @Override
+  protected void resetResultHolder(AggregationResultHolder resultHolder) {
+    if (_nullHandlingEnabled) {
+      resultHolder.setValue(null);
+    } else {
+      resultHolder.setValue(Double.POSITIVE_INFINITY);
+    }
+  }
+
+  @Override
+  protected Comparable extractFinalResult(AggregationResultHolder resultHolder) {
+    if (_nullHandlingEnabled) {
+      return resultHolder.getResult();
+    } else {
+      return resultHolder.getDoubleResult();
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkModeAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkModeAggregation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.perf;
+package org.apache.pinot.perf.aggregation;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -31,6 +31,8 @@ import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.ModeAggregationFunction;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSumAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSumAggregation.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkSumAggregation extends AbstractAggregationFunctionBenchmark.Stable {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+
+  @Param({"false", "true"})
+  private boolean _nullHandlingEnabled;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkSumAggregation.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected AggregationFunction<?, ?> createAggregationFunction() {
+    return new SumAggregationFunction(Collections.singletonList(EXPR), _nullHandlingEnabled);
+  }
+
+  @Override
+  protected AggregationResultHolder createResultHolder() {
+    return getAggregationFunction().createAggregationResultHolder();
+  }
+
+  @Override
+  protected Map<ExpressionContext, BlockValSet> createBlockValSetMap() {
+    Random valueRandom = new Random(420);
+    int numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+    RoaringBitmap nullBitmap = SyntheticNullBitmapFactories.Periodic.randomInPeriod(numDocs, _nullPeriod);
+    BlockValSet block = SyntheticBlockValSets.Long.create(numDocs, _nullHandlingEnabled ? nullBitmap : null,
+        valueRandom::nextInt);
+    return Map.of(EXPR, block);
+  }
+
+  @Override
+  protected Object createExpectedResult(Map<ExpressionContext, BlockValSet> map) {
+    Double sum = null;
+    BlockValSet blockValSet = getBlockValSetMap().get(EXPR);
+    long[] longValuesSV = blockValSet.getLongValuesSV();
+    RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+
+    for (int i = 0; i < longValuesSV.length; i++) {
+      if (nullBitmap != null && nullBitmap.contains(i)) {
+        continue;
+      }
+      sum = (sum == null) ? longValuesSV[i] : sum + longValuesSV[i];
+    }
+
+    if (!_nullHandlingEnabled && sum == null) {
+      return 0.0d;
+    } else {
+      return sum;
+    }
+  }
+
+  @Override
+  protected void resetResultHolder(AggregationResultHolder resultHolder) {
+    if (_nullHandlingEnabled) {
+      resultHolder.setValue(null);
+    } else {
+      resultHolder.setValue(0.0);
+    }
+  }
+
+  @Override
+  protected Comparable extractFinalResult(AggregationResultHolder resultHolder) {
+    if (_nullHandlingEnabled) {
+      return resultHolder.getResult();
+    } else {
+      return resultHolder.getDoubleResult();
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSumQuery.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSumQuery.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@State(Scope.Benchmark)
+public class BenchmarkSumQuery extends AbstractAggregationQueryBenchmark {
+
+  @Param({"false", "true"})
+  public boolean _nullHandling;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(BenchmarkSumQuery.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected Schema createSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName("benchmark")
+        .addMetricField("col", FieldSpec.DataType.INT)
+        .build();
+  }
+
+  @Override
+  protected TableConfig createTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("benchmark")
+        .setNullHandlingEnabled(true)
+        .build();
+  }
+
+  @Override
+  protected List<List<Object[][]>> createSegmentsPerServer() {
+    Random valueRandom = new Random(420);
+    List<List<Object[][]>> segmentsPerServer = new ArrayList<>();
+    segmentsPerServer.add(new ArrayList<>());
+    segmentsPerServer.add(new ArrayList<>());
+
+    // 2 servers
+    for (int server = 0; server < 2; server++) {
+      List<Object[][]> segments = segmentsPerServer.get(server);
+      // 3 segments per server
+      for (int seg = 0; seg < 3; seg++) {
+        // 10000 single column rows per segment
+        Object[][] segment = new Object[10000][1];
+        for (int row = 0; row < 10000; row++) {
+          segment[row][0] = (row % _nullPeriod) == 0 ? null : valueRandom.nextInt();
+        }
+        segments.add(segment);
+      }
+    }
+
+    return segmentsPerServer;
+  }
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    init(_nullHandling);
+  }
+
+  @Benchmark
+  public void test(Blackhole bh) {
+    executeQuery("SELECT SUM(col) FROM mytable", bh);
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkVarianceAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkVarianceAggregation.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.VarianceAggregationFunction;
+import org.apache.pinot.core.query.aggregation.utils.StatisticalAggregationFunctionUtils;
+import org.apache.pinot.perf.SyntheticBlockValSets;
+import org.apache.pinot.perf.SyntheticNullBitmapFactories;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 50, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkVarianceAggregation extends AbstractAggregationFunctionBenchmark.Stable {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+
+  @Param({"false", "true"})
+  private boolean _nullHandlingEnabled;
+
+  @Param({"1", "2", "4", "8", "16", "32", "64", "128"})
+  protected int _nullPeriod;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkVarianceAggregation.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  @Override
+  protected AggregationFunction<?, ?> createAggregationFunction() {
+    return new VarianceAggregationFunction(Collections.singletonList(EXPR), true, false, _nullHandlingEnabled);
+  }
+
+  @Override
+  protected AggregationResultHolder createResultHolder() {
+    return getAggregationFunction().createAggregationResultHolder();
+  }
+
+  @Override
+  protected Map<ExpressionContext, BlockValSet> createBlockValSetMap() {
+    Random valueRandom = new Random(420);
+    int numDocs = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+    RoaringBitmap nullBitmap = SyntheticNullBitmapFactories.Periodic.randomInPeriod(numDocs, _nullPeriod);
+    BlockValSet block = SyntheticBlockValSets.Double.create(numDocs, _nullHandlingEnabled ? nullBitmap : null,
+        valueRandom::nextInt);
+    return Map.of(EXPR, block);
+  }
+
+  @Override
+  protected Object createExpectedResult(Map<ExpressionContext, BlockValSet> map) {
+    BlockValSet blockValSet = getBlockValSetMap().get(EXPR);
+    double[] doubleValuesSV = blockValSet.getDoubleValuesSV();
+    RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+
+    List<Double> values = IntStream.range(0, doubleValuesSV.length)
+        .filter(i -> nullBitmap == null || !nullBitmap.contains(i))
+        .mapToDouble(i -> doubleValuesSV[i])
+        .boxed()
+        .collect(Collectors.toList());
+
+    Double variance = null;
+    if (!values.isEmpty()) {
+      variance = StatisticalAggregationFunctionUtils.calculateVariance(values, AggregationFunctionType.VARSAMP);
+    }
+    return variance;
+  }
+
+  @Override
+  protected void resetResultHolder(AggregationResultHolder resultHolder) {
+    resultHolder.setValue(null);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPair.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPair.java
@@ -26,6 +26,10 @@ public class AvgPair implements Comparable<AvgPair> {
   private double _sum;
   private long _count;
 
+  public AvgPair() {
+    this(0.0, 0L);
+  }
+
   public AvgPair(double sum, long count) {
     _sum = sum;
     _count = count;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/VarianceTuple.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/VarianceTuple.java
@@ -32,6 +32,15 @@ public class VarianceTuple implements Comparable<VarianceTuple> {
     _m2 = m2;
   }
 
+  public void apply(double value) {
+    _count++;
+    _sum += value;
+    if (_count > 1) {
+      double t = _count * value - _sum;
+      _m2 += (t * t) / (_count * (_count - 1));
+    }
+  }
+
   public void apply(long count, double sum, double m2) {
     if (count == 0) {
       return;


### PR DESCRIPTION
- Currently, a subset of single input aggregation functions support null handling (see [here](https://github.com/apache/pinot/blob/53fbf88027c47b3c6f7d1526576ba0bd257fe9d5/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java#L70-L484)).
- Out of these, only a few use the `NullableSingleInputAggregationFunction` framework added in https://github.com/apache/pinot/pull/12227. The ones that don't use the framework instead use a very inefficient way of checking nulls - iterating over all the values in the block and checking the null bitmap for every value. This leads to a performance degradation of 10-20X in most aggregation functions.
- The `NullableSingleInputAggregationFunction` framework makes much more efficient use of the `RoaringBitmap` via the iterator API.
- We intend to enable null handling by default for leaf stages in the multi-stage query engine (see https://github.com/apache/pinot/pull/13570). It's crucial to avoid such a large performance degradation by default.
- This patch refactors the remaining nullable single input aggregation functions to use the faster framework and adds some representative benchmarks to demonstrate the performance improvement in the null handling enabled case (and also to show that there isn't any noticeable performance degradation in the null handling disabled case with these changes).
- Using the `NullableSingleInputAggregationFunction` framework also results in a lot of code cleanup since many of the aggregation functions had a lot of redundant duplication between the null handling enabled and disabled paths.
- The remaining single input aggregation functions that currently don't support null handling whatsoever will also be updated in a future patch.
- A number of unit tests using the fluent test framework (added in https://github.com/apache/pinot/pull/12215) are also added here in order to verify the correctness of the changes especially w.r.t. null handling.

<hr>

These are the benchmark results on an M3 Max chip with Temurin JDK 17:

### SumAggregationFunction

#### Old

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt       Score     Error   Units
BenchmarkSumAggregation.test                   false              1  thrpt   50     141.922 ±   1.030  ops/ms
BenchmarkSumAggregation.test                   false              2  thrpt   50     142.837 ±   1.184  ops/ms
BenchmarkSumAggregation.test                   false              4  thrpt   50     143.824 ±   0.684  ops/ms
BenchmarkSumAggregation.test                   false              8  thrpt   50     143.524 ±   0.854  ops/ms
BenchmarkSumAggregation.test                   false             16  thrpt   50     143.585 ±   0.907  ops/ms
BenchmarkSumAggregation.test                   false             32  thrpt   50     143.183 ±   0.945  ops/ms
BenchmarkSumAggregation.test                   false             64  thrpt   50     142.501 ±   1.180  ops/ms
BenchmarkSumAggregation.test                   false            128  thrpt   50     143.732 ±   0.802  ops/ms
BenchmarkSumAggregation.test                    true              1  thrpt   50  171031.995 ± 972.930  ops/ms
BenchmarkSumAggregation.test                    true              2  thrpt   50     133.537 ±   1.683  ops/ms
BenchmarkSumAggregation.test                    true              4  thrpt   50       6.216 ±   0.035  ops/ms
BenchmarkSumAggregation.test                    true              8  thrpt   50       7.334 ±   0.033  ops/ms
BenchmarkSumAggregation.test                    true             16  thrpt   50       8.308 ±   0.037  ops/ms
BenchmarkSumAggregation.test                    true             32  thrpt   50       9.448 ±   0.121  ops/ms
BenchmarkSumAggregation.test                    true             64  thrpt   50      11.076 ±   0.071  ops/ms
BenchmarkSumAggregation.test                    true            128  thrpt   50      11.947 ±   0.069  ops/ms
```

#### New

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt       Score      Error   Units
BenchmarkSumAggregation.test                   false              1  thrpt   50     143.044 ±    1.463  ops/ms
BenchmarkSumAggregation.test                   false              2  thrpt   50     141.605 ±    2.040  ops/ms
BenchmarkSumAggregation.test                   false              4  thrpt   50     143.155 ±    1.499  ops/ms
BenchmarkSumAggregation.test                   false              8  thrpt   50     141.408 ±    2.080  ops/ms
BenchmarkSumAggregation.test                   false             16  thrpt   50     143.193 ±    0.794  ops/ms
BenchmarkSumAggregation.test                   false             32  thrpt   50     143.326 ±    1.292  ops/ms
BenchmarkSumAggregation.test                   false             64  thrpt   50     142.913 ±    1.425  ops/ms
BenchmarkSumAggregation.test                   false            128  thrpt   50     144.853 ±    0.685  ops/ms
BenchmarkSumAggregation.test                    true              1  thrpt   50  241239.579 ± 1136.547  ops/ms
BenchmarkSumAggregation.test                    true              2  thrpt   50      71.465 ±    0.671  ops/ms
BenchmarkSumAggregation.test                    true              4  thrpt   50     122.977 ±    0.769  ops/ms
BenchmarkSumAggregation.test                    true              8  thrpt   50     197.443 ±    1.333  ops/ms
BenchmarkSumAggregation.test                    true             16  thrpt   50     278.517 ±    1.447  ops/ms
BenchmarkSumAggregation.test                    true             32  thrpt   50     242.543 ±    0.869  ops/ms
BenchmarkSumAggregation.test                    true             64  thrpt   50     256.617 ±    2.179  ops/ms
BenchmarkSumAggregation.test                    true            128  thrpt   50     207.354 ±    0.678  ops/ms
```

<hr>

### AvgAggregationFunction

#### Old

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt    Score   Error   Units
BenchmarkAvgAggregation.test                   false              1  thrpt   50  144.106 ± 1.299  ops/ms
BenchmarkAvgAggregation.test                   false              2  thrpt   50  145.306 ± 1.391  ops/ms
BenchmarkAvgAggregation.test                   false              4  thrpt   50  141.760 ± 3.740  ops/ms
BenchmarkAvgAggregation.test                   false              8  thrpt   50  145.969 ± 0.806  ops/ms
BenchmarkAvgAggregation.test                   false             16  thrpt   50  146.584 ± 0.963  ops/ms
BenchmarkAvgAggregation.test                   false             32  thrpt   50  143.416 ± 2.946  ops/ms
BenchmarkAvgAggregation.test                   false             64  thrpt   50  146.223 ± 0.848  ops/ms
BenchmarkAvgAggregation.test                   false            128  thrpt   50  146.637 ± 0.898  ops/ms
BenchmarkAvgAggregation.test                    true              1  thrpt   50  273607.474 ± 822.817  ops/ms
BenchmarkAvgAggregation.test                    true              2  thrpt   50  169.814 ± 2.570  ops/ms
BenchmarkAvgAggregation.test                    true              4  thrpt   50    6.433 ± 0.046  ops/ms
BenchmarkAvgAggregation.test                    true              8  thrpt   50    7.488 ± 0.056  ops/ms
BenchmarkAvgAggregation.test                    true             16  thrpt   50    8.484 ± 0.064  ops/ms
BenchmarkAvgAggregation.test                    true             32  thrpt   50    9.675 ± 0.076  ops/ms
BenchmarkAvgAggregation.test                    true             64  thrpt   50   11.081 ± 0.084  ops/ms
BenchmarkAvgAggregation.test                    true            128  thrpt   50   13.104 ± 0.084  ops/ms
```

#### New

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt    Score   Error   Units
BenchmarkAvgAggregation.test                   false              1  thrpt   50  138.875 ± 1.609  ops/ms
BenchmarkAvgAggregation.test                   false              2  thrpt   50  139.859 ± 2.670  ops/ms
BenchmarkAvgAggregation.test                   false              4  thrpt   50  142.453 ± 1.805  ops/ms
BenchmarkAvgAggregation.test                   false              8  thrpt   50  143.638 ± 1.807  ops/ms
BenchmarkAvgAggregation.test                   false             16  thrpt   50  140.297 ± 2.983  ops/ms
BenchmarkAvgAggregation.test                   false             32  thrpt   50  143.873 ± 1.352  ops/ms
BenchmarkAvgAggregation.test                   false             64  thrpt   50  144.444 ± 1.037  ops/ms
BenchmarkAvgAggregation.test                   false            128  thrpt   50  141.255 ± 3.213  ops/ms
BenchmarkAvgAggregation.test                    true              1  thrpt   50  274400.836 ± 1372.961  ops/ms
BenchmarkAvgAggregation.test                    true              2  thrpt   50   80.724 ± 0.885  ops/ms
BenchmarkAvgAggregation.test                    true              4  thrpt   50  136.979 ± 1.178  ops/ms
BenchmarkAvgAggregation.test                    true              8  thrpt   50  158.269 ± 0.765  ops/ms
BenchmarkAvgAggregation.test                    true             16  thrpt   50  147.872 ± 0.701  ops/ms
BenchmarkAvgAggregation.test                    true             32  thrpt   50  143.951 ± 0.807  ops/ms
BenchmarkAvgAggregation.test                    true             64  thrpt   50  141.555 ± 1.113  ops/ms
BenchmarkAvgAggregation.test                    true            128  thrpt   50  141.092 ± 2.150  ops/ms
```

<hr>

### MinAggregationFunction

#### Old

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt    Score   Error   Units
BenchmarkMinAggregation.test                   false              1  thrpt   50  198.780 ± 1.772  ops/ms
BenchmarkMinAggregation.test                   false              2  thrpt   50  199.408 ± 1.591  ops/ms
BenchmarkMinAggregation.test                   false              4  thrpt   50  201.402 ± 0.932  ops/ms
BenchmarkMinAggregation.test                   false              8  thrpt   50  199.532 ± 1.327  ops/ms
BenchmarkMinAggregation.test                   false             16  thrpt   50  197.042 ± 3.784  ops/ms
BenchmarkMinAggregation.test                   false             32  thrpt   50  201.312 ± 1.005  ops/ms
BenchmarkMinAggregation.test                   false             64  thrpt   50  199.076 ± 1.789  ops/ms
BenchmarkMinAggregation.test                   false            128  thrpt   50  197.485 ± 3.533  ops/ms
BenchmarkMinAggregation.test                    true              1  thrpt   50  233503.544 ± 757.227  ops/ms
BenchmarkMinAggregation.test                    true              2  thrpt   50  135.514 ± 0.548  ops/ms
BenchmarkMinAggregation.test                    true              4  thrpt   50    6.263 ± 0.033  ops/ms
BenchmarkMinAggregation.test                    true              8  thrpt   50    7.291 ± 0.059  ops/ms
BenchmarkMinAggregation.test                    true             16  thrpt   50    8.268 ± 0.045  ops/ms
BenchmarkMinAggregation.test                    true             32  thrpt   50    9.917 ± 0.072  ops/ms
BenchmarkMinAggregation.test                    true             64  thrpt   50   10.773 ± 0.069  ops/ms
BenchmarkMinAggregation.test                    true            128  thrpt   50   11.961 ± 0.077  ops/ms
```

#### New

```
Benchmark                     (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt    Score   Error   Units
BenchmarkMinAggregation.test                   false              1  thrpt   50  200.789 ± 1.174  ops/ms
BenchmarkMinAggregation.test                   false              2  thrpt   50  198.568 ± 2.002  ops/ms
BenchmarkMinAggregation.test                   false              4  thrpt   50  201.473 ± 0.975  ops/ms
BenchmarkMinAggregation.test                   false              8  thrpt   50  199.809 ± 1.575  ops/ms
BenchmarkMinAggregation.test                   false             16  thrpt   50  195.557 ± 3.168  ops/ms
BenchmarkMinAggregation.test                   false             32  thrpt   50  201.504 ± 0.909  ops/ms
BenchmarkMinAggregation.test                   false             64  thrpt   50  201.442 ± 0.955  ops/ms
BenchmarkMinAggregation.test                   false            128  thrpt   50  198.635 ± 3.376  ops/ms
BenchmarkMinAggregation.test                    true              1  thrpt   50  233460.938 ± 878.133  ops/ms
BenchmarkMinAggregation.test                    true              2  thrpt   50   74.088 ± 0.454  ops/ms
BenchmarkMinAggregation.test                    true              4  thrpt   50  126.207 ± 1.104  ops/ms
BenchmarkMinAggregation.test                    true              8  thrpt   50  205.234 ± 4.209  ops/ms
BenchmarkMinAggregation.test                    true             16  thrpt   50  340.715 ± 5.285  ops/ms
BenchmarkMinAggregation.test                    true             32  thrpt   50  351.642 ± 1.903  ops/ms
BenchmarkMinAggregation.test                    true             64  thrpt   50  354.432 ± 3.337  ops/ms
BenchmarkMinAggregation.test                    true            128  thrpt   50  349.553 ± 2.757  ops/ms
```

<hr>

### DistinctCountAggregationFunction

#### Old

```
Benchmark                               (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt   Score   Error   Units
BenchmarkDistinctCountAggregation.test                   false              1  thrpt   50  19.555 ± 0.246  ops/ms
BenchmarkDistinctCountAggregation.test                   false              2  thrpt   50  19.581 ± 0.164  ops/ms
BenchmarkDistinctCountAggregation.test                   false              4  thrpt   50  19.643 ± 0.138  ops/ms
BenchmarkDistinctCountAggregation.test                   false              8  thrpt   50  19.329 ± 0.261  ops/ms
BenchmarkDistinctCountAggregation.test                   false             16  thrpt   50  19.752 ± 0.138  ops/ms
BenchmarkDistinctCountAggregation.test                   false             32  thrpt   50  19.751 ± 0.092  ops/ms
BenchmarkDistinctCountAggregation.test                   false             64  thrpt   50  19.419 ± 0.263  ops/ms
BenchmarkDistinctCountAggregation.test                   false            128  thrpt   50  19.629 ± 0.111  ops/ms
BenchmarkDistinctCountAggregation.test                    true              1  thrpt   50  57.300 ± 0.276  ops/ms
BenchmarkDistinctCountAggregation.test                    true              2  thrpt   50  24.248 ± 0.256  ops/ms
BenchmarkDistinctCountAggregation.test                    true              4  thrpt   50   4.427 ± 0.069  ops/ms
BenchmarkDistinctCountAggregation.test                    true              8  thrpt   50   5.066 ± 0.045  ops/ms
BenchmarkDistinctCountAggregation.test                    true             16  thrpt   50   5.481 ± 0.077  ops/ms
BenchmarkDistinctCountAggregation.test                    true             32  thrpt   50   5.927 ± 0.055  ops/ms
BenchmarkDistinctCountAggregation.test                    true             64  thrpt   50   6.325 ± 0.070  ops/ms
BenchmarkDistinctCountAggregation.test                    true            128  thrpt   50   6.616 ± 0.032  ops/ms
```

#### New

```
Benchmark                               (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt      Score     Error   Units
BenchmarkDistinctCountAggregation.test                   false              1  thrpt   50     19.596 ±   0.242  ops/ms
BenchmarkDistinctCountAggregation.test                   false              2  thrpt   50     19.610 ±   0.196  ops/ms
BenchmarkDistinctCountAggregation.test                   false              4  thrpt   50     19.731 ±   0.152  ops/ms
BenchmarkDistinctCountAggregation.test                   false              8  thrpt   50     19.362 ±   0.150  ops/ms
BenchmarkDistinctCountAggregation.test                   false             16  thrpt   50     19.769 ±   0.135  ops/ms
BenchmarkDistinctCountAggregation.test                   false             32  thrpt   50     19.280 ±   0.113  ops/ms
BenchmarkDistinctCountAggregation.test                   false             64  thrpt   50     20.812 ±   0.249  ops/ms
BenchmarkDistinctCountAggregation.test                   false            128  thrpt   50     19.783 ±   0.142  ops/ms
BenchmarkDistinctCountAggregation.test                    true              1  thrpt   50  32847.118 ± 534.264  ops/ms
BenchmarkDistinctCountAggregation.test                    true              2  thrpt   50     26.943 ±   0.196  ops/ms
BenchmarkDistinctCountAggregation.test                    true              4  thrpt   50     20.160 ±   0.128  ops/ms
BenchmarkDistinctCountAggregation.test                    true              8  thrpt   50     19.321 ±   0.242  ops/ms
BenchmarkDistinctCountAggregation.test                    true             16  thrpt   50     20.170 ±   0.390  ops/ms
BenchmarkDistinctCountAggregation.test                    true             32  thrpt   50     19.501 ±   0.089  ops/ms
BenchmarkDistinctCountAggregation.test                    true             64  thrpt   50     20.306 ±   0.303  ops/ms
BenchmarkDistinctCountAggregation.test                    true            128  thrpt   50     19.463 ±   0.092  ops/ms
```

<hr>

### VarianceAggregationFunction

#### Old

```
Benchmark                          (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt    Score   Error   Units
BenchmarkVarianceAggregation.test                   false              1  thrpt   50  127.548 ± 0.816  ops/ms
BenchmarkVarianceAggregation.test                   false              2  thrpt   50  126.447 ± 1.044  ops/ms
BenchmarkVarianceAggregation.test                   false              4  thrpt   50  125.703 ± 0.447  ops/ms
BenchmarkVarianceAggregation.test                   false              8  thrpt   50  125.822 ± 0.612  ops/ms
BenchmarkVarianceAggregation.test                   false             16  thrpt   50  125.850 ± 0.550  ops/ms
BenchmarkVarianceAggregation.test                   false             32  thrpt   50  125.811 ± 1.134  ops/ms
BenchmarkVarianceAggregation.test                   false             64  thrpt   50  125.293 ± 1.243  ops/ms
BenchmarkVarianceAggregation.test                   false            128  thrpt   50  124.949 ± 1.062  ops/ms
BenchmarkVarianceAggregation.test                    true              1  thrpt   50   70.489 ± 0.259  ops/ms
BenchmarkVarianceAggregation.test                    true              2  thrpt   50  132.470 ± 0.637  ops/ms
BenchmarkVarianceAggregation.test                    true              4  thrpt   50    5.306 ± 0.037  ops/ms
BenchmarkVarianceAggregation.test                    true              8  thrpt   50    6.325 ± 0.038  ops/ms
BenchmarkVarianceAggregation.test                    true             16  thrpt   50    7.656 ± 0.065  ops/ms
BenchmarkVarianceAggregation.test                    true             32  thrpt   50    9.575 ± 0.103  ops/ms
BenchmarkVarianceAggregation.test                    true             64  thrpt   50   11.163 ± 0.090  ops/ms
BenchmarkVarianceAggregation.test                    true            128  thrpt   50   12.187 ± 0.127  ops/ms
```

#### New

```
Benchmark                          (_nullHandlingEnabled)  (_nullPeriod)   Mode  Cnt       Score      Error   Units
BenchmarkVarianceAggregation.test                   false              1  thrpt   50     126.163 ±    0.453  ops/ms
BenchmarkVarianceAggregation.test                   false              2  thrpt   50     125.970 ±    0.412  ops/ms
BenchmarkVarianceAggregation.test                   false              4  thrpt   50     125.252 ±    0.663  ops/ms
BenchmarkVarianceAggregation.test                   false              8  thrpt   50     121.283 ±    0.382  ops/ms
BenchmarkVarianceAggregation.test                   false             16  thrpt   50     123.634 ±    1.386  ops/ms
BenchmarkVarianceAggregation.test                   false             32  thrpt   50     125.439 ±    0.738  ops/ms
BenchmarkVarianceAggregation.test                   false             64  thrpt   50     125.730 ±    0.520  ops/ms
BenchmarkVarianceAggregation.test                   false            128  thrpt   50     122.904 ±    2.077  ops/ms
BenchmarkVarianceAggregation.test                    true              1  thrpt   50  245923.814 ± 1944.703  ops/ms
BenchmarkVarianceAggregation.test                    true              2  thrpt   50      66.258 ±    0.474  ops/ms
BenchmarkVarianceAggregation.test                    true              4  thrpt   50     101.951 ±    1.929  ops/ms
BenchmarkVarianceAggregation.test                    true              8  thrpt   50     124.706 ±    1.027  ops/ms
BenchmarkVarianceAggregation.test                    true             16  thrpt   50     137.289 ±    1.032  ops/ms
BenchmarkVarianceAggregation.test                    true             32  thrpt   50     131.492 ±    1.169  ops/ms
BenchmarkVarianceAggregation.test                    true             64  thrpt   50     128.387 ±    0.372  ops/ms
BenchmarkVarianceAggregation.test                    true            128  thrpt   50     126.453 ±    1.039  ops/ms
```