### PR TITLE
Handling of empty server tags in controller's availability check

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -550,8 +550,8 @@ public class HelixHelper {
   }
 
   public static List<String> getInstancesWithoutTag(List<InstanceConfig> instanceConfigs) {
-    List<InstanceConfig> instancesWithTag = getInstancesConfigsWithoutTag(instanceConfigs);
-    return instancesWithTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
+    List<InstanceConfig> instancesWithoutTag = getInstancesConfigsWithoutTag(instanceConfigs);
+    return instancesWithoutTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
   }
 
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -534,8 +534,8 @@ public class HelixHelper {
   /**
    *  Returns the instances in the cluster without any tag.
    */
-  public static List<String> getInstancesWithoutTag(HelixManager helixManager) {
-    return getInstancesWithoutTag(getInstanceConfigs(helixManager));
+  public static List<String> getInstancesWithoutTag(HelixManager helixManager, String tag) {
+    return getInstancesWithoutTag(getInstanceConfigs(helixManager), tag);
   }
 
   /**
@@ -549,8 +549,8 @@ public class HelixHelper {
     return instancesWithTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
   }
 
-  public static List<String> getInstancesWithoutTag(List<InstanceConfig> instanceConfigs) {
-    List<InstanceConfig> instancesWithoutTag = getInstancesConfigsWithoutTag(instanceConfigs);
+  public static List<String> getInstancesWithoutTag(List<InstanceConfig> instanceConfigs, String tag) {
+    List<InstanceConfig> instancesWithoutTag = getInstancesConfigsWithoutTag(instanceConfigs, tag);
     return instancesWithoutTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
   }
 
@@ -565,11 +565,11 @@ public class HelixHelper {
     return instancesWithTag;
   }
 
-  public static List<InstanceConfig> getInstancesConfigsWithoutTag(List<InstanceConfig> instanceConfigs) {
+  public static List<InstanceConfig> getInstancesConfigsWithoutTag(List<InstanceConfig> instanceConfigs, String tag) {
     List<InstanceConfig> instancesWithoutTag = new ArrayList<>();
     for (InstanceConfig instanceConfig : instanceConfigs) {
       // instanceConfig.getTags() never returns null
-      if (instanceConfig.getTags().isEmpty()) {
+      if (instanceConfig.getTags().isEmpty() || instanceConfig.containsTag(tag)) {
         instancesWithoutTag.add(instanceConfig);
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -532,6 +532,13 @@ public class HelixHelper {
   }
 
   /**
+   *  Returns the instances in the cluster without any tag.
+   */
+  public static List<String> getInstancesWithoutTag(HelixManager helixManager) {
+    return getInstancesWithoutTag(getInstanceConfigs(helixManager));
+  }
+
+  /**
    * Returns the instances in the cluster with the given tag.
    *
    * TODO: refactor code to use this method over {@link #getInstancesWithTag(HelixManager, String)} if applicable to
@@ -542,10 +549,27 @@ public class HelixHelper {
     return instancesWithTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
   }
 
+  public static List<String> getInstancesWithoutTag(List<InstanceConfig> instanceConfigs) {
+    List<InstanceConfig> instancesWithTag = getInstancesConfigsWithoutTag(instanceConfigs);
+    return instancesWithTag.stream().map(InstanceConfig::getInstanceName).collect(Collectors.toList());
+  }
+
+
   public static List<InstanceConfig> getInstancesConfigsWithTag(List<InstanceConfig> instanceConfigs, String tag) {
     List<InstanceConfig> instancesWithTag = new ArrayList<>();
     for (InstanceConfig instanceConfig : instanceConfigs) {
       if (instanceConfig.containsTag(tag)) {
+        instancesWithTag.add(instanceConfig);
+      }
+    }
+    return instancesWithTag;
+  }
+
+  public static List<InstanceConfig> getInstancesConfigsWithoutTag(List<InstanceConfig> instanceConfigs) {
+    List<InstanceConfig> instancesWithTag = new ArrayList<>();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      // instanceConfig.getTags() never returns null
+      if (instanceConfig.getTags().isEmpty()) {
         instancesWithTag.add(instanceConfig);
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -566,14 +566,14 @@ public class HelixHelper {
   }
 
   public static List<InstanceConfig> getInstancesConfigsWithoutTag(List<InstanceConfig> instanceConfigs) {
-    List<InstanceConfig> instancesWithTag = new ArrayList<>();
+    List<InstanceConfig> instancesWithoutTag = new ArrayList<>();
     for (InstanceConfig instanceConfig : instanceConfigs) {
       // instanceConfig.getTags() never returns null
       if (instanceConfig.getTags().isEmpty()) {
-        instancesWithTag.add(instanceConfig);
+        instancesWithoutTag.add(instanceConfig);
       }
     }
-    return instancesWithTag;
+    return instancesWithoutTag;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3439,7 +3439,11 @@ public class PinotHelixResourceManager {
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
     List<String> instanceList = HelixHelper.getInstancesWithTag(_helixZkManager, Helix.UNTAGGED_SERVER_INSTANCE);
+    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager);
     List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
+
+    // instanceList and instanceListWithoutTags are always mutually exclusive
+    instanceList.addAll(instanceListWithoutTags);
     instanceList.retainAll(liveInstances);
     return instanceList;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3438,7 +3438,8 @@ public class PinotHelixResourceManager {
    * @return List of untagged online server instances.
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
-    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager,  Helix.UNTAGGED_SERVER_INSTANCE);
+    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager,
+        Helix.UNTAGGED_SERVER_INSTANCE);
     List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
 
     instanceListWithoutTags.retainAll(liveInstances);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3438,14 +3438,11 @@ public class PinotHelixResourceManager {
    * @return List of untagged online server instances.
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
-    List<String> instanceList = HelixHelper.getInstancesWithTag(_helixZkManager, Helix.UNTAGGED_SERVER_INSTANCE);
-    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager);
+    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager,  Helix.UNTAGGED_SERVER_INSTANCE);
     List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
 
-    // instanceList and instanceListWithoutTags are always mutually exclusive
-    instanceList.addAll(instanceListWithoutTags);
-    instanceList.retainAll(liveInstances);
-    return instanceList;
+    instanceListWithoutTags.retainAll(liveInstances);
+    return instanceListWithoutTags;
   }
 
   public List<String> getOnlineInstanceList() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -96,6 +96,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
   private static final int NUM_SERVER_INSTANCES = NUM_OFFLINE_SERVER_INSTANCES + NUM_REALTIME_SERVER_INSTANCES;
   private static final String BROKER_TENANT_NAME = "brokerTenant";
   private static final String SERVER_TENANT_NAME = "serverTenant";
+  private static final String SERVER_NAME_UNTAGGED = "Server_localhost_4";
 
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
@@ -1145,6 +1146,20 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
+  }
+  @Test
+  public void testHandleEmptyServerTags()
+      throws Exception {
+    // Create an instance with no tags
+    Instance instance = new Instance("localhost", NUM_SERVER_INSTANCES , InstanceType.SERVER,
+        Collections.emptyList(), null, 0, 12345, 0, 0, false);
+
+    _helixResourceManager.addInstance(instance,false);
+    addFakeServerInstanceToAutoJoinHelixClusterWithEmptyTag(SERVER_NAME_UNTAGGED, false);
+
+    // Verify that the server is considered untagged
+    List<String> untaggedServers = _helixResourceManager.getOnlineUnTaggedServerInstanceList();
+    assertTrue(untaggedServers.contains(SERVER_NAME_UNTAGGED), "Server with empty tags should be considered untagged");
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -97,6 +97,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
   private static final String BROKER_TENANT_NAME = "brokerTenant";
   private static final String SERVER_TENANT_NAME = "serverTenant";
   private static final String SERVER_NAME_UNTAGGED = "Server_localhost_4";
+  private static final String SERVER_NAME_TAGGED = "Server_localhost_0";
 
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
@@ -1160,6 +1161,9 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Verify that the server is considered untagged
     List<String> untaggedServers = _helixResourceManager.getOnlineUnTaggedServerInstanceList();
     assertTrue(untaggedServers.contains(SERVER_NAME_UNTAGGED), "Server with empty tags should be considered untagged");
+
+    // Takes care of the negative case
+    assertFalse(untaggedServers.contains(SERVER_NAME_TAGGED), "Server with tags should not be considered untagged");
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -733,7 +733,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     assertFalse(allInstances.contains(serverName));
     allLiveInstances = _helixResourceManager.getAllLiveInstances();
     assertFalse(allLiveInstances.contains(serverName));
-
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -96,7 +96,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
   private static final int NUM_SERVER_INSTANCES = NUM_OFFLINE_SERVER_INSTANCES + NUM_REALTIME_SERVER_INSTANCES;
   private static final String BROKER_TENANT_NAME = "brokerTenant";
   private static final String SERVER_TENANT_NAME = "serverTenant";
-  private static final String SERVER_NAME_UNTAGGED = "Server_localhost_4";
   private static final String SERVER_NAME_TAGGED = "Server_localhost_0";
 
   private static final String RAW_TABLE_NAME = "testTable";
@@ -721,7 +720,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Verify that the server is considered untagged
     List<String> untaggedServers = _helixResourceManager.getOnlineUnTaggedServerInstanceList();
-    assertTrue(untaggedServers.contains(SERVER_NAME_UNTAGGED), "Server with empty tags should be considered untagged");
+    assertTrue(untaggedServers.contains(serverName), "Server with empty tags should be considered untagged");
 
     // Takes care of the negative case
     assertFalse(untaggedServers.contains(SERVER_NAME_TAGGED), "Server with tags should not be considered untagged");


### PR DESCRIPTION
PR addresses an issue where the Pinot controller incorrectly interprets servers with empty tag lists as "tagged" servers. The current logic in PinotHelixResourceManager checks for the presence of the "server_untagged" tag to determine if a server is untagged and thus available. However, when a server has no tags, it is mistakenly considered as tagged, leading to incorrect behavior in server availability checks.

https://apache-pinot.slack.com/archives/C011C9JHN7R/p1725801169774139



![image](https://github.com/user-attachments/assets/ac2004fe-af94-4713-8a05-4e9fc2cbf192)

 
