### PR TITLE
Fix bugs in DynamicBrokerSelector

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
@@ -45,11 +45,11 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicBrokerSelector.class);
   private static final Random RANDOM = new Random();
 
-  private final AtomicReference<Map<String, List<String>>> _tableToBrokerListMapRef = new AtomicReference<>();
-  private final AtomicReference<List<String>> _allBrokerListRef = new AtomicReference<>();
-  private final ZkClient _zkClient;
-  private final ExternalViewReader _evReader;
-  private final List<String> _brokerList;
+  protected final AtomicReference<Map<String, List<String>>> _tableToBrokerListMapRef = new AtomicReference<>();
+  protected final AtomicReference<List<String>> _allBrokerListRef = new AtomicReference<>();
+  protected final ZkClient _zkClient;
+  protected final ExternalViewReader _evReader;
+  protected final List<String> _brokerList;
   //The preferTlsPort will be mapped to client config in the future, when we support full TLS
   public DynamicBrokerSelector(String zkServers, boolean preferTlsPort) {
     _zkClient = getZkClient(zkServers);
@@ -112,7 +112,7 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
 
   @Override
   public List<String> getBrokers() {
-    return _brokerList;
+    return _allBrokerListRef.get();
   }
 
   @Override

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -49,7 +48,6 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
   protected final AtomicReference<List<String>> _allBrokerListRef = new AtomicReference<>();
   protected final ZkClient _zkClient;
   protected final ExternalViewReader _evReader;
-  protected final List<String> _brokerList;
   //The preferTlsPort will be mapped to client config in the future, when we support full TLS
   public DynamicBrokerSelector(String zkServers, boolean preferTlsPort) {
     _zkClient = getZkClient(zkServers);
@@ -57,7 +55,6 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
     _zkClient.waitUntilConnected(60, TimeUnit.SECONDS);
     _zkClient.subscribeDataChanges(ExternalViewReader.BROKER_EXTERNAL_VIEW_PATH, this);
     _evReader = getEvReader(_zkClient, preferTlsPort);
-    _brokerList = ImmutableList.of(zkServers);
     refresh();
   }
   public DynamicBrokerSelector(String zkServers) {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
@@ -57,7 +57,8 @@ public class BrokerSelectorUtils {
       return null;
     }
 
-    // Make a copy of the brokersList for the first table. retainAll does inplace modifications corrupting brokerData.
+    // Make a copy of the brokersList of the first table. retainAll does inplace modifications.
+    // So lists from brokerData should not be used directly.
     List<String> commonBrokers = new ArrayList<>(tablesBrokersList.get(0));
     for (int i = 1; i < tablesBrokersList.size(); i++) {
       commonBrokers.retainAll(tablesBrokersList.get(i));

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
@@ -19,11 +19,9 @@
 package org.apache.pinot.client.utils;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.apache.pinot.client.ExternalViewReader;
 
 
@@ -60,12 +58,11 @@ public class BrokerSelectorUtils {
     }
 
     // Make a copy of the brokersList for the first table. retainAll does inplace modifications corrupting brokerData.
-    Set<String> commonBrokers = tablesBrokersList.stream()
-        .skip(1) // skip because the HashSet is initialized with the first list.
-        .collect(() -> new HashSet<>(tablesBrokersList.get(0)), Set::retainAll, Set::retainAll);
-    List<String> commonBrokerList = new ArrayList<>(commonBrokers.size());
-    commonBrokerList.addAll(commonBrokers);
-    return commonBrokerList;
+    List<String> commonBrokers = new ArrayList<>(tablesBrokersList.get(0));
+    for (int i = 1; i < tablesBrokersList.size(); i++) {
+      commonBrokers.retainAll(tablesBrokersList.get(i));
+    }
+    return commonBrokers;
   }
 
   private static String getTableNameWithoutSuffix(String tableName) {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.client.utils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.pinot.client.ExternalViewReader;
 
 
@@ -57,11 +59,13 @@ public class BrokerSelectorUtils {
       return null;
     }
 
-    List<String> commonBrokers = tablesBrokersList.get(0);
-    for (int i = 1; i < tablesBrokersList.size(); i++) {
-      commonBrokers.retainAll(tablesBrokersList.get(i));
-    }
-    return commonBrokers;
+    // Make a copy of the brokersList for the first table. retainAll does inplace modifications corrupting brokerData.
+    Set<String> commonBrokers = tablesBrokersList.stream()
+        .skip(1) // skip because the HashSet is initialized with the first list.
+        .collect(() -> new HashSet<>(tablesBrokersList.get(0)), Set::retainAll, Set::retainAll);
+    List<String> commonBrokerList = new ArrayList<>(commonBrokers.size());
+    commonBrokerList.addAll(commonBrokers);
+    return commonBrokerList;
   }
 
   private static String getTableNameWithoutSuffix(String tableName) {

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ConnectionFactoryTest.java
@@ -37,6 +37,8 @@ public class ConnectionFactoryTest {
   public void testZkConnection() {
     // Create a dummy Helix structure
     final String givenZkServers = "127.0.0.1:1234";
+    final String givenBrokerInfo = "localhost:2345";
+
     DynamicBrokerSelector dynamicBrokerSelector = Mockito.spy(new DynamicBrokerSelector(givenZkServers) {
       @Override
       protected ZkClient getZkClient(String zkServers) {
@@ -46,6 +48,11 @@ public class ConnectionFactoryTest {
       @Override
       protected ExternalViewReader getEvReader(ZkClient zkClient) {
         return Mockito.mock(ExternalViewReader.class);
+      }
+
+      @Override
+      public List<String> getBrokers() {
+        return ImmutableList.of(givenBrokerInfo);
       }
     });
 
@@ -57,7 +64,7 @@ public class ConnectionFactoryTest {
             pinotClientTransport);
 
     // Check that the broker list has the right length and has the same servers
-    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of(givenZkServers));
+    Assert.assertEquals(connection.getBrokerList(), ImmutableList.of(givenBrokerInfo));
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/DynamicBrokerSelectorTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/DynamicBrokerSelectorTest.java
@@ -143,7 +143,7 @@ public class DynamicBrokerSelectorTest {
 
   @Test
   public void testGetBrokers() {
-    assertEquals(_dynamicBrokerSelectorUnderTest.getBrokers(), ImmutableList.of(ZK_SERVER));
+    assertEquals(_dynamicBrokerSelectorUnderTest.getBrokers(), ImmutableList.of("broker1"));
   }
 
   @Test


### PR DESCRIPTION
DynamicBrokerSelector.getBrokers returned a list of zkServers instead of brokers.

BrokerSelectorUtils.getTablesCommonBrokers made inplace updates to lists in brokerData. Make a copy of the lists so that the contents of brokerData is unchanged.

Member variables of DynamicBrokerSelector have been changed to protected scope so that the class can be derived.

tags: bugfix