### PR TITLE
Improvements to OOM protection for Multi-Stage Engine

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
@@ -109,7 +109,7 @@ public class CPUMemThreadLevelAccountingObjects {
       return taskEntry == null ? ThreadExecutionContext.TaskType.UNKNOWN : taskEntry.getTaskType();
     }
 
-    public void setThreadTaskStatus(@Nonnull String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
+    public void setThreadTaskStatus(@Nullable String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
         @Nonnull Thread anchorThread) {
       _currentThreadTaskStatus.set(new TaskEntry(queryId, taskId, taskType, anchorThread));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -325,6 +325,10 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       return _threadLocalEntry.get().getCurrentThreadTaskStatus();
     }
 
+    public CPUMemThreadLevelAccountingObjects.ThreadEntry getThreadEntry() {
+      return _threadLocalEntry.get();
+    }
+
     /**
      * clears thread accounting info once a runner/worker thread has finished a particular run
      */

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.AbstractMetrics;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -286,17 +287,16 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     @Override
-    public void createExecutionContextInner(@Nullable String queryId, int taskId, @Nullable
-        ThreadExecutionContext parentContext) {
+    public void createExecutionContextInner(@Nonnull String queryId, int taskId,
+        ThreadExecutionContext.TaskType taskType, @Nullable ThreadExecutionContext parentContext) {
       _threadLocalEntry.get()._errorStatus.set(null);
       if (parentContext == null) {
         // is anchor thread
-        assert queryId != null;
-        _threadLocalEntry.get().setThreadTaskStatus(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID,
-            ThreadExecutionContext.TaskType.UNKNOWN, Thread.currentThread());
+        _threadLocalEntry.get()
+            .setThreadTaskStatus(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType, Thread.currentThread());
       } else {
         // not anchor thread
-        _threadLocalEntry.get().setThreadTaskStatus(parentContext.getQueryId(), taskId, parentContext.getTaskType(),
+        _threadLocalEntry.get().setThreadTaskStatus(queryId, taskId, parentContext.getTaskType(),
             parentContext.getAnchorThread());
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -124,6 +124,9 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     // track memory usage
     private final boolean _isThreadMemorySamplingEnabled;
 
+    // is sampling allowed for MSE queries
+    private final boolean _isThreadSamplingEnabledForMSE;
+
     private final Set<String> _inactiveQuery;
 
     // the periodical task that aggregates and preempts queries
@@ -156,6 +159,11 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       _isThreadMemorySamplingEnabled = memorySamplingConfig && threadMemoryMeasurementEnabled;
       LOGGER.info("_isThreadCPUSamplingEnabled: {}, _isThreadMemorySamplingEnabled: {}", _isThreadCPUSamplingEnabled,
           _isThreadMemorySamplingEnabled);
+
+      _isThreadSamplingEnabledForMSE =
+          config.getProperty(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE,
+              CommonConstants.Accounting.DEFAULT_ENABLE_THREAD_SAMPLING_MSE);
+      LOGGER.info("_isThreadSamplingEnabledForMSE: {}", _isThreadSamplingEnabledForMSE);
 
       // ThreadMXBean wrapper
       _threadResourceUsageProvider = new ThreadLocal<>();
@@ -229,6 +237,17 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     public void sampleUsage() {
       sampleThreadBytesAllocated();
       sampleThreadCPUTime();
+    }
+
+    /**
+     * Sample Usage for Multi-stage engine queries
+     */
+    @Override
+    public void sampleUsageMSE() {
+      if (_isThreadSamplingEnabledForMSE) {
+        sampleThreadBytesAllocated();
+        sampleThreadCPUTime();
+      }
     }
 
     /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.AbstractMetrics;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -287,11 +286,12 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     @Override
-    public void createExecutionContextInner(@Nonnull String queryId, int taskId,
+    public void createExecutionContextInner(@Nullable String queryId, int taskId,
         ThreadExecutionContext.TaskType taskType, @Nullable ThreadExecutionContext parentContext) {
       _threadLocalEntry.get()._errorStatus.set(null);
       if (parentContext == null) {
         // is anchor thread
+        assert queryId != null;
         _threadLocalEntry.get()
             .setThreadTaskStatus(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType, Thread.currentThread());
       } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -57,6 +57,9 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -270,10 +273,14 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private Future<Void> startExecution() {
     ResultsBlockConsumer resultsBlockConsumer = new ResultsBlockConsumer();
     ServerQueryLogger queryLogger = ServerQueryLogger.getInstance();
+    ThreadExecutionContext parentContext = Tracing.getThreadAccountant().getThreadExecutionContext();
     return _executorService.submit(() -> {
       try {
         if (_requests.size() == 1) {
           ServerQueryRequest request = _requests.get(0);
+          ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
+          Tracing.ThreadAccountantOps.setupWorker(1, threadResourceUsageProvider, parentContext);
+
           InstanceResponseBlock instanceResponseBlock =
               _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
           if (queryLogger != null) {
@@ -303,7 +310,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
           CountDownLatch latch = new CountDownLatch(2);
           for (int i = 0; i < 2; i++) {
             ServerQueryRequest request = _requests.get(i);
+            int taskId = i;
             futures[i] = _executorService.submit(() -> {
+              ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
+              Tracing.ThreadAccountantOps.setupWorker(taskId, threadResourceUsageProvider, parentContext);
+
               try {
                 InstanceResponseBlock instanceResponseBlock =
                     _queryExecutor.execute(request, _executorService, resultsBlockConsumer);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -69,7 +69,7 @@ public abstract class MultiStageOperator
   // Samples resource usage of the operator. The operator should call this function for every block of data or
   // assuming the block holds 10000 rows or more.
   protected void sampleAndCheckInterruption() {
-    Tracing.ThreadAccountantOps.sample();
+    Tracing.ThreadAccountantOps.sampleMSE();
     if (Tracing.ThreadAccountantOps.isInterrupted()) {
       earlyTerminate();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -120,6 +120,9 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     int numStages = protoStagePlans.size();
     CompletableFuture<?>[] stageSubmissionStubs = new CompletableFuture[numStages];
     ThreadExecutionContext parentContext = Tracing.getThreadAccountant().getThreadExecutionContext();
+    if (parentContext == null) {
+      LOGGER.warn("For request id {}, parentContext is not available", requestId);
+    }
     for (int i = 0; i < numStages; i++) {
       Worker.StagePlan protoStagePlan = protoStagePlans.get(i);
       stageSubmissionStubs[i] = CompletableFuture.runAsync(() -> {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -120,9 +120,6 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     int numStages = protoStagePlans.size();
     CompletableFuture<?>[] stageSubmissionStubs = new CompletableFuture[numStages];
     ThreadExecutionContext parentContext = Tracing.getThreadAccountant().getThreadExecutionContext();
-    if (parentContext == null) {
-      LOGGER.warn("For request id {}, parentContext is not available", requestId);
-    }
     for (int i = 0; i < numStages; i++) {
       Worker.StagePlan protoStagePlan = protoStagePlans.get(i);
       stageSubmissionStubs[i] = CompletableFuture.runAsync(() -> {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -32,6 +32,7 @@ import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.QueryRunner;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
 import org.apache.pinot.query.testutils.QueryTestUtils;
+import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -111,9 +112,9 @@ public class QueryServerEnclosure {
   }
 
   public CompletableFuture<Void> processQuery(WorkerMetadata workerMetadata, StagePlan stagePlan,
-      Map<String, String> requestMetadataMap) {
+      Map<String, String> requestMetadataMap, ThreadExecutionContext parentContext) {
     return CompletableFuture.runAsync(
-        () -> _queryRunner.processQuery(workerMetadata, stagePlan, requestMetadataMap, null),
+        () -> _queryRunner.processQuery(workerMetadata, stagePlan, requestMetadataMap, parentContext),
         _queryRunner.getExecutorService());
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerAccountingTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.queries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.core.accounting.CPUMemThreadLevelAccountingObjects;
+import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
+import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.apache.pinot.query.QueryServerEnclosure;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
+import org.apache.pinot.query.testutils.QueryTestUtils;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
+import org.apache.pinot.spi.trace.Tracing;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class QueryRunnerAccountingTest extends QueryRunnerTestBase {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    MockInstanceDataManagerFactory factory1 = new MockInstanceDataManagerFactory("server1");
+    factory1.registerTable(QueryRunnerTest.SCHEMA_BUILDER.setSchemaName("a").build(), "a_REALTIME");
+    factory1.addSegment("a_REALTIME", QueryRunnerTest.buildRows("a_REALTIME"));
+
+    MockInstanceDataManagerFactory factory2 = new MockInstanceDataManagerFactory("server2");
+    factory2.registerTable(QueryRunnerTest.SCHEMA_BUILDER.setSchemaName("b").build(), "b_REALTIME");
+    factory2.addSegment("b_REALTIME", QueryRunnerTest.buildRows("b_REALTIME"));
+
+    _reducerHostname = "localhost";
+    _reducerPort = QueryTestUtils.getAvailablePort();
+    Map<String, Object> reducerConfig = new HashMap<>();
+    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
+    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerPort);
+    _mailboxService = new MailboxService(_reducerHostname, _reducerPort, new PinotConfiguration(reducerConfig));
+    _mailboxService.start();
+
+    QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
+    server1.start();
+    // Start server1 to ensure the next server will have a different port.
+    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
+    server2.start();
+    // this doesn't test the QueryServer functionality so the server port can be the same as the mailbox port.
+    // this is only use for test identifier purpose.
+    int port1 = server1.getPort();
+    int port2 = server2.getPort();
+    _servers.put(new QueryServerInstance("localhost", port1, port1), server1);
+    _servers.put(new QueryServerInstance("localhost", port2, port2), server2);
+
+    _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(_reducerPort, server1.getPort(), server2.getPort(),
+        factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
+        null);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (QueryServerEnclosure server : _servers.values()) {
+      server.shutDown();
+    }
+    _mailboxService.shutdown();
+  }
+
+  @Test
+  void testWithDefaultThreadAccountant() {
+    Tracing.forceRegister(new Tracing.DefaultThreadResourceUsageAccountant());
+
+    ResultTable resultTable = queryRunner("SELECT * FROM a LIMIT 2", false).getResultTable();
+    Assert.assertEquals(resultTable.getRows().size(), 2);
+
+    ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
+    Assert.assertTrue(threadAccountant.getThreadResources().isEmpty());
+    Assert.assertTrue(threadAccountant.getQueryResources().isEmpty());
+  }
+
+  static class XRayAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
+    List<CPUMemThreadLevelAccountingObjects.ThreadEntry> _threadEntryList = new ArrayList<>();
+
+    public XRayAccountant(PinotConfiguration config, String instanceId) {
+      super(config, instanceId);
+    }
+
+    @Override
+    public void sampleThreadBytesAllocated() {
+      super.sampleThreadBytesAllocated();
+      _threadEntryList.add(getThreadEntry());
+    }
+  }
+
+  @Test
+  void testWithPerQueryAccountantFactory() {
+    HashMap<String, Object> configs = getAccountingConfig();
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(configs),
+            "testWithPerQueryAccountantFactory");
+    Tracing.forceRegister(accountant);
+
+    ResultTable resultTable = queryRunner("SELECT * FROM a LIMIT 2", false).getResultTable();
+    Assert.assertEquals(resultTable.getRows().size(), 2);
+
+    Map<String, ? extends QueryResourceTracker> resources = accountant.getQueryResources();
+    Assert.assertEquals(resources.size(), 1);
+    Assert.assertTrue(resources.entrySet().iterator().next().getValue().getAllocatedBytes() > 0);
+  }
+
+  @Test
+  void testDisableSamplingForMSE() {
+    HashMap<String, Object> configs = getAccountingConfig();
+    configs.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE, false);
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(configs),
+            "testWithPerQueryAccountantFactory");
+    Tracing.forceRegister(accountant);
+
+    ResultTable resultTable = queryRunner("SELECT * FROM a LIMIT 2", false).getResultTable();
+    Assert.assertEquals(resultTable.getRows().size(), 2);
+
+    Map<String, ? extends QueryResourceTracker> resources = accountant.getQueryResources();
+    Assert.assertEquals(resources.size(), 1);
+    Assert.assertEquals(resources.entrySet().iterator().next().getValue().getAllocatedBytes(), 0);
+  }
+
+  public static class InterruptingAccountant
+      extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
+
+    public InterruptingAccountant(PinotConfiguration config, String instanceId) {
+      super(config, instanceId);
+    }
+
+    @Override
+    public boolean isAnchorThreadInterrupted() {
+      return true;
+    }
+  }
+
+  @Test(expectedExceptions = EarlyTerminationException.class)
+  void testInterrupt() {
+    HashMap<String, Object> configs = getAccountingConfig();
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    InterruptingAccountant accountant =
+        new InterruptingAccountant(new PinotConfiguration(configs), "testWithPerQueryAccountantFactory");
+    Tracing.forceRegister(accountant);
+
+    queryRunner("SELECT * FROM a LIMIT 2", false).getResultTable();
+  }
+
+  private static HashMap<String, Object> getAccountingConfig() {
+    HashMap<String, Object> configs = new HashMap<>();
+    ServerMetrics.register(Mockito.mock(ServerMetrics.class));
+    configs.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    return configs;
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -135,7 +135,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     List<CompletableFuture<?>> submissionStubs = new ArrayList<>();
     for (int stageId = 0; stageId < stagePlans.size(); stageId++) {
       if (stageId != 0) {
-        submissionStubs.addAll(processDistributedStagePlans(dispatchableSubPlan, requestId, stageId, requestMetadataMap));
+        submissionStubs.addAll(processDistributedStagePlans(dispatchableSubPlan, requestId, stageId,
+            requestMetadataMap));
       }
     }
     try {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -61,9 +61,11 @@ import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.StagePlan;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
+import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.StringUtil;
@@ -133,7 +135,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     List<CompletableFuture<?>> submissionStubs = new ArrayList<>();
     for (int stageId = 0; stageId < stagePlans.size(); stageId++) {
       if (stageId != 0) {
-        submissionStubs.addAll(processDistributedStagePlans(dispatchableSubPlan, stageId, requestMetadataMap));
+        submissionStubs.addAll(processDistributedStagePlans(dispatchableSubPlan, requestId, stageId, requestMetadataMap));
       }
     }
     try {
@@ -155,20 +157,22 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   }
 
   protected List<CompletableFuture<?>> processDistributedStagePlans(DispatchableSubPlan dispatchableSubPlan,
-      int stageId, Map<String, String> requestMetadataMap) {
+      long requestId, int stageId, Map<String, String> requestMetadataMap) {
     DispatchablePlanFragment dispatchableStagePlan = dispatchableSubPlan.getQueryStageList().get(stageId);
     List<WorkerMetadata> stageWorkerMetadataList = dispatchableStagePlan.getWorkerMetadataList();
     List<CompletableFuture<?>> submissionStubs = new ArrayList<>();
     for (Map.Entry<QueryServerInstance, List<Integer>> entry : dispatchableStagePlan.getServerInstanceToWorkerIdMap()
         .entrySet()) {
       QueryServerEnclosure serverEnclosure = _servers.get(entry.getKey());
+      Tracing.ThreadAccountantOps.setupRunner(Long.toString(requestId), ThreadExecutionContext.TaskType.MSE);
+      ThreadExecutionContext parentContext = Tracing.getThreadAccountant().getThreadExecutionContext();
       List<WorkerMetadata> workerMetadataList =
           entry.getValue().stream().map(stageWorkerMetadataList::get).collect(Collectors.toList());
       StageMetadata stageMetadata =
           new StageMetadata(stageId, workerMetadataList, dispatchableStagePlan.getCustomProperties());
       StagePlan stagePlan = new StagePlan(dispatchableStagePlan.getPlanFragment().getFragmentRoot(), stageMetadata);
       for (WorkerMetadata workerMetadata : workerMetadataList) {
-        submissionStubs.add(serverEnclosure.processQuery(workerMetadata, stagePlan, requestMetadataMap));
+        submissionStubs.add(serverEnclosure.processQuery(workerMetadata, stagePlan, requestMetadataMap, parentContext));
       }
     }
     return submissionStubs;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -61,6 +61,11 @@ public interface ThreadResourceUsageAccountant {
   void sampleUsage();
 
   /**
+   * Sample Usage for Multi-stage engine queries
+   */
+  void sampleUsageMSE();
+
+  /**
    * special interface to aggregate usage to the stats store only once, it is used for response
    * ser/de threads where the thread execution context cannot be setup before hands as
    * queryId/taskId is unknown and the execution process is hard to instrument

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -89,10 +89,6 @@ public class Tracing {
     return ACCOUNTANT_REGISTRATION.compareAndSet(null, threadResourceUsageAccountant);
   }
 
-  public static void forceRegister(ThreadResourceUsageAccountant threadResourceUsageAccountant) {
-    ACCOUNTANT_REGISTRATION.set(threadResourceUsageAccountant);
-  }
-
   /**
    * visible for testing only
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -89,6 +89,10 @@ public class Tracing {
     return ACCOUNTANT_REGISTRATION.compareAndSet(null, threadResourceUsageAccountant);
   }
 
+  public static void forceRegister(ThreadResourceUsageAccountant threadResourceUsageAccountant) {
+    ACCOUNTANT_REGISTRATION.set(threadResourceUsageAccountant);
+  }
+
   /**
    * visible for testing only
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -198,6 +198,10 @@ public class Tracing {
     }
 
     @Override
+    public void sampleUsageMSE() {
+    }
+
+    @Override
     public void updateQueryUsageConcurrently(String queryId) {
     }
 
@@ -305,6 +309,10 @@ public class Tracing {
 
     public static void sample() {
       Tracing.getThreadAccountant().sampleUsage();
+    }
+
+    public static void sampleMSE() {
+      Tracing.getThreadAccountant().sampleUsageMSE();
     }
 
     public static void clear() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -202,13 +202,13 @@ public class Tracing {
     }
 
     @Override
-    public final void createExecutionContext(String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
-        @Nullable ThreadExecutionContext parentContext) {
+    public final void createExecutionContext(@Nullable String queryId, int taskId,
+        ThreadExecutionContext.TaskType taskType, @Nullable ThreadExecutionContext parentContext) {
       _anchorThread.set(parentContext == null ? Thread.currentThread() : parentContext.getAnchorThread());
       createExecutionContextInner(queryId, taskId, taskType, parentContext);
     }
 
-    public void createExecutionContextInner(@Nonnull String queryId, int taskId,
+    public void createExecutionContextInner(@Nullable String queryId, int taskId,
         ThreadExecutionContext.TaskType taskType, @Nullable ThreadExecutionContext parentContext) {
     }
 
@@ -262,11 +262,11 @@ public class Tracing {
     private ThreadAccountantOps() {
     }
 
-    public static void setupRunner(String queryId) {
+    public static void setupRunner(@Nonnull String queryId) {
       setupRunner(queryId, ThreadExecutionContext.TaskType.SSE);
     }
 
-    public static void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType) {
+    public static void setupRunner(@Nonnull String queryId, ThreadExecutionContext.TaskType taskType) {
       Tracing.getThreadAccountant().setThreadResourceUsageProvider(new ThreadResourceUsageProvider());
       Tracing.getThreadAccountant()
           .createExecutionContext(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType, null);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
@@ -201,12 +203,13 @@ public class Tracing {
 
     @Override
     public final void createExecutionContext(String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
-        ThreadExecutionContext parentContext) {
+        @Nullable ThreadExecutionContext parentContext) {
       _anchorThread.set(parentContext == null ? Thread.currentThread() : parentContext.getAnchorThread());
-      createExecutionContextInner(queryId, taskId, parentContext);
+      createExecutionContextInner(queryId, taskId, taskType, parentContext);
     }
 
-    public void createExecutionContextInner(String queryId, int taskId, ThreadExecutionContext parentContext) {
+    public void createExecutionContextInner(@Nonnull String queryId, int taskId,
+        ThreadExecutionContext.TaskType taskType, @Nullable ThreadExecutionContext parentContext) {
     }
 
     @Override
@@ -290,7 +293,8 @@ public class Tracing {
         ThreadResourceUsageProvider threadResourceUsageProvider,
         ThreadExecutionContext threadExecutionContext) {
       Tracing.getThreadAccountant().setThreadResourceUsageProvider(threadResourceUsageProvider);
-      Tracing.getThreadAccountant().createExecutionContext(null, taskId, taskType, threadExecutionContext);
+      Tracing.getThreadAccountant()
+          .createExecutionContext(threadExecutionContext.getQueryId(), taskId, taskType, threadExecutionContext);
     }
 
     public static void sample() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -293,8 +293,14 @@ public class Tracing {
         ThreadResourceUsageProvider threadResourceUsageProvider,
         ThreadExecutionContext threadExecutionContext) {
       Tracing.getThreadAccountant().setThreadResourceUsageProvider(threadResourceUsageProvider);
+      String queryId = null;
+      if (threadExecutionContext != null) {
+        queryId = threadExecutionContext.getQueryId();
+      } else {
+        LOGGER.warn("Request ID not available. ParentContext not set for query worker thread.");
+      }
       Tracing.getThreadAccountant()
-          .createExecutionContext(threadExecutionContext.getQueryId(), taskId, taskType, threadExecutionContext);
+          .createExecutionContext(queryId, taskId, taskType, threadExecutionContext);
     }
 
     public static void sample() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -971,6 +971,10 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
     public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
+
+    public static final String CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE =
+        "accounting.enable.thread.sampling.mse.debug";
+    public static final Boolean DEFAULT_ENABLE_THREAD_SAMPLING_MSE = true;
   }
 
   public static class ExecutorService {


### PR DESCRIPTION
The PR add the following improvements to OOM protection for Multi-Stage Engine.

# Add a config parameter to turn off sampling for MSE

`pinot.query.scheduler.accounting.enable.thread.sampling.mse.debug`
Since the feature is new, a debug config has been added to turn off sampling for MSE when there are mixed workloads.

As part of this change, a new fn `Tracing::sampleMSE` has been added to not add an `if` condition in the sampling path. The sample function is in the critical path wrt performance and SSE will not be affected by the extra check.

# Assign query id to workers

Worker threads are not assigned query ids. Refer:

```
Tracing.getThreadAccountant().createExecutionContext(null, taskId, taskType, threadExecutionContext);
```

Therefore, the resource used by these threads was not attributed to a query. Now, if there is a `parentContext` available, the query id is set. During aggregation, memory used by workers is also added to a query's aggregate statistics.

```
  String queryId = null;
      if (threadExecutionContext != null) {
        queryId = threadExecutionContext.getQueryId();
      } else {
        LOGGER.warn("Request ID not available. ParentContext not set for query worker thread.");
      }
      Tracing.getThreadAccountant()
          .createExecutionContext(queryId, taskId, taskType, threadExecutionContext);
    }
```

# Instrument threads for Leaf Stage Operator.

Threads that executed Leaf Stage operators in MSE were not tracked. Now runners and workers are instrumented correctly.

# Fix annotations

Nullable/NotNull annotations have been added. The most important is `CPUMemThreadLevelAccountingObjects.::setThreadTaskStatus` . `Tracing::setupWorker` can pass null for `queryId`. 
 
tags: bugfix