### PR TITLE
Expose Get Segments/Table Config Change capture 

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -319,9 +319,6 @@ public class ControllerConf extends PinotConfiguration {
   public static final String ENFORCE_POOL_BASED_ASSIGNMENT_KEY = "enforce.pool.based.assignment";
   public static final boolean DEFAULT_ENFORCE_POOL_BASED_ASSIGNMENT = false;
 
-  public static final String THRESHOLD_REPLICATION_FACTOR = "controller.replication";
-  public static final int DEFAULT_THRESHOLD_REPLICATION_FACTOR = 3;
-
   public ControllerConf() {
     super(new HashMap<>());
   }
@@ -1074,9 +1071,5 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isEnforcePoolBasedAssignmentEnabled() {
     return getProperty(ENFORCE_POOL_BASED_ASSIGNMENT_KEY, DEFAULT_ENFORCE_POOL_BASED_ASSIGNMENT);
-  }
-
-  public int getThresholdReplicationFactor() {
-    return getProperty(THRESHOLD_REPLICATION_FACTOR, DEFAULT_THRESHOLD_REPLICATION_FACTOR);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -319,6 +319,9 @@ public class ControllerConf extends PinotConfiguration {
   public static final String ENFORCE_POOL_BASED_ASSIGNMENT_KEY = "enforce.pool.based.assignment";
   public static final boolean DEFAULT_ENFORCE_POOL_BASED_ASSIGNMENT = false;
 
+  public static final String THRESHOLD_REPLICATION_FACTOR = "controller.replication";
+  public static final int DEFAULT_THRESHOLD_REPLICATION_FACTOR = 3;
+
   public ControllerConf() {
     super(new HashMap<>());
   }
@@ -1071,5 +1074,9 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isEnforcePoolBasedAssignmentEnabled() {
     return getProperty(ENFORCE_POOL_BASED_ASSIGNMENT_KEY, DEFAULT_ENFORCE_POOL_BASED_ASSIGNMENT);
+  }
+
+  public int getThresholdReplicationFactor() {
+    return getProperty(THRESHOLD_REPLICATION_FACTOR, DEFAULT_THRESHOLD_REPLICATION_FACTOR);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -60,7 +60,7 @@ public class TableMetadataReader {
 
   public Map<String, JsonNode> getServerCheckSegmentsReloadMetadata(String tableNameWithType, int timeoutMs)
       throws InvalidConfigException, IOException {
-    List<String> segmentsMetadata = getIsReloadNeeded(tableNameWithType, timeoutMs);
+    List<String> segmentsMetadata = getReloadCheckResponses(tableNameWithType, timeoutMs);
     Map<String, JsonNode> response = new HashMap<>();
     for (String segmentMetadata : segmentsMetadata) {
       JsonNode responseJson = JsonUtils.stringToJsonNode(segmentMetadata);
@@ -69,7 +69,7 @@ public class TableMetadataReader {
     return response;
   }
 
-  private List<String> getIsReloadNeeded(String tableNameWithType, int timeoutMs)
+  private List<String> getReloadCheckResponses(String tableNameWithType, int timeoutMs)
       throws InvalidConfigException {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     List<String> serverInstances = _pinotHelixResourceManager.getServerInstancesForTable(tableNameWithType, tableType);
@@ -77,11 +77,8 @@ public class TableMetadataReader {
     BiMap<String, String> endpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverInstanceSet);
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager);
-    List<String> segmentsMetadata;
-    segmentsMetadata =
-        serverSegmentMetadataReader.getCheckReloadSegmentsFromServer(tableNameWithType, serverInstanceSet, endpoints,
-            timeoutMs);
-    return segmentsMetadata;
+    return serverSegmentMetadataReader.getCheckReloadSegmentsFromServer(tableNameWithType, serverInstanceSet, endpoints,
+        timeoutMs);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -86,6 +86,17 @@ public class TableMetadataReader {
     return getSegmentsMetadataInternal(tableNameWithType, columns, segmentsToInclude, timeoutMs);
   }
 
+  /**
+   * This api takes in table name and checks if there exists any mismtach in the segments/table configs
+   */
+  public JsonNode getSegmentsReloadCheckMetadata(String tableNameWithType, List<String> columns,
+      Set<String> segmentsToInclude, int timeoutMs)
+      throws InvalidConfigException, IOException {
+    Map<String, JsonNode> jsonNodeMap = getServerCheckSegmentsReloadMetadata(tableNameWithType, timeoutMs);
+    boolean needReload = jsonNodeMap.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
+    return JsonUtils.stringToJsonNode(Boolean.toString(needReload));
+  }
+
   private JsonNode getSegmentsMetadataInternal(String tableNameWithType, List<String> columns,
       Set<String> segmentsToInclude, int timeoutMs)
       throws InvalidConfigException, IOException {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -69,7 +69,7 @@ public class TableMetadataReader {
     return response;
   }
 
-  private List<String> getReloadCheckResponses(String tableNameWithType, int timeoutMs)
+  public List<String> getReloadCheckResponses(String tableNameWithType, int timeoutMs)
       throws InvalidConfigException {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     List<String> serverInstances = _pinotHelixResourceManager.getServerInstancesForTable(tableNameWithType, tableType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -87,10 +87,9 @@ public class TableMetadataReader {
   }
 
   /**
-   * This api takes in table name and checks if there exists any mismtach in the segments/table configs
+   * This method takes in table name and checks if there exists any mismtach in the segments/table configs
    */
-  public JsonNode getSegmentsReloadCheckMetadata(String tableNameWithType, List<String> columns,
-      Set<String> segmentsToInclude, int timeoutMs)
+  public JsonNode getSegmentsReloadCheckMetadata(String tableNameWithType, int timeoutMs)
       throws InvalidConfigException, IOException {
     Map<String, JsonNode> jsonNodeMap = getServerCheckSegmentsReloadMetadata(tableNameWithType, timeoutMs);
     boolean needReload = jsonNodeMap.values().stream().anyMatch(value -> value.get("needReload").booleanValue());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -21,7 +21,6 @@ package org.apache.pinot.controller.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.BiMap;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;


### PR DESCRIPTION
This PR is to capture the meta data when reload is needed on the table. 
This method can be used externally to get the api result inorder to check for table reload (i.e in specific if any of the segments need reload).