### PR TITLE
Move untar method to BaseTaskExecutor and untar with peerDownload segment if deepstore corrupted

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -208,9 +208,6 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         try {
           indexDir = downloadSegmentToLocalAndUntar(tableNameWithType, segmentName, downloadURLs[i], taskType,
               tempDataDir, "_" + i);
-          if (indexDir == null) {
-            throw new RuntimeException("Unable to download and untar segment from download url: " + downloadURLs[i]);
-          }
         } catch (Exception e) {
           LOGGER.error("Failed to download segment from download url: {}", downloadURLs[i], e);
           _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_DOWNLOAD_FAIL_COUNT, 1L);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -200,30 +200,24 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
       for (int i = 0; i < downloadURLs.length; i++) {
         String segmentName = segmentNames[i];
-        // Download the segment file
+        // Download and decompress the segment file
         _eventObserver.notifyProgress(_pinotTaskConfig,
-            String.format("Downloading segment from: %s (%d out of %d)", downloadURLs[i], (i + 1),
+            String.format("Downloading and decompressing segment from: %s (%d out of %d)", downloadURLs[i], (i + 1),
                 downloadURLs.length));
-        File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile_" + i);
+        File indexDir;
         try {
-          downloadSegmentToLocal(tableNameWithType, segmentName, downloadURLs[i], taskType, tarredSegmentFile);
+          indexDir = downloadSegmentToLocalAndUntar(tableNameWithType, segmentName, downloadURLs[i], taskType,
+              tempDataDir, "_" + i);
+          if (indexDir == null) {
+            throw new RuntimeException("Unable to download and untar segment from download url: " + downloadURLs[i]);
+          }
         } catch (Exception e) {
           LOGGER.error("Failed to download segment from download url: {}", downloadURLs[i], e);
           _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_DOWNLOAD_FAIL_COUNT, 1L);
           _eventObserver.notifyTaskError(_pinotTaskConfig, e);
           throw e;
         }
-
-        // Un-tar the segment file
-        _eventObserver.notifyProgress(_pinotTaskConfig,
-            String.format("Decompressing segment from: %s (%d out of %d)", downloadURLs[i], (i + 1),
-                downloadURLs.length));
-        File segmentDir = new File(tempDataDir, "segmentDir_" + i);
-        File indexDir = TarCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
         inputSegmentDirs.add(indexDir);
-        if (!FileUtils.deleteQuietly(tarredSegmentFile)) {
-          LOGGER.warn("Failed to delete tarred input segment: {}", tarredSegmentFile.getAbsolutePath());
-        }
 
         reportSegmentDownloadMetrics(indexDir, tableNameWithType, taskType);
         SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -104,9 +104,6 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       try {
         indexDir = downloadSegmentToLocalAndUntar(tableNameWithType, segmentName, downloadURL, taskType,
             tempDataDir, "");
-        if (indexDir == null) {
-          throw new RuntimeException("Unable to download and untar segment from download url: " + downloadURL);
-        }
       } catch (Exception e) {
         LOGGER.error("Failed to download segment from download url: {}", downloadURL, e);
         _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_DOWNLOAD_FAIL_COUNT, 1L);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -97,25 +97,21 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs(), "Failed to create temporary directory: %s", tempDataDir);
     try {
-      // Download the tarred segment file
-      _eventObserver.notifyProgress(_pinotTaskConfig, "Downloading segment from: " + downloadURL);
-      File tarredSegmentFile = new File(tempDataDir, "tarredSegment");
-      LOGGER.info("Downloading segment from {} to {}", downloadURL, tarredSegmentFile.getAbsolutePath());
+      // Download and decompress the segment file
+      _eventObserver.notifyProgress(_pinotTaskConfig, "Downloading and decompressing segment from: "
+          + downloadURL);
+      File indexDir;
       try {
-        downloadSegmentToLocal(tableNameWithType, segmentName, downloadURL, taskType, tarredSegmentFile);
+        indexDir = downloadSegmentToLocalAndUntar(tableNameWithType, segmentName, downloadURL, taskType,
+            tempDataDir, "");
+        if (indexDir == null) {
+          throw new RuntimeException("Unable to download and untar segment from download url: " + downloadURL);
+        }
       } catch (Exception e) {
         LOGGER.error("Failed to download segment from download url: {}", downloadURL, e);
         _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_DOWNLOAD_FAIL_COUNT, 1L);
         _eventObserver.notifyTaskError(_pinotTaskConfig, e);
         throw e;
-      }
-
-      // Un-tar the segment file
-      _eventObserver.notifyProgress(_pinotTaskConfig, "Decompressing segment from: " + downloadURL);
-      File segmentDir = new File(tempDataDir, "segmentDir");
-      File indexDir = TarCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
-      if (!FileUtils.deleteQuietly(tarredSegmentFile)) {
-        LOGGER.warn("Failed to delete tarred input segment: {}", tarredSegmentFile.getAbsolutePath());
       }
 
       // Publish metrics related to segment download

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -112,7 +111,6 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
     _minionMetrics.addMeteredTableValue(tableName, taskType, meter, unitCount);
   }
 
-  @Nullable
   protected File downloadSegmentToLocalAndUntar(String tableNameWithType, String segmentName, String deepstoreURL,
       String taskType, File tempDataDir, String suffix)
       throws Exception {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutor.java
@@ -23,12 +23,14 @@ import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.metrics.MinionMetrics;
+import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.core.util.PeerServerSegmentFinder;
@@ -110,20 +112,28 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
     _minionMetrics.addMeteredTableValue(tableName, taskType, meter, unitCount);
   }
 
-  protected void downloadSegmentToLocal(String tableNameWithType, String segmentName, String deepstoreURL,
-      String taskType, File tarredSegmentFile)
+  @Nullable
+  protected File downloadSegmentToLocalAndUntar(String tableNameWithType, String segmentName, String deepstoreURL,
+      String taskType, File tempDataDir, String suffix)
       throws Exception {
-    LOGGER.info("Downloading segment {} from {} to {}", segmentName, deepstoreURL, tarredSegmentFile.getAbsolutePath());
+    File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile" + suffix);
+    File segmentDir = new File(tempDataDir, "segmentDir" + suffix);
+    File indexDir;
     TableConfig tableConfig = getTableConfig(tableNameWithType);
     String crypterName = tableConfig.getValidationConfig().getCrypterClassName();
+    LOGGER.info("Downloading segment {} from {} to {}", segmentName, deepstoreURL, tarredSegmentFile.getAbsolutePath());
+
     try {
       // download from deepstore first
       SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(deepstoreURL, tarredSegmentFile, crypterName);
+      // untar the segment file
+      indexDir = TarCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
     } catch (Exception e) {
       LOGGER.error("Segment download failed from deepstore for {}, crypter:{}", deepstoreURL, crypterName, e);
       String peerDownloadScheme = tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
       if (MinionTaskUtils.extractMinionAllowDownloadFromServer(tableConfig, taskType,
           MINION_CONTEXT.isAllowDownloadFromServer()) && peerDownloadScheme != null) {
+        // if allowDownloadFromServer is enabled, download the segment from a peer server as deepstore download failed
         LOGGER.info("Trying to download from servers for segment {} post deepstore download failed", segmentName);
         SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(segmentName, peerDownloadScheme, () -> {
           List<URI> uris =
@@ -132,9 +142,16 @@ public abstract class BaseTaskExecutor implements PinotTaskExecutor {
           Collections.shuffle(uris);
           return uris;
         }, tarredSegmentFile, crypterName);
+        // untar the segment file
+        indexDir = TarCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
       } else {
         throw e;
       }
+    } finally {
+      if (!FileUtils.deleteQuietly(tarredSegmentFile)) {
+        LOGGER.warn("Failed to delete tarred input segment: {}", tarredSegmentFile.getAbsolutePath());
+      }
     }
+    return indexDir;
   }
 }


### PR DESCRIPTION
While running a minion-task, we found that while fetching from deepstore, untarring the segment was throwing the following exception:

```
java.io.EOFException: null at 
org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream.read(GzipCompressorInputStream.java:306) 
at org.apache.commons.compress.archivers.tar.TarArchiveInputStream.read(TarArchiveInputStream.java:738)
at java.base/java.io.InputStream.read(InputStream.java:205) 
at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1309) 
at org.apache.commons.io.IOUtils.copy(IOUtils.java:978)
at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1282) 
at org.apache.commons.io.IOUtils.copy(IOUtils.java:953) 
at org.apache.pinot.common.utils.TarGzCompressionUtils.untarWithRateLimiter(TarGzCompressionUtils.java:202) 
at org.apache.pinot.common.utils.TarGzCompressionUtils.untar(TarGzCompressionUtils.java:148) 
at org.apache.pinot.common.utils.TarGzCompressionUtils.untar(TarGzCompressionUtils.java:138) 
at org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor.executeTask(BaseSingleSegmentConversionExecutor.java:121) 
at org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor.executeTask(BaseSingleSegmentConversionExecutor.java:60)
at org.apache.pinot.minion.taskfactory.TaskFactoryRegistry$1.runInternal(TaskFactoryRegistry.java:157) 
at org.apache.pinot.minion.taskfactory.TaskFactoryRegistry$1.run(TaskFactoryRegistry.java:118) 
at org.apache.helix.task.TaskRunner.run(TaskRunner.java:75) 
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) 
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) 
at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) 
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) 
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) 
at java.base/java.lang.Thread.run(Thread.java:829)
```

I downloaded the deepstore copy to local and tried untarring it and saw EOF exception, thus the deepstore copy is somehow corrupted. 
```
$ tar -xf <segmentName>

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

I am not sure of the exact reason of this but found some similar issue in #9003 

In #12960 we had added the functionality for minion nodes to download segments from peer-servers if deepstore fetching fails. In this PR, we are moving the untarring method to BaseTaskExecutor where if we fetch a deepstore copy but untarring it fails, we will download and untar the segment from peer-server if `allowDownloadFromServer` is set.

