### PR TITLE
The apache-jar-resource-bundle was processed twice with different versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2782,21 +2782,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <projectName>Apache Pinot</projectName>
-              </properties>
-              <resourceBundles>
-                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
-              </resourceBundles>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <properties>
+            <projectName>Apache Pinot</projectName>
+          </properties>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This is causing new jars and because of that also recompilations.

The apache-parent itself already takes care of this, no need to do it twice.
