### PR TITLE
Revert Hadoop back to 3.3.6 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <javassist.version>3.30.2-GA</javassist.version>
     <swagger.version>1.6.14</swagger.version>
     <swagger-ui.version>5.17.14</swagger-ui.version>
-    <hadoop.version>3.4.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.1</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>


### PR DESCRIPTION
Hadoop 3.4.0 is causing issues with the AWS SDK S3 library.  Specifically, the following exception is being thrown:

```
Caused by: java.lang.ClassNotFoundException: software.amazon.awssdk.transfer.s3.internal.ApplyUserAgentInterceptor
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581) ~[?:?]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:315) ~[?:?]
```