### PR TITLE
Store index metadata file for Lucene text indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -118,6 +118,11 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
       _indexFile = getV1TextIndexFile(segmentIndexDir);
 
+      // write properties file for the immutable segment
+      if (_commitOnClose) {
+        TextIndexUtils.writeConfigToPropertiesFile(_indexFile, config);
+      }
+
       Analyzer luceneAnalyzer = TextIndexUtils.getAnalyzer(config);
       IndexWriterConfig indexWriterConfig = new IndexWriterConfig(luceneAnalyzer);
       indexWriterConfig.setRAMBufferSizeMB(config.getLuceneMaxBufferSizeMB());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -93,10 +93,15 @@ public class LuceneTextIndexReader implements TextIndexReader {
       // TODO: consider using a threshold of num docs per segment to decide between building
       // mapping file upfront on segment load v/s on-the-fly during query processing
       _docIdTranslator = new DocIdTranslator(indexDir, _column, numDocs, _indexSearcher);
+      // If the properties file exists, use the analyzer properties and query parser class from the properties file
+      File propertiesFile = new File(indexFile, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE);
+      if (propertiesFile.exists()) {
+        config = TextIndexUtils.getUpdatedConfigFromPropertiesFile(propertiesFile, config);
+      }
       _analyzer = TextIndexUtils.getAnalyzer(config);
       _queryParserClass = config.getLuceneQueryParserClass();
       _queryParserClassConstructor =
-              TextIndexUtils.getQueryParserWithStringAndAnalyzerTypeConstructor(_queryParserClass);
+          TextIndexUtils.getQueryParserWithStringAndAnalyzerTypeConstructor(_queryParserClass);
       LOGGER.info("Successfully read lucene index for {} from {}", _column, indexDir);
     } catch (Exception e) {
       LOGGER.error("Failed to instantiate Lucene text index reader for column {}, exception {}", column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -300,6 +300,12 @@ public class TextIndexUtils {
     return (Constructor<QueryParserBase>) queryParserClass.getConstructor(String.class, Analyzer.class);
   }
 
+  /**
+   * Writes the config to the properties file.
+   *
+   * @param indexDir directory where the properties file is saved
+   * @param config config to write to the properties file
+   */
   public static void writeConfigToPropertiesFile(File indexDir, TextIndexConfig config) {
     PropertiesConfiguration properties = new PropertiesConfiguration();
     List<String> escapedLuceneAnalyzerClassArgs = config.getLuceneAnalyzerClassArgs().stream()
@@ -316,6 +322,13 @@ public class TextIndexUtils {
     CommonsConfigurationUtils.saveToFile(properties, propertiesFile);
   }
 
+  /**
+   * Returns an updated TextIndexConfig, overriding the values in the config with the values in the properties file.
+   *
+   * @param file properties file to read from
+   * @param config config to update
+   * @return updated TextIndexConfig
+   */
   public static TextIndexConfig getUpdatedConfigFromPropertiesFile(File file, TextIndexConfig config)
       throws ConfigurationException {
     PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(file);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -301,7 +301,8 @@ public class TextIndexUtils {
   }
 
   /**
-   * Writes the config to the properties file.
+   * Writes the config to the properties file. Configs saved include luceneAnalyzerClass, luceneAnalyzerClassArgs,
+   * luceneAnalyzerClassArgTypes, and luceneQueryParserClass.
    *
    * @param indexDir directory where the properties file is saved
    * @param config config to write to the properties file
@@ -324,6 +325,8 @@ public class TextIndexUtils {
 
   /**
    * Returns an updated TextIndexConfig, overriding the values in the config with the values in the properties file.
+   * The configs overwritten include luceneAnalyzerClass, luceneAnalyzerClassArgs, luceneAnalyzerClassArgTypes,
+   * and luceneQueryParserClass.
    *
    * @param file properties file to read from
    * @param config config to update

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.store;
+
+import java.io.File;
+import java.util.Arrays;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.index.text.TextIndexConfigBuilder;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class TextIndexUtilsTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "TextIndexUtilsTest");
+
+  @Test
+  public void testRoundTripProperties()
+      throws ConfigurationException {
+    TextIndexConfig config =
+        new TextIndexConfigBuilder().withLuceneAnalyzerClass("org.apache.lucene.analysis.core.KeywordAnalyzer")
+            .withLuceneAnalyzerClassArgs(
+                Arrays.asList(" \\,.\n\t()[]{}\"':=-_$\\?@&|#+/", "\\,.()[]{}\"':=-_$\\?@&|#+"))
+            .withLuceneAnalyzerClassArgTypes(Arrays.asList("java.lang.String", "java.lang.String"))
+            .withLuceneQueryParserClass("org.apache.pinot.utils.lucene.queryparser.FakeQueryParser").build();
+
+    TextIndexUtils.writeConfigToPropertiesFile(TEMP_DIR, config);
+    TextIndexConfig readConfig = TextIndexUtils.getUpdatedConfigFromPropertiesFile(
+        new File(TEMP_DIR, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE), config);
+    assertEquals(readConfig, config);
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -56,6 +56,7 @@ public class V1Constants {
     public static final String LUCENE_V9_TEXT_INDEX_FILE_EXTENSION = ".lucene.v9.index";
     public static final String LUCENE_V99_FST_INDEX_FILE_EXTENSION = ".lucene.v99.fst";
     public static final String LUCENE_V99_TEXT_INDEX_FILE_EXTENSION = ".lucene.v99.index";
+    public static final String LUCENE_TEXT_INDEX_PROPERTIES_FILE = "lucene.properties";
     public static final String VECTOR_INDEX_FILE_EXTENSION = ".vector.index";
     public static final String VECTOR_HNSW_INDEX_FILE_EXTENSION = ".vector.hnsw.index";
     public static final String VECTOR_V99_INDEX_FILE_EXTENSION = ".vector.v99.index";


### PR DESCRIPTION
Currently the Lucene text index is written using some Analyzer and queried with some QueryParser. Updating these in the table config can cause unpredictable behavior as when the segments are loaded they'll use the new configs but segments were built with the old configs. This can cause incorrect results when querying. 

For example, 
1. segment1 created with `Analyzer1` and `QueryPaserForAnalyzer1`
2. table config updated with `Analyzer2` and `QueryParserForAnalyzer2`
3. segment 2 created with `Analyzer2` and `QueryParserForAnalyzer2`
4. segment 1 loaded, Reader uses `QueryParserForAnalyzer2` but index uses `Analyzer1`

Storing metadata per segment allows for compatible QueryParser/Analyzer pairs to be maintained. Now,`4` becomes 
4. segment 1 loaded, Reader uses `QueryParserForAnalyzer1` and index uses `Analyzer1`. 

This allows for seamless updates of realtime tables without breaking queries against old segments (provided the `QueryParser` and `Analyzer` classes are managed correctly). In the future this metadata can be leveraged by TextIndexHandler to provide better index reload/rebuilding capabilities for Lucene text index. 

Testing: we've been using this internally for around half a year

tags: `enhancement`, `docs`