### PR TITLE
Trying to prevent confusion regarding jars as testresources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,19 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    ignore:
+    - dependency-name: "org.apache.pinot:pinot-dropwizard"
+      # Locked test resource for pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ClassLoaderTest.java
+      versions: ["0.10.0"]
+    - dependency-name: "org.apache.pinot:pinot-yammer"
+      # Locked test resource for pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ClassLoaderTest.java
+      versions: ["0.10.0"]
+    - dependency-name: "commons-io:commons-io"
+      # Locked test resource for pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ClassLoaderTest.java
+      versions: ["2.11.0"]
+    - dependency-name: "com.yammer.metrics:metrics-core"
+      # Locked test resource for pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ClassLoaderTest.java
+      versions: ["2.1.5"]
 
   - package-ecosystem: "npm"
     directory: "/pinot-controller/src/main/resources"

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -58,34 +58,34 @@
                 <artifactItem>
                   <groupId>org.apache.pinot</groupId>
                   <artifactId>pinot-dropwizard</artifactId>
-                  <version>0.10.0</version>
+                  <version>0.10.0</version> <!-- @dependabot ignore -->
                   <classifier>shaded</classifier>
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/pinot-dropwizard</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.pinot</groupId>
                   <artifactId>pinot-yammer</artifactId>
-                  <version>0.10.0</version>
+                  <version>0.10.0</version> <!-- @dependabot ignore -->
                   <classifier>shaded</classifier>
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/pinot-yammer</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.pinot</groupId>
                   <artifactId>pinot-yammer</artifactId>
-                  <version>0.10.0</version>
+                  <version>0.10.0</version> <!-- @dependabot ignore -->
                   <classifier>shaded</classifier>
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/pinot-shaded-yammer</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>commons-io</groupId>
                   <artifactId>commons-io</artifactId>
-                  <version>2.11.0</version>
+                  <version>2.11.0</version> <!-- @dependabot ignore -->
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/assemblybased-pinot-plugin</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>com.yammer.metrics</groupId>
                   <artifactId>metrics-core</artifactId>
-                  <version>2.2.0</version>
+                  <version>2.1.5</version> <!-- @dependabot ignore -->
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/assemblybased-pinot-plugin</outputDirectory>
                 </artifactItem>
               </artifactItems>
@@ -109,7 +109,7 @@
                 <artifactItem>
                   <groupId>org.apache.pinot</groupId>
                   <artifactId>pinot-yammer</artifactId>
-                  <version>0.10.0</version>
+                  <version>0.10.0</version> <!-- @dependabot ignore -->
                   <outputDirectory>${project.build.testOutputDirectory}/plugins/assemblybased-pinot-plugin/classes</outputDirectory>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
These jars are not dependencies, tests depend on their name and content.
Hence they have a specific version, which is not managed globally.
