### PR TITLE
Fix vulnerabilities for msopenjdk 11 pinot-base-runtime image.

### DIFF
--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -20,18 +20,18 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu as builder
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS builder
 
 FROM ubuntu:24.10
+ARG JAVA_VERSION
 ENV LANG=en_US.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11
+ENV JAVA_HOME="/usr/lib/jvm/msopenjdk-${JAVA_VERSION}"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
   apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -20,12 +20,19 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu as builder
+
+FROM ubuntu:24.10
+ENV LANG=en_US.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
+  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/13461), This PR tries to fix all the vulnerabilities based on the Ubuntu OS version. Using the newer version of the Ubuntu `24.10`([reference](https://hub.docker.com/layers/library/ubuntu/24.10/images/sha256-f1295b0bad93cde7ab6b1bd4e2af4eb3acdc25e3d964484ceab27146e7918dbb?context=explore)), with 0 vulnerabilities.

Docker scout for the image build using the command
```bash
$  docker build -t  apachepinot/pinot-base-runtime:11-ms-openjdk -f docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile . --no-cache

$ docker scout quickview                                                                                                         (sbx/consumer)
    i New version 1.13.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 242 packages

    i Base image was auto-detected. To get more accurate results, build images with max-mode provenance attestations.
      Review docs.docker.com ↗ for more information.
      
  Target     │  local://apachepinot/pinot-base-runtime:17-ms-openjdk  │    0C     0H     0M     0L   
    digest   │  60f9e6fdfb01                                          │                              
  Base image │  ubuntu:24.10                                          │    0C     0H     0M     0L   


```