### PR TITLE
Apply filter reduce expressions Calcite rule at the end to prevent literal-only filter pushdown to leaf stage

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -897,6 +897,15 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
+  public void testLiteralFilterPushdown() throws Exception {
+    String sqlQuery = "SELECT * FROM (SELECT CASE WHEN AirTime > 0 THEN 'positive' ELSE 'negative' END AS AirTime "
+        + "FROM mytable) WHERE AirTime IN ('positive', 'negative')";
+    JsonNode jsonNode = postQuery(sqlQuery);
+    assertNoError(jsonNode);
+    assertEquals(jsonNode.get("resultTable").get("rows").size(), getCountStarResult());
+  }
+
+  @Test
   public void testMVNumericCastInFilter() throws Exception {
     String sqlQuery = "SELECT COUNT(*) FROM mytable WHERE arrayToMV(CAST(DivAirportIDs AS BIGINT ARRAY)) > 0";
     JsonNode jsonNode = postQuery(sqlQuery);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -119,8 +119,6 @@ public class PinotQueryRuleSets {
 
   // Pinot specific rules that should be run AFTER all other rules
   public static final List<RelOptRule> PINOT_POST_RULES = List.of(
-      // Evaluate the Literal filter nodes
-      CoreRules.FILTER_REDUCE_EXPRESSIONS,
       // TODO: Merge the following 2 rules into a single rule
       // add an extra exchange for sort
       PinotSortExchangeNodeInsertRule.INSTANCE,
@@ -144,7 +142,9 @@ public class PinotQueryRuleSets {
       // NOTE: Keep this rule at the end because it can potentially create a lot of predicates joined by OR/AND for IN/
       //       NOT IN clause, which can be expensive to process in other rules.
       // TODO: Consider removing this rule and directly handle SEARCH in RexExpressionUtils.
-      PinotFilterExpandSearchRule.INSTANCE
+      PinotFilterExpandSearchRule.INSTANCE,
+      // Evaluate the Literal filter nodes
+      CoreRules.FILTER_REDUCE_EXPRESSIONS
   );
   //@formatter:on
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -144,7 +144,8 @@ public class PinotQueryRuleSets {
       // TODO: Consider removing this rule and directly handle SEARCH in RexExpressionUtils.
       PinotFilterExpandSearchRule.INSTANCE,
       // Evaluate the Literal filter nodes
-      CoreRules.FILTER_REDUCE_EXPRESSIONS
+      CoreRules.FILTER_REDUCE_EXPRESSIONS,
+      PinotFilterExpandSearchRule.INSTANCE
   );
   //@formatter:on
 }


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/14010
- Without this change, the plan for a query like `SELECT * FROM (SELECT CASE WHEN AirTime > 0 THEN 'positive' ELSE 'negative' END AS AirTime FROM mytable) WHERE AirTime IN ('positive', 'negative')` looked like:
```
LogicalProject(AirTime=[CASE(>($4, 0), _UTF-8'Positive', _UTF-8'Negative')])
  LogicalFilter(condition=[OR(AND(>($4, 0), OR(=(_UTF-8'Positive', _UTF-8'Negative'), =(_UTF-8'Positive', _UTF-8'Positive'))), AND(OR(=(_UTF-8'Negative', _UTF-8'Negative'), =(_UTF-8'Negative', _UTF-8'Positive')), <=($4, 0)))])
    LogicalTableScan(table=[[default, mytable]])
```
- This is a problem because literal-only filter expressions are being pushed down to the leaf stage which doesn't support evaluating such filter expressions. The above query failed with the error:
```
java.lang.RuntimeException: Caught exception while running CombinePlanNode.
...
Caused by: java.lang.NullPointerException: DataSource for null should not be null. Potentially invalid column name specified.
```
- Moving the `FILTER_REDUCE_EXPRESSIONS` Calcite rule to the end ensures that these literal-only filter expressions will be reduced. The plan for the same query now looks like:
```
LogicalProject(AirTime=[CASE(>($4, 0), _UTF-8'Positive', _UTF-8'Negative')])
  LogicalTableScan(table=[[default, mytable]])
```