### PR TITLE
Improve column null handling

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -309,7 +309,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private String _stopReason = null;
   private final Semaphore _segBuildSemaphore;
   private final boolean _isOffHeap;
-  private final boolean _nullHandlingEnabled;
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   */
+  private final boolean _defaultNullHandlingEnabled;
   private final SegmentCommitterFactory _segmentCommitterFactory;
   private final ConsumptionRateLimiter _partitionRateLimiter;
   private final ConsumptionRateLimiter _serverRateLimiter;
@@ -1023,7 +1027,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, tempSegmentFolder.getAbsolutePath(),
               _schema, _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
-              _columnIndicesForRealtimeTable, _nullHandlingEnabled);
+              _columnIndicesForRealtimeTable, _defaultNullHandlingEnabled);
       _segmentLogger.info("Trying to build segment");
       try {
         converter.build(_segmentVersion, _serverMetrics);
@@ -1542,7 +1546,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     _isOffHeap = indexLoadingConfig.isRealtimeOffHeapAllocation();
 
-    _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
+    _defaultNullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
 
     _columnIndicesForRealtimeTable = new ColumnIndicesForRealtimeTable(sortedColumn,
         new ArrayList<>(indexLoadingConfig.getInvertedIndexColumns()),
@@ -1563,7 +1567,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setAggregateMetrics(indexingConfig.isAggregateMetrics())
             .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
-            .setNullHandlingEnabled(_nullHandlingEnabled)
+            .setDefaultNullHandlingEnabled(_defaultNullHandlingEnabled)
             .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
             .setUpsertConsistencyMode(tableConfig.getUpsertConsistencyMode())
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -95,7 +95,8 @@ public class SegmentMapper {
         tableConfig.getIndexingConfig().getSortedColumn());
     _fieldSpecs = pair.getLeft();
     _numSortFields = pair.getRight();
-    _includeNullFields = tableConfig.getIndexingConfig().isNullHandlingEnabled();
+    _includeNullFields =
+        schema.isEnableColumnBasedNullHandling() || tableConfig.getIndexingConfig().isNullHandlingEnabled();
     _recordEnricherPipeline = RecordEnricherPipeline.fromTableConfig(tableConfig);
     _recordTransformer = CompositeTransformer.composeAllTransformers(_customRecordTransformers, tableConfig, schema);
     _complexTypeTransformer = ComplexTypeTransformer.getComplexTypeTransformer(tableConfig);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
@@ -160,7 +160,7 @@ public class SelectionOrderByOperatorTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(_tempDir.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
@@ -105,7 +105,7 @@ public class StreamingSelectionOnlyOperatorTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(TEMP_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/AllNullQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/AllNullQueriesTest.java
@@ -108,7 +108,7 @@ public class AllNullQueriesTest extends BaseQueriesTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(indexDir.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
@@ -122,7 +122,7 @@ public class BigDecimalQueriesTest extends BaseQueriesTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
@@ -147,7 +147,7 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(recordSet));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanNullEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanNullEnabledQueriesTest.java
@@ -143,7 +143,7 @@ public class BooleanNullEnabledQueriesTest extends BaseQueriesTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
@@ -142,7 +142,7 @@ public class NullEnabledQueriesTest extends BaseQueriesTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -85,7 +85,7 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setNullHandlingEnabled(true);
+    segmentGeneratorConfig.setDefaultNullHandlingEnabled(true);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -139,7 +139,7 @@ public class MutableSegmentImpl implements MutableSegment {
   private final String _partitionColumn;
   private final PartitionFunction _partitionFunction;
   private final int _mainPartitionId; // partition id designated for this consuming segment
-  private final boolean _nullHandlingEnabled;
+  private final boolean _defaultNullHandlingEnabled;
   private final File _consumerDir;
 
   private final Map<String, IndexContainer> _indexContainerMap = new HashMap<>();
@@ -216,7 +216,7 @@ public class MutableSegmentImpl implements MutableSegment {
     _partitionColumn = config.getPartitionColumn();
     _partitionFunction = config.getPartitionFunction();
     _mainPartitionId = config.getPartitionId();
-    _nullHandlingEnabled = config.isNullHandlingEnabled();
+    _defaultNullHandlingEnabled = config.isNullHandlingEnabled();
     _consumerDir = new File(config.getConsumerDir());
 
     Collection<FieldSpec> allFieldSpecs = _schema.getAllFieldSpecs();
@@ -392,7 +392,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private boolean isNullable(FieldSpec fieldSpec) {
-    return _schema.isEnableColumnBasedNullHandling() ? fieldSpec.isNullable() : _nullHandlingEnabled;
+    return _schema.isEnableColumnBasedNullHandling() ? fieldSpec.isNullable() : _defaultNullHandlingEnabled;
   }
 
   private <C extends IndexConfig> void addMutableIndex(Map<IndexType, MutableIndex> mutableIndexes,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -115,7 +115,7 @@ public class RealtimeSegmentConverter {
 
     SegmentPartitionConfig segmentPartitionConfig = _realtimeSegmentImpl.getSegmentPartitionConfig();
     genConfig.setSegmentPartitionConfig(segmentPartitionConfig);
-    genConfig.setNullHandlingEnabled(_nullHandlingEnabled);
+    genConfig.setDefaultNullHandlingEnabled(_nullHandlingEnabled);
     genConfig.setSegmentZKPropsConfig(_segmentZKPropsConfig);
 
     // flush any artifacts to disk to improve mutable to immutable segment conversion

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -73,6 +73,11 @@ public class RealtimeSegmentConfig {
   private final List<AggregationConfig> _ingestionAggregationConfigs;
 
   // TODO: Clean up this constructor. Most of these things can be extracted from tableConfig.
+
+  /**
+   * @param nullHandlingEnabled whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   */
   private RealtimeSegmentConfig(String tableNameWithType, String segmentName, String streamName, Schema schema,
       String timeColumnName, int capacity, int avgNumMultiValues, Map<String, FieldIndexConfigs> indexConfigByCol,
       SegmentZKMetadata segmentZKMetadata, boolean offHeap, PinotDataBufferMemoryManager memoryManager,
@@ -251,7 +256,11 @@ public class RealtimeSegmentConfig {
     private PartitionFunction _partitionFunction;
     private int _partitionId;
     private boolean _aggregateMetrics = false;
-    private boolean _nullHandlingEnabled = false;
+    /**
+     * Whether null handling is enabled by default. This value is only used if
+     * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+     */
+    private boolean _defaultNullHandlingEnabled = false;
     private String _consumerDir;
     private UpsertConfig.Mode _upsertMode;
     private UpsertConfig.ConsistencyMode _upsertConsistencyMode;
@@ -375,8 +384,21 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    /**
+     * Whether null handling is enabled by default. This value is only used if
+     * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+     */
+    @Deprecated
     public Builder setNullHandlingEnabled(boolean nullHandlingEnabled) {
-      _nullHandlingEnabled = nullHandlingEnabled;
+      return setDefaultNullHandlingEnabled(nullHandlingEnabled);
+    }
+
+    /**
+     * Whether null handling is enabled by default. This value is only used if
+     * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+     */
+    public Builder setDefaultNullHandlingEnabled(boolean defaultNullHandlingEnabled) {
+      _defaultNullHandlingEnabled = defaultNullHandlingEnabled;
       return this;
     }
 
@@ -449,7 +471,7 @@ public class RealtimeSegmentConfig {
       return new RealtimeSegmentConfig(_tableNameWithType, _segmentName, _streamName, _schema, _timeColumnName,
           _capacity, _avgNumMultiValues, Collections.unmodifiableMap(indexConfigByCol), _segmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
-          _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertConsistencyMode, _upsertComparisonColumns,
+          _defaultNullHandlingEnabled, _consumerDir, _upsertMode, _upsertConsistencyMode, _upsertComparisonColumns,
           _upsertDeleteRecordColumn, _upsertOutOfOrderRecordColumn, _upsertDropOutOfOrderRecord,
           _partitionUpsertMetadataManager, _dedupTimeColumn, _partitionDedupMetadataManager, _fieldConfigList,
           _ingestionAggregationConfigs);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -227,7 +227,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
   }
 
   private boolean isNullable(FieldSpec fieldSpec) {
-    return _schema.isEnableColumnBasedNullHandling() ? fieldSpec.isNullable() : _config.isNullHandlingEnabled();
+    return _schema.isEnableColumnBasedNullHandling() ? fieldSpec.isNullable() : _config.isDefaultNullHandlingEnabled();
   }
 
   private FieldIndexConfigs adaptConfig(String columnName, FieldIndexConfigs config,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1002,7 +1002,8 @@ public final class TableConfigUtils {
       return;
     }
 
-    Preconditions.checkState(tableConfig.getIndexingConfig().isNullHandlingEnabled(),
+    Preconditions.checkState(schema.isEnableColumnBasedNullHandling()
+            || tableConfig.getIndexingConfig().isNullHandlingEnabled(),
         "Null handling must be enabled for partial upsert tables");
 
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
@@ -2083,18 +2084,14 @@ public class TableConfigUtilsTest {
     }
 
     partialUpsertStratgies.put("myCol1", UpsertConfig.Strategy.INCREMENT);
-    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeCol")
-        .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(false).setRoutingConfig(
+    tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName("timeCol")
+        .setUpsertConfig(partialUpsertConfig)
+        .setNullHandlingEnabled(true)
+        .setRoutingConfig(
             new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
         .setStreamConfigs(streamConfigs).build();
-    try {
-      TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
-      Assert.fail();
-    } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(), "Null handling must be enabled for partial upsert tables");
-    }
-
-    tableConfig.getIndexingConfig().setNullHandlingEnabled(true);
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -2137,6 +2134,98 @@ public class TableConfigUtilsTest {
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "INCREMENT merger cannot be applied to date time column: myTimeCol");
     }
+  }
+
+  /**
+   * Utility function that can be used to write simple tests that modify the table config and schema.
+   *
+   * This function has been designed to test the nullability of the partial upsert config, but feel free to use it to
+   * other tests as well (probably changing the method name).
+   *
+   * @param configureFun A BiConsumer that takes a TableConfigBuilder and a Schema.SchemaBuilder and modifies them
+   *                   accordingly to what the test needs.
+   */
+  private void testPartialUpsertConfigNullability(BiConsumer<TableConfigBuilder, Schema.SchemaBuilder> configureFun) {
+    Map<String, String> streamConfigs = getStreamConfigs();
+    streamConfigs.put("stream.kafka.consumer.type", "simple");
+
+    Map<String, UpsertConfig.Strategy> partialUpsertStratgies = new HashMap<>();
+    partialUpsertStratgies.put("myTimeCol", UpsertConfig.Strategy.IGNORE);
+    UpsertConfig partialUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    partialUpsertConfig.setPartialUpsertStrategies(partialUpsertStratgies);
+    partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
+    partialUpsertConfig.setComparisonColumn("myCol2");
+
+    Schema.SchemaBuilder schemaBuilder = new Schema.SchemaBuilder()
+        .setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)
+        .addSingleValueDimension("myCol2", FieldSpec.DataType.STRING)
+        .addDateTime("myTimeCol", FieldSpec.DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
+        .setPrimaryKeyColumns(Lists.newArrayList("myCol1"));
+
+    TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName("timeCol")
+        .setUpsertConfig(partialUpsertConfig)
+        .setNullHandlingEnabled(true)
+        .setRoutingConfig(
+            new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
+        .setStreamConfigs(streamConfigs);
+
+    configureFun.accept(tableConfigBuilder, schemaBuilder);
+
+    TableConfig tableConfig = tableConfigBuilder.build();
+    Schema schema = schemaBuilder.build();
+
+    TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
+  }
+
+  /**
+   * Tests that the partial upsert config fails when the null handling is disabled.
+   *
+   * This means that both table config and schema nullability is turned off.
+   */
+  @Test
+  public void partialUpsertConfigFailWhenNotNullableColumns() {
+    try {
+      testPartialUpsertConfigNullability((tableConfigBuilder, schemaBuilder) -> {
+        tableConfigBuilder.setNullHandlingEnabled(false);
+        schemaBuilder.setEnableColumnBasedNullHandling(false);
+      });
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(e.getMessage(), "Null handling must be enabled for partial upsert tables");
+    }
+  }
+
+  /**
+   * Tests that the partial upsert config succeeds when table null handling is used.
+   *
+   * This means that schema nullability is turned off, but table null handling is turned on.
+   */
+  @Test
+  public void partialUpsertConfigSuccessWhenUsingTableLevelNullability() {
+    testPartialUpsertConfigNullability((tableConfigBuilder, schemaBuilder) -> {
+      tableConfigBuilder.setNullHandlingEnabled(true);
+      schemaBuilder.setEnableColumnBasedNullHandling(false);
+    });
+  }
+
+  /**
+   * Tests that the partial upsert config succeeds when column null handling is used.
+   *
+   * This means that schema nullability is turned on, but table null handling can be either true or false.
+   */
+  @Test
+  public void partialUpsertConfigSuccessWhenUsingColumnLevelNullability() {
+    testPartialUpsertConfigNullability((tableConfigBuilder, schemaBuilder) -> {
+      tableConfigBuilder.setNullHandlingEnabled(false);
+      schemaBuilder.setEnableColumnBasedNullHandling(true);
+    });
+
+    testPartialUpsertConfigNullability((tableConfigBuilder, schemaBuilder) -> {
+      tableConfigBuilder.setNullHandlingEnabled(true);
+      schemaBuilder.setEnableColumnBasedNullHandling(true);
+    });
   }
 
   @Test

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -115,7 +115,11 @@ public class SegmentGeneratorConfig implements Serializable {
   private DateTimeFormatSpec _dateTimeFormatSpec = null;
   // Use on-heap or off-heap memory to generate index (currently only affect inverted index and star-tree v2)
   private boolean _onHeap = false;
-  private boolean _nullHandlingEnabled = false;
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   */
+  private boolean _defaultNullHandlingEnabled = false;
   private boolean _continueOnError = false;
   private boolean _rowTimeValueCheck = false;
   private boolean _segmentTimeValueCheck = true;
@@ -199,7 +203,7 @@ public class SegmentGeneratorConfig implements Serializable {
       extractCompressionCodecConfigsFromTableConfig(tableConfig);
 
       _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
-      _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
+      _defaultNullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
 
       _optimizeDictionary = indexingConfig.isOptimizeDictionary();
       _optimizeDictionaryForMetrics = indexingConfig.isOptimizeDictionaryForMetrics();
@@ -695,12 +699,42 @@ public class SegmentGeneratorConfig implements Serializable {
     return fields;
   }
 
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   *
+   * @deprecated Use {@link #isDefaultNullHandlingEnabled()} instead
+   */
+  @Deprecated
   public boolean isNullHandlingEnabled() {
-    return _nullHandlingEnabled;
+    return _defaultNullHandlingEnabled;
   }
 
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   */
+  public boolean isDefaultNullHandlingEnabled() {
+    return _defaultNullHandlingEnabled;
+  }
+
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   *
+   * @deprecated Use {@link #setDefaultNullHandlingEnabled(boolean)} instead
+   */
+  @Deprecated
   public void setNullHandlingEnabled(boolean nullHandlingEnabled) {
-    _nullHandlingEnabled = nullHandlingEnabled;
+    setDefaultNullHandlingEnabled(nullHandlingEnabled);
+  }
+
+  /**
+   * Whether null handling is enabled by default. This value is only used if
+   * {@link Schema#isEnableColumnBasedNullHandling()} is false.
+   */
+  public void setDefaultNullHandlingEnabled(boolean nullHandlingEnabled) {
+    _defaultNullHandlingEnabled = nullHandlingEnabled;
   }
 
   public boolean isContinueOnError() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -337,6 +337,12 @@ public class IndexingConfig extends BaseJsonConfig {
     _aggregateMetrics = value;
   }
 
+  /**
+   * Returns {@code true} if null handling is enabled at table config level.
+   *
+   * Remember that {@link org.apache.pinot.spi.data.Schema} can also have null handling enabled at column level and
+   * that one has more priority.
+   */
   public boolean isNullHandlingEnabled() {
     return _nullHandlingEnabled;
   }


### PR DESCRIPTION
This PR improves the usage of column based null handling. It mostly:
1. Renames some usages of `isNullHandlingEnabled` to `isDefaultNullHandlingEnabled` to make it clearer the semantic of the method. It also adds javadoc.
2. Modify `TableConfigUtils.validatePartialUpsertStrategies` and `SegmentMapper` constructor to also use column based null handling.