### PR TITLE
Rename dangling occurrences of StageNode to PlanNode

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/ColocationKey.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/ColocationKey.java
@@ -31,8 +31,8 @@ import org.apache.calcite.rex.RexInputRef;
  * behavior.
  *
  * <p>
- *  In other words, when a StageNode has the schema: (user_uuid, col1, col2, ...), and the ColocationKey is
- *  ([0], 8, murmur), then that means that the data for the StageNode is partitioned using the user_uuid column, into
+ *  In other words, when a PlanNode has the schema: (user_uuid, col1, col2, ...), and the ColocationKey is
+ *  ([0], 8, murmur), then that means that the data for the PlanNode is partitioned using the user_uuid column, into
  *  8 partitions where the partitionId is computed using murmur(user_uuid) % 8.
  *
  *  For a join stage the data is partitioned by the senders using their respective join-keys. In that case, we may

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewriteContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewriteContext.java
@@ -32,7 +32,7 @@ import org.apache.pinot.query.planner.plannode.PlanNode;
  * Context used for running the {@link GreedyShuffleRewriteVisitor}.
  */
 class GreedyShuffleRewriteContext {
-  private final Map<Integer, PlanNode> _rootStageNode;
+  private final Map<Integer, PlanNode> _rootPlanNode;
   private final Map<Integer, List<PlanNode>> _leafNodes;
   private final Set<Integer> _joinStages;
   private final Set<Integer> _setOpStages;
@@ -45,7 +45,7 @@ class GreedyShuffleRewriteContext {
   private final Map<Integer, Set<ColocationKey>> _senderInputColocationKeys;
 
   GreedyShuffleRewriteContext() {
-    _rootStageNode = new HashMap<>();
+    _rootPlanNode = new HashMap<>();
     _leafNodes = new HashMap<>();
     _joinStages = new HashSet<>();
     _setOpStages = new HashSet<>();
@@ -53,21 +53,21 @@ class GreedyShuffleRewriteContext {
   }
 
   /**
-   * Returns the root StageNode for a given planFragmentId.
+   * Returns the root PlanNode for a given planFragmentId.
    */
-  PlanNode getRootStageNode(Integer planFragmentId) {
-    return _rootStageNode.get(planFragmentId);
+  PlanNode getRootPlanNode(Integer planFragmentId) {
+    return _rootPlanNode.get(planFragmentId);
   }
 
   /**
-   * Sets the root StageNode for a given planFragmentId.
+   * Sets the root PlanNode for a given planFragmentId.
    */
-  void setRootStageNode(Integer planFragmentId, PlanNode planNode) {
-    _rootStageNode.put(planFragmentId, planNode);
+  void setRootPlanNode(Integer planFragmentId, PlanNode planNode) {
+    _rootPlanNode.put(planFragmentId, planNode);
   }
 
   /**
-   * Returns all the leaf StageNode for a given planFragmentId.
+   * Returns all the leaf PlanNode for a given planFragmentId.
    */
   List<PlanNode> getLeafNodes(Integer planFragmentId) {
     return _leafNodes.get(planFragmentId);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewritePreComputeVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewritePreComputeVisitor.java
@@ -41,7 +41,7 @@ class GreedyShuffleRewritePreComputeVisitor
   @Override
   public Integer process(PlanNode planNode, GreedyShuffleRewriteContext context) {
     int currentStageId = planNode.getStageId();
-    context.setRootStageNode(currentStageId, planNode);
+    context.setRootPlanNode(currentStageId, planNode);
     return 0;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewriteVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/colocated/GreedyShuffleRewriteVisitor.java
@@ -78,7 +78,7 @@ public class GreedyShuffleRewriteVisitor implements PlanNodeVisitor<Set<Colocati
     // This assumes that if planFragmentId(S1) > planFragmentId(S2), then S1 is not an ancestor of S2.
     // TODO: If this assumption is wrong, we can compute the reverse topological ordering explicitly.
     for (int planFragmentId = dispatchablePlanMetadataMap.size() - 1; planFragmentId >= 0; planFragmentId--) {
-      PlanNode planNode = context.getRootStageNode(planFragmentId);
+      PlanNode planNode = context.getRootPlanNode(planFragmentId);
       planNode.visit(new GreedyShuffleRewriteVisitor(tableCache, dispatchablePlanMetadataMap), context);
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -116,7 +116,7 @@ public class ServerPlanRequestUtils {
     Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(requestMetadata);
     pinotQuery.setLimit(leafNodeLimit != null ? leafNodeLimit : DEFAULT_LEAF_NODE_LIMIT);
     // visit the plan and create PinotQuery and determine the leaf stage boundary PlanNode.
-    ServerPlanRequestVisitor.walkStageNode(stagePlan.getRootNode(), serverContext);
+    ServerPlanRequestVisitor.walkPlanNode(stagePlan.getRootNode(), serverContext);
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
@@ -60,7 +60,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPlanRequestContext> {
   private static final ServerPlanRequestVisitor INSTANCE = new ServerPlanRequestVisitor();
 
-  static void walkStageNode(PlanNode node, ServerPlanRequestContext context) {
+  static void walkPlanNode(PlanNode node, ServerPlanRequestContext context) {
     node.visit(INSTANCE, context);
   }
 


### PR DESCRIPTION
- `StageNode` was renamed to `PlanNode` in https://github.com/apache/pinot/pull/10735 but some method / variable names and Javadocs weren't updated.
- This patch updates all the remaining dangling occurrences of `StageNode` to `PlanNode`.