### PR TITLE
Fix log typo to avoid confusion

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -126,7 +126,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     nonExistingSegmentNames.removeAll(segmentNamesForTable);
     if (!CollectionUtils.isEmpty(nonExistingSegmentNames)) {
       throw new RuntimeException(
-          String.format("table: %s does have the following segments to process: %s", tableNameWithType,
+          String.format("table: %s does not have the following segments to process: %s", tableNameWithType,
               nonExistingSegmentNames));
     }
   }


### PR DESCRIPTION
Fix a log typo where the log message says `table: %s does have the following segments to process: %s`. It should say `table: %s does not have the following segments to process: %s` instead.

