### PR TITLE
Add missing dependencies to pinot-perf for JMH benchmarks

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -88,6 +88,15 @@
       <artifactId>testng</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
       <scope>provided</scope>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -90,16 +90,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -821,14 +821,8 @@
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-core</artifactId>
-        <version>${jmh.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>${jmh.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <!-- log4j2 related dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -821,6 +821,11 @@
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>${jmh.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/13832 removed the `jmh-core` dependency (presumably by accident) from the `pinot-perf` module leading to the following error on attempting to run any of the JMH benchmarks locally:
```
Caused by: java.lang.ClassNotFoundException: org.openjdk.jmh.runner.options.OptionsBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 1 more
```
- Furthermore, `BenchmarkQueries` and `BenchmarkOrderByQueries` fail with:
```
Caused by: java.lang.ClassNotFoundException: org.mockito.Mockito
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 1 more
```
- This patch adds the necessary dependencies to fix both the above issues (although the Mockito one was probably an issue for a longer time since it wasn't removed in https://github.com/apache/pinot/pull/13832).