### PR TITLE
Log nullable columns on creation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -338,7 +338,14 @@ public class MutableSegmentImpl implements MutableSegment {
       }
 
       // Null value vector
-      MutableNullValueVector nullValueVector = isNullable(fieldSpec) ? new MutableNullValueVector() : null;
+      MutableNullValueVector nullValueVector;
+      if (isNullable(fieldSpec)) {
+        _logger.info("Column: {} is nullable", column);
+        nullValueVector = new MutableNullValueVector();
+      } else {
+        _logger.info("Column: {} is not nullable", column);
+        nullValueVector = null;
+      }
 
       Map<IndexType, MutableIndex> mutableIndexes = new HashMap<>();
       for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -223,8 +223,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         // Initialize Null value vector map
         LOGGER.info("Column: {} is nullable", columnName);
         _nullValueVectorCreatorMap.put(columnName, new NullValueVectorCreator(_indexDir, columnName));
-      } else if (LOGGER.isInfoEnabled()) {
-        LOGGER.info("Column: {} is nullable", columnName);
+      } else {
+        LOGGER.info("Column: {} is not nullable", columnName);
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -218,10 +218,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
     // Although NullValueVector is implemented as an index, it needs to be treated in a different way than other indexes
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      String columnName = fieldSpec.getName();
       if (isNullable(fieldSpec)) {
         // Initialize Null value vector map
-        String columnName = fieldSpec.getName();
+        LOGGER.info("Column: {} is nullable", columnName);
         _nullValueVectorCreatorMap.put(columnName, new NullValueVectorCreator(_indexDir, columnName));
+      } else if (LOGGER.isInfoEnabled()) {
+        LOGGER.info("Column: {} is nullable", columnName);
       }
     }
   }


### PR DESCRIPTION
This is a simple PR that adds logs indicating whether columns are nullable or not when online segments are created or when offline segments are being created and/or updated.

Currently whether an index is used or not is indirectly logged in most indexes because we log whenever we allocate offheap memory. But given null vectors use roaring bitmap, that is not logged.