### PR TITLE
Return improved dataschema for empty results when all segments are pruned by broker

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
@@ -261,7 +261,7 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
     assertDataTypes(response, "LONG", "DOUBLE");
   }
 
-  @Test(priority = 1)
+  @Test
   public void testDataSchemaForBrokerPrunedEmptyResults() throws Exception {
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.setRoutingConfig(

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -180,6 +180,6 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
     String query = "SELECT COUNT(*) FROM " + tableName;
     JsonNode response = postQuery(query);
     JsonNode resTbl = response.get("resultTable");
-    return (resTbl == null) ? 0 : resTbl.get("rows").get(0).get(0).asInt();
+    return (resTbl.get("rows").size() == 0) ? 0 : resTbl.get("rows").get(0).get(0).asInt();
   }
 }


### PR DESCRIPTION
When all segments are pruned on the server, we construct a [empty responseBlock](https://github.com/apache/pinot/blob/8603164cc646dcb4bc2a6ead51cc9ad37441fda7/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java#L377) . As this response block is constructed without access to segment data, we default to STRING as the datatype for the column - [here is the code link](https://github.com/apache/pinot/blob/8603164cc646dcb4bc2a6ead51cc9ad37441fda7/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java#L66) . This problem does not exist for pure Aggregation queries. 

This PR fixes that by just processing one segment. 

Added tests to verify the code changes. 
