### PR TITLE
Handle DUAL SQL Queries without NullPointerException in JDBC

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -532,7 +532,9 @@ public class RequestUtils {
   }
 
   private static Set<String> getTableNames(DataSource dataSource) {
-    if (dataSource.getSubquery() != null) {
+    if (dataSource == null) {
+      return null;
+    } else if (dataSource.getSubquery() != null) {
       return getTableNames(dataSource.getSubquery());
     } else if (dataSource.isSetJoin()) {
       return ImmutableSet.<String>builder().addAll(getTableNames(dataSource.getJoin().getLeft()))

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3407,6 +3407,19 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Assert.assertTrue(connection.isClosed());
   }
 
+  @Test
+  public void testNoTableQueryThroughJDBCClient()
+      throws Exception {
+    String query = "SELECT 1";
+    java.sql.Connection connection = getJDBCConnectionFromController(getControllerPort());
+    Statement statement = connection.createStatement();
+    ResultSet resultSet = statement.executeQuery(query);
+    resultSet.first();
+    Assert.assertTrue(resultSet.getLong(1) > 0);
+    connection.close();
+    Assert.assertTrue(connection.isClosed());
+  }
+
   private java.sql.Connection getJDBCConnectionFromController(int controllerPort)
       throws Exception {
     PinotDriver pinotDriver = new PinotDriver();


### PR DESCRIPTION
JDBC clients parse queries to extract tables and choose the right broker. However the clients do not handle queries with no FROM clause. The clients work because of two catch-all blocks.

Fix the code to handle queries with no FROM clause.

Example:

```
2024-08-19 18:50:31,096             [main] ERROR org.apache.pinot.client.Connection - Cannot parse table name from query: SET useMultistageEngine=true;
select '3' as "one",
  case
    when 1 < 2 then 3
  end as "simple when" LIMIT 1000000. Fallback to broker selector default.
java.lang.NullPointerException: Cannot invoke "org.apache.pinot.common.request.DataSource.getSubquery()" because "dataSource" is null
	at org.apache.pinot.common.utils.request.RequestUtils.getTableNames(RequestUtils.java:535) ~[pinot-common-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at org.apache.pinot.common.utils.request.RequestUtils.getTableNames(RequestUtils.java:545) ~[pinot-common-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at org.apache.pinot.client.Connection.resolveTableName(Connection.java:146) ~[pinot-java-client-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at org.apache.pinot.client.Connection.execute(Connection.java:96) ~[pinot-java-client-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at org.apache.pinot.client.Connection.execute(Connection.java:83) ~[pinot-java-client-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at org.apache.pinot.client.PinotStatement.executeQuery(PinotStatement.java:67) ~[pinot-jdbc-client-1.3.0-SNAPSHOT.jar:1.3.0-SNAPSHOT-186115880ee7ec9aedaf1925f707b5836bafc6fd]
	at com.startree.repository.PinotRepository.executeSelectQuery(PinotRepository.java:86) ~[classes/:?]
```
tag: bugfix
