### PR TITLE
Fix plugin modules pom for pinot library usage 

### DIFF
--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -44,6 +44,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -38,10 +38,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -38,10 +38,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/pinot-plugins/pinot-minion-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pom.xml
@@ -43,10 +43,12 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-controller</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-minion</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
+++ b/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-core</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
@@ -39,10 +39,12 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-avro</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-json</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Pinot plugins are unnecessarily packaging pinot libs which shouldn't be included as they are anyway provided by the pinot distribution.

Ensure all the pinot libs referenced in plugin modules are in the provided scope

The whole distribution size is reduced from 966MB -> 718M

The plugin directory size is reduced from 699MB -> 427MB

Before:
```
## whole pinot binary size:
-rw-r--r--  1 xiangfu  staff   966M Aug 16 17:36 apache-pinot-1.3.0-SNAPSHOT-bin.tar.gz

## plugins size:
 20K	plugins/pinot-segment-writer/pinot-segment-writer-file-based
 20K	plugins/pinot-segment-writer
112M	plugins/pinot-environment/pinot-azure
112M	plugins/pinot-environment
132K	plugins/pinot-minion-tasks/pinot-minion-builtin-tasks
132K	plugins/pinot-minion-tasks
 47M	plugins/pinot-file-system/pinot-gcs
 24M	plugins/pinot-file-system/pinot-adls
Move pinot-common to plugin root and ensure all the pinot libs reference in plugins are provided scope
 14M	plugins/pinot-file-system/pinot-s3
1.8M	plugins/pinot-file-system/pinot-hdfs
 87M	plugins/pinot-file-system
100K	plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone
100K	plugins/pinot-batch-ingestion
112M	plugins/pinot-input-format/pinot-clp-log
 36M	plugins/pinot-input-format/pinot-protobuf
 71M	plugins/pinot-input-format/pinot-orc
984K	plugins/pinot-input-format/pinot-csv
 24M	plugins/pinot-input-format/pinot-confluent-avro
105M	plugins/pinot-input-format/pinot-parquet
5.5M	plugins/pinot-input-format/pinot-avro
 76K	plugins/pinot-input-format/pinot-json
1.1M	plugins/pinot-input-format/pinot-thrift
354M	plugins/pinot-input-format
 20K	plugins/pinot-segment-uploader/pinot-segment-uploader-default
 20K	plugins/pinot-segment-uploader
 40M	plugins/pinot-stream-ingestion/pinot-kafka-2.0
 14M	plugins/pinot-stream-ingestion/pinot-kinesis
 43M	plugins/pinot-stream-ingestion/pinot-pulsar
 96M	plugins/pinot-stream-ingestion
 24M	plugins/pinot-metrics/pinot-dropwizard
 24M	plugins/pinot-metrics/pinot-yammer
 49M	plugins/pinot-metrics
699M	plugins
```
After:
```
## whole pinot binary size:
-rw-r--r--  1 xiangfu  staff   718M Aug 16 17:57 apache-pinot-1.3.0-SNAPSHOT-bin.tar.gz

## plugins size:
 16K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-segment-writer/pinot-segment-writer-file-based
 16K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-segment-writer
8.0K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-environment/pinot-azure
8.0K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-environment
124K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-minion-tasks/pinot-minion-builtin-tasks
124K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-minion-tasks
 47M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-file-system/pinot-gcs
 24M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-file-system/pinot-adls
 14M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-file-system/pinot-s3
1.8M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-file-system/pinot-hdfs
 87M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-file-system
100K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone
100K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-batch-ingestion
632K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-clp-log
 36M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-protobuf
 71M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-orc
984K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-csv
 24M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-confluent-avro
105M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-parquet
5.5M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-avro
 76K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-json
1.1M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-thrift
243M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-input-format
 12K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-segment-uploader/pinot-segment-uploader-default
 12K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-segment-uploader
 40M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-stream-ingestion/pinot-kafka-2.0
 14M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-stream-ingestion/pinot-kinesis
 43M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-stream-ingestion/pinot-pulsar
 96M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-stream-ingestion
232K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-metrics/pinot-dropwizard
164K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-metrics/pinot-yammer
396K	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins/pinot-metrics
427M	pinot-distribution/target/apache-pinot-1.3.0-SNAPSHOT-bin/apache-pinot-1.3.0-SNAPSHOT-bin/plugins
```