### PR TITLE
Fix race condition in consistent push REVERT scenario

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -4287,6 +4287,27 @@ public class PinotHelixResourceManager {
     return tagMinInstanceMap;
   }
 
+  public boolean isSegmentRevertedInConsistentPush(String segmentName, String tableNameWithType) {
+    SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, tableNameWithType);
+    return isSegmentRevertedInConsistentPush(segmentName, segmentLineage);
+  }
+
+  @VisibleForTesting
+  static boolean isSegmentRevertedInConsistentPush(String segmentName, SegmentLineage segmentLineage) {
+    if (segmentLineage == null) {
+      return false;
+    }
+    for (LineageEntry lineageEntry : segmentLineage.getLineageEntries().values()) {
+      if (lineageEntry.getState() == LineageEntryState.REVERTED) {
+        Set<String> segmentsTo = new HashSet<>(lineageEntry.getSegmentsTo()); // convert to hashset for faster lookup
+        if (segmentsTo.contains(segmentName)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   /*
    * Uncomment and use for testing on a real cluster
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
When a consistent push is being reverted, there is no point on uploading segments in "segmentTo" list. In fact, there is a problematic race condition in REVERT of consistent push for cases with a lot of segments. This is the process for revert case: 
1) lineage is marked as REVERTED, 
2) all segments listed in segmentsTo get deleted from Ideal State, and 
3) segments in segmentsTo list get deleted from deep store one by one. 

If a segment in the segmentTo list is uploaded after step 2 and before/during step 3, it gets added back to the Ideal State,
but it gets deleted from deep store in the step 3. This is problematic as servers try to react to Ideal State
changes and download the segment, but the segment is missing in the deep store.

This PR fixes this issue by failing the upload request if the segment name appears in segmentTo list of a REVERTED lineage entry.