### PR TITLE
Improve error messages when creating star-tree indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkForwardIndexWriter.java
@@ -186,7 +186,8 @@ public abstract class BaseChunkForwardIndexWriter implements Closeable {
     }
 
     if (_headerEntryChunkOffsetSize == Integer.BYTES) {
-      Preconditions.checkState(_dataOffset <= Integer.MAX_VALUE, "Integer overflow detected");
+      Preconditions.checkState(_dataOffset <= Integer.MAX_VALUE, "Integer overflow detected. "
+          + "Try to use raw version 3 or 4, reduce targetDocsPerChunk or targetMaxChunkSize");
       _header.putInt((int) _dataOffset);
     } else if (_headerEntryChunkOffsetSize == Long.BYTES) {
       _header.putLong(_dataOffset);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -520,11 +520,22 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
         }
       }
     } finally {
-      for (SingleValueUnsortedForwardIndexCreator dimensionIndexCreator : dimensionIndexCreators) {
-        dimensionIndexCreator.close();
+      for (int i = 0; i < dimensionIndexCreators.length; i++) {
+        try {
+          dimensionIndexCreators[i].close();
+        } catch (Throwable e) {
+          LOGGER.warn("Caught throwable while closing dimension index creator for dimension: {}",
+              _dimensionsSplitOrder[i], e);
+          throw e;
+        }
       }
-      for (ForwardIndexCreator metricIndexCreator : metricIndexCreators) {
-        metricIndexCreator.close();
+      for (int i = 0; i < metricIndexCreators.length; i++) {
+        try {
+          metricIndexCreators[i].close();
+        } catch (Throwable e) {
+          LOGGER.warn("Caught throwable while closing metric index creator for metric: {}", _metrics[i], e);
+          throw e;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR improves the error messages when star-tree or forward index creation end up failing due to integer overflow produced when chunks are too large.