### PR TITLE
Validate if Table Replication Factor Can be Honoured during Table Create/Update

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -83,7 +83,6 @@ import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.DatabaseUtils;
-import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
@@ -131,18 +130,15 @@ import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
 
-@Api(tags = Constants.TABLE_TAG, authorizations = {
-    @Authorization(value = SWAGGER_AUTHORIZATION_KEY), @Authorization(value = DATABASE)
-})
+@Api(tags = Constants.TABLE_TAG, authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
+    @Authorization(value = DATABASE)})
 @SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
-    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key =
-        SWAGGER_AUTHORIZATION_KEY, description =
-        "The format of the key is  ```\"Basic <token>\" or \"Bearer "
-            + "<token>\"```"), @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER
-    , key = DATABASE, description =
-    "Database context passed through http header. If no context is provided 'default' database "
-        + "context will be considered.")
-}))
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        key = SWAGGER_AUTHORIZATION_KEY,
+        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
+    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
+        description = "Database context passed through http header. If no context is provided 'default' database "
+            + "context will be considered.")}))
 @Path("/")
 public class PinotTableRestletResource {
   /**
@@ -209,7 +205,6 @@ public class PinotTableRestletResource {
     TableConfig tableConfig;
     String tableNameWithType;
     try {
-
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
       tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
@@ -219,8 +214,8 @@ public class PinotTableRestletResource {
       handleLegacySchemaConfig(tableConfig, httpHeaders);
 
       // validate permission
-      ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders, AccessType.CREATE,
-          Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
+      ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
+          AccessType.CREATE, Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
 
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
 
@@ -237,7 +232,6 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
-        ensureCanHostAllReplicas(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
       }
@@ -299,10 +293,11 @@ public class PinotTableRestletResource {
 
       // If tableTypeStr is dimension, then tableType is set to TableType.OFFLINE.
       // So, checking the isDimensionTable to get the list of dimension tables only.
-      List<String> tableNamesWithType = isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables(database)
-          : tableType == null ? _pinotHelixResourceManager.getAllTables(database)
-              : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables(database)
-                  : _pinotHelixResourceManager.getAllOfflineTables(database));
+      List<String> tableNamesWithType =
+          isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables(database)
+              : tableType == null ? _pinotHelixResourceManager.getAllTables(database)
+                  : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables(database)
+                      : _pinotHelixResourceManager.getAllOfflineTables(database));
 
       if (StringUtils.isNotBlank(taskType)) {
         Set<String> tableNamesForTaskType = new HashSet<>();
@@ -531,8 +526,8 @@ public class PinotTableRestletResource {
   @POST
   @Path("/tables/validate")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Validate table config for a table", notes =
-      "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
+  @ApiOperation(value = "Validate table config for a table",
+      notes = "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
           + " This allows us to validate table config before apply.")
   @ManualAuthorization // performed after parsing TableConfig
   public ObjectNode checkTableConfig(String tableConfigStr,
@@ -555,8 +550,8 @@ public class PinotTableRestletResource {
     handleLegacySchemaConfig(tableConfig, httpHeaders);
 
     // validate permission
-    ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders, AccessType.READ,
-        Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
+    ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
+        AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
 
     ObjectNode validationResponse =
         validateConfig(tableConfig, _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig), typesToSkip);
@@ -589,8 +584,8 @@ public class PinotTableRestletResource {
   @Authenticate(AccessType.UPDATE)
   @Path("/tables/{tableName}/rebalance")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.REBALANCE_TABLE)
-  @ApiOperation(value = "Rebalances a table (reassign instances and segments for a table)", notes = "Rebalances a "
-      + "table (reassign instances and segments for a table)")
+  @ApiOperation(value = "Rebalances a table (reassign instances and segments for a table)",
+      notes = "Rebalances a table (reassign instances and segments for a table)")
   public RebalanceResult rebalance(
       //@formatter:off
       @ApiParam(value = "Name of the table to rebalance", required = true) @PathParam("tableName") String tableName,
@@ -670,16 +665,16 @@ public class PinotTableRestletResource {
           rebalanceConfig.setDryRun(false);
           Future<RebalanceResult> rebalanceResultFuture = _executorService.submit(() -> {
             try {
-              return _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId,
-                  true);
+              return _pinotHelixResourceManager.rebalanceTable(
+                  tableNameWithType, rebalanceConfig, rebalanceJobId, true);
             } catch (Throwable t) {
               String errorMsg = String.format("Caught exception/error while rebalancing table: %s", tableNameWithType);
               LOGGER.error(errorMsg, t);
               return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED, errorMsg, null, null, null);
             }
           });
-          boolean isJobIdPersisted =
-              waitForRebalanceToPersist(dryRunResult.getJobId(), tableNameWithType, rebalanceResultFuture);
+          boolean isJobIdPersisted = waitForRebalanceToPersist(
+              dryRunResult.getJobId(), tableNameWithType, rebalanceResultFuture);
 
           if (rebalanceResultFuture.isDone()) {
             try {
@@ -711,13 +706,13 @@ public class PinotTableRestletResource {
    * Tables with 100k+ segments take up to a few seconds for the jobId to persist. This ensures the jobId is present
    * before returning the jobId to the caller, so they can correctly poll the jobId.
    */
-  public boolean waitForRebalanceToPersist(String jobId, String tableNameWithType,
-      Future<RebalanceResult> rebalanceResultFuture) {
+  public boolean waitForRebalanceToPersist(
+      String jobId, String tableNameWithType, Future<RebalanceResult> rebalanceResultFuture) {
     try {
       // This retry policy waits at most for 7.5s to 15s in total. This is chosen to cover typical delays for tables
       // with many segments and avoid excessive HTTP request timeouts.
-      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0)
-          .attempt(() -> getControllerJobMetadata(jobId) != null || rebalanceResultFuture.isDone());
+      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0).attempt(() ->
+          getControllerJobMetadata(jobId) != null || rebalanceResultFuture.isDone());
       return true;
     } catch (Exception e) {
       LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
@@ -772,8 +767,8 @@ public class PinotTableRestletResource {
   @Authenticate(AccessType.UPDATE)
   @Path("/rebalanceStatus/{jobId}")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_REBALANCE_STATUS)
-  @ApiOperation(value = "Gets detailed stats of a rebalance operation", notes = "Gets detailed stats of a rebalance "
-      + "operation")
+  @ApiOperation(value = "Gets detailed stats of a rebalance operation",
+      notes = "Gets detailed stats of a rebalance operation")
   public ServerRebalanceJobStatusResponse rebalanceStatus(
       @ApiParam(value = "Rebalance Job Id", required = true) @PathParam("jobId") String jobId)
       throws JsonProcessingException {
@@ -831,8 +826,10 @@ public class PinotTableRestletResource {
   @Consumes(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Enable/disable a table", notes = "Enable/disable a table")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 400, message = "Bad Request"),
-      @ApiResponse(code = 404, message = "Table not found"), @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 404, message = "Table not found"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public SuccessResponse toggleTableState(
       @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
@@ -921,26 +918,24 @@ public class PinotTableRestletResource {
     int replication = tableConfig.getReplication();
     //check if server tags have been overridden
     TagOverrideConfig tagOverrideConfig = tableConfig.getTenantConfig().getTagOverrideConfig();
-    //in the current behaviour, tag overrides are honoured only when both realtimeConsuming and realtimeCompleted
-    // tags are specified. Otherwise, overrides are ignored
+    //Currently, tag overrides are honoured only when both realtimeConsuming and realtimeCompleted tags are specified
+    // . Otherwise, overrides are ignored
     if (tagOverrideConfig != null && tagOverrideConfig.getRealtimeCompleted() != null
         && tagOverrideConfig.getRealtimeConsuming() != null) {
       String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
-      String realtimeConsumingTenant = TagNameUtils.getTenantFromTag(realtimeConsumingTag);
-      boolean hasEnoughConsumingServers =
-          _pinotHelixResourceManager.getAllInstancesForServerTenant(realtimeConsumingTenant).size() >= replication;
+      boolean hasMinConsumingServersToHost =
+          _pinotHelixResourceManager.getAllInstancesWithTag(realtimeConsumingTag).size() >= replication;
 
       String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
-      String realtimeCompletedTenant = TagNameUtils.getTenantFromTag(realtimeCompletedTag);
-      boolean hasEnoughCompletedServers =
-          _pinotHelixResourceManager.getAllInstancesForServerTenant(realtimeCompletedTenant).size() >= replication;
+      boolean hasMinCompletedServersToHost =
+          _pinotHelixResourceManager.getAllInstancesWithTag(realtimeCompletedTag).size() >= replication;
 
-      if (!hasEnoughConsumingServers || !hasEnoughCompletedServers) {
-        if (!hasEnoughConsumingServers && !hasEnoughCompletedServers) {
+      if (!hasMinConsumingServersToHost || !hasMinCompletedServersToHost) {
+        if (!hasMinConsumingServersToHost && !hasMinCompletedServersToHost) {
           throw new IllegalStateException(String.format(
-              "Not enough CONSUMING and COMPLETED servers with tags %s and s %s to host the requested replication of "
+              "Not enough CONSUMING and COMPLETED servers with tags %s and %s to host the requested replication of "
                   + "%s", realtimeConsumingTag, realtimeCompletedTag, replication));
-        } else if (!hasEnoughConsumingServers) {
+        } else if (!hasMinConsumingServersToHost) {
           throw new IllegalStateException(
               String.format("Not enough CONSUMING servers with tag %s to host the requested replication of %s",
                   realtimeConsumingTag, replication));
@@ -1005,8 +1000,8 @@ public class PinotTableRestletResource {
   @Path("tables/{tableName}/metadata")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get the aggregate metadata of all segments for a table", notes = "Get the aggregate metadata"
-      + " of all segments for a table")
+  @ApiOperation(value = "Get the aggregate metadata of all segments for a table",
+      notes = "Get the aggregate metadata of all segments for a table")
   public String getTableAggregateMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
@@ -1048,10 +1043,11 @@ public class PinotTableRestletResource {
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
-      @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType") @DefaultValue("SNAPSHOT")
-      ValidDocIdsType validDocIdsType,
-      @ApiParam(value = "Number of segments in a batch per server request") @QueryParam("serverRequestBatchSize")
-      @DefaultValue("500") int serverRequestBatchSize, @Context HttpHeaders headers) {
+      @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType")
+      @DefaultValue("SNAPSHOT") ValidDocIdsType validDocIdsType,
+      @ApiParam(value = "Number of segments in a batch per server request")
+      @QueryParam("serverRequestBatchSize") @DefaultValue("500") int serverRequestBatchSize,
+      @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch aggregate validDocIds metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
@@ -1168,8 +1164,8 @@ public class PinotTableRestletResource {
   @Path("table/{tableName}/jobs")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_CONTROLLER_JOBS)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get list of controller jobs for this table", notes = "Get list of controller jobs for this "
-      + "table")
+  @ApiOperation(value = "Get list of controller jobs for this table",
+      notes = "Get list of controller jobs for this table")
   public Map<String, Map<String, String>> getControllerJobs(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
@@ -1182,13 +1178,13 @@ public class PinotTableRestletResource {
             LOGGER);
     Set<String> jobTypesToFilter = null;
     if (StringUtils.isNotEmpty(jobTypesString)) {
-      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ','))).stream()
-          .collect(Collectors.toSet());
+      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ',')))
+          .stream().collect(Collectors.toSet());
     }
     Map<String, Map<String, String>> result = new HashMap<>();
     for (String tableNameWithType : tableNamesWithType) {
-      result.putAll(_pinotHelixResourceManager.getAllJobs(
-          jobTypesToFilter == null ? ControllerJobType.VALID_CONTROLLER_JOB_TYPE : jobTypesToFilter,
+      result.putAll(_pinotHelixResourceManager.getAllJobs(jobTypesToFilter == null
+              ? ControllerJobType.VALID_CONTROLLER_JOB_TYPE : jobTypesToFilter,
           jobMetadata -> jobMetadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE)
               .equals(tableNameWithType)));
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -232,6 +232,7 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
+        ensureCanHostAllReplicas(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
       }
@@ -506,6 +507,7 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
+        ensureCanHostAllReplicas(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -83,6 +83,7 @@ import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
@@ -115,6 +116,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableStats;
 import org.apache.pinot.spi.config.table.TableStatus;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TagOverrideConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -129,15 +131,18 @@ import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
 
-@Api(tags = Constants.TABLE_TAG, authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
-    @Authorization(value = DATABASE)})
+@Api(tags = Constants.TABLE_TAG, authorizations = {
+    @Authorization(value = SWAGGER_AUTHORIZATION_KEY), @Authorization(value = DATABASE)
+})
 @SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
-    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
-        key = SWAGGER_AUTHORIZATION_KEY,
-        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
-    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
-        description = "Database context passed through http header. If no context is provided 'default' database "
-            + "context will be considered.")}))
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key =
+        SWAGGER_AUTHORIZATION_KEY, description =
+        "The format of the key is  ```\"Basic <token>\" or \"Bearer "
+            + "<token>\"```"), @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER
+    , key = DATABASE, description =
+    "Database context passed through http header. If no context is provided 'default' database "
+        + "context will be considered.")
+}))
 @Path("/")
 public class PinotTableRestletResource {
   /**
@@ -204,6 +209,7 @@ public class PinotTableRestletResource {
     TableConfig tableConfig;
     String tableNameWithType;
     try {
+
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
       tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
@@ -213,8 +219,8 @@ public class PinotTableRestletResource {
       handleLegacySchemaConfig(tableConfig, httpHeaders);
 
       // validate permission
-      ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
-          AccessType.CREATE, Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
+      ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders, AccessType.CREATE,
+          Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
 
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
 
@@ -231,6 +237,7 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
+        ensureCanHostAllReplicas(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
       }
@@ -292,11 +299,10 @@ public class PinotTableRestletResource {
 
       // If tableTypeStr is dimension, then tableType is set to TableType.OFFLINE.
       // So, checking the isDimensionTable to get the list of dimension tables only.
-      List<String> tableNamesWithType =
-          isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables(database)
-              : tableType == null ? _pinotHelixResourceManager.getAllTables(database)
-                  : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables(database)
-                      : _pinotHelixResourceManager.getAllOfflineTables(database));
+      List<String> tableNamesWithType = isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables(database)
+          : tableType == null ? _pinotHelixResourceManager.getAllTables(database)
+              : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables(database)
+                  : _pinotHelixResourceManager.getAllOfflineTables(database));
 
       if (StringUtils.isNotBlank(taskType)) {
         Set<String> tableNamesForTaskType = new HashSet<>();
@@ -525,8 +531,8 @@ public class PinotTableRestletResource {
   @POST
   @Path("/tables/validate")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Validate table config for a table",
-      notes = "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
+  @ApiOperation(value = "Validate table config for a table", notes =
+      "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
           + " This allows us to validate table config before apply.")
   @ManualAuthorization // performed after parsing TableConfig
   public ObjectNode checkTableConfig(String tableConfigStr,
@@ -549,8 +555,8 @@ public class PinotTableRestletResource {
     handleLegacySchemaConfig(tableConfig, httpHeaders);
 
     // validate permission
-    ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
-        AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
+    ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders, AccessType.READ,
+        Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
 
     ObjectNode validationResponse =
         validateConfig(tableConfig, _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig), typesToSkip);
@@ -583,8 +589,8 @@ public class PinotTableRestletResource {
   @Authenticate(AccessType.UPDATE)
   @Path("/tables/{tableName}/rebalance")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.REBALANCE_TABLE)
-  @ApiOperation(value = "Rebalances a table (reassign instances and segments for a table)",
-      notes = "Rebalances a table (reassign instances and segments for a table)")
+  @ApiOperation(value = "Rebalances a table (reassign instances and segments for a table)", notes = "Rebalances a "
+      + "table (reassign instances and segments for a table)")
   public RebalanceResult rebalance(
       //@formatter:off
       @ApiParam(value = "Name of the table to rebalance", required = true) @PathParam("tableName") String tableName,
@@ -664,16 +670,16 @@ public class PinotTableRestletResource {
           rebalanceConfig.setDryRun(false);
           Future<RebalanceResult> rebalanceResultFuture = _executorService.submit(() -> {
             try {
-              return _pinotHelixResourceManager.rebalanceTable(
-                  tableNameWithType, rebalanceConfig, rebalanceJobId, true);
+              return _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId,
+                  true);
             } catch (Throwable t) {
               String errorMsg = String.format("Caught exception/error while rebalancing table: %s", tableNameWithType);
               LOGGER.error(errorMsg, t);
               return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED, errorMsg, null, null, null);
             }
           });
-          boolean isJobIdPersisted = waitForRebalanceToPersist(
-              dryRunResult.getJobId(), tableNameWithType, rebalanceResultFuture);
+          boolean isJobIdPersisted =
+              waitForRebalanceToPersist(dryRunResult.getJobId(), tableNameWithType, rebalanceResultFuture);
 
           if (rebalanceResultFuture.isDone()) {
             try {
@@ -705,13 +711,13 @@ public class PinotTableRestletResource {
    * Tables with 100k+ segments take up to a few seconds for the jobId to persist. This ensures the jobId is present
    * before returning the jobId to the caller, so they can correctly poll the jobId.
    */
-  public boolean waitForRebalanceToPersist(
-      String jobId, String tableNameWithType, Future<RebalanceResult> rebalanceResultFuture) {
+  public boolean waitForRebalanceToPersist(String jobId, String tableNameWithType,
+      Future<RebalanceResult> rebalanceResultFuture) {
     try {
       // This retry policy waits at most for 7.5s to 15s in total. This is chosen to cover typical delays for tables
       // with many segments and avoid excessive HTTP request timeouts.
-      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0).attempt(() ->
-          getControllerJobMetadata(jobId) != null || rebalanceResultFuture.isDone());
+      RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0)
+          .attempt(() -> getControllerJobMetadata(jobId) != null || rebalanceResultFuture.isDone());
       return true;
     } catch (Exception e) {
       LOGGER.warn("waiting for jobId not successful while rebalancing table: {}", tableNameWithType);
@@ -766,8 +772,8 @@ public class PinotTableRestletResource {
   @Authenticate(AccessType.UPDATE)
   @Path("/rebalanceStatus/{jobId}")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_REBALANCE_STATUS)
-  @ApiOperation(value = "Gets detailed stats of a rebalance operation",
-      notes = "Gets detailed stats of a rebalance operation")
+  @ApiOperation(value = "Gets detailed stats of a rebalance operation", notes = "Gets detailed stats of a rebalance "
+      + "operation")
   public ServerRebalanceJobStatusResponse rebalanceStatus(
       @ApiParam(value = "Rebalance Job Id", required = true) @PathParam("jobId") String jobId)
       throws JsonProcessingException {
@@ -825,10 +831,8 @@ public class PinotTableRestletResource {
   @Consumes(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Enable/disable a table", notes = "Enable/disable a table")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"),
-      @ApiResponse(code = 400, message = "Bad Request"),
-      @ApiResponse(code = 404, message = "Table not found"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 404, message = "Table not found"), @ApiResponse(code = 500, message = "Internal error")
   })
   public SuccessResponse toggleTableState(
       @ApiParam(value = "Table name", required = true) @PathParam("tableName") String tableName,
@@ -909,6 +913,54 @@ public class PinotTableRestletResource {
     }
   }
 
+  /*
+   * Validates that we have sufficient number of servers in the specified tenants to be able to serve the requested
+   * replication in the table config
+   */
+  private void ensureCanHostAllReplicas(TableConfig tableConfig) {
+    int replication = tableConfig.getReplication();
+    //check if server tags have been overridden
+    TagOverrideConfig tagOverrideConfig = tableConfig.getTenantConfig().getTagOverrideConfig();
+    //in the current behaviour, tag overrides are honoured only when both realtimeConsuming and realtimeCompleted
+    // tags are specified. Otherwise, overrides are ignored
+    if (tagOverrideConfig != null && tagOverrideConfig.getRealtimeCompleted() != null
+        && tagOverrideConfig.getRealtimeConsuming() != null) {
+      String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
+      String realtimeConsumingTenant = TagNameUtils.getTenantFromTag(realtimeConsumingTag);
+      boolean hasEnoughConsumingServers =
+          _pinotHelixResourceManager.getAllInstancesForServerTenant(realtimeConsumingTenant).size() >= replication;
+
+      String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
+      String realtimeCompletedTenant = TagNameUtils.getTenantFromTag(realtimeCompletedTag);
+      boolean hasEnoughCompletedServers =
+          _pinotHelixResourceManager.getAllInstancesForServerTenant(realtimeCompletedTenant).size() >= replication;
+
+      if (!hasEnoughConsumingServers || !hasEnoughCompletedServers) {
+        if (!hasEnoughConsumingServers && !hasEnoughCompletedServers) {
+          throw new IllegalStateException(String.format(
+              "Not enough CONSUMING and COMPLETED servers with tags %s and s %s to host the requested replication of "
+                  + "%s", realtimeConsumingTag, realtimeCompletedTag, replication));
+        } else if (!hasEnoughConsumingServers) {
+          throw new IllegalStateException(
+              String.format("Not enough CONSUMING servers with tag %s to host the requested replication of %s",
+                  realtimeConsumingTag, replication));
+        } else {
+          throw new IllegalStateException(
+              String.format("Not enough COMPLETED servers with tag %s to host the requested replication of %s",
+                  realtimeConsumingTag, replication));
+        }
+      }
+    } else {
+      String serverTenant = tableConfig.getTenantConfig().getServer();
+      Set<String> instancesInServerTenant = _pinotHelixResourceManager.getAllInstancesForServerTenant(serverTenant);
+      if (instancesInServerTenant.size() < replication) {
+        throw new IllegalStateException(
+            String.format("Not enough servers in tenant %s to serve the requested replication of %s", serverTenant,
+                replication));
+      }
+    }
+  }
+
   @GET
   @Path("/tables/{tableName}/status")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
@@ -953,8 +1005,8 @@ public class PinotTableRestletResource {
   @Path("tables/{tableName}/metadata")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get the aggregate metadata of all segments for a table",
-      notes = "Get the aggregate metadata of all segments for a table")
+  @ApiOperation(value = "Get the aggregate metadata of all segments for a table", notes = "Get the aggregate metadata"
+      + " of all segments for a table")
   public String getTableAggregateMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
@@ -996,11 +1048,10 @@ public class PinotTableRestletResource {
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
-      @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType")
-      @DefaultValue("SNAPSHOT") ValidDocIdsType validDocIdsType,
-      @ApiParam(value = "Number of segments in a batch per server request")
-      @QueryParam("serverRequestBatchSize") @DefaultValue("500") int serverRequestBatchSize,
-      @Context HttpHeaders headers) {
+      @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType") @DefaultValue("SNAPSHOT")
+      ValidDocIdsType validDocIdsType,
+      @ApiParam(value = "Number of segments in a batch per server request") @QueryParam("serverRequestBatchSize")
+      @DefaultValue("500") int serverRequestBatchSize, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch aggregate validDocIds metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
@@ -1117,8 +1168,8 @@ public class PinotTableRestletResource {
   @Path("table/{tableName}/jobs")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_CONTROLLER_JOBS)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get list of controller jobs for this table",
-      notes = "Get list of controller jobs for this table")
+  @ApiOperation(value = "Get list of controller jobs for this table", notes = "Get list of controller jobs for this "
+      + "table")
   public Map<String, Map<String, String>> getControllerJobs(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
@@ -1131,13 +1182,13 @@ public class PinotTableRestletResource {
             LOGGER);
     Set<String> jobTypesToFilter = null;
     if (StringUtils.isNotEmpty(jobTypesString)) {
-      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ',')))
-          .stream().collect(Collectors.toSet());
+      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ','))).stream()
+          .collect(Collectors.toSet());
     }
     Map<String, Map<String, String>> result = new HashMap<>();
     for (String tableNameWithType : tableNamesWithType) {
-      result.putAll(_pinotHelixResourceManager.getAllJobs(jobTypesToFilter == null
-              ? ControllerJobType.VALID_CONTROLLER_JOB_TYPE : jobTypesToFilter,
+      result.putAll(_pinotHelixResourceManager.getAllJobs(
+          jobTypesToFilter == null ? ControllerJobType.VALID_CONTROLLER_JOB_TYPE : jobTypesToFilter,
           jobMetadata -> jobMetadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE)
               .equals(tableNameWithType)));
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -718,7 +718,9 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       sendPostRequest(_createTableUrl, realtimeTableConfigWithoutTagOverrides.toJsonString());
       fail("Create table with a replication > no of servers in the tenant should fail");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Got error status code: 400"));
+      assertTrue(e.getMessage().contains(
+          "Invalid table config for table testTable_REALTIME: java.lang.IllegalStateException: Not enough servers in "
+              + "tenant DefaultTenant to serve the requested replication of 5"));
     }
 
     // Create a valid REALTIME table with tenant overrides
@@ -730,7 +732,9 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       sendPostRequest(_createTableUrl, realtimeTableConfigWithTagOverrides.toJsonString());
       fail("Create table with a replication > no of servers in the tenant should fail");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Got error status code: 400"));
+      assertTrue(e.getMessage().contains(
+          "Not enough CONSUMING and COMPLETED servers with tags DefaultTenant_REALTIME and DefaultTenant_OFFLINE to"
+              + " host the requested replication of 5"));
     }
 
     // Create a valid OFFLINE table


### PR DESCRIPTION
Instructions:
Recently, we've observed that RT ingestion stopped simply because of not enough servers to fulfil the replication configured and no warning / error given to user. This PR adds a check during table create/update. 
 
