### PR TITLE
Minor improvements to polymorphic scalar comparison functions for better backward compatibility

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/EqualsScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/EqualsScalarFunction.java
@@ -99,6 +99,22 @@ public class EqualsScalarFunction extends PolymorphicComparisonScalarFunction {
 
   @Nullable
   @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 2) {
+      return null;
+    }
+
+    // In case of heterogeneous argument types, fall back to double based comparison with tolerance and allow
+    // FunctionInvoker to convert argument types for v1 engine support.
+    if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
+      return DOUBLE_EQUALS_WITH_TOLERANCE;
+    }
+
+    return functionInfoForType(argumentTypes[0].getStoredType());
+  }
+
+  @Nullable
+  @Override
   public FunctionInfo getFunctionInfo(int numArguments) {
     if (numArguments != 2) {
       return null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/EqualsScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/EqualsScalarFunction.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -97,30 +96,8 @@ public class EqualsScalarFunction extends PolymorphicComparisonScalarFunction {
     return TYPE_FUNCTION_INFO_MAP.get(argumentType);
   }
 
-  @Nullable
   @Override
-  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
-    if (argumentTypes.length != 2) {
-      return null;
-    }
-
-    // In case of heterogeneous argument types, fall back to double based comparison with tolerance and allow
-    // FunctionInvoker to convert argument types for v1 engine support.
-    if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
-      return DOUBLE_EQUALS_WITH_TOLERANCE;
-    }
-
-    return functionInfoForType(argumentTypes[0].getStoredType());
-  }
-
-  @Nullable
-  @Override
-  public FunctionInfo getFunctionInfo(int numArguments) {
-    if (numArguments != 2) {
-      return null;
-    }
-
-    // For backward compatibility
+  protected FunctionInfo defaultFunctionInfo() {
     return DOUBLE_EQUALS_WITH_TOLERANCE;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/NotEqualsScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/NotEqualsScalarFunction.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -97,30 +96,8 @@ public class NotEqualsScalarFunction extends PolymorphicComparisonScalarFunction
     return TYPE_FUNCTION_INFO_MAP.get(argumentType);
   }
 
-  @Nullable
   @Override
-  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
-    if (argumentTypes.length != 2) {
-      return null;
-    }
-
-    // In case of heterogeneous argument types, fall back to double based comparison with tolerance and allow
-    // FunctionInvoker to convert argument types for v1 engine support.
-    if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
-      return DOUBLE_NOT_EQUALS_WITH_TOLERANCE;
-    }
-
-    return functionInfoForType(argumentTypes[0].getStoredType());
-  }
-
-  @Nullable
-  @Override
-  public FunctionInfo getFunctionInfo(int numArguments) {
-    if (numArguments != 2) {
-      return null;
-    }
-
-    // For backward compatibility
+  protected FunctionInfo defaultFunctionInfo() {
     return DOUBLE_NOT_EQUALS_WITH_TOLERANCE;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/NotEqualsScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/NotEqualsScalarFunction.java
@@ -99,6 +99,22 @@ public class NotEqualsScalarFunction extends PolymorphicComparisonScalarFunction
 
   @Nullable
   @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 2) {
+      return null;
+    }
+
+    // In case of heterogeneous argument types, fall back to double based comparison with tolerance and allow
+    // FunctionInvoker to convert argument types for v1 engine support.
+    if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
+      return DOUBLE_NOT_EQUALS_WITH_TOLERANCE;
+    }
+
+    return functionInfoForType(argumentTypes[0].getStoredType());
+  }
+
+  @Nullable
+  @Override
   public FunctionInfo getFunctionInfo(int numArguments) {
     if (numArguments != 2) {
       return null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/PolymorphicComparisonScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/PolymorphicComparisonScalarFunction.java
@@ -40,7 +40,7 @@ public abstract class PolymorphicComparisonScalarFunction implements PinotScalar
 
     // In case of heterogeneous argument types, fall back to double based comparison and allow FunctionInvoker to
     // convert argument types for v1 engine support.
-    if (argumentTypes[0] != argumentTypes[1]) {
+    if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
       return functionInfoForType(ColumnDataType.DOUBLE);
     }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/PolymorphicComparisonScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/comparison/PolymorphicComparisonScalarFunction.java
@@ -41,7 +41,7 @@ public abstract class PolymorphicComparisonScalarFunction implements PinotScalar
     // In case of heterogeneous argument types, fall back to double based comparison and allow FunctionInvoker to
     // convert argument types for v1 engine support.
     if (argumentTypes[0].getStoredType() != argumentTypes[1].getStoredType()) {
-      return functionInfoForType(ColumnDataType.DOUBLE);
+      return defaultFunctionInfo();
     }
 
     return functionInfoForType(argumentTypes[0].getStoredType());
@@ -55,7 +55,7 @@ public abstract class PolymorphicComparisonScalarFunction implements PinotScalar
     }
 
     // For backward compatibility
-    return functionInfoForType(ColumnDataType.DOUBLE);
+    return defaultFunctionInfo();
   }
 
   /**
@@ -63,4 +63,13 @@ public abstract class PolymorphicComparisonScalarFunction implements PinotScalar
    * take two arguments of the same type.
    */
   protected abstract FunctionInfo functionInfoForType(ColumnDataType argumentType);
+
+  /**
+   * Get the comparison scalar function's default {@link FunctionInfo}. The default function is used when the argument
+   * types are mismatched or when the function info is retrieved based on the number of arguments rather than the
+   * argument types. This is in order to maintain backward compatibility.
+   */
+  protected FunctionInfo defaultFunctionInfo() {
+    return functionInfoForType(ColumnDataType.DOUBLE);
+  }
 }


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/13711
- https://github.com/apache/pinot/pull/13711#discussion_r1725797174, https://github.com/apache/pinot/pull/13711#discussion_r1725956430
- Use double comparison with tolerance for `=`, `!=` when argument types are different.
- Compare argument stored types instead of argument types directly.