### PR TITLE
[bugfix] Init BrokerQueryEventListener

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/BrokerQueryEventListenerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/BrokerQueryEventListenerFactory.java
@@ -61,6 +61,7 @@ public class BrokerQueryEventListenerFactory {
       _brokerQueryEventListener =
           (BrokerQueryEventListener) Class.forName(brokerQueryEventListenerClassName).getDeclaredConstructor()
               .newInstance();
+      _brokerQueryEventListener.init(config);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
During testing of release-1.2, we discovered that our broker query event listener framework was not functioning as expected. When initializing the BrokerQueryEventListener, we call the `init` method with configurations needed for pushing messages to Kafka and M3. However, after the release, we stopped receiving messages in both systems.

It appears that during the refactoring in #13179, we missed the call to `_brokerQueryEventListener.init(config);` after creating the listener instance. This PR reintroduces that missing call.