### PR TITLE
Remove Kafka 0.9 PluginManager entry

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -81,8 +81,6 @@ public class PluginManager {
       put("org.apache.pinot.filesystem.LocalPinotFS", "org.apache.pinot.spi.filesystem.LocalPinotFS");
 
       // StreamConsumerFactory
-      put("org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory",
-          "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory");
       put("org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory",
           "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory");
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataServerStartable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataServerStartable.java
@@ -25,7 +25,7 @@ import java.util.Properties;
  * StreamDataServerStartable is the interface for stream data sources.
  * Each stream data connector should implement a mock/wrapper of the data server.
  *
- * E.g. KafkaDataServerStartable is a wrapper class of Kafka 0.9 broker.
+ * E.g. KafkaDataServerStartable is a wrapper class of Kafka 2.x broker.
  *
  */
 public interface StreamDataServerStartable {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -191,9 +191,6 @@ public class PluginManagerTest {
 
     // StreamConsumerFactory
     Assert.assertEquals(PluginManager
-            .loadClassWithBackwardCompatibleCheck("org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory"),
-        "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory");
-    Assert.assertEquals(PluginManager
             .loadClassWithBackwardCompatibleCheck("org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory"),
         "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory");
   }


### PR DESCRIPTION
We removed the Kafka 0.9 support from Kafka from Pinot a long time ago; however, the PluginManager still manages the entry for it. In this PR, we just removing the entry from the PluginManager