### PR TITLE
Optimize Adaptive Server Selection

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -140,8 +140,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     // No need to adjust this map per total segment numbers, as optional segments should be empty most of the time.
     Map<String, String> optionalSegmentToInstanceMap = new HashMap<>();
-    // To avoid selecting the same server for multiple segments.
-    Set<String> selectedServers = new HashSet<>();
     for (String segment : segments) {
       // NOTE: candidates can be null when there is no enabled instances for the segment, or the instance selector has
       // not been updated (we update all components for routing in sequence)
@@ -161,7 +159,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
           Integer rank = serverRankMap.get(candidate.getInstance());
           if (rank == null) {
             // Let's use the round-robin approach until stats for all servers are populated.
-            selectedInstance = candidates.get(instanceIdx);
             break;
           }
           // Update the candidate if the current one has a better rank
@@ -171,12 +168,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
           }
         }
       }
-
-      if (selectedServers.contains(selectedInstance.getInstance())) {
-        continue;
-      }
-      selectedServers.add(selectedInstance.getInstance());
-
       // This can only be offline when it is a new segment. And such segment is marked as optional segment so that
       // broker or server can skip it upon any issue to process it.
       if (selectedInstance.isOnline()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -157,7 +157,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       if (!serverRankMap.isEmpty()) {
         int bestRank = Integer.MAX_VALUE;
         for (SegmentInstanceCandidate candidate : candidates) {
-          // If the candidate is already selected, implying that it is the best candidate for the segment, select it and exit the loop.
+          // If the candidate is already selected previously, implying that it is the best candidate, select it and exit the loop.
           if (selectedServers.contains(candidate.getInstance())) {
             selectedInstance = candidate;
             break;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -157,10 +157,11 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       if (!serverRankMap.isEmpty()) {
         // Use instance with the best rank if all servers have stats populated, if not use round-robin selected instance
         selectedInstance = candidates.stream()
-            .filter(candidate -> serverRankMap.containsKey(candidate.getInstance()))
-            .min(Comparator.comparingInt(candidate ->
-                serverRankMap.getOrDefault(candidate.getInstance(), Integer.MAX_VALUE)))
-            .orElse(candidates.get(roundRobinInstanceIdx));
+            .anyMatch(candidate -> !serverRankMap.containsKey(candidate.getInstance()))
+            ? candidates.get(roundRobinInstanceIdx)
+            : candidates.stream()
+                .min(Comparator.comparingInt(candidate -> serverRankMap.get(candidate.getInstance())))
+                .orElse(candidates.get(roundRobinInstanceIdx));
       }
       // This can only be offline when it is a new segment. And such segment is marked as optional segment so that
       // broker or server can skip it upon any issue to process it.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -79,7 +79,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
       // Fetch serverRankList before looping through all the segments. This is important to make sure that we pick
       // the least amount of instances for a query by referring to a single snapshot of the rankings.
-
       List<Pair<String, Double>> serverRankListWithScores =
           _adaptiveServerSelector.fetchServerRankingsWithScores(candidateServers);
       Map<String, Integer> serverRankMap = new HashMap<>();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -165,7 +165,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
             selectedInstance = candidates.get(instanceIdx);
             break;
           }
-          // Update the best candidate if the current one has a better rank
+          // Update the candidate if the current one has a better rank
           if (rank < bestRank) {
             bestRank = rank;
             selectedInstance = candidate;
@@ -173,11 +173,9 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
         }
       }
 
-      // Check if selectedInstance is in the selectedServers set.
       if (selectedServers.contains(selectedInstance.getInstance())) {
         continue;
       }
-      // Add the selected instance to the set.
       selectedServers.add(selectedInstance.getInstance());
 
       // This can only be offline when it is a new segment. And such segment is marked as optional segment so that

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -140,7 +140,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     // No need to adjust this map per total segment numbers, as optional segments should be empty most of the time.
     Map<String, String> optionalSegmentToInstanceMap = new HashMap<>();
-    Set<String> selectedServers = new HashSet<>();
     for (String segment : segments) {
       // NOTE: candidates can be null when there is no enabled instances for the segment, or the instance selector has
       // not been updated (we update all components for routing in sequence)
@@ -150,21 +149,17 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       }
       // Round Robin.
       int numCandidates = candidates.size();
-      int instanceIdx = requestId % numCandidates;
-      SegmentInstanceCandidate selectedInstance = candidates.get(instanceIdx);
+      int roundRobinInstanceIdx = requestId % numCandidates;
+      SegmentInstanceCandidate selectedInstance = candidates.get(roundRobinInstanceIdx);
       // Adaptive Server Selection
       // TODO: Support numReplicaGroupsToQuery with Adaptive Server Selection.
       if (!serverRankMap.isEmpty()) {
         int bestRank = Integer.MAX_VALUE;
         for (SegmentInstanceCandidate candidate : candidates) {
-          // If the candidate is already selected previously, implying that it is the best candidate, select it and exit the loop.
-          if (selectedServers.contains(candidate.getInstance())) {
-            selectedInstance = candidate;
-            break;
-          }
           Integer rank = serverRankMap.get(candidate.getInstance());
           if (rank == null) {
             // Let's use the round-robin approach until stats for all servers are populated.
+            selectedInstance = candidates.get(roundRobinInstanceIdx);
             break;
           }
           // Update the candidate if the current one has a better rank
@@ -174,8 +169,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
           }
         }
       }
-      // Add the selected instance to the set.
-      selectedServers.add(selectedInstance.getInstance());
       // This can only be offline when it is a new segment. And such segment is marked as optional segment so that
       // broker or server can skip it upon any issue to process it.
       if (selectedInstance.isOnline()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -141,12 +141,12 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     // No need to adjust this map per total segment numbers, as optional segments should be empty most of the time.
     Map<String, String> optionalSegmentToInstanceMap = new HashMap<>();
-    segments.forEach(segment -> {
+    for (String segment : segments) {
       // NOTE: candidates can be null when there is no enabled instances for the segment, or the instance selector has
       // not been updated (we update all components for routing in sequence)
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
       if (candidates == null) {
-        return; // continue to the next iteration
+        continue;
       }
 
       // Round Robin selection
@@ -170,7 +170,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       } else {
         optionalSegmentToInstanceMap.put(segment, selectedInstance.getInstance());
       }
-    });
+    }
     return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -42,7 +42,6 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.broker.routing.adaptiveserverselector.AdaptiveServerSelector;
 import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -1972,9 +1971,14 @@ public class InstanceSelectorTest {
         offlineTableName, propertyStore, brokerMetrics, hybridSelector, Clock.systemUTC(), false, 300);
 
     // Define instances and segments
-    String instance0 = "instance0", instance1 = "instance1", instance2 = "instance2", instance3 = "instance3";
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    String instance3 = "instance3";
     String instance4 = "instance4";
-    String segment0 = "segment0", segment1 = "segment1", segment2 = "segment2";
+    String segment0 = "segment0";
+    String segment1 = "segment1";
+    String segment2 = "segment2";
     List<String> segments = Arrays.asList(segment0, segment1, segment2);
 
     // Define candidates for each segment

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1973,8 +1973,9 @@ public class InstanceSelectorTest {
 
     // Define instances and segments
     String instance0 = "instance0", instance1 = "instance1", instance2 = "instance2", instance3 = "instance3";
-    String segment0 = "segment0", segment1 = "segment1";
-    List<String> segments = Arrays.asList(segment0, segment1);
+    String instance4 = "instance4";
+    String segment0 = "segment0", segment1 = "segment1", segment2 = "segment2";
+    List<String> segments = Arrays.asList(segment0, segment1, segment2);
 
     // Define candidates for each segment
     Map<String, List<SegmentInstanceCandidate>> instanceCandidatesMap = new HashMap<>();
@@ -1984,6 +1985,8 @@ public class InstanceSelectorTest {
     // segment1 -> instance2, instance3
     instanceCandidatesMap.put(segment1, Arrays.asList(new SegmentInstanceCandidate(instance2, true),
         new SegmentInstanceCandidate(instance3, true)));
+    // segment2 -> instance4 // instance4 is not in the hybrid selector's server ranking
+    instanceCandidatesMap.put(segment2, Collections.singletonList(new SegmentInstanceCandidate(instance4, true)));
 
     // Define the segment states
     SegmentStates segmentStates = new SegmentStates(instanceCandidatesMap, new HashSet<>(segments), null);
@@ -2005,6 +2008,7 @@ public class InstanceSelectorTest {
     Map<String, String> expectedSelection = new HashMap<>();
     expectedSelection.put(segment0, instance1);
     expectedSelection.put(segment1, instance3);
+    expectedSelection.put(segment2, instance4);
 
     assertEquals(selectedResult.getLeft(), expectedSelection);
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1989,8 +1989,9 @@ public class InstanceSelectorTest {
     // segment1 -> instance2, instance3
     instanceCandidatesMap.put(segment1, Arrays.asList(new SegmentInstanceCandidate(instance2, true),
         new SegmentInstanceCandidate(instance3, true)));
-    // segment2 -> instance4 // instance4 is not in the hybrid selector's server ranking
-    instanceCandidatesMap.put(segment2, Collections.singletonList(new SegmentInstanceCandidate(instance4, true)));
+    // segment2 -> instance3, instance4 // instance4 is not in the hybrid selector's server ranking
+    instanceCandidatesMap.put(segment2, Arrays.asList(new SegmentInstanceCandidate(instance4, true),
+        new SegmentInstanceCandidate(instance3, true)));
 
     // Define the segment states
     SegmentStates segmentStates = new SegmentStates(instanceCandidatesMap, new HashSet<>(segments), null);


### PR DESCRIPTION
## Summary
This PR enhances the server selection logic in the `adaptive server selector` by using a `HashMap` for efficient server rank lookups and a `HashSet` to track selected servers. These changes improve performance when processing large sets of segments and servers, resulting in faster and more scalable server selection.
<img width="1469" alt="Screenshot 2024-09-09 at 1 31 26 PM" src="https://github.com/user-attachments/assets/752f507c-24bb-4baf-a9cb-9cf80b08e7f3">

## Description
The existing implementation of the adaptive server selector uses a linear search on a list (`serverRankList`) to determine server rankings, leading to performance inefficiencies when handling large numbers of servers

- The `serverRankMap` is now used for ranking lookups, providing O(1) access to server ranks compared to the previous O(n) list iteration.
- A `HashSet` (selectedServers) is introduced to track which servers have been selected and use it exit early

Complexity:
Total complexity of the adaptive server selection process per segment is reduced to O(m) per segment (with m being the number of candidates), improving the overall process to O(n * m) for n segments.

Previous:  O(n* m * s) (with s being the number of total servers).

