### PR TITLE
remove checks introduced in https://github.com/apache/pinot/issues/945 that is backward incompatible

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -65,10 +65,6 @@ public class ForwardIndexConfig extends IndexConfig {
     _rawIndexWriterVersion = rawIndexWriterVersion == null ? DEFAULT_RAW_WRITER_VERSION : rawIndexWriterVersion;
     _compressionCodec = compressionCodec;
 
-    if (targetMaxChunkSize != null && !(_deriveNumDocsPerChunk || _rawIndexWriterVersion == 4)) {
-      throw new IllegalStateException(
-          "targetMaxChunkSize should only be used when deriveNumDocsPerChunk is true or rawIndexWriterVersion is 4");
-    }
     _targetMaxChunkSizeBytes = targetMaxChunkSize == null ? DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES
         : (int) DataSizeUtils.toBytes(targetMaxChunkSize);
     _targetMaxChunkSize =


### PR DESCRIPTION
This condition check introduced in https://github.com/apache/pinot/pull/12945 is breaking our internal segment build 
```
Caused by: java.lang.IllegalStateException: targetMaxChunkSize should only be used when deriveNumDocsPerChunk is true or rawIndexWriterVersion is 4
	at org.apache.pinot.segment.spi.index.ForwardIndexConfig.<init>(ForwardIndexConfig.java:69)
	at org.apache.pinot.segment.spi.index.ForwardIndexConfig$Builder.build(ForwardIndexConfig.java:325)
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator.adaptConfig(SegmentColumnarIndexCreator.java:246)
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator.init(SegmentColumnarIndexCreator.java:172)
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.build(SegmentIndexCreationDriverImpl.java:266)
	at 
...
```
rc is our existing config does not contain either `_targetMaxChunkSize` or `_deriveNumDocsPerChunk` and has `_rawIndexWriterVersion` < 4. When this is read into `SegmentGeneratorConfig`, `_targetMaxChunkSize` get assigned with non null default value by the new code,
```
 _targetMaxChunkSizeBytes = targetMaxChunkSize == null ? DEFAULT_TARGET_MAX_CHUNK_SIZE_BYTES
        : (int) DataSizeUtils.toBytes(targetMaxChunkSize);
    _targetMaxChunkSize =
        targetMaxChunkSize == null ? DEFAULT_TARGET_MAX_CHUNK_SIZE : targetMaxChunkSize;
```
 
and `_deriveNumDocsPerChunk` is set to false. And later in `SegmentColumnarIndexCreator`, when this config is used to build ForwardIndexConfig, it gets rejected because `_targetMaxChunkSize` is non-null in the following check
```
    if (targetMaxChunkSize != null && !(_deriveNumDocsPerChunk || _rawIndexWriterVersion == 4)) {
      throw new IllegalStateException(
          "targetMaxChunkSize should only be used when deriveNumDocsPerChunk is true or rawIndexWriterVersion is 4");
    }
```
 This check and the default value assignment is self contradictory, causing regression.

Meanwhile, after reading the new code, I'm not sure about the rational behind the check... `_targetMaxChunkSize` and `_targetMaxChunkSizeBytes` are used in `MultiValueVarByteRawIndexCreator` for version<4 and regardless of `_deriveNumDocsPerChunk` https://github.com/apache/pinot/blob/b4dfd04c4db8539b1d286786ebf904442877714a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java#L82

