### PR TITLE
Introduce pinot-plugin assembly-desciptor as a better alternative tha…

### DIFF
--- a/pinot-plugins/assembly-descriptor/pom.xml
+++ b/pinot-plugins/assembly-descriptor/pom.xml
@@ -32,8 +32,8 @@
   <artifactId>assembly-descriptor</artifactId>
   <name>Pinot Plugin Assembly Descriptor</name>
   <description>By adding this descriptor to the maven-assembly-plugin of your project an extra artifact will be created.
-    It will be a zip, classified with plugin, putting all classes under PINOT-INF/classes
-    and all runtime dependencies under PINOT-INF/lib.
+    It will be a zip, classified with plugin, putting all classes under /classes/
+    and all runtime dependencies in the root of the zip
     See also https://maven.apache.org/plugins/maven-assembly-plugin/examples/sharing-descriptors.html
   </description>
 
@@ -46,8 +46,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
+          <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+          <extraArtifacts>
+            <artifact>org.apache.pinot:pinot-spi:${project.version}:jar</artifact>
+          </extraArtifacts>
           <projectsDirectory>src/it/projects</projectsDirectory>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <postBuildHookScript>verify</postBuildHookScript>
@@ -73,5 +77,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/pinot-plugins/assembly-descriptor/pom.xml
+++ b/pinot-plugins/assembly-descriptor/pom.xml
@@ -30,6 +30,12 @@
   </parent>
 
   <artifactId>assembly-descriptor</artifactId>
+  <name>Pinot Plugin Assembly Descriptor</name>
+  <description>By adding this descriptor to the maven-assembly-plugin of your project an extra artifact will be created.
+    It will be a zip, classified with plugin, putting all classes under PINOT-INF/classes
+    and all runtime dependencies under PINOT-INF/lib.
+    See also https://maven.apache.org/plugins/maven-assembly-plugin/examples/sharing-descriptors.html
+  </description>
 
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>

--- a/pinot-plugins/assembly-descriptor/pom.xml
+++ b/pinot-plugins/assembly-descriptor/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot-plugins</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>assembly-descriptor</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <projectsDirectory>src/it/projects</projectsDirectory>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <postBuildHookScript>verify</postBuildHookScript>
+          <filterProperties> <!-- for @property@ in pom.xml -->
+            <commons-lang3.version>${commons-lang3.version}</commons-lang3.version>
+            <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
+            <pinot.version>${project.version}</pinot.version>
+          </filterProperties>
+          <scriptVariables> <!-- ${property} for verify.groovy-->
+            <commonslang3_version>${commons-lang3.version}</commonslang3_version>
+          </scriptVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>its</id>
+            <goals>
+              <goal>install</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pinot-plugins/assembly-descriptor/pom.xml
+++ b/pinot-plugins/assembly-descriptor/pom.xml
@@ -48,6 +48,7 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
+          <streamLogsOnFailures>true</streamLogsOnFailures> 
           <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
           <extraArtifacts>
             <artifact>org.apache.pinot:pinot-spi:${project.version}:jar</artifact>

--- a/pinot-plugins/assembly-descriptor/pom.xml
+++ b/pinot-plugins/assembly-descriptor/pom.xml
@@ -48,7 +48,6 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <streamLogsOnFailures>true</streamLogsOnFailures> 
           <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
           <extraArtifacts>
             <artifact>org.apache.pinot:pinot-spi:${project.version}:jar</artifact>
@@ -58,6 +57,7 @@
           <postBuildHookScript>verify</postBuildHookScript>
           <filterProperties> <!-- for @property@ in pom.xml -->
             <commons-lang3.version>${commons-lang3.version}</commons-lang3.version>
+            <version.maven-compiler-plugin>${version.maven-compiler-plugin}</version.maven-compiler-plugin>
             <maven.compiler.release>${maven.compiler.release}</maven.compiler.release>
             <pinot.version>${project.version}</pinot.version>
           </filterProperties>

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/pom.xml
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/pom.xml
@@ -32,6 +32,15 @@
   </properties>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@version.maven-compiler-plugin@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/pom.xml
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.pinot.it</groupId>
+  <artifactId>simple-assembly</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.release>@maven.compiler.release@</maven.compiler.release>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>@project.artifactId@</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>pinot-plugin</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>@commons-lang3.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-spi</artifactId>
+      <version>@pinot.version@</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/java/org/apache/pinot/it/Simple.java
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/java/org/apache/pinot/it/Simple.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.it;
+
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+
+public class Simple {
+
+  public static void main(String[] args) {
+    Stream.of(args).map(StringUtils::upperCase).forEach(System.out::println);
+  }
+}

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/resources/pinot-plugin.properties
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/resources/pinot-plugin.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+importFrom.pinot=org.apache.pinot.segment.spi

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/resources/pinot-plugin.properties
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/src/main/resources/pinot-plugin.properties
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,5 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 importFrom.pinot=org.apache.pinot.segment.spi

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
@@ -8,8 +8,9 @@ def expected = [
 def entries = new File(basedir,'target/simple-assembly-0.0.1-SNAPSHOT-plugin.zip').with {
   f ->
     def archive = new ZipFile(f)
-    archive.entries().findAll{ !it.directory }.collect { it.name } as Set
+    def result = archive.entries().findAll{ !it.directory }.collect { it.name } as Set
     archive.close()
+    return result
 }
 
 assert entries == expected

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import java.util.zip.ZipFile
 
 def expected = [

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
@@ -1,8 +1,9 @@
 import java.util.zip.ZipFile
 
 def expected = [
-    'PINOT-INF/classes/org/apache/pinot/it/Simple.class',
-    "PINOT-INF/lib/commons-lang3-${commonslang3_version}.jar"
+    'pinot-plugin.properties',
+    'classes/org/apache/pinot/it/Simple.class',
+    "commons-lang3-${commonslang3_version}.jar"
 ] as Set
 
 def entries = new File(basedir,'target/simple-assembly-0.0.1-SNAPSHOT-plugin.zip').with {

--- a/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
+++ b/pinot-plugins/assembly-descriptor/src/it/projects/simple-assembly/verify.groovy
@@ -1,0 +1,15 @@
+import java.util.zip.ZipFile
+
+def expected = [
+    'PINOT-INF/classes/org/apache/pinot/it/Simple.class',
+    "PINOT-INF/lib/commons-lang3-${commonslang3_version}.jar"
+] as Set
+
+def entries = new File(basedir,'target/simple-assembly-0.0.1-SNAPSHOT-plugin.zip').with {
+  f ->
+    def archive = new ZipFile(f)
+    archive.entries().findAll{ !it.directory }.collect { it.name } as Set
+    archive.close()
+}
+
+assert entries == expected

--- a/pinot-plugins/assembly-descriptor/src/main/resources/assemblies/pinot-plugin.xml
+++ b/pinot-plugins/assembly-descriptor/src/main/resources/assemblies/pinot-plugin.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>plugin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory>PINOT-INF/classes</outputDirectory>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
+      <scope>runtime</scope>
+      <outputDirectory>PINOT-INF/lib</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/pinot-plugins/assembly-descriptor/src/main/resources/assemblies/pinot-plugin.xml
+++ b/pinot-plugins/assembly-descriptor/src/main/resources/assemblies/pinot-plugin.xml
@@ -28,16 +28,27 @@
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
+    <!-- the pinot-plugin.properties is the plugin metadata file and is moved to the root of the zip -->
     <fileSet>
       <directory>${project.build.outputDirectory}</directory>
-      <outputDirectory>PINOT-INF/classes</outputDirectory>
+      <excludes>
+        <exclude>pinot-plugin.properties</exclude>
+      </excludes>
+      <outputDirectory>classes</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <includes>
+        <include>pinot-plugin.properties</include>
+      </includes>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
       <scope>runtime</scope>
-      <outputDirectory>PINOT-INF/lib</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -36,6 +36,15 @@
     <shade.phase.prop>package</shade.phase.prop>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -50,6 +50,39 @@
     <module>assembly-descriptor</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.7.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.pinot</groupId>
+              <artifactId>assembly-descriptor</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>make-assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <configuration>
+                <descriptorRefs>
+                  <descriptorRef>pinot-plugin</descriptorRef>
+                </descriptorRefs>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -47,6 +47,7 @@
     <module>pinot-segment-writer</module>
     <module>pinot-segment-uploader</module>
     <module>pinot-environment</module>
+    <module>assembly-descriptor</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
…n shading

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
