### PR TITLE
Improve Adaptive Server Selection to penalize servers returning server side exceptions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -28,9 +28,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
-import org.apache.pinot.common.exception.QueryException;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -99,8 +99,8 @@ public class AsyncQueryResponse implements QueryResponse {
         ServerResponse response = entry.getValue();
         long latency;
 
+        // If server has not responded or if the server response has exceptions, the latency is set to timeout
         if (hasServerNotResponded(response) || hasServerReturnedExceptions(response)) {
-          // TODO Improve Hybrid Server Selector to mark server is unhealthy when there are server side exceptions
           latency = _timeoutMs;
         } else {
           latency = response.getResponseDelayMs();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -30,6 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.common.exception.QueryException;
 
 
 /**
@@ -96,16 +97,42 @@ public class AsyncQueryResponse implements QueryResponse {
       // servers even if the query times out or if servers have not responded.
       for (Map.Entry<ServerRoutingInstance, ServerResponse> entry : _responseMap.entrySet()) {
         ServerResponse response = entry.getValue();
+        long latency;
 
-        // ServerResponse returns -1 if responseDelayMs is not set. This indicates that a response was not received
-        // from the server. Hence we set the latency to the timeout value.
-        long latency =
-            (response != null && response.getResponseDelayMs() >= 0) ? response.getResponseDelayMs() : _timeoutMs;
+        if (hasServerNotResponded(response) || hasServerReturnedExceptions(response)) {
+          // TODO Improve Hybrid Server Selector to mark server is unhealthy when there are server side exceptions
+          latency = _timeoutMs;
+        } else {
+          latency = response.getResponseDelayMs();
+        }
         _serverRoutingStatsManager.recordStatsUponResponseArrival(_requestId, entry.getKey().getInstanceId(), latency);
       }
 
       _queryRouter.markQueryDone(_requestId);
     }
+  }
+
+  private boolean hasServerReturnedExceptions(ServerResponse response) {
+    if (response.getDataTable() != null && response.getDataTable().getExceptions().size() > 0) {
+      DataTable dataTable = response.getDataTable();
+      Map<Integer, String> exceptions = dataTable.getExceptions();
+
+      // If Server response has exceptions in Datatable set the latency for timeout value.
+      for (Map.Entry<Integer, String> exception : exceptions.entrySet()) {
+        // Check if the exceptions received are server side exceptions
+        if (!QueryException.isClientError(exception.getKey())) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+
+  private boolean hasServerNotResponded(ServerResponse response) {
+    // ServerResponse returns -1 if responseDelayMs is not set. This indicates that a response was not received
+    // from the server. Hence we set the latency to the timeout value.
+    return response == null || response.getResponseDelayMs() < 0;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -237,7 +237,9 @@ public class QueryRoutingTest {
       // This corresponds to the EWMA value when a latency timeout value of 1000 is set. Latency set to timeout value
       //when server side exception occurs.
       double serverEWMALatency = 666.334;
-      assertEquals(latencyAfter, serverEWMALatency);
+      // Leaving an error budget of 2%
+      double delta = 13.32;
+      assertEquals(latencyAfter, serverEWMALatency, delta);
     } else {
       assertTrue(latencyAfter > latencyBefore, latencyAfter + " should be greater than " + latencyBefore);
     }
@@ -327,7 +329,9 @@ public class QueryRoutingTest {
       //to 666.334.
       // This corresponds to the EWMA value when a latency timeout value of 1000 is set.
       double serverEWMALatency = 666.334;
-      assertEquals(latencyAfter, serverEWMALatency);
+      // Leaving an error budget of 2%
+      double delta = 13.32;
+      assertEquals(latencyAfter, serverEWMALatency, delta);
     } else {
       assertTrue(latencyAfter > latencyBefore, latencyAfter + " should be greater than " + latencyBefore);
     }


### PR DESCRIPTION
- Currently if server response has exceptions they are not considered and the latency is set to time taken to receive response. This potentially ranks servers with underlying issues better. So the algorithm would prefer these servers. 
- With this change, the response from server is parsed and if there are server side exceptions the latency of the server is set to max as timeout ms. This will rank the server lower than healthy servers.

Unit test cases
- Response with no exception will have latency set to response time
- Response with client exceptions will have latency set to response time
- Response with at least one server exception will have latency set to timeout ms  
