### PR TITLE
remove parent relative path, which was incorrect

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-broker</artifactId>
   <name>Pinot Broker</name>

--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-clients</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-java-client</artifactId>
   <name>Pinot Java Client</name>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-clients</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-jdbc-client</artifactId>
   <name>Pinot JDBC Client</name>

--- a/pinot-clients/pom.xml
+++ b/pinot-clients/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-clients</artifactId>
   <packaging>pom</packaging>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-common</artifactId>
   <name>Pinot Common</name>

--- a/pinot-compatibility-verifier/pom.xml
+++ b/pinot-compatibility-verifier/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-compatibility-verifier</artifactId>
   <name>Pinot Compatibility Verifier</name>

--- a/pinot-connectors/pinot-flink-connector/pom.xml
+++ b/pinot-connectors/pinot-flink-connector/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot-connectors</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-flink-connector</artifactId>
   <name>Pinot Flink Connector</name>

--- a/pinot-connectors/pinot-spark-2-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-2-connector/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-connectors</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-spark-2-connector</artifactId>
   <name>Pinot Spark 2 Connector</name>

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-connectors</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-spark-3-connector</artifactId>
   <name>Pinot Spark 3 Connector</name>

--- a/pinot-connectors/pinot-spark-common/pom.xml
+++ b/pinot-connectors/pinot-spark-common/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-connectors</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-spark-common</artifactId>
   <name>Pinot Spark Common</name>

--- a/pinot-connectors/pom.xml
+++ b/pinot-connectors/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-connectors</artifactId>
   <packaging>pom</packaging>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-controller</artifactId>
   <name>Pinot Controller</name>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-core</artifactId>
   <name>Pinot Core</name>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-distribution</artifactId>
   <name>Pinot Distribution</name>

--- a/pinot-integration-test-base/pom.xml
+++ b/pinot-integration-test-base/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-integration-test-base</artifactId>
   <name>Pinot Test Utils</name>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-integration-tests</artifactId>
   <name>Pinot Integration Tests</name>

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-minion</artifactId>
   <name>Pinot Minion</name>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-perf</artifactId>
   <name>Pinot Perf</name>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-batch-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-batch-ingestion-common</artifactId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-batch-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-batch-ingestion-hadoop</artifactId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-batch-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-batch-ingestion-spark-2.4</artifactId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-batch-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-batch-ingestion-spark-3</artifactId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-batch-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-batch-ingestion-standalone</artifactId>

--- a/pinot-plugins/pinot-batch-ingestion/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-batch-ingestion</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-environment</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-azure</artifactId>
   <name>Pinot Azure Environment</name>

--- a/pinot-plugins/pinot-environment/pom.xml
+++ b/pinot-plugins/pinot-environment/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-environment</artifactId>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-file-system</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-adls</artifactId>
   <name>Pinot Azure Data Lake Storage</name>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-file-system</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-gcs</artifactId>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-file-system</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-hdfs</artifactId>
   <name>Pinot Hadoop Filesystem</name>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-file-system</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-s3</artifactId>

--- a/pinot-plugins/pinot-file-system/pom.xml
+++ b/pinot-plugins/pinot-file-system/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-file-system</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-avro-base</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-avro</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-clp-log</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-confluent-avro</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-csv</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-json</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-orc</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-parquet</artifactId>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
 

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-thrift</artifactId>

--- a/pinot-plugins/pinot-input-format/pom.xml
+++ b/pinot-plugins/pinot-input-format/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-input-format</artifactId>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-metrics</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-dropwizard</artifactId>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-metrics</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-yammer</artifactId>

--- a/pinot-plugins/pinot-metrics/pom.xml
+++ b/pinot-plugins/pinot-metrics/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-metrics</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-minion-tasks</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-minion-builtin-tasks</artifactId>

--- a/pinot-plugins/pinot-minion-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-minion-tasks</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
+++ b/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-segment-uploader</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-segment-uploader-default</artifactId>

--- a/pinot-plugins/pinot-segment-uploader/pom.xml
+++ b/pinot-plugins/pinot-segment-uploader/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-segment-uploader</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-segment-writer</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-segment-writer-file-based</artifactId>

--- a/pinot-plugins/pinot-segment-writer/pom.xml
+++ b/pinot-plugins/pinot-segment-writer/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-segment-writer</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-stream-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-kafka-2.0</artifactId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-stream-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-kafka-3.0</artifactId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-stream-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-kafka-base</artifactId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-stream-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-kinesis</artifactId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-stream-ingestion</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-pulsar</artifactId>

--- a/pinot-plugins/pinot-stream-ingestion/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-stream-ingestion</artifactId>
   <packaging>pom</packaging>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-plugins</artifactId>
   <packaging>pom</packaging>

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-segment-local</artifactId>
   <name>Pinot local segment implementations</name>

--- a/pinot-segment-spi/pom.xml
+++ b/pinot-segment-spi/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-segment-spi</artifactId>
   <name>Pinot Segment Service Provider Interface</name>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-server</artifactId>
   <name>Pinot Server</name>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-spi</artifactId>
   <name>Pinot Service Provider Interface</name>

--- a/pinot-timeseries/pom.xml
+++ b/pinot-timeseries/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <packaging>pom</packaging>
 

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-tools</artifactId>
   <name>Pinot Tools</name>


### PR DESCRIPTION
Our pom.xml files include a `parent.relativePath` declaration whose value is always `..`. That is not necessary and in fact it was incorrect (the correct value should have been `../pom.xml`, which is in fact the default value).