### PR TITLE
Don't replace environment variables and system properties in get table configs REST API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -378,14 +378,14 @@ public class PinotTableRestletResource {
 
       if ((tableTypeStr == null || TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName);
+        TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false);
         Preconditions.checkNotNull(tableConfig);
         ret.set(TableType.OFFLINE.name(), tableConfig.toJsonNode());
       }
 
       if ((tableTypeStr == null || TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName);
+        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false);
         Preconditions.checkNotNull(tableConfig);
         ret.set(TableType.REALTIME.name(), tableConfig.toJsonNode());
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -156,8 +156,8 @@ public class TableConfigsRestletResource {
     try {
       tableName = DatabaseUtils.translateTableName(tableName, headers);
       Schema schema = _pinotHelixResourceManager.getTableSchema(tableName);
-      TableConfig offlineTableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName);
-      TableConfig realtimeTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName);
+      TableConfig offlineTableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false);
+      TableConfig realtimeTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false);
       TableConfigs config = new TableConfigs(tableName, schema, offlineTableConfig, realtimeTableConfig);
       return config.toJsonString();
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3093,25 +3093,51 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Get the offline table config for the given table name.
+   * Get the offline table config for the given table name. Any environment variables and system properties will be
+   * replaced with their actual values.
    *
    * @param tableName Table name with or without type suffix
    * @return Table config
    */
   @Nullable
   public TableConfig getOfflineTableConfig(String tableName) {
-    return ZKMetadataProvider.getOfflineTableConfig(_propertyStore, tableName);
+    return getOfflineTableConfig(tableName, true);
   }
 
   /**
-   * Get the realtime table config for the given table name.
+   * Get the offline table config for the given table name.
+   *
+   * @param tableName Table name with or without type suffix
+   * @param replaceVariables Whether to replace environment variables and system properties with their actual values
+   * @return Table config
+   */
+  @Nullable
+  public TableConfig getOfflineTableConfig(String tableName, boolean replaceVariables) {
+    return ZKMetadataProvider.getOfflineTableConfig(_propertyStore, tableName, replaceVariables);
+  }
+
+  /**
+   * Get the realtime table config for the given table name. Any environment variables and system properties will be
+   * replaced with their actual values.
    *
    * @param tableName Table name with or without type suffix
    * @return Table config
    */
   @Nullable
   public TableConfig getRealtimeTableConfig(String tableName) {
-    return ZKMetadataProvider.getRealtimeTableConfig(_propertyStore, tableName);
+    return getRealtimeTableConfig(tableName, true);
+  }
+
+  /**
+   * Get the realtime table config for the given table name.
+   *
+   * @param tableName Table name with or without type suffix
+   * @param replaceVariables Whether to replace environment variables and system properties with their actual values
+   * @return Table config
+   */
+  @Nullable
+  public TableConfig getRealtimeTableConfig(String tableName, boolean replaceVariables) {
+    return ZKMetadataProvider.getRealtimeTableConfig(_propertyStore, tableName, replaceVariables);
   }
 
   /**
@@ -3438,8 +3464,8 @@ public class PinotHelixResourceManager {
    * @return List of untagged online server instances.
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
-    List<String> instanceListWithoutTags = HelixHelper.getInstancesWithoutTag(_helixZkManager,
-        Helix.UNTAGGED_SERVER_INSTANCE);
+    List<String> instanceListWithoutTags =
+        HelixHelper.getInstancesWithoutTag(_helixZkManager, Helix.UNTAGGED_SERVER_INSTANCE);
     List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
 
     instanceListWithoutTags.retainAll(liveInstances);


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/13983
- When the table configs are stored in ZK, the environment variables and system properties are stored as is (i.e., without replacing with actual values).
- However, the table config retrieval REST APIs use an internal ZK metadata API that replaces these variables with their actual values for use internally within Pinot.
- This shouldn't be the case for the user facing REST API since these values could contain secrets.