### PR TITLE
Replace fmpp-maven-plugin with fmpp Ant Task to avoid pulling the vulnerable log4j jars

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -94,7 +94,7 @@
               <goal>javacc</goal>
             </goals>
             <configuration>
-              <sourceDirectory>${project.build.directory}/generated-sources/fmpp/javacc</sourceDirectory>
+              <sourceDirectory>${project.build.directory}/generated-sources/javacc/</sourceDirectory>
               <includes>
                 <include>Parser.jj</include>
               </includes>
@@ -269,6 +269,10 @@
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.fmpp</groupId>
+      <artifactId>fmpp</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>
@@ -347,11 +351,11 @@
       </properties>
     </profile>
     <profile>
-      <!-- The fmpp-maven-plugin doesn't care about unchanged (re)sources and will always generate.
+      <!-- The Ant task doesn't care about unchanged (re)sources and will always generate.
       This causes the maven-compiler-plugin to detect changes and always recompile the Java sources.
 
       If there are changes in src/main/codegen, either enforcer activation of this profile by using -Psqlparser or by
-      removing the generated-sources/fmpp directory
+      removing the generated-sources/javacc directory
 
       NOTICE: In Maven the profile activation is decided BEFORE plugin execution.
       When running clean+verify, the profile will not be activated (because the file still exists),
@@ -361,7 +365,7 @@
       <id>sqlparser</id>
       <activation>
         <file>
-          <missing>target/generated-sources/fmpp/javacc/Parser.jj</missing>
+          <missing>${project.build.directory}/generated-sources/javacc/Parser.jj</missing>
         </file>
       </activation>
       <build>
@@ -369,19 +373,22 @@
           <!-- "Plugs in" the Calcite's Parser.jj with the variables present in config.fmpp. These contain the custom rules
      as well as the class to which the custom implementation will get generated -->
           <plugin>
-            <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-            <artifactId>fmpp-maven-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
                 <id>generate-fmpp-sources</id>
                 <phase>generate-sources</phase>
                 <goals>
-                  <goal>generate</goal>
+                  <goal>run</goal>
                 </goals>
                 <configuration>
-                  <cfgFile>src/main/codegen/config.fmpp</cfgFile>
-                  <templateDirectory>src/main/codegen/templates</templateDirectory>
-                  <outputDirectory>${project.build.directory}/generated-sources/fmpp</outputDirectory>
+                  <target name="generate-code">
+                    <taskdef name="fmpp" classname="fmpp.tools.AntTask" classpathref="maven.compile.classpath"/>
+                    <fmpp configuration="src/main/codegen/config.fmpp"
+                        sourceRoot="src/main/codegen/templates"
+                        outputRoot="${project.build.directory}/generated-sources/"/>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
     <h2.version>2.3.232</h2.version>
     <jnr-posix.version>3.1.20</jnr-posix.version>
     <scalatest.version>3.2.19</scalatest.version>
+    <fmpp.version>0.9.16</fmpp.version>
   </properties>
 
   <profiles>
@@ -2025,6 +2026,11 @@
         <version>${scalatest.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>net.sourceforge.fmpp</groupId>
+        <artifactId>fmpp</artifactId>
+        <version>${fmpp.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -2300,11 +2306,6 @@
               </path>
             </annotationProcessorPaths>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>com.googlecode.fmpp-maven-plugin</groupId>
-          <artifactId>fmpp-maven-plugin</artifactId>
-          <version>1.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Solve #14011 