### PR TITLE
[#13862] add --host option to pinot-admin.sh StartKafka

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
@@ -37,6 +37,9 @@ import picocli.CommandLine;
 public class StartKafkaCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartKafkaCommand.class);
 
+  @CommandLine.Option(names = {"-host"}, required = false, description = "Host to start Kafka server on.")
+  private String _host = KafkaStarterUtils.DEFAULT_KAFKA_HOST;
+
   @CommandLine.Option(names = {"-port"}, required = false, description = "Port to start Kafka server on.")
   private int _port = KafkaStarterUtils.DEFAULT_KAFKA_PORT;
 
@@ -49,6 +52,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
 
   @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "Address of Zookeeper.")
   private String _zkAddress = KafkaStarterUtils.getDefaultKafkaZKAddress();
+
   private StreamDataServerStartable _kafkaStarter;
 
   @Override
@@ -63,7 +67,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
 
   @Override
   public String toString() {
-    return "StartKafka -port " + _port + " -brokerId " + _brokerId + " -zkAddress " + _zkAddress;
+    return "StartKafka -host " + _host + " -port " + _port + " -brokerId " + _brokerId + " -zkAddress " + _zkAddress;
   }
 
   @Override
@@ -78,6 +82,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
     kafkaConfiguration.put(KafkaStarterUtils.BROKER_ID, _brokerId);
     kafkaConfiguration.put(KafkaStarterUtils.PORT, _port);
     kafkaConfiguration.put(KafkaStarterUtils.ZOOKEEPER_CONNECT, _zkAddress);
+    KafkaStarterUtils.configureHostName(kafkaConfiguration, _host);
     try {
       _kafkaStarter = StreamDataProvider
           .getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, kafkaConfiguration);
@@ -85,7 +90,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }
     _kafkaStarter.start();
-    LOGGER.info("Start kafka at localhost:{} in thread {}", _port, Thread.currentThread().getName());
+    LOGGER.info("Start kafka at {}:{} in thread {}", _host, _port, Thread.currentThread().getName());
     savePID(System.getProperty("java.io.tmpdir") + File.separator + ".kafka.pid");
     return true;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KafkaStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KafkaStarterUtils.java
@@ -37,7 +37,8 @@ public class KafkaStarterUtils {
 
   public static final int DEFAULT_BROKER_ID = 0;
   public static final int DEFAULT_KAFKA_PORT = 19092;
-  public static final String DEFAULT_KAFKA_BROKER = "localhost:" + DEFAULT_KAFKA_PORT;
+  public static final String DEFAULT_KAFKA_HOST = "localhost";
+  public static final String DEFAULT_KAFKA_BROKER = DEFAULT_KAFKA_HOST + ":" + DEFAULT_KAFKA_PORT;
 
   public static final String PORT = "port";
   public static final String BROKER_ID = "broker.id";
@@ -78,7 +79,7 @@ public class KafkaStarterUtils {
     configuration.put("transaction.state.log.min.isr", 1);
 
     // Set host name
-    configureHostName(configuration, "localhost");
+    configureHostName(configuration, DEFAULT_KAFKA_HOST);
     configureOffsetsTopicReplicationFactor(configuration, (short) 1);
     configuration.put(PORT, DEFAULT_KAFKA_PORT);
     configuration.put(BROKER_ID, DEFAULT_BROKER_ID);


### PR DESCRIPTION
Fixes #13862. 

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`

 
(*) Other labels to consider:
- `tools`
- `release-notes`

(**) Use `release-notes` label for scenarios like:
- Add "--host" option to `bin/pinot-admin.sh StartKafka` 