### PR TITLE
[Hotfix] init correct upsert manager with enableDeletedKeysCompactionConsistency config

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -49,8 +49,8 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public BasePartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> _enableDeletedKeysCompactionConsistency
-            ? new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context)
-            : new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context));
+            ? new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context)
+            : new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
   }
 
   @Override


### PR DESCRIPTION
Introduced in #13347 

When `enableDeletedKeysCompactionConsistency` is set to true, we should initialize `ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes` and in case of false initialize `ConcurrentMapPartitionUpsertMetadataManager`. The values were reversed.

This patch fixes the above. Also added UTs.