### PR TITLE
For non-aggregation group-by query, if select clause is not matching to group by clause, return original query

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -188,7 +188,8 @@ public class CalciteSqlParser {
         aggregateExprCount++;
       } else if (hasGroupByClause && expressionOutsideGroupByList(selectExpression, groupByExprs)) {
         throw new SqlCompilationException(
-            "'" + RequestUtils.prettyPrint(selectExpression) + "' should be functionally dependent on the columns used in GROUP BY clause.");
+            "'" + RequestUtils.prettyPrint(selectExpression) + "' should be functionally dependent on the columns "
+                + "used in GROUP BY clause.");
       }
     }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -188,7 +188,7 @@ public class CalciteSqlParser {
         aggregateExprCount++;
       } else if (hasGroupByClause && expressionOutsideGroupByList(selectExpression, groupByExprs)) {
         throw new SqlCompilationException(
-            "'" + RequestUtils.prettyPrint(selectExpression) + "' should appear in GROUP BY clause.");
+            "'" + RequestUtils.prettyPrint(selectExpression) + "' should be functionally dependent on the columns used in GROUP BY clause.");
       }
     }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
@@ -75,7 +75,7 @@ public class NonAggregationGroupByToDistinctQueryRewriter implements QueryRewrit
       }
     }
     Set<Expression> groupByExpressions = new HashSet<>(pinotQuery.getGroupByList());
-    //If SELECT and GROUP BY set are equal, rewrite the query as DISTINCT
+    // If SELECT and GROUP BY set are equal, rewrite the query as DISTINCT
     if (selectExpressions.equals(groupByExpressions)) {
       Expression distinct = RequestUtils.getFunctionExpression("distinct", pinotQuery.getSelectList());
       // NOTE: Create an ArrayList because we might need to modify the list later

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1379,7 +1379,8 @@ public class CalciteSqlCompilerTest {
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertTrue(e.getMessage().contains("'group_city' should be functionally dependent on the columns used in GROUP BY clause."));
+      Assert.assertTrue(e.getMessage().contains("'group_city' should be functionally dependent on the columns "
+          + "used in GROUP BY clause."));
     }
 
     // Valid groupBy non-aggregate function should pass.
@@ -1397,7 +1398,8 @@ public class CalciteSqlCompilerTest {
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertTrue(e.getMessage().contains("'secondsSinceEpoch' should be functionally dependent on the columns used in GROUP BY clause."));
+      Assert.assertTrue(e.getMessage().contains("'secondsSinceEpoch' should be functionally dependent on the columns "
+          + "used in GROUP BY clause."));
     }
 
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2624,8 +2624,6 @@ public class CalciteSqlCompilerTest {
         () -> compileToPinotQuery("SELECT col1 + col2 FROM foo GROUP BY col1"));
   }
 
-
-
   @Test
   public void testFlattenAndOr() {
     {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1379,7 +1379,7 @@ public class CalciteSqlCompilerTest {
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertTrue(e.getMessage().contains("'group_city' should appear in GROUP BY clause."));
+      Assert.assertTrue(e.getMessage().contains("'group_city' should be functionally dependent on the columns used in GROUP BY clause."));
     }
 
     // Valid groupBy non-aggregate function should pass.
@@ -1397,7 +1397,7 @@ public class CalciteSqlCompilerTest {
       Assert.fail("Query should have failed compilation");
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertTrue(e.getMessage().contains("'secondsSinceEpoch' should appear in GROUP BY clause."));
+      Assert.assertTrue(e.getMessage().contains("'secondsSinceEpoch' should be functionally dependent on the columns used in GROUP BY clause."));
     }
 
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
@@ -53,13 +53,23 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
 
   @Test
   public void testUnsupportedQueries() {
-    testUnsupportedQuery("SELECT col1 FROM foo GROUP BY col1, col2");
     testUnsupportedQuery("SELECT col1, col2 FROM foo GROUP BY col1");
-    testUnsupportedQuery("SELECT col1 + col2 FROM foo GROUP BY col1, col2");
+    testUnsupportedQuery("SELECT concat(col1, col2) FROM foo GROUP BY col1");
   }
 
   private void testUnsupportedQuery(String query) {
     assertThrows(SqlCompilationException.class,
         () -> QUERY_REWRITER.rewrite(CalciteSqlParser.compileToPinotQuery(query)));
+  }
+
+  @Test
+  public void testSkipQueryRewrite() {
+    testSkipQueryRewrite("SELECT col1 FROM foo GROUP BY col1, col2");
+    testSkipQueryRewrite("SELECT col1 + col2 FROM foo GROUP BY col1, col2");
+  }
+
+  private void testSkipQueryRewrite(String query) {
+    assertEquals(QUERY_REWRITER.rewrite(CalciteSqlParser.compileToPinotQuery(query)),
+        CalciteSqlParser.compileToPinotQuery(query));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
@@ -55,6 +55,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
   public void testUnsupportedQueries() {
     testUnsupportedQuery("SELECT col1, col2 FROM foo GROUP BY col1");
     testUnsupportedQuery("SELECT concat(col1, col2) FROM foo GROUP BY col1");
+    testUnsupportedQuery("SELECT col1+col2*5 FROM foo GROUP BY col1");
   }
 
   private void testUnsupportedQuery(String query) {
@@ -66,6 +67,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
   public void testSkipQueryRewrite() {
     testSkipQueryRewrite("SELECT col1 FROM foo GROUP BY col1, col2");
     testSkipQueryRewrite("SELECT col1 + col2 FROM foo GROUP BY col1, col2");
+    testSkipQueryRewrite("SELECT col1+col2*5 FROM foo GROUP BY col1, col2");
   }
 
   private void testSkipQueryRewrite(String query) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2776,6 +2776,18 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     h2Query = "SELECT CAST(ArrTime-DepTime AS FLOAT) FROM mytable GROUP BY CAST(ArrTime-DepTime AS FLOAT)";
     testQuery(pinotQuery, h2Query);
 
+    pinotQuery = "SELECT ArrTime-DepTime FROM mytable GROUP BY ArrTime, DepTime LIMIT 1000000";
+    h2Query = "SELECT ArrTime-DepTime FROM mytable GROUP BY ArrTime, DepTime";
+    testQuery(pinotQuery, h2Query);
+
+    pinotQuery = "SELECT ArrTime-DepTime,ArrTime/3,DepTime*2 FROM mytable GROUP BY ArrTime, DepTime LIMIT 1000000";
+    h2Query = "SELECT ArrTime-DepTime,ArrTime/3,DepTime*2 FROM mytable GROUP BY ArrTime, DepTime";
+    testQuery(pinotQuery, h2Query);
+
+    pinotQuery = "SELECT ArrTime+DepTime FROM mytable GROUP BY ArrTime + DepTime LIMIT 1000000";
+    h2Query = "SELECT ArrTime+DepTime FROM mytable GROUP BY ArrTime + DepTime";
+    testQuery(pinotQuery, h2Query);
+
     pinotQuery = "SELECT ArrTime+DepTime AS A FROM mytable GROUP BY A LIMIT 1000000";
     h2Query = "SELECT CAST(ArrTime+DepTime AS FLOAT) AS A FROM mytable GROUP BY A";
     testQuery(pinotQuery, h2Query);


### PR DESCRIPTION
In #9605, we introduced a change to not resolve non-aggregation group by queries into distinct query, if select clause is not exactly matching to group-by clause. This is a breaking change for our customer as existing query stopped working for us. 
To fix this, instead of throwing an exception, we can return original query and let pinot handle the query as group-by query.

We already have a [validateGroupByClause](https://github.com/apache/pinot/blob/53fbf88027c47b3c6f7d1526576ba0bd257fe9d5/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java#L181) that recursively checks if an expression contains any reference not appearing in the GROUP BY clause. So we don't need to verify the same in NonAggregationGroupByToDistinctQueryRewriter. 