### PR TITLE
Fix race condition in shared literal transform functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
@@ -48,12 +48,15 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
   private final double[] _doubleArrayLiteral;
   private final String[] _stringArrayLiteral;
 
-  // literals may be shared but values are intentionally not volatile as assignment races are benign
-  private int[][] _intArrayResult;
-  private long[][] _longArrayResult;
-  private float[][] _floatArrayResult;
-  private double[][] _doubleArrayResult;
-  private String[][] _stringArrayResult;
+  // NOTE:
+  // This class can be shared across multiple threads, and the result arrays are lazily initialized and cached. They
+  // need to be declared as volatile to ensure instructions are not reordered, or some threads might see uninitialized
+  // arrays.
+  private volatile int[][] _intArrayResult;
+  private volatile long[][] _longArrayResult;
+  private volatile float[][] _floatArrayResult;
+  private volatile double[][] _doubleArrayResult;
+  private volatile String[][] _stringArrayResult;
 
   public ArrayLiteralTransformFunction(LiteralContext literalContext) {
     _dataType = literalContext.getType();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GenerateArrayTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GenerateArrayTransformFunction.java
@@ -41,10 +41,15 @@ public class GenerateArrayTransformFunction implements TransformFunction {
   private final long[] _longArrayLiteral;
   private final float[] _floatArrayLiteral;
   private final double[] _doubleArrayLiteral;
-  private int[][] _intArrayResult;
-  private long[][] _longArrayResult;
-  private float[][] _floatArrayResult;
-  private double[][] _doubleArrayResult;
+
+  // NOTE:
+  // This class can be shared across multiple threads, and the result arrays are lazily initialized and cached. They
+  // need to be declared as volatile to ensure instructions are not reordered, or some threads might see uninitialized
+  // arrays.
+  private volatile int[][] _intArrayResult;
+  private volatile long[][] _longArrayResult;
+  private volatile float[][] _floatArrayResult;
+  private volatile double[][] _doubleArrayResult;
 
   public GenerateArrayTransformFunction(List<ExpressionContext> literalContexts) {
     Preconditions.checkNotNull(literalContexts);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -40,14 +40,17 @@ public class LiteralTransformFunction implements TransformFunction {
 
   private final LiteralContext _literalContext;
 
-  // literals may be shared but values are intentionally not volatile as assignment races are benign
-  private int[] _intResult;
-  private long[] _longResult;
-  private float[] _floatResult;
-  private double[] _doubleResult;
-  private BigDecimal[] _bigDecimalResult;
-  private String[] _stringResult;
-  private byte[][] _bytesResult;
+  // NOTE:
+  // This class can be shared across multiple threads, and the result arrays are lazily initialized and cached. They
+  // need to be declared as volatile to ensure instructions are not reordered, or some threads might see uninitialized
+  // arrays.
+  private volatile int[] _intResult;
+  private volatile long[] _longResult;
+  private volatile float[] _floatResult;
+  private volatile double[] _doubleResult;
+  private volatile BigDecimal[] _bigDecimalResult;
+  private volatile String[] _stringResult;
+  private volatile byte[][] _bytesResult;
 
   public LiteralTransformFunction(LiteralContext literalContext) {
     _literalContext = literalContext;


### PR DESCRIPTION
Even though assignment races are benign, without declaring the fields as `volatile`, instructions might be re-ordered by JVM and causing some threads accessing the uninitialized array.
There is no easy way to add a test, but we have seen NPE when reading string literal array, and the only explanation is one thread get an string array without any values filled.