### PR TITLE
Make NetUtils.getHostAddress ipv6 compatible

### DIFF
--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -131,6 +131,10 @@
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -134,6 +134,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <profiles>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
@@ -20,30 +20,71 @@ package org.apache.pinot.spi.utils;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class NetUtils {
   private NetUtils() {
   }
 
-  private static final String DUMMY_OUT_IP = "74.125.224.0";
+  private static final Logger LOGGER = LoggerFactory.getLogger(NetUtils.class);
+  // Google Public DNS IPs dns.google
+  private static final int HTTP_PORT = 80;
+  private static final String DUMMY_OUT_IPV4 = "8.8.8.8";
+  private static final String DUMMY_OUT_IPV6 = "2001:4860:4860::8888";
 
   /**
    * Get the ip address of local host.
+   *
+   * @return IP address {@link String}, either IPv4 or IPv6 format depending on java.net.preferIPv6Addresses property.
    */
   public static String getHostAddress()
       throws SocketException, UnknownHostException {
+    boolean isIPv6Preferred = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses"));
     DatagramSocket ds = new DatagramSocket();
-    ds.connect(InetAddress.getByName(DUMMY_OUT_IP), 80);
-    InetAddress localAddress = ds.getLocalAddress();
-    if (localAddress.getHostAddress().equals("0.0.0.0")) {
-      localAddress = InetAddress.getLocalHost();
+    try {
+      ds.connect(isIPv6Preferred ? Inet6Address.getByName(DUMMY_OUT_IPV6) : Inet4Address.getByName(DUMMY_OUT_IPV4),
+          HTTP_PORT);
+    } catch (java.io.UncheckedIOException e) {
+      if (isIPv6Preferred) {
+        LOGGER.warn("No IPv6 route available on host, falling back to IPv4");
+        ds.connect(Inet4Address.getByName(DUMMY_OUT_IPV4), HTTP_PORT);
+      } else {
+        LOGGER.warn("No IPv4 route available on host, falling back to IPv6");
+        ds.connect(Inet6Address.getByName(DUMMY_OUT_IPV6), HTTP_PORT);
+      }
     }
+
+    InetAddress localAddress = ds.getLocalAddress();
+    if (localAddress.isAnyLocalAddress()) {
+      localAddress = isIPv6Preferred ? getLocalIPv6Address() : InetAddress.getLocalHost();
+    }
+
     return localAddress.getHostAddress();
+  }
+
+  /**
+   * Get a local IPv6 address out of IPv4/IPv6 addresses queried based on the local hostname.
+   * If no IPv6 address is found, fall back to default InetAddress.getLocalHost() behavior.
+   *
+   * @return {@link InetAddress} object representing a local IPv6 address.
+   */
+  private static InetAddress getLocalIPv6Address() throws UnknownHostException {
+    for (InetAddress address : InetAddress.getAllByName(InetAddress.getLocalHost().getHostName())) {
+      if (address instanceof Inet6Address && !address.isAnyLocalAddress()) {
+        return address;
+      }
+    }
+
+    LOGGER.warn("Failed to find a non-wildcard IPv6 address, falling back to localhost");
+    return Inet4Address.getLocalHost();
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
@@ -53,6 +53,7 @@ public class NetUtils {
       ds.connect(isIPv6Preferred ? Inet6Address.getByName(DUMMY_OUT_IPV6) : Inet4Address.getByName(DUMMY_OUT_IPV4),
           HTTP_PORT);
     } catch (java.io.UncheckedIOException e) {
+      LOGGER.warn(e.getMessage());
       if (isIPv6Preferred) {
         LOGGER.warn("No IPv6 route available on host, falling back to IPv4");
         ds.connect(Inet4Address.getByName(DUMMY_OUT_IPV4), HTTP_PORT);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/NetUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/NetUtilsTest.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.net.DatagramSocket;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class NetUtilsTest {
+  private static final String LOCAL_ADDRESS_IPV4 = "172.16.184.0";
+  private static final String LOCAL_ADDRESS_IPV6 = "2001:db8::1";
+
+  @BeforeMethod
+  public void setUp() {
+    System.clearProperty("java.net.preferIPv6Addresses");
+  }
+
+  @Test(description = "Test getHostAddress with no preferIPv6Addresses in IPv4 only environment")
+  public void testGetHostAddressIPv4Env() {
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // IPv6 address is not available
+    doThrow(new java.io.UncheckedIOException(new java.net.NoRouteToHostException()))
+        .when(mockDatagramSocket).connect(isA(Inet6Address.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV4);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV4, hostAddress);
+      verify(mockDatagramSocket, times(1)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test(description = "Test getHostAddress with preferIPv6Addresses=true in IPv4 only environment")
+  public void testGetHostAddressIPv4EnvIPv6Preferred() {
+    System.setProperty("java.net.preferIPv6Addresses", "true");
+
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // IPv6 address is not available
+    doThrow(new java.io.UncheckedIOException(new java.net.NoRouteToHostException()))
+        .when(mockDatagramSocket).connect(isA(Inet6Address.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV4);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV4, hostAddress);
+      verify(mockDatagramSocket, times(2)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test(description = "Test getHostAddress with no preferIPv6Addresses in dual stack environment")
+  public void testGetHostAddressDualStackEnv() {
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // Both IPv4/IPv6 address is available
+    doNothing().when(mockDatagramSocket).connect(isA(InetAddress.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV4);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV4, hostAddress);
+      verify(mockDatagramSocket, times(1)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test(description = "Test getHostAddress with preferIPv6Addresses=true in dual stack environment")
+  public void testGetHostAddressDualStackEnvIPv6Preferred() {
+    System.setProperty("java.net.preferIPv6Addresses", "true");
+
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // Both IPv4/IPv6 address is available
+    doNothing().when(mockDatagramSocket).connect(isA(InetAddress.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV6);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV6, hostAddress);
+      verify(mockDatagramSocket, times(1)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test(description = "Test getHostAddress with no preferIPv6Addresses in IPv6 only environment")
+  public void testGetHostAddressIPv6Env() {
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // Only IPv6 address is available
+    doThrow(new java.io.UncheckedIOException(new java.net.SocketException()))
+        .when(mockDatagramSocket).connect(isA(Inet4Address.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV6);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV6, hostAddress);
+      // Two attempts to connect because ipv4 is tried first
+      verify(mockDatagramSocket, times(2)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+
+  @Test(description = "Test getHostAddress with preferIPv6Addresses=true in IPv6 only environment")
+  public void testGetHostAddressIPv6EnvIPv6Preferred() {
+    System.setProperty("java.net.preferIPv6Addresses", "true");
+
+    DatagramSocket mockDatagramSocket = mock(DatagramSocket.class);
+    InetAddress mockInetAddress = mock(InetAddress.class);
+    when(mockDatagramSocket.getLocalAddress()).thenReturn(mockInetAddress);
+    // Only IPv6 address is available
+    doThrow(new java.io.UncheckedIOException(new java.net.SocketException()))
+        .when(mockDatagramSocket).connect(isA(Inet4Address.class), anyInt());
+    when(mockInetAddress.isAnyLocalAddress()).thenReturn(false);
+    when(mockInetAddress.getHostAddress()).thenReturn(LOCAL_ADDRESS_IPV6);
+
+    try (MockedStatic<DatagramSocket> mockedStaticDatagramSocket = mockStatic(DatagramSocket.class)) {
+      mockedStaticDatagramSocket.when(DatagramSocket::new).thenReturn(mockDatagramSocket);
+      String hostAddress = NetUtils.getHostAddress();
+
+      assertEquals(LOCAL_ADDRESS_IPV6, hostAddress);
+      verify(mockDatagramSocket, times(1)).connect(any(), anyInt());
+    } catch (SocketException | UnknownHostException e) {
+      Assert.fail("Should not throw: " + e.getMessage());
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/NetUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/NetUtilsTest.java
@@ -29,7 +29,16 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 


### PR DESCRIPTION
# Summary
Fix NetUtils.getHostAddress() so that it works in ipv6 only env. Take `java.net.preferIPv6Addresses` property into account for dual stack env.

## Expected behavior
* ipv4 only env: returns ipv4 address regardless of `preferIPv6Addresses` flag
* dual stack env: returns ipv4 or ipv6 address depending on `preferIPv6Addresses` flag
* ipv6 only env: returns ipv6 address regardless of `preferIPv6Addresses` flag

## Related issue
https://github.com/apache/pinot/issues/13772

# Testing
- [x] Passing unit tests
```
mvn test  -Dcheckstyle.skip -Dspotless.skip -Denforcer.skip -Dlicense.skip -Dmaven.plugin.appassembler.skip=true -pl 'pinot-spi' -Djdk.version={Used 11 and 17}

[INFO] Tests run: 178, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco:0.8.12:report-aggregate (report) @ pinot-spi ---
[INFO] Loading execution data file /SOME/PATH/pinot/pinot-spi/target/jacoco.exec
[INFO] Analyzed bundle 'pinot-spi' with 335 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.708 s
[INFO] Finished at: 2024-08-12T13:03:31-07:00
[INFO] ------------------------------------------------------------------------
[INFO] 15 goals, 15 executed
```


- [x] NetUtils.getHostAddress shouldn't throw errors in any env (ipv4/dual stack/ipv6)