### PR TITLE
Add missing s3-transfer-manager library

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3-transfer-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
We observed this class no found issue for pinot-s3.
```
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.transfer.s3.internal.ApplyUserAgentInterceptor
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[?:?]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:421) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:412) ~[?:?]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.internal.util.ClassLoaderHelper.loadClass(ClassLoaderHelper.java:114) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.internal.util.ClassLoaderHelper.loadClass(ClassLoaderHelper.java:73) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory.createExecutionInterceptor(ClasspathInterceptorChainFactory.java:123) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory.createExecutionInterceptorFromResource(ClasspathInterceptorChainFactory.java:95) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273) ~[?:?]
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory.createExecutionInterceptorsFromClasspath(ClasspathInterceptorChainFactory.java:64) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory.getInterceptors(ClasspathInterceptorChainFactory.java:51) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.services.s3.DefaultS3BaseClientBuilder.finalizeServiceConfiguration(DefaultS3BaseClientBuilder.java:113) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.finalizeChildConfiguration(AwsDefaultClientBuilder.java:167) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.syncClientConfiguration(SdkDefaultClientBuilder.java:197) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:37) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:26) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.shaded.software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.build(SdkDefaultClientBuilder.java:164) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.plugin.filesystem.S3PinotFS.init(S3PinotFS.java:160) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	at org.apache.pinot.spi.filesystem.PinotFSFactory.register(PinotFSFactory.java:52) ~[startree-pinot-all-1.3.0-ST.2-jar-with-dependencies.jar:1.3.0-ST.2-52b0f026b5f02d84a8119e0ef903b86e7b6ef898]
	... 25 more
```