### PR TITLE
track newly added segments for upsert tables for a more complete upsert data view

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -508,6 +508,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
             schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
             partitionDedupMetadataManager, _isTableReadyToConsumeData);
     registerSegment(segmentName, realtimeSegmentDataManager, partitionUpsertMetadataManager);
+    if (partitionUpsertMetadataManager != null) {
+      partitionUpsertMetadataManager.trackNewlyAddedSegment(segmentName);
+    }
     realtimeSegmentDataManager.startConsumption();
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1);
 
@@ -615,6 +618,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       // access the new segment asap even though its validDocId bitmap is still being filled by
       // partitionUpsertMetadataManager.
       registerSegment(segmentName, newSegmentManager, partitionUpsertMetadataManager);
+      partitionUpsertMetadataManager.trackNewlyAddedSegment(segmentName);
       partitionUpsertMetadataManager.addSegment(immutableSegment);
       _logger.info("Added new immutable segment: {} with upsert enabled", segmentName);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -210,7 +210,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     List<SegmentDataManager> segmentDataManagers;
     List<IndexSegment> indexSegments;
     Map<IndexSegment, SegmentContext> providedSegmentContexts = null;
-    if (!isUpsertTableUsingConsistencyMode(tableDataManager)) {
+    if (!isUpsertTable(tableDataManager)) {
       segmentDataManagers = tableDataManager.acquireSegments(segmentsToQuery, optionalSegments, notAcquiredSegments);
       numSegmentsAcquired = segmentDataManagers.size();
       indexSegments = new ArrayList<>(numSegmentsAcquired);
@@ -220,18 +220,21 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     } else {
       RealtimeTableDataManager rtdm = (RealtimeTableDataManager) tableDataManager;
       TableUpsertMetadataManager tumm = rtdm.getTableUpsertMetadataManager();
-      tumm.lockForSegmentContexts();
+      boolean isUsingConsistencyMode =
+          rtdm.getTableUpsertMetadataManager().getUpsertConsistencyMode() != UpsertConfig.ConsistencyMode.NONE;
+      if (isUsingConsistencyMode) {
+        tumm.lockForSegmentContexts();
+      }
       try {
-        // Server can start consuming segment before broker can update its routing table upon IdealState changes, so
-        // broker can miss the new consuming segment even with the previous fix #11978. For a complete upsert data view,
-        // the consuming segment should be acquired all the time speculatively if it's not included by the broker.
+        // Get newly added segments as tracked by the upsert table manager to expand the list of segments for query.
+        // Those segments are treated as optional segments as they don't fail the query if not able to get acquired.
         Set<String> allSegmentsToQuery = new HashSet<>(segmentsToQuery);
         if (optionalSegments == null) {
           optionalSegments = new ArrayList<>();
         } else {
           allSegmentsToQuery.addAll(optionalSegments);
         }
-        for (String segmentName : tumm.getOptionalSegments()) {
+        for (String segmentName : tumm.getNewlyAddedSegments()) {
           if (!allSegmentsToQuery.contains(segmentName)) {
             optionalSegments.add(segmentName);
           }
@@ -240,22 +243,25 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         numSegmentsAcquired = segmentDataManagers.size();
         indexSegments = new ArrayList<>(numSegmentsAcquired);
         for (SegmentDataManager segmentDataManager : segmentDataManagers) {
-          // When using consistency mode, a segment data manager may track two segments with same name, and they both
-          // contain part of the valid docs for the segment.
           if (segmentDataManager.hasMultiSegments()) {
             indexSegments.addAll(segmentDataManager.getSegments());
           } else {
             indexSegments.add(segmentDataManager.getSegment());
           }
         }
-        List<SegmentContext> segmentContexts =
-            tableDataManager.getSegmentContexts(indexSegments, queryContext.getQueryOptions());
-        providedSegmentContexts = new HashMap<>(segmentContexts.size());
-        for (SegmentContext sc : segmentContexts) {
-          providedSegmentContexts.put(sc.getIndexSegment(), sc);
+        // When using consistency mode, we should acquire segments and get their contexts atomically.
+        if (isUsingConsistencyMode) {
+          List<SegmentContext> segmentContexts =
+              tableDataManager.getSegmentContexts(indexSegments, queryContext.getQueryOptions());
+          providedSegmentContexts = new HashMap<>(segmentContexts.size());
+          for (SegmentContext sc : segmentContexts) {
+            providedSegmentContexts.put(sc.getIndexSegment(), sc);
+          }
         }
       } finally {
-        tumm.unlockForSegmentContexts();
+        if (isUsingConsistencyMode) {
+          tumm.unlockForSegmentContexts();
+        }
       }
     }
     if (LOGGER.isDebugEnabled()) {
@@ -394,15 +400,14 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     return instanceResponse;
   }
 
-  private boolean isUpsertTableUsingConsistencyMode(TableDataManager tableDataManager) {
-    // For upsert table using consistency mode, we have to acquire segments and get their validDocIds atomically.
-    // Otherwise, the query may not have access to new segments added just before it gets validDocIds for the acquired
-    // segments, thus missing valid docs replaced by the newly added segments.
+  private boolean isUpsertTable(TableDataManager tableDataManager) {
+    // For upsert table, the server can start to process newly added segments before brokers can add those segments
+    // into their routing tables, like newly created consuming segment or newly uploaded segments. We should include
+    // those segments in the list of segments for query to process on the server, otherwise, the query will see less
+    // than expected valid docs from the upsert table.
     if (tableDataManager instanceof RealtimeTableDataManager) {
       RealtimeTableDataManager rtdm = (RealtimeTableDataManager) tableDataManager;
-      if (rtdm.isUpsertEnabled()) {
-        return rtdm.getTableUpsertMetadataManager().getUpsertConsistencyMode() != UpsertConfig.ConsistencyMode.NONE;
-      }
+      return rtdm.isUpsertEnabled();
     }
     return false;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -169,7 +169,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (cmode == UpsertConfig.ConsistencyMode.SYNC || cmode == UpsertConfig.ConsistencyMode.SNAPSHOT) {
       _upsertViewManager = new UpsertViewManager(cmode, context);
       // For consistency mode, we have to track newly added segments, so use default tracking time to enable the
-      // tracking of newly added segments if it's not enabled explicitly.
+      // tracking of newly added segments if it's not enabled explicitly. This is for existing tables to work.
+      // New tables are required to set a positive newSegmentTrackingTimeMs when to enable consistency mode.
       _newSegmentTrackingTimeMs =
           trackingTimeMs > 0 ? trackingTimeMs : UpsertViewManager.DEFAULT_NEW_SEGMENT_TRACKING_TIME_MS;
     } else {
@@ -1255,7 +1256,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       if (_logger.isDebugEnabled()) {
         _logger.debug("Cleaning stale segments from tracking map: {} with nowMs: {}", _newlyAddedSegments, nowMs);
       }
-      _newlyAddedSegments.entrySet().removeIf(e -> e.getValue() > 0 && e.getValue() < nowMs);
+      _newlyAddedSegments.values().removeIf(v -> v > 0 && v < nowMs);
       return _newlyAddedSegments.keySet();
     }
     return Collections.emptySet();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -1230,6 +1230,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   public void trackNewlyAddedSegment(String segmentName) {
     if (_newSegmentTrackingTimeMs > 0) {
       _newlyAddedSegments.put(segmentName, System.currentTimeMillis() + _newSegmentTrackingTimeMs);
+      if (_logger.isDebugEnabled()) {
+        _logger.debug("Tracked newly added segments: {}", _newlyAddedSegments);
+      }
     }
   }
 
@@ -1237,9 +1240,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (_newSegmentTrackingTimeMs > 0) {
       // Untrack stale segments at query time. The overhead should be limited as the tracking map should be very small.
       long nowMs = System.currentTimeMillis();
-      if (_logger.isDebugEnabled()) {
-        _logger.debug("Removing stale segments from tracking map: {} with nowMs: {}", _newlyAddedSegments, nowMs);
-      }
       _newlyAddedSegments.values().removeIf(v -> v < nowMs);
       return _newlyAddedSegments.keySet();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -138,6 +138,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
   // By default, the upsert consistency mode is NONE and upsertViewManager is disabled.
   private final UpsertViewManager _upsertViewManager;
+
   // We track newly added segments to get them included in the list of selected segments for queries to get a more
   // complete upsert data view, e.g. the newly created consuming segment or newly uploaded immutable segments. Such
   // segments can be processed by the server even before they get included in the broker's routing table. Server can
@@ -417,7 +418,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip adding segment: {} because metadata manager is already stopped", segment.getSegmentName());
       return;
     }
-    trackNewlyAddedSegment(segment);
     if (_enableSnapshot) {
       _snapshotLock.readLock().lock();
     }
@@ -1217,9 +1217,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (_upsertViewManager != null) {
       _upsertViewManager.trackSegment(segment);
     }
-    if (segment instanceof MutableSegment) {
-      trackNewlyAddedSegment(segment);
-    }
   }
 
   @Override
@@ -1229,10 +1226,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
   }
 
-  @VisibleForTesting
-  void trackNewlyAddedSegment(IndexSegment segment) {
+  @Override
+  public void trackNewlyAddedSegment(String segmentName) {
     if (_newSegmentTrackingTimeMs > 0) {
-      _newlyAddedSegments.put(segment.getSegmentName(), System.currentTimeMillis() + _newSegmentTrackingTimeMs);
+      _newlyAddedSegments.put(segmentName, System.currentTimeMillis() + _newSegmentTrackingTimeMs);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -78,6 +78,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
       _consistencyMode = UpsertConfig.ConsistencyMode.NONE;
     }
     long upsertViewRefreshIntervalMs = upsertConfig.getUpsertViewRefreshIntervalMs();
+    long newSegmentTrackingTimeMs = upsertConfig.getNewSegmentTrackingTimeMs();
     File tableIndexDir = tableDataManager.getTableDataDir();
     _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
@@ -85,16 +86,18 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
         .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot)
         .setEnablePreload(_enablePreload).setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL)
         .setConsistencyMode(_consistencyMode).setUpsertViewRefreshIntervalMs(upsertViewRefreshIntervalMs)
-        .setTableIndexDir(tableIndexDir).setDropOutOfOrderRecord(upsertConfig.isDropOutOfOrderRecord())
+        .setNewSegmentTrackingTimeMs(newSegmentTrackingTimeMs).setTableIndexDir(tableIndexDir)
+        .setDropOutOfOrderRecord(upsertConfig.isDropOutOfOrderRecord())
         .setEnableDeletedKeysCompactionConsistency(_enableDeletedKeysCompactionConsistency)
         .setTableDataManager(tableDataManager).build();
     LOGGER.info(
         "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
             + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-            + " deleted Keys TTL: {}, consistency mode: {}, upsert view refresh interval: {}ms, table index dir: {}",
-        getClass().getSimpleName(), _tableNameWithType, primaryKeyColumns, comparisonColumns, deleteRecordColumn,
-        hashFunction, upsertConfig.getMode(), enableSnapshot, _enablePreload, metadataTTL, deletedKeysTTL,
-        _consistencyMode, upsertViewRefreshIntervalMs, tableIndexDir);
+            + " deleted Keys TTL: {}, consistency mode: {}, upsert view refresh interval: {}ms, new segment tracking"
+            + " time: {}ms, table index dir: {}", getClass().getSimpleName(), _tableNameWithType, primaryKeyColumns,
+        comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(), enableSnapshot, _enablePreload,
+        metadataTTL, deletedKeysTTL, _consistencyMode, upsertViewRefreshIntervalMs, newSegmentTrackingTimeMs,
+        tableIndexDir);
 
     initCustomVariables();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -47,10 +47,9 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
 
   @Override
   public BasePartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
-        k -> _enableDeletedKeysCompactionConsistency
-            ? new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context)
-            : new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
+    return _partitionMetadataManagerMap.computeIfAbsent(partitionId, k -> _enableDeletedKeysCompactionConsistency
+        ? new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context)
+        : new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
   }
 
   @Override
@@ -82,11 +81,11 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
-  public Set<String> getOptionalSegments() {
-    Set<String> optionalSegments = new HashSet<>();
-    _partitionMetadataManagerMap.forEach((partitionID, upsertMetadataManager) -> optionalSegments.addAll(
-        upsertMetadataManager.getUpsertViewManager().getOptionalSegments()));
-    return optionalSegments;
+  public Set<String> getNewlyAddedSegments() {
+    Set<String> newlyAddedSegments = new HashSet<>();
+    _partitionMetadataManagerMap.forEach((partitionID, upsertMetadataManager) -> newlyAddedSegments.addAll(
+        upsertMetadataManager.getNewlyAddedSegments()));
+    return newlyAddedSegments;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -129,4 +129,11 @@ public interface PartitionUpsertMetadataManager extends Closeable {
    * ongoing queries that are still accessing the segment.
    */
   void untrackSegmentForUpsertView(IndexSegment segment);
+
+  /**
+   * Track newly added segments to get them included in the list of selected segments for queries to get a more
+   * complete upsert data view, e.g. the newly created consuming segment or newly uploaded immutable segments. Such
+   * segments can be processed by the server even before they get included in the broker's routing table.
+   */
+  void trackNewlyAddedSegment(String segmentName);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -68,7 +68,7 @@ public interface TableUpsertMetadataManager extends Closeable {
   default void unlockForSegmentContexts() {
   }
 
-  default Set<String> getOptionalSegments() {
+  default Set<String> getNewlyAddedSegments() {
     return Collections.emptySet();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -44,6 +44,7 @@ public class UpsertContext {
   private final double _deletedKeysTTL;
   private final UpsertConfig.ConsistencyMode _consistencyMode;
   private final long _upsertViewRefreshIntervalMs;
+  private final long _newSegmentTrackingTimeMs;
   private final File _tableIndexDir;
   private final boolean _dropOutOfOrderRecord;
   private final boolean _enableDeletedKeysCompactionConsistency;
@@ -53,7 +54,7 @@ public class UpsertContext {
       List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
       @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
       double metadataTTL, double deletedKeysTTL, UpsertConfig.ConsistencyMode consistencyMode,
-      long upsertViewRefreshIntervalMs, File tableIndexDir, boolean dropOutOfOrderRecord,
+      long upsertViewRefreshIntervalMs, long newSegmentTrackingTimeMs, File tableIndexDir, boolean dropOutOfOrderRecord,
       boolean enableDeletedKeysCompactionConsistency, @Nullable TableDataManager tableDataManager) {
     _tableConfig = tableConfig;
     _schema = schema;
@@ -68,6 +69,7 @@ public class UpsertContext {
     _deletedKeysTTL = deletedKeysTTL;
     _consistencyMode = consistencyMode;
     _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
+    _newSegmentTrackingTimeMs = newSegmentTrackingTimeMs;
     _tableIndexDir = tableIndexDir;
     _dropOutOfOrderRecord = dropOutOfOrderRecord;
     _enableDeletedKeysCompactionConsistency = enableDeletedKeysCompactionConsistency;
@@ -126,6 +128,10 @@ public class UpsertContext {
     return _upsertViewRefreshIntervalMs;
   }
 
+  public long getNewSegmentTrackingTimeMs() {
+    return _newSegmentTrackingTimeMs;
+  }
+
   public File getTableIndexDir() {
     return _tableIndexDir;
   }
@@ -156,6 +162,7 @@ public class UpsertContext {
     private double _deletedKeysTTL;
     private UpsertConfig.ConsistencyMode _consistencyMode;
     private long _upsertViewRefreshIntervalMs;
+    private long _newSegmentTrackingTimeMs;
     private File _tableIndexDir;
     private boolean _dropOutOfOrderRecord;
     private boolean _enableDeletedKeysCompactionConsistency;
@@ -226,6 +233,11 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setNewSegmentTrackingTimeMs(long newSegmentTrackingTimeMs) {
+      _newSegmentTrackingTimeMs = newSegmentTrackingTimeMs;
+      return this;
+    }
+
     public Builder setTableIndexDir(File tableIndexDir) {
       _tableIndexDir = tableIndexDir;
       return this;
@@ -255,8 +267,8 @@ public class UpsertContext {
       Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
       return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
           _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
-          _consistencyMode, _upsertViewRefreshIntervalMs, _tableIndexDir, _dropOutOfOrderRecord,
-          _enableDeletedKeysCompactionConsistency, _tableDataManager);
+          _consistencyMode, _upsertViewRefreshIntervalMs, _newSegmentTrackingTimeMs, _tableIndexDir,
+          _dropOutOfOrderRecord, _enableDeletedKeysCompactionConsistency, _tableDataManager);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * thread can specify a freshness threshold query option to refresh the bitmap copies if not fresh enough.
  */
 public class UpsertViewManager {
-  public static final long DEFAULT_NEW_SEGMENT_TRACKING_TIME_MS = 30000L;
+  public static final long DEFAULT_NEW_SEGMENT_TRACKING_TIME_MS = 10000;
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertViewManager.class);
   private final UpsertConfig.ConsistencyMode _consistencyMode;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -49,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * thread can specify a freshness threshold query option to refresh the bitmap copies if not fresh enough.
  */
 public class UpsertViewManager {
+  public static final long DEFAULT_NEW_SEGMENT_TRACKING_TIME_MS = 30000L;
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertViewManager.class);
   private final UpsertConfig.ConsistencyMode _consistencyMode;
 
@@ -59,10 +59,6 @@ public class UpsertViewManager {
   // contexts, so the need of the R/W lock.
   private final ReadWriteLock _trackedSegmentsLock = new ReentrantReadWriteLock();
   private final Set<IndexSegment> _trackedSegments = ConcurrentHashMap.newKeySet();
-  // Optional segments are part of the tracked segments. They can get processed by server before getting included in
-  // broker's routing table, like the new consuming segment. Although broker misses such segments, the server needs
-  // to acquire them to avoid missing the new valid docs in them.
-  private final Set<String> _optionalSegments = ConcurrentHashMap.newKeySet();
 
   // Updating and accessing segments' validDocIds bitmaps are synchronized with a separate R/W lock for clarity.
   // The query threads always get _upsertViewTrackedSegmentsLock then _upsertViewSegmentDocIdsLock to avoid deadlock.
@@ -276,17 +272,10 @@ public class UpsertViewManager {
     _trackedSegmentsLock.readLock().unlock();
   }
 
-  public Set<String> getOptionalSegments() {
-    return _optionalSegments;
-  }
-
   public void trackSegment(IndexSegment segment) {
     _trackedSegmentsLock.writeLock().lock();
     try {
       _trackedSegments.add(segment);
-      if (segment instanceof MutableSegment) {
-        _optionalSegments.add(segment.getSegmentName());
-      }
       if (_consistencyMode == UpsertConfig.ConsistencyMode.SNAPSHOT) {
         // Note: it's possible the segment is already tracked and the _trackedSegments doesn't really change here. But
         // we should force to refresh the upsert view to include the latest bitmaps of the segments. This is
@@ -305,9 +294,6 @@ public class UpsertViewManager {
     _trackedSegmentsLock.writeLock().lock();
     try {
       _trackedSegments.remove(segment);
-      if (segment instanceof MutableSegment) {
-        _optionalSegments.remove(segment.getSegmentName());
-      }
       // No need to eagerly refresh the upsert view for SNAPSHOT mode when untracking a segment, as the untracked
       // segment won't be used by any new queries, thus it can be removed when next refresh happens later.
     } finally {
@@ -323,5 +309,10 @@ public class UpsertViewManager {
   @VisibleForTesting
   Set<IndexSegment> getUpdatedSegmentsSinceLastRefresh() {
     return _updatedSegmentsSinceLastRefresh;
+  }
+
+  @VisibleForTesting
+  Set<IndexSegment> getTrackedSegments() {
+    return _trackedSegments;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -638,19 +638,14 @@ public class BasePartitionUpsertMetadataManagerTest {
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 
-    IndexSegment seg1 = mock(MutableSegment.class);
-    when(seg1.getSegmentName()).thenReturn("seg1");
-    IndexSegment seg2 = mock(MutableSegment.class);
-    when(seg2.getSegmentName()).thenReturn("seg2");
-
-    upsertMetadataManager.trackNewlyAddedSegment(seg1);
-    upsertMetadataManager.trackNewlyAddedSegment(seg2);
+    upsertMetadataManager.trackNewlyAddedSegment("seg1");
+    upsertMetadataManager.trackNewlyAddedSegment("seg2");
     assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 0);
 
     when(upsertContext.getNewSegmentTrackingTimeMs()).thenReturn(100L);
     upsertMetadataManager = new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
-    upsertMetadataManager.trackNewlyAddedSegment(seg1);
-    upsertMetadataManager.trackNewlyAddedSegment(seg2);
+    upsertMetadataManager.trackNewlyAddedSegment("seg1");
+    upsertMetadataManager.trackNewlyAddedSegment("seg2");
     assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 2);
     // There is 100ms delay before removal of stale segments.
     assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 2);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -632,8 +632,7 @@ public class BasePartitionUpsertMetadataManagerTest {
   }
 
   @Test
-  public void testTrackUntrackNewlyAddedSegments()
-      throws InterruptedException {
+  public void testTrackNewlyAddedSegments() {
     UpsertContext upsertContext = mock(UpsertContext.class);
     when(upsertContext.getNewSegmentTrackingTimeMs()).thenReturn(0L);
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
@@ -653,16 +652,11 @@ public class BasePartitionUpsertMetadataManagerTest {
     upsertMetadataManager.trackNewlyAddedSegment(seg1);
     upsertMetadataManager.trackNewlyAddedSegment(seg2);
     assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 2);
-    // Segments are kept if not untracked explicitly, as delay timer starts after untracking.
-    Thread.sleep(300);
-    assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 2);
-    upsertMetadataManager.untrackNewlyAddedSegment(seg1);
-    upsertMetadataManager.untrackNewlyAddedSegment(seg2);
     // There is 100ms delay before removal of stale segments.
     assertEquals(upsertMetadataManager.getNewlyAddedSegments().size(), 2);
     DummyPartitionUpsertMetadataManager finalUpsertMetadataManager = upsertMetadataManager;
     TestUtils.waitForCondition(aVoid -> finalUpsertMetadataManager.getNewlyAddedSegments().isEmpty(), 300L,
-        "Failed to untrack segments");
+        "Failed to remove stale segments");
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
@@ -30,7 +30,10 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 
 public class UpsertViewManagerTest {
@@ -46,12 +49,12 @@ public class UpsertViewManagerTest {
 
     SegmentContext segCtx1 = new SegmentContext(seg1);
     mgr.trackSegment(seg1);
-    assertEquals(mgr.getOptionalSegments(), Collections.singleton(seg1.getSegmentName()));
+    assertEquals(mgr.getTrackedSegments(), Collections.singleton(seg1));
     mgr.setSegmentContexts(Collections.singletonList(segCtx1), new HashMap<>());
     assertSame(segCtx1.getQueryableDocIdsSnapshot(), mutableRoaringBitmap);
 
     mgr.untrackSegment(seg1);
-    assertTrue(mgr.getOptionalSegments().isEmpty());
+    assertTrue(mgr.getTrackedSegments().isEmpty());
     segCtx1 = new SegmentContext(seg1);
     mgr.setSegmentContexts(Collections.singletonList(segCtx1), new HashMap<>());
     assertNull(segCtx1.getQueryableDocIdsSnapshot());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -88,10 +88,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Refresh interval when using the snapshot consistency mode")
   private long _upsertViewRefreshIntervalMs = 3000;
 
-  // As the time to process a segment can very long and vary greatly, so delay timer starts after the segment is
-  // fully processed on the server.
-  @JsonPropertyDescription("How long to track a newly added segment, after it is processed by the server.")
-  private long _newSegmentTrackingTimeMs = 30000;
+  // Setting this time to 0 to disable the tracking feature.
+  @JsonPropertyDescription("Track newly added segments on the server for a more complete upsert data view.")
+  private long _newSegmentTrackingTimeMs = 10000;
 
   @JsonPropertyDescription("Custom class for upsert metadata manager")
   private String _metadataManagerClass;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -88,6 +88,11 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Refresh interval when using the snapshot consistency mode")
   private long _upsertViewRefreshIntervalMs = 3000;
 
+  // As the time to process a segment can very long and vary greatly, so delay timer starts after the segment is
+  // fully processed on the server.
+  @JsonPropertyDescription("How long to track a newly added segment, after it is processed by the server.")
+  private long _newSegmentTrackingTimeMs = 30000;
+
   @JsonPropertyDescription("Custom class for upsert metadata manager")
   private String _metadataManagerClass;
 
@@ -173,6 +178,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public long getUpsertViewRefreshIntervalMs() {
     return _upsertViewRefreshIntervalMs;
+  }
+
+  public long getNewSegmentTrackingTimeMs() {
+    return _newSegmentTrackingTimeMs;
   }
 
   public boolean isDropOutOfOrderRecord() {
@@ -273,6 +282,10 @@ public class UpsertConfig extends BaseJsonConfig {
     _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
   }
 
+  public void setNewSegmentTrackingTimeMs(long newSegmentTrackingTimeMs) {
+    _newSegmentTrackingTimeMs = newSegmentTrackingTimeMs;
+  }
+
   public void setDropOutOfOrderRecord(boolean dropOutOfOrderRecord) {
     _dropOutOfOrderRecord = dropOutOfOrderRecord;
   }
@@ -289,8 +302,7 @@ public class UpsertConfig extends BaseJsonConfig {
     _metadataManagerConfigs = metadataManagerConfigs;
   }
 
-  public void setAllowPartialUpsertConsumptionDuringCommit(
-      boolean allowPartialUpsertConsumptionDuringCommit) {
+  public void setAllowPartialUpsertConsumptionDuringCommit(boolean allowPartialUpsertConsumptionDuringCommit) {
     _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
   }
 


### PR DESCRIPTION
When uploading a segment, the server may process it ahead of broker adding it to routing table. Broker listens to IS changes to add the newly added segments into routing table, which may take a few seconds or many seconds, depending on the load of the broker. 

If query gets routed by broker during this short window, broker may not include the new segment in the list of selected segments for the query, although the server already starts to process the new segment and invalidate the docs in existing segments. Due to this race condition, the query may access less than expected valid docs. 

In this PR, we tracks newly uploaded segments on server side for a configurable period, so that server can ask query to access them as optional segments. Optional segment is a mechanism we added earlier on to handle a similar race condition for consuming segment.

This PR adds a new config `newSegmentTrackingTimeMs` to enable this feature, essentially as a best effort to wait for broker to add a segment into their routing table upon IS changes. By default, it's 10s to enable this tracking feature.