### PR TITLE
Add broker config to set default query null handling behavior

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -42,7 +42,9 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListener;
@@ -67,6 +69,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   protected final BrokerRequestIdGenerator _requestIdGenerator;
   protected final long _brokerTimeoutMs;
   protected final QueryLogger _queryLogger;
+  @Nullable
+  protected final String _enableQueryNullHandling;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, String brokerId, BrokerRoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache) {
@@ -82,6 +86,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _requestIdGenerator = new BrokerRequestIdGenerator(brokerId);
     _brokerTimeoutMs = config.getProperty(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
     _queryLogger = new QueryLogger(config);
+    _enableQueryNullHandling = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING);
   }
 
   @Override
@@ -116,8 +121,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       if (StringUtils.isNotBlank(failureMessage)) {
         failureMessage = "Reason: " + failureMessage;
       }
-      throw new WebApplicationException("Permission denied." + failureMessage,
-          Response.Status.FORBIDDEN);
+      throw new WebApplicationException("Permission denied." + failureMessage, Response.Status.FORBIDDEN);
     }
 
     JsonNode sql = request.get(Broker.Request.SQL);
@@ -129,6 +133,24 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     String query = sql.textValue();
     requestContext.setQuery(query);
+
+    // Parse the query if needed
+    if (sqlNodeAndOptions == null) {
+      try {
+        sqlNodeAndOptions = RequestUtils.parseQuery(query, request);
+      } catch (Exception e) {
+        // Do not log or emit metric here because it is pure user error
+        requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
+        return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
+      }
+    }
+
+    // Add null handling option from broker config only if there is no override in the query
+    if (_enableQueryNullHandling != null) {
+      sqlNodeAndOptions.getOptions()
+          .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableQueryNullHandling);
+    }
+
     BrokerResponse brokerResponse =
         handleRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
             accessControl);
@@ -139,9 +161,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     return brokerResponse;
   }
 
-  protected abstract BrokerResponse handleRequest(long requestId, String query,
-      @Nullable SqlNodeAndOptions sqlNodeAndOptions, JsonNode request, @Nullable RequesterIdentity requesterIdentity,
-      RequestContext requestContext, @Nullable HttpHeaders httpHeaders, AccessControl accessControl)
+  protected abstract BrokerResponse handleRequest(long requestId, String query, SqlNodeAndOptions sqlNodeAndOptions,
+      JsonNode request, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
+      @Nullable HttpHeaders httpHeaders, AccessControl accessControl)
       throws Exception;
 
   protected static void augmentStatistics(RequestContext statistics, BrokerResponse response) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -70,7 +70,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   protected final long _brokerTimeoutMs;
   protected final QueryLogger _queryLogger;
   @Nullable
-  protected final String _enableQueryNullHandling;
+  protected final String _enableNullHandling;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, String brokerId, BrokerRoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache) {
@@ -86,7 +86,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _requestIdGenerator = new BrokerRequestIdGenerator(brokerId);
     _brokerTimeoutMs = config.getProperty(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
     _queryLogger = new QueryLogger(config);
-    _enableQueryNullHandling = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING);
+    _enableNullHandling = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING);
   }
 
   @Override
@@ -146,9 +146,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // Add null handling option from broker config only if there is no override in the query
-    if (_enableQueryNullHandling != null) {
+    if (_enableNullHandling != null) {
       sqlNodeAndOptions.getOptions()
-          .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableQueryNullHandling);
+          .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableNullHandling);
     }
 
     BrokerResponse brokerResponse =

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -987,9 +987,9 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       }
 
       // Add null handling option from broker config only if there is no override in the query
-      if (_enableQueryNullHandling != null) {
+      if (_enableNullHandling != null) {
         sqlNodeAndOptions.getOptions()
-            .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableQueryNullHandling);
+            .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableNullHandling);
       }
 
       BrokerResponse response =

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -51,7 +51,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.ExceptionUtils;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
-import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.query.QueryEnvironment;
@@ -110,31 +109,13 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   }
 
   @Override
-  protected BrokerResponse handleRequest(long requestId, String query, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+  protected BrokerResponse handleRequest(long requestId, String query, SqlNodeAndOptions sqlNodeAndOptions,
       JsonNode request, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
       HttpHeaders httpHeaders, AccessControl accessControl) {
     LOGGER.debug("SQL query for request {}: {}", requestId, query);
 
-    // Parse the query if needed
-    if (sqlNodeAndOptions == null) {
-      try {
-        sqlNodeAndOptions = RequestUtils.parseQuery(query, request);
-      } catch (Exception e) {
-        // Do not log or emit metric here because it is pure user error
-        requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
-        return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
-      }
-    }
-
     // Compile the request
     Map<String, String> queryOptions = sqlNodeAndOptions.getOptions();
-
-    // Add null handling option from broker config only if there is no override in the query
-    if (!queryOptions.containsKey(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING)
-        && _config.containsKey(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING)) {
-      queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING,
-          _config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING));
-    }
 
     long compilationStartTimeNs = System.nanoTime();
     long queryTimeoutMs;
@@ -157,8 +138,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
             if (StringUtils.isNotBlank(failureMessage)) {
               failureMessage = "Reason: " + failureMessage;
             }
-            throw new WebApplicationException("Permission denied. " + failureMessage,
-                Response.Status.FORBIDDEN);
+            throw new WebApplicationException("Permission denied. " + failureMessage, Response.Status.FORBIDDEN);
           }
           return constructMultistageExplainPlan(query, plan);
         case SELECT:
@@ -210,8 +190,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       if (StringUtils.isNotBlank(failureMessage)) {
         failureMessage = "Reason: " + failureMessage;
       }
-      throw new WebApplicationException("Permission denied." + failureMessage,
-          Response.Status.FORBIDDEN);
+      throw new WebApplicationException("Permission denied." + failureMessage, Response.Status.FORBIDDEN);
     }
 
     // Validate QPS quota
@@ -299,10 +278,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
     } catch (Exception e) {
       LOGGER.warn("Error encountered while collecting multi-stage stats", e);
-      brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode().put(
-          "error",
-          "Error encountered while collecting multi-stage stats - " + e)
-      );
+      brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode()
+          .put("error", "Error encountered while collecting multi-stage stats - " + e));
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -128,6 +128,14 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     // Compile the request
     Map<String, String> queryOptions = sqlNodeAndOptions.getOptions();
+
+    // Add null handling option from broker config only if there is no override in the query
+    if (!queryOptions.containsKey(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING)
+        && _config.containsKey(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING)) {
+      queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING,
+          _config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING));
+    }
+
     long compilationStartTimeNs = System.nanoTime();
     long queryTimeoutMs;
     QueryEnvironment.QueryPlannerResult queryPlanResult;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -198,11 +200,11 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   public void testTotalCountWithNullHandlingQueryOptionEnabled(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String pinotQuery = "SELECT COUNT(*) FROM " + getTableName() + " option(enableNullHandling=true)";
+    String pinotQuery = "SELECT COUNT(*) FROM " + getTableName();
     String h2Query = "SELECT COUNT(*) FROM " + getTableName();
     testQuery(pinotQuery, h2Query);
 
-    pinotQuery = "SELECT COUNT(1) FROM " + getTableName() + " option(enableNullHandling=true)";
+    pinotQuery = "SELECT COUNT(1) FROM " + getTableName();
     h2Query = "SELECT COUNT(1) FROM " + getTableName();
     testQuery(pinotQuery, h2Query);
   }
@@ -256,41 +258,34 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   public void testOrderByByNullableKeepsOtherColNulls()
       throws Exception {
     setUseMultiStageQueryEngine(false);
-    String h2Query = "select salary from mytable"
+    String query = "select salary from mytable"
         + " where salary is null"
         + " order by description";
-    String pinotQuery = h2Query + " option(enableNullHandling=true)";
-    testQuery(pinotQuery, h2Query);
+    testQuery(query);
   }
 
   @Test(dataProvider = "useBothQueryEngines")
   public void testOrderByNullsFirst(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String h2Query = "SELECT salary FROM " + getTableName() + " ORDER BY salary NULLS FIRST";
-    String pinotQuery = h2Query + " option(enableNullHandling=true)";
-
-    testQuery(pinotQuery, h2Query);
+    String query = "SELECT salary FROM " + getTableName() + " ORDER BY salary NULLS FIRST";
+    testQuery(query);
   }
 
   @Test(dataProvider = "useBothQueryEngines")
   public void testOrderByNullsLast(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String h2Query = "SELECT salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
-    String pinotQuery = h2Query + " option(enableNullHandling=true)";
-
-    testQuery(pinotQuery, h2Query);
+    String query = "SELECT salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
+    testQuery(query);
   }
 
   @Test(dataProvider = "useBothQueryEngines")
   public void testDistinctOrderByNullsLast(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String h2Query = "SELECT distinct salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
-    String pinotQuery = h2Query + " option(enableNullHandling=true)";
-
-    testQuery(pinotQuery, h2Query);
+    String query = "SELECT distinct salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
+    testQuery(query);
   }
 
   @Test(dataProvider = "useBothQueryEngines")
@@ -299,7 +294,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     // Need to also select an identifier column to skip the all literal query optimization which returns without
     // querying the segment.
-    String sqlQuery = "SELECT NULL, salary FROM mytable OPTION(enableNullHandling=true)";
+    String sqlQuery = "SELECT NULL, salary FROM mytable";
 
     JsonNode response = postQuery(sqlQuery);
 
@@ -311,12 +306,14 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   public void testCaseWhenAllLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String sqlQuery =
-        "SELECT CASE WHEN true THEN 1 WHEN NOT true THEN 0 ELSE NULL END FROM mytable OPTION(enableNullHandling=true)";
-
+    String sqlQuery = "SELECT CASE WHEN true THEN 1 WHEN NOT true THEN 0 ELSE NULL END FROM mytable";
     JsonNode response = postQuery(sqlQuery);
-
     assertEquals(response.get("resultTable").get("rows").get(0).get(0).asInt(), 1);
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING, "true");
   }
 
   @DataProvider(name = "nullLiteralQueries")
@@ -324,32 +321,24 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     // Query string, expected value
     return new Object[][]{
         // Null literal only
-        {String.format("SELECT null FROM %s OPTION(enableNullHandling=true)", getTableName()), "null"},
+        {String.format("SELECT null FROM %s", getTableName()), "null"},
         // Null related functions
-        {String.format("SELECT isNull(null) FROM %s OPTION (enableNullHandling=true)", getTableName()), true},
-        {String.format("SELECT isNotNull(null) FROM %s OPTION (enableNullHandling=true)", getTableName()), false},
-        {String.format("SELECT coalesce(null, 1) FROM %s OPTION (enableNullHandling=true)", getTableName()), 1},
-        {String.format("SELECT coalesce(null, null) FROM %s OPTION (enableNullHandling=true)", getTableName()), "null"},
-        {String.format("SELECT isDistinctFrom(null, null) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            false},
-        {String.format("SELECT isNotDistinctFrom(null, null) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            true},
-        {String.format("SELECT isDistinctFrom(null, 1) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            true},
-        {String.format("SELECT isNotDistinctFrom(null, 1) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            false},
-        {String.format("SELECT case when true then null end FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            "null"},
-        {String.format("SELECT case when false then 1 end FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            "null"},
+        {String.format("SELECT isNull(null) FROM %s", getTableName()), true},
+        {String.format("SELECT isNotNull(null) FROM %s", getTableName()), false},
+        {String.format("SELECT coalesce(null, 1) FROM %s", getTableName()), 1},
+        {String.format("SELECT coalesce(null, null) FROM %s", getTableName()), "null"},
+        {String.format("SELECT isDistinctFrom(null, null) FROM %s", getTableName()), false},
+        {String.format("SELECT isNotDistinctFrom(null, null) FROM %s", getTableName()), true},
+        {String.format("SELECT isDistinctFrom(null, 1) FROM %s", getTableName()), true},
+        {String.format("SELECT isNotDistinctFrom(null, 1) FROM %s", getTableName()), false},
+        {String.format("SELECT case when true then null end FROM %s", getTableName()), "null"},
+        {String.format("SELECT case when false then 1 end FROM %s", getTableName()), "null"},
         // Null intolerant functions
-        {String.format("SELECT add(null, 1) FROM %s OPTION (enableNullHandling=true)", getTableName()), "null"},
-        {String.format("SELECT greater_than(null, 1) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            "null"},
-        {String.format("SELECT to_epoch_seconds(null) FROM %s OPTION (enableNullHandling=true)", getTableName()),
-            "null"},
-        {String.format("SELECT not(null) FROM %s OPTION (enableNullHandling=true)", getTableName()), "null"},
-        {String.format("SELECT tan(null) FROM %s OPTION (enableNullHandling=true)", getTableName()), "null"}
+        {String.format("SELECT add(null, 1) FROM %s", getTableName()), "null"},
+        {String.format("SELECT greater_than(null, 1) FROM %s", getTableName()), "null"},
+        {String.format("SELECT to_epoch_seconds(null) FROM %s", getTableName()), "null"},
+        {String.format("SELECT not(null) FROM %s", getTableName()), "null"},
+        {String.format("SELECT tan(null) FROM %s", getTableName()), "null"}
     };
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -248,6 +248,7 @@ public class CommonConstants {
     public static final int DEFAULT_BROKER_QUERY_LOG_LENGTH = Integer.MAX_VALUE;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND =
         "pinot.broker.query.log.maxRatePerSecond";
+    public static final String CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING = "pinot.broker.query.enable.null.handling";
     public static final String CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION = "pinot.broker.enable.query.cancellation";
     public static final double DEFAULT_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND = 10_000d;
     public static final String CONFIG_OF_BROKER_TIMEOUT_MS = "pinot.broker.timeoutMs";


### PR DESCRIPTION
- Currently, query null handling support can be enabled via the query option `enableNullHandling` (see https://docs.pinot.apache.org/developers/advanced/null-value-support#advanced-null-handling-support). By default, this "advanced" null handling support is disabled for both the v1 and v2 query engines.
- This patch adds a new broker config `pinot.broker.query.enable.null.handling` that will allow users to enable null handling for queries by default (i.e., without having to set the query option for every query). Note that this applies to both the query engines.
- This is useful if users always want null handling to be enabled especially in cases where the queries are being generated by an external system where the user doesn't have any control over the individual queries (and hence can't set the query option explicitly).
- If needed, users can still override the null handling behavior on a per query basis using the existing query option even when the new broker config is set.
- Note that even if we enable null handling support by default for the multistage query engine in the future (see https://github.com/apache/pinot/pull/13570), the behavior of this broker config won't change - i.e., if it is explicitly configured to `false` this will disable query null handling support for both the query engines.