### PR TITLE
Fixing the vulnerabilities of amazon corretto pinot-base-runtime docker image.

### DIFF
--- a/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
@@ -19,14 +19,13 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=amazoncorretto
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-al2-jdk
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-alpine3.20-jdk
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
-RUN yum update -y && \
-  yum groupinstall 'Development Tools' -y && \
-  yum install -y procps vim less wget curl git python sysstat perf libtasn1 zstd && \
-  yum clean all
+RUN apk update && \
+  apk add -q vim less wget curl git python3 sysstat procps zstd ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \
   x86_64) arch=x64; ;; \

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -20,18 +20,18 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu as builder
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS builder
 
 FROM ubuntu:24.10
+ARG JAVA_VERSION
 ENV LANG=en_US.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11
+ENV JAVA_HOME="/usr/lib/jvm/msopenjdk-${JAVA_VERSION}"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
   apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -20,19 +20,12 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS builder
-
-FROM ubuntu:24.10
-ARG JAVA_VERSION
-ENV LANG=en_US.UTF-8
-ENV JAVA_HOME="/usr/lib/jvm/msopenjdk-${JAVA_VERSION}"
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
-COPY --from=builder $JAVA_HOME $JAVA_HOME
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd ca-certificates && \
+  apt-get install -y --no-install-recommends vim less wget curl git python sysstat procps linux-tools-generic libtasn1-6 zstd && \
   rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -25,7 +25,7 @@ FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends vim less wget curl git python sysstat procps linux-tools-generic libtasn1-6 zstd && \
+  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
   rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -20,12 +20,19 @@
 ARG JAVA_VERSION=11
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
-FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu
+FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu as builder
+
+FROM ubuntu:24.10
+ENV LANG=en_US.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-11
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+COPY --from=builder $JAVA_HOME $JAVA_HOME
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd && \
+  apt-get install -y --no-install-recommends vim less wget curl git python-is-python3 sysstat procps linux-tools-generic libtasn1-6 zstd ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
 RUN case `uname -m` in \


### PR DESCRIPTION
As per https://github.com/apache/pinot/issues/13461, This PR tries to fix the vulnerabilities of the Amazon corretto jdk image. Here are some details
- There are 0 vulnerabilities in the Amazon corretto [11-al2023-jdk⁠](https://github.com/corretto/corretto-docker/blob/cdcc44b8859544a47ce8c64ed0b3cc051a8c58c8/11/jdk/al2023/Dockerfile) image, however while installing git and several other packages we get around 50 high vulnerability. The base image is Amazon Linux-based, and all the packages are installed from the Amazon repo list. Using the fedora epel repo is cumbersome; hence, in this PR, we are switching to an Alpine Linux-based image.
- Using a based image, reduced the size of the image; it is now close to 400MB only.
- With this change, there is only now 1 Medium vulnerability because of curl package

```bash
docker scout quickview 
Abhi-Sharma's-MacBook-Pro :: ~/work/pinot ‹13461-fix-amazoncorretto-vuln*› » docker scout quickview                                                                                 (sbx/consumer)
    i New version 1.13.0 available (installed version is 1.11.0) at https://github.com/docker/scout-cli
    ✓ Image stored for indexing
    ✓ Indexed 70 packages

    i Base image was auto-detected. To get more accurate results, build images with max-mode provenance attestations.
      Review docs.docker.com ↗ for more information.
      
  Target             │  local://apachepinot/pinot-base-runtime:11-amazoncorretto  │    0C     0H     1M     0L   
    digest           │  d52984cecc31                                              │                              
  Base image         │  amazoncorretto:11-alpine                                  │    0C     0H     0M     0L   
  Updated base image │  amazoncorretto:22-alpine                                  │    0C     0H     0M     0L   
                     │                                                            │                              


```

Also, I would like to highlight the [PR comment](https://github.com/apache/pinot/pull/10422/files#r1136640737) by @gortiz, I think we should follow the route suggested in the comment and also recommend two sets of Pinot images, one with [distroless image ](https://github.com/GoogleContainerTools/distroless) and other set with various packages installed.