### PR TITLE
Fixing python library in ms-openjdk.dockerfile

### DIFF
--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -25,7 +25,7 @@ FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends vim less wget curl git python sysstat procps linux-tools-generic libtasn1-6 zstd && \
+  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
   rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \


### PR DESCRIPTION
```
8.612 Package python is not available, but is referred to by another package.
8.612 This may mean that the package is missing, has been obsoleted, or
8.612 is only available from another source
8.612 However the following packages replace it:
8.612   2to3 python2-minimal python2 dh-python python-is-python3
8.612
8.613 E: Package 'python' has no installation candidate
```