### PR TITLE
Avro version upgrade with primitive array handling.

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -56,6 +56,7 @@ import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.minion.BaseMinionStarter;
 import org.apache.pinot.minion.MinionStarter;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor;
 import org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractorConfig;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
@@ -480,7 +481,7 @@ public abstract class ClusterTest extends ControllerTest {
       config.init(props);
       _recordExtractor = new AvroRecordExtractor();
       _recordExtractor.init(fieldsToRead, config);
-      _reader = new GenericDatumReader<>(avroSchema);
+      _reader = new GenericDatumReader<>(avroSchema, avroSchema, new AvroCustomGenericData());
     }
 
     @Override

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/QueryGenerator.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/QueryGenerator.java
@@ -39,6 +39,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -121,7 +122,7 @@ public class QueryGenerator {
 
     // Read Avro schema and initialize storage.
     File schemaAvroFile = avroFiles.get(0);
-    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
+    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(null, null, new AvroCustomGenericData());
     try (DataFileReader<GenericRecord> fileReader = new DataFileReader<>(schemaAvroFile, datumReader)) {
       Schema schema = fileReader.getSchema();
       for (Schema.Field field : schema.getFields()) {
@@ -242,7 +243,7 @@ public class QueryGenerator {
    */
   private void addAvroData(File avroFile) {
     // Read in records and update the values stored.
-    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
+    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(null, null, new AvroCustomGenericData());
     try (DataFileReader<GenericRecord> fileReader = new DataFileReader<>(avroFile, datumReader)) {
       for (GenericRecord genericRecord : fileReader) {
         for (String columnName : _columnNames) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
@@ -33,7 +33,8 @@ public class AvroCustomGenericData extends GenericData {
 
   /**
    * Creates a new array instance based on the provided schema.
-   * If the old object is an instance of {@link org.apache.avro.generic.GenericArray} or {@link java.util.Collection}, it clears and reuses it.
+   * If the old object is an instance of {@link org.apache.avro.generic.GenericArray}
+   * or {@link java.util.Collection}, it clears and reuses it.
    * Otherwise, it creates a new {@link org.apache.avro.generic.GenericData.Array} instance.
    * This is the old implementation of avro, which is changed in version 1.12.0
    *

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
+import java.util.Collection;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
-import java.util.Collection;
 
 public class AvroCustomGenericData extends GenericData {
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
@@ -23,8 +23,25 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 
+/**
+ * AvroCustomGenericData is a custom implementation of GenericData that overrides the newArray method.
+ * This class provides a custom way to create new array instances based on the provided schema.
+ * Reason for custom implementation: when creating a new array instance, Avro's default implementation uses
+ * {@link org.apache.avro.generic.PrimitivesArrays} for primitive types which results into boxing/unboxing value issue.
+ */
 public class AvroCustomGenericData extends GenericData {
 
+  /**
+   * Creates a new array instance based on the provided schema.
+   * If the old object is an instance of {@link org.apache.avro.generic.GenericArray} or {@link java.util.Collection}, it clears and reuses it.
+   * Otherwise, it creates a new {@link org.apache.avro.generic.GenericData.Array} instance.
+   * This is the old implementation of avro, which is changed in version 1.12.0
+   *
+   * @param old the old array object to reuse if possible
+   * @param size the size of the new array
+   * @param schema the schema of the array items
+   * @return a new or reused array instance
+   */
   @Override
   public Object newArray(Object old, int size, Schema schema) {
     if (old instanceof GenericArray) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroCustomGenericData.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import java.util.Collection;
+
+public class AvroCustomGenericData extends GenericData {
+
+  @Override
+  public Object newArray(Object old, int size, Schema schema) {
+    if (old instanceof GenericArray) {
+      ((GenericArray<?>) old).clear();
+      return old;
+    } else if (old instanceof Collection) {
+      ((Collection<?>) old).clear();
+      return old;
+    }
+    return new GenericData.Array<>(size, schema);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -32,6 +32,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -215,10 +216,11 @@ public class AvroUtils {
    */
   public static DataFileStream<GenericRecord> getAvroReader(File avroFile)
       throws IOException {
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(null, null, new AvroCustomGenericData());
     if (RecordReaderUtils.isGZippedFile(avroFile)) {
-      return new DataFileStream<>(new GZIPInputStream(new FileInputStream(avroFile)), new GenericDatumReader<>());
+      return new DataFileStream<>(new GZIPInputStream(new FileInputStream(avroFile)), datumReader);
     } else {
-      return new DataFileStream<>(new FileInputStream(avroFile), new GenericDatumReader<>());
+      return new DataFileStream<>(new FileInputStream(avroFile), datumReader);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
@@ -187,7 +187,7 @@ public class AvroSchemaUtilTest {
   private GenericRecord readAndConvertRecord(File avroFile, Schema schema)
       throws IOException {
     try (DataFileStream<GenericRecord> avroReader = new DataFileStream<>(new FileInputStream(avroFile),
-        new GenericDatumReader<>(schema))) {
+        new GenericDatumReader<>(schema, schema, new AvroCustomGenericData()))) {
       if (avroReader.hasNext()) {
         GenericRecord record = avroReader.next();
         return AvroSchemaUtil.convertLogicalType(record);

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/KafkaAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/KafkaAvroMessageDecoder.java
@@ -170,7 +170,7 @@ public class KafkaAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
         }
       }
     }
-    DatumReader<Record> reader = new GenericDatumReader<Record>(schema);
+    DatumReader<Record> reader = new GenericDatumReader<>(schema, schema, new AvroCustomGenericData());
     try {
       GenericData.Record avroRecord = reader.read(null,
           _decoderFactory.createBinaryDecoder(payload, HEADER_LENGTH + offset, length - HEADER_LENGTH, null));

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
@@ -58,7 +58,7 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
       throws Exception {
     Preconditions.checkState(props.containsKey(SCHEMA), "Avro schema must be provided");
     _avroSchema = new org.apache.avro.Schema.Parser().parse(props.get(SCHEMA));
-    _datumReader = new GenericDatumReader<>(_avroSchema);
+    _datumReader = new GenericDatumReader<>(_avroSchema, _avroSchema, new AvroCustomGenericData());
     String recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
     String recordExtractorConfigClass = props.get(RECORD_EXTRACTOR_CONFIG_CONFIG_KEY);
     // Backward compatibility to support Avro by default

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/BitmapInvertedIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/BitmapInvertedIndexTest.java
@@ -28,6 +28,7 @@ import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -95,7 +96,7 @@ public class BitmapInvertedIndexTest {
 
     // Compare the loaded inverted index with the record in avro file
     try (DataFileStream<GenericRecord> reader = new DataFileStream<>(new FileInputStream(_avroFile),
-        new GenericDatumReader<>())) {
+        new GenericDatumReader<>(null, null, new AvroCustomGenericData()))) {
       // Check the first 1000 records
       for (int docId = 0; docId < 1000; docId++) {
         GenericRecord record = reader.next();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
@@ -30,6 +30,7 @@ import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
@@ -165,7 +166,8 @@ public class DictionaryOptimiserTest {
   public static Schema extractSchemaFromAvroWithoutTime(File avroFile)
       throws IOException {
     DataFileStream<GenericRecord> dataStream =
-        new DataFileStream<GenericRecord>(new FileInputStream(avroFile), new GenericDatumReader<GenericRecord>());
+        new DataFileStream<GenericRecord>(new FileInputStream(avroFile),
+            new GenericDatumReader<>(null, null, new AvroCustomGenericData()));
     Schema schema = new Schema();
 
     for (final org.apache.avro.Schema.Field field : dataStream.getSchema().getFields()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/SegmentTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/SegmentTestUtils.java
@@ -34,6 +34,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.plugin.inputformat.avro.AvroSchemaUtil;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -124,7 +125,8 @@ public class SegmentTestUtils {
   public static Schema extractSchemaFromAvroWithoutTime(File avroFile)
       throws IOException {
     DataFileStream<GenericRecord> dataStream =
-        new DataFileStream<GenericRecord>(new FileInputStream(avroFile), new GenericDatumReader<GenericRecord>());
+        new DataFileStream<GenericRecord>(new FileInputStream(avroFile),
+            new GenericDatumReader<>(null, null, new AvroCustomGenericData()));
     Schema schema = new Schema();
 
     for (final Field field : dataStream.getSchema().getFields()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AvroFileSourceGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AvroFileSourceGenerator.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.Strings;
+import org.apache.pinot.plugin.inputformat.avro.AvroCustomGenericData;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -131,7 +132,8 @@ public class AvroFileSourceGenerator implements PinotSourceDataGenerator {
         _avroDataStream = null;
       }
       if (_avroDataStream == null) {
-        _avroDataStream = new DataFileStream<>(new FileInputStream(_avroFile.getPath()), new GenericDatumReader<>());
+        _avroDataStream = new DataFileStream<>(new FileInputStream(_avroFile.getPath()),
+            new GenericDatumReader<>(null, null, new AvroCustomGenericData()));
       }
     } catch (IOException ex) {
       LOGGER.error("Failed to open/close {}", _avroFile.getPath(), ex);

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <shade.phase.prop>none</shade.phase.prop>
 
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.12.0</avro.version>
     <parquet.version>1.14.1</parquet.version>
     <orc.version>1.9.3</orc.version>
     <hive.version>2.8.1</hive.version>


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/13764).

As mentioned in the issue, Avro introduced the new class [PrimitivesArrays.java](https://github.com/apache/avro/pull/2389/files#diff-902e4a96b065212aa56ec8b8d83c7031a219b5d0efe3c4deafe3b4f3e05ef70e) in Avro version `1.12.0`. Here is the merged: https://github.com/apache/avro/pull/2389 for reference. Because of this, we observed several issues related to the boxing/unboxing of primitive data types. 

The solution is simple and suggested in the Javadoc of GenericData class to extend the class with a custom implementation. We have introduced the new class `AvroCustomGenericData` with the previous implementation of the `newArray` method. 