### PR TITLE
Fix controller port logging in quickstart

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
@@ -179,7 +179,9 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q5)));
     printStatus(Color.GREEN, "***************************************************");
 
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+    printStatus(Color.GREEN,
+        String.format("You can always go to http://localhost:%d to play around in the query console",
+            QuickstartRunner.DEFAULT_CONTROLLER_PORT));
   }
 
   private String getTableConfigFilePath() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -141,6 +141,8 @@ public class HybridQuickstart extends Quickstart {
     printStatus(Color.YELLOW, "***** Realtime quickstart setup complete *****");
     runSampleQueries(runner);
 
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+    printStatus(Color.GREEN,
+        String.format("You can always go to http://localhost:%d to play around in the query console",
+            QuickstartRunner.DEFAULT_CONTROLLER_PORT));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -94,7 +94,9 @@ public class Quickstart extends QuickStartBase {
       runSampleQueries(runner);
     }
 
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+    printStatus(Color.GREEN,
+        String.format("You can always go to http://localhost:%d to play around in the query console",
+            QuickstartRunner.DEFAULT_CONTROLLER_PORT));
   }
 
   protected int getNumQuickstartRunnerServers() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -125,6 +125,8 @@ public class RealtimeQuickStart extends QuickStartBase {
     printStatus(Color.YELLOW, "***** Realtime quickstart setup complete *****");
     runSampleQueries(runner);
 
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+    printStatus(Color.GREEN,
+        String.format("You can always go to http://localhost:%d to play around in the query console",
+            QuickstartRunner.DEFAULT_CONTROLLER_PORT));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -76,7 +76,7 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   private String _table;
 
   @CommandLine.Option(names = {"-controllerURI"}, description = "Pinot Controller URI.")
-  private String _controllerURI = "http://localhost:9000";
+  private String _controllerURI = String.format("http://localhost:%d", QuickstartRunner.DEFAULT_CONTROLLER_PORT);
 
   @CommandLine.Option(names = {"-user"}, required = false, description = "Username for basic auth.")
   private String _user;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -47,6 +47,8 @@ public class QuickstartRunner {
 
   private static final int ZK_PORT = 2123;
   private static final String ZK_ADDRESS = "localhost:" + ZK_PORT;
+
+  public static final int DEFAULT_CONTROLLER_PORT = 9000;
   private static final int DEFAULT_BROKER_PORT = 8000;
   private static final int DEFAULT_SERVER_ADMIN_API_PORT = 7500;
   private static final int DEFAULT_SERVER_NETTY_PORT = 7050;
@@ -75,7 +77,6 @@ public class QuickstartRunner {
   private final List<Integer> _controllerPorts = new ArrayList<>();
   private final List<Integer> _brokerPorts = new ArrayList<>();
   private boolean _isStopped = false;
-  public static final int DEFAULT_CONTROLLER_PORT = 9000;
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, int numMinions, File tempDir, Map<String, Object> configOverrides)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -47,8 +47,6 @@ public class QuickstartRunner {
 
   private static final int ZK_PORT = 2123;
   private static final String ZK_ADDRESS = "localhost:" + ZK_PORT;
-
-  private static final int DEFAULT_CONTROLLER_PORT = 9000;
   private static final int DEFAULT_BROKER_PORT = 8000;
   private static final int DEFAULT_SERVER_ADMIN_API_PORT = 7500;
   private static final int DEFAULT_SERVER_NETTY_PORT = 7050;
@@ -77,6 +75,7 @@ public class QuickstartRunner {
   private final List<Integer> _controllerPorts = new ArrayList<>();
   private final List<Integer> _brokerPorts = new ArrayList<>();
   private boolean _isStopped = false;
+  public static final int DEFAULT_CONTROLLER_PORT = 9000;
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, int numMinions, File tempDir, Map<String, Object> configOverrides)


### PR DESCRIPTION
Sometimes we have to change the controller port because some other applications are running on `9000`. Mostly i have seen this to be daemon threads. At present, the port is hardcoded to 9000 everywhere. Minor changes to take the value from `QuickStartRunner#DEFAULT_CONTROLLER_PORT`