### PR TITLE
Skip encoding the path url for azure deep store

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFSUtil.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFSUtil.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
-import com.azure.storage.common.Utility;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -52,22 +50,7 @@ public class AzurePinotFSUtil {
     if (path.endsWith(DIRECTORY_DELIMITER)) {
       path = path.substring(0, path.length() - 1);
     }
-    // We need to use azure's url encoder to be compatible
     return path;
-  }
-
-  /**
-   * Extract 'url encoded' Azure Data Lake Gen2 style path from uri
-   *
-   * NOTE: returning path 'should be' url encoded. (e.g. should return 'a%2Fsegment' instead of 'a/segment')
-   *
-   * @param uri a uri path
-   * @return url encoded path in Azure Data Lake Gen2 format
-   * @throws IOException
-   */
-  public static String convertUriToUrlEncodedAzureStylePath(URI uri)
-      throws IOException {
-    return Utility.urlEncode(convertUriToAzureStylePath(uri));
   }
 
   /**

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -441,7 +441,7 @@ public class ADLSGen2PinotFSTest {
     InputStream actual = _adlsGen2PinotFsUnderTest.open(_mockURI);
     Assert.assertEquals(actual, _mockInputStream);
 
-    verify(_mockFileSystemClient).getFileClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(_mockURI));
+    verify(_mockFileSystemClient).getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(_mockURI));
     verify(_mockFileClient).openInputStream();
     verify(_mockFileOpenInputStreamResult).getInputStream();
   }

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSUtilTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSUtilTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.plugin.filesystem.test;
 
 import com.azure.storage.common.Utility;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -35,19 +34,10 @@ public class AzurePinotFSUtilTest {
   @Test
   public void testConvertUriToAzureStylePath()
       throws Exception {
-    testUriToAzureStylePath("table_0", "segment_1", false);
-    testUriToAzureStylePath("table_0", "segment %", false);
-    testUriToAzureStylePath("table %", "segment_1", false);
-    testUriToAzureStylePath("table %", "segment %", false);
-  }
-
-  @Test
-  public void testConvertUriToUrlEncodedAzureStylePath()
-      throws Exception {
-    testUriToAzureStylePath("table_0", "segment_1", true);
-    testUriToAzureStylePath("table_0", "segment %", true);
-    testUriToAzureStylePath("table %", "segment_1", true);
-    testUriToAzureStylePath("table %", "segment %", true);
+    testUriToAzureStylePath("table_0", "segment_1");
+    testUriToAzureStylePath("table_0", "segment %");
+    testUriToAzureStylePath("table %", "segment_1");
+    testUriToAzureStylePath("table %", "segment %");
   }
 
   @Test
@@ -64,36 +54,31 @@ public class AzurePinotFSUtilTest {
     Assert.assertEquals(AzurePinotFSUtil.convertAzureStylePathToUriStylePath("/table/segment %/"), "/table/segment %");
   }
 
-  public void testUriToAzureStylePath(String tableName, String segmentName, boolean urlEncoded)
+  public void testUriToAzureStylePath(String tableName, String segmentName)
       throws Exception {
     // "/encode(dir)/encode(segment)"
     String expectedPath = String.join(File.separator, tableName, segmentName);
     URI uri = createUri(URLEncoder.encode(tableName, StandardCharsets.UTF_8), URLEncoder.encode(segmentName,
         StandardCharsets.UTF_8));
-    checkUri(uri, expectedPath, urlEncoded);
+    checkUri(uri, expectedPath);
 
     // "/encode(dir/segment)"
     uri = createUri(URLEncoder.encode(String.join(File.separator, tableName, segmentName), StandardCharsets.UTF_8));
-    checkUri(uri, expectedPath, urlEncoded);
+    checkUri(uri, expectedPath);
 
     // "/encode(dir/segment)"
     uri = createUri(Utility.urlEncode(String.join(File.separator, tableName, segmentName)));
-    checkUri(uri, expectedPath, urlEncoded);
+    checkUri(uri, expectedPath);
 
     // Using a URI constructor. In this case, we don't need to encode
     // /dir/segment
     uri = new URI(uri.getScheme(), uri.getHost(), File.separator + String.join(File.separator, tableName, segmentName),
         null);
-    checkUri(uri, expectedPath, urlEncoded);
+    checkUri(uri, expectedPath);
   }
 
-  private void checkUri(URI uri, String expectedPath, boolean urlEncoded)
-      throws IOException {
-    if (urlEncoded) {
-      Assert.assertEquals(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(uri), Utility.urlEncode(expectedPath));
-    } else {
-      Assert.assertEquals(AzurePinotFSUtil.convertUriToAzureStylePath(uri), expectedPath);
-    }
+  private void checkUri(URI uri, String expectedPath) {
+    Assert.assertEquals(AzurePinotFSUtil.convertUriToAzureStylePath(uri), expectedPath);
   }
 
   private URI createUri(String tableName, String segmentName) {


### PR DESCRIPTION
## Description
Since the recents upgrades to azure sdk, the adls deep store plugin started creating flat hierarchy files in the azure blob storage. This happened as recently the azure sdk started doing double encoding to ensure that the file is stored exactly as provided and user is not expected to pass an encoded url.

ref : https://github.com/Azure/azure-sdk-for-java/pull/37711

This behaviour has been changed since `azure-storage-file-datalake` version [12.19.0](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/storage/azure-storage-file-datalake/CHANGELOG.md#12190-2024-05-15) 