### PR TITLE
Part-3: Working E2E Quickstart for Time Series Engine

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -38,6 +38,14 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-query-runtime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-planner</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -238,19 +238,20 @@ public class PinotClientRequest {
     }
   }
 
-  @POST
+  @GET
   @ManagedAsync
   @Produces(MediaType.APPLICATION_JSON)
   @Path("timeseries/api/v1/query_range")
   @ApiOperation(value = "Prometheus Compatible API for Pinot's Time Series Engine")
   @ManualAuthorization
-  public void processTimeSeriesQueryEnginePost(String request, @Suspended AsyncResponse asyncResponse,
-      @QueryParam("engine") String engine,
+  public void processTimeSeriesQueryEnginePost(@Suspended AsyncResponse asyncResponse,
+      @QueryParam("language") String language,
       @Context org.glassfish.grizzly.http.server.Request requestCtx,
       @Context HttpHeaders httpHeaders) {
     try {
       try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
-        PinotBrokerTimeSeriesResponse response = executeTimeSeriesQuery(engine, request, requestContext);
+        String queryString = requestCtx.getQueryString();
+        PinotBrokerTimeSeriesResponse response = executeTimeSeriesQuery(language, queryString, requestContext);
         if (response.getErrorType() != null && !response.getErrorType().isEmpty()) {
           asyncResponse.resume(Response.serverError().entity(response).build());
           return;
@@ -266,7 +267,7 @@ public class PinotClientRequest {
     }
   }
 
-  @POST
+  @GET
   @ManagedAsync
   @Produces(MediaType.APPLICATION_JSON)
   @Path("timeseries/api/v1/query")
@@ -385,9 +386,9 @@ public class PinotClientRequest {
     }
   }
 
-  private PinotBrokerTimeSeriesResponse executeTimeSeriesQuery(String engine, String queryString,
+  private PinotBrokerTimeSeriesResponse executeTimeSeriesQuery(String language, String queryString,
       RequestContext requestContext) {
-    return _requestHandler.handleTimeSeriesRequest(engine, queryString, requestContext);
+    return _requestHandler.handleTimeSeriesRequest(language, queryString, requestContext);
   }
 
   private static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -244,7 +244,7 @@ public class PinotClientRequest {
   @Path("timeseries/api/v1/query_range")
   @ApiOperation(value = "Prometheus Compatible API for Pinot's Time Series Engine")
   @ManualAuthorization
-  public void processTimeSeriesQueryEnginePost(@Suspended AsyncResponse asyncResponse,
+  public void processTimeSeriesQueryEngine(@Suspended AsyncResponse asyncResponse,
       @QueryParam("language") String language,
       @Context org.glassfish.grizzly.http.server.Request requestCtx,
       @Context HttpHeaders httpHeaders) {
@@ -273,7 +273,7 @@ public class PinotClientRequest {
   @Path("timeseries/api/v1/query")
   @ApiOperation(value = "Prometheus Compatible API for Instant Queries")
   @ManualAuthorization
-  public void processTimeSeriesInstantQueryPost(String request, @Suspended AsyncResponse asyncResponse,
+  public void processTimeSeriesInstantQuery(@Suspended AsyncResponse asyncResponse,
       @Context org.glassfish.grizzly.http.server.Request requestCtx,
       @Context HttpHeaders httpHeaders) {
     // TODO: Not implemented yet.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -61,6 +61,7 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.PinotBrokerTimeSeriesResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -69,6 +70,7 @@ import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
+import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.RequestScope;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
@@ -236,6 +238,47 @@ public class PinotClientRequest {
     }
   }
 
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("timeseries/api/v1/query_range")
+  @ApiOperation(value = "Prometheus Compatible API for Pinot's Time Series Engine")
+  @ManualAuthorization
+  public void processTimeSeriesQueryEnginePost(String request, @Suspended AsyncResponse asyncResponse,
+      @QueryParam("engine") String engine,
+      @Context org.glassfish.grizzly.http.server.Request requestCtx,
+      @Context HttpHeaders httpHeaders) {
+    try {
+      try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
+        PinotBrokerTimeSeriesResponse response = executeTimeSeriesQuery(engine, request, requestContext);
+        if (response.getErrorType() != null && !response.getErrorType().isEmpty()) {
+          asyncResponse.resume(Response.serverError().entity(response).build());
+          return;
+        }
+        asyncResponse.resume(response);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing POST request", e);
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);
+      asyncResponse.resume(Response.serverError().entity(
+              new PinotBrokerTimeSeriesResponse("error", null, e.getClass().getSimpleName(), e.getMessage()))
+          .build());
+    }
+  }
+
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("timeseries/api/v1/query")
+  @ApiOperation(value = "Prometheus Compatible API for Instant Queries")
+  @ManualAuthorization
+  public void processTimeSeriesInstantQueryPost(String request, @Suspended AsyncResponse asyncResponse,
+      @Context org.glassfish.grizzly.http.server.Request requestCtx,
+      @Context HttpHeaders httpHeaders) {
+    // TODO: Not implemented yet.
+    asyncResponse.resume(Response.ok().entity("{}").build());
+  }
+
   @DELETE
   @Path("query/{queryId}")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.CANCEL_QUERY)
@@ -340,6 +383,11 @@ public class PinotClientRequest {
         return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR,
             new UnsupportedOperationException("Unsupported SQL type - " + sqlType)));
     }
+  }
+
+  private PinotBrokerTimeSeriesResponse executeTimeSeriesQuery(String engine, String queryString,
+      RequestContext requestContext) {
+    return _requestHandler.handleTimeSeriesRequest(engine, queryString, requestContext);
   }
 
   private static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.HttpHeaders;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.PinotBrokerTimeSeriesResponse;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.RequestScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -57,6 +58,14 @@ public interface BrokerRequestHandler {
       requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
       return handleRequest(request, null, null, requestContext, null);
     }
+  }
+
+  /**
+   * Run a query and use the time-series engine.
+   */
+  default PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
+      RequestContext requestContext) {
+    throw new UnsupportedOperationException("Handler does not support Time Series requests");
   }
 
   Map<Long, String> getRunningQueries();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.broker.api.RequesterIdentity;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.queryquota.QueryQuotaManager;
+import org.apache.pinot.broker.routing.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.PinotBrokerTimeSeriesResponse;
+import org.apache.pinot.common.utils.HumanReadableDuration;
+import org.apache.pinot.query.service.dispatch.QueryDispatcher;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.apache.pinot.tsdb.planner.TimeSeriesQueryEnvironment;
+import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
+import org.apache.pinot.tsdb.spi.RangeTimeSeriesRequest;
+import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesRequestHandler.class);
+  private static final long DEFAULT_STEP_SECONDS = 60L;
+  private final TimeSeriesQueryEnvironment _queryEnvironment;
+  private final QueryDispatcher _queryDispatcher;
+
+  public TimeSeriesRequestHandler(PinotConfiguration config, String brokerId, BrokerRoutingManager routingManager,
+      AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
+      QueryDispatcher queryDispatcher) {
+    super(config, brokerId, routingManager, accessControlFactory, queryQuotaManager, tableCache);
+    _queryEnvironment = new TimeSeriesQueryEnvironment(config, routingManager, tableCache);
+    _queryEnvironment.init(config);
+    _queryDispatcher = queryDispatcher;
+  }
+
+  @Override
+  protected BrokerResponse handleRequest(long requestId, String query, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+      JsonNode request, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
+      @Nullable HttpHeaders httpHeaders, AccessControl accessControl)
+      throws Exception {
+    throw new IllegalArgumentException("Not supported yet");
+  }
+
+  @Override
+  public void start() {
+    LOGGER.info("Starting time-series request handler");
+  }
+
+  @Override
+  public void shutDown() {
+    LOGGER.info("Shutting down time-series request handler");
+  }
+
+  @Override
+  public PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
+      RequestContext requestContext) {
+    RangeTimeSeriesRequest timeSeriesRequest = null;
+    try {
+      timeSeriesRequest = buildRangeTimeSeriesRequest(lang, rawQueryParamString);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    TimeSeriesLogicalPlanResult logicalPlanResult = _queryEnvironment.buildLogicalPlan(timeSeriesRequest);
+    TimeSeriesDispatchablePlan dispatchablePlan = _queryEnvironment.buildPhysicalPlan(timeSeriesRequest, requestContext,
+        logicalPlanResult);
+    return _queryDispatcher.submitAndGet(requestContext, dispatchablePlan, 15_000L, new HashMap<>());
+  }
+
+  @Override
+  public Map<Long, String> getRunningQueries() {
+    // TODO: Implement this.
+    return Map.of();
+  }
+
+  @Override
+  public boolean cancelQuery(long queryId, int timeoutMs, Executor executor, HttpClientConnectionManager connMgr,
+      Map<String, Integer> serverResponses)
+      throws Exception {
+    // TODO: Implement this.
+    return false;
+  }
+
+  private RangeTimeSeriesRequest buildRangeTimeSeriesRequest(String engine, String rawQueryParamString)
+      throws URISyntaxException {
+    List<NameValuePair> pairs = URLEncodedUtils.parse(
+        new URI("http://localhost?" + rawQueryParamString), "UTF-8");
+    String query = null;
+    Long startTs = null;
+    Long endTs = null;
+    String step = null;
+    String timeoutStr = null;
+    for (NameValuePair nameValuePair : pairs) {
+      switch (nameValuePair.getName()) {
+        case "query":
+          query = nameValuePair.getValue();
+          break;
+        case "start":
+          startTs = Long.parseLong(nameValuePair.getValue());
+          break;
+        case "end":
+          endTs = Long.parseLong(nameValuePair.getValue());
+          break;
+        case "step":
+          step = nameValuePair.getValue();
+          break;
+        case "timeout":
+          timeoutStr = nameValuePair.getValue();
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown query parameter: " + nameValuePair.getName());
+      }
+    }
+    Preconditions.checkNotNull(query, "Query cannot be null");
+    Preconditions.checkNotNull(startTs, "Start time cannot be null");
+    Preconditions.checkNotNull(endTs, "End time cannot be null");
+    Duration timeout = Duration.ofMillis(_brokerTimeoutMs);
+    if (StringUtils.isNotBlank(timeoutStr)) {
+      timeout = HumanReadableDuration.from(timeoutStr);
+    }
+    // TODO: Pass full raw query param string to the request
+    return new RangeTimeSeriesRequest(engine, query, startTs, endTs, getStepSeconds(step), timeout);
+  }
+
+  public static Long getStepSeconds(@Nullable String step) {
+    if (step == null) {
+      return DEFAULT_STEP_SECONDS;
+    }
+    try {
+      return Long.parseLong(step);
+    } catch (NumberFormatException ignored) {
+    }
+    return HumanReadableDuration.from(step).getSeconds();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.tsdb.spi.series.TimeSeries;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+
+
+/**
+ * POJO returned by the Pinot broker in a time-series query response. Format is defined
+ * <a href="https://prometheus.io/docs/prometheus/latest/querying/api/">in the prometheus docs.</a>
+ * TODO: We will evolve this until Pinot 1.3. At present we are mimicking Prometheus HTTP API.
+ */
+@InterfaceStability.Evolving
+public class PinotBrokerTimeSeriesResponse {
+  public static final String SUCCESS_STATUS = "success";
+  public static final String ERROR_STATUS = "error";
+  public static final String METRIC_NAME_KEY = "__name__";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private String _status;
+  private Data _data;
+  private String _errorType;
+  private String _error;
+
+  static {
+    OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  @JsonCreator
+  public PinotBrokerTimeSeriesResponse(@JsonProperty("status") String status, @JsonProperty("data") Data data,
+      @JsonProperty("errorType") String errorType, @JsonProperty("error") String error) {
+    _status = status;
+    _data = data;
+    _errorType = errorType;
+    _error = error;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+
+  public Data getData() {
+    return _data;
+  }
+
+  public String getErrorType() {
+    return _errorType;
+  }
+
+  public String getError() {
+    return _error;
+  }
+
+  public String serialize()
+      throws JsonProcessingException {
+    return OBJECT_MAPPER.writeValueAsString(this);
+  }
+
+  public static PinotBrokerTimeSeriesResponse newSuccessResponse(Data data) {
+    return new PinotBrokerTimeSeriesResponse(SUCCESS_STATUS, data, null, null);
+  }
+
+  public static PinotBrokerTimeSeriesResponse newErrorResponse(String errorType, String errorMessage) {
+    return new PinotBrokerTimeSeriesResponse(ERROR_STATUS, Data.EMPTY, errorType, errorMessage);
+  }
+
+  public static PinotBrokerTimeSeriesResponse fromTimeSeriesBlock(TimeSeriesBlock seriesBlock) {
+    if (seriesBlock.getTimeBuckets() == null) {
+      throw new UnsupportedOperationException("Non-bucketed series block not supported yet");
+    }
+    return convertBucketedSeriesBlock(seriesBlock);
+  }
+
+  private static PinotBrokerTimeSeriesResponse convertBucketedSeriesBlock(TimeSeriesBlock seriesBlock) {
+    Long[] timeValues = Objects.requireNonNull(seriesBlock.getTimeBuckets()).getTimeBuckets();
+    List<PinotBrokerTimeSeriesResponse.Value> result = new ArrayList<>();
+    for (var listOfTimeSeries : seriesBlock.getSeriesMap().values()) {
+      Preconditions.checkState(!listOfTimeSeries.isEmpty(), "Received empty time-series");
+      TimeSeries anySeries = listOfTimeSeries.get(0);
+      // TODO: Ideally we should allow "aliasing" a series, and hence we should store something like a series-name.
+      //  Though in most contexts that would serve the same purpose as an ID.
+      Map<String, String> metricMap = new HashMap<>();
+      metricMap.put(METRIC_NAME_KEY, anySeries.getTagsSerialized());
+      metricMap.putAll(anySeries.getTagKeyValuesAsMap());
+      for (TimeSeries timeSeries : listOfTimeSeries) {
+        Object[][] values = new Object[timeValues.length][];
+        for (int i = 0; i < timeValues.length; i++) {
+          Object nullableValue = timeSeries.getValues()[i];
+          values[i] = new Object[]{timeValues[i], nullableValue == null ? null : nullableValue.toString()};
+        }
+        result.add(new PinotBrokerTimeSeriesResponse.Value(metricMap, values));
+      }
+    }
+    PinotBrokerTimeSeriesResponse.Data data = PinotBrokerTimeSeriesResponse.Data.newMatrix(result);
+    return PinotBrokerTimeSeriesResponse.newSuccessResponse(data);
+  }
+
+  public static class Data {
+    public static final Data EMPTY = new Data("", new ArrayList<>());
+    private final String _resultType;
+    private final List<Value> _result;
+
+    @JsonCreator
+    public Data(@JsonProperty("resultType") String resultType, @JsonProperty("result") List<Value> result) {
+      _resultType = resultType;
+      _result = result;
+    }
+
+    public String getResultType() {
+      return _resultType;
+    }
+
+    public List<Value> getResult() {
+      return _result;
+    }
+
+    public static Data newMatrix(List<Value> result) {
+      return new Data("matrix", result);
+    }
+  }
+
+  public static class Value {
+    private final Map<String, String> _metric;
+    private final Object[][] _values;
+
+    @JsonCreator
+    public Value(@JsonProperty("metric") Map<String, String> metric, @JsonProperty("values") Object[][] values) {
+      _metric = metric;
+      _values = values;
+    }
+
+    public Map<String, String> getMetric() {
+      return _metric;
+    }
+
+    public Object[][] getValues() {
+      return _values;
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/HumanReadableDuration.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/HumanReadableDuration.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class HumanReadableDuration {
+  private static final Pattern DURATION_PATTERN = Pattern.compile("(\\d+)\\s*(\\S+)");
+  private static final Map<String, TimeUnit> SUFFIXES = createSuffixes();
+
+  private HumanReadableDuration() {
+  }
+
+  private static Map<String, TimeUnit> createSuffixes() {
+    Map<String, TimeUnit> suffixes = new HashMap<>();
+    suffixes.put("ns", TimeUnit.NANOSECONDS);
+    suffixes.put("nanosecond", TimeUnit.NANOSECONDS);
+    suffixes.put("nanoseconds", TimeUnit.NANOSECONDS);
+    suffixes.put("us", TimeUnit.MICROSECONDS);
+    suffixes.put("microsecond", TimeUnit.MICROSECONDS);
+    suffixes.put("microseconds", TimeUnit.MICROSECONDS);
+    suffixes.put("ms", TimeUnit.MILLISECONDS);
+    suffixes.put("millisecond", TimeUnit.MILLISECONDS);
+    suffixes.put("milliseconds", TimeUnit.MILLISECONDS);
+    suffixes.put("s", TimeUnit.SECONDS);
+    suffixes.put("second", TimeUnit.SECONDS);
+    suffixes.put("seconds", TimeUnit.SECONDS);
+    suffixes.put("m", TimeUnit.MINUTES);
+    suffixes.put("minute", TimeUnit.MINUTES);
+    suffixes.put("minutes", TimeUnit.MINUTES);
+    suffixes.put("h", TimeUnit.HOURS);
+    suffixes.put("hour", TimeUnit.HOURS);
+    suffixes.put("hours", TimeUnit.HOURS);
+    suffixes.put("d", TimeUnit.DAYS);
+    suffixes.put("day", TimeUnit.DAYS);
+    suffixes.put("days", TimeUnit.DAYS);
+    return suffixes;
+  }
+
+  public static Duration from(String durationStr) {
+    final Matcher matcher = DURATION_PATTERN.matcher(durationStr);
+    Preconditions.checkArgument(matcher.matches(), "Invalid duration string: %s", durationStr);
+
+    final long count = Long.parseLong(matcher.group(1));
+    final TimeUnit unit = SUFFIXES.get(matcher.group(2));
+    if (unit == null) {
+      throw new IllegalArgumentException(String.format("Unknown time-unit: %s", matcher.group(2)));
+    }
+    return Duration.of(count, unit.toChronoUnit());
+  }
+}

--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -25,6 +25,8 @@ service PinotQueryWorker {
   // Dispatch a QueryRequest to a PinotQueryWorker
   rpc Submit(QueryRequest) returns (QueryResponse);
 
+  rpc SubmitTimeSeries(TimeSeriesQueryRequest) returns (TimeSeriesResponse);
+
   rpc Cancel(CancelRequest) returns (CancelResponse);
 }
 
@@ -47,6 +49,16 @@ message QueryRequest {
 message QueryResponse {
   map<string, string> metadata = 1;
   bytes payload = 2;
+}
+
+message TimeSeriesQueryRequest {
+  bytes dispatchPlan = 1;
+  map<string, string> metadata = 2;
+}
+
+message TimeSeriesResponse {
+  bytes payload = 1;
+  map<string, string> metadata = 2;
 }
 
 message StagePlan {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -171,7 +171,7 @@ public class QueryExecutorTest {
 
     // Setup time series builder factory
     TimeSeriesBuilderFactoryProvider.registerSeriesBuilderFactory(TIME_SERIES_ENGINE_NAME,
-        SimpleTimeSeriesBuilderFactory.INSTANCE);
+        new SimpleTimeSeriesBuilderFactory());
   }
 
   @Test

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -227,6 +227,16 @@
       </destName>
     </file>
     <!-- End Include Pinot Segment Uploader Plugins-->
+    <!-- Start Include Pinot Time Series Plugins -->
+    <file>
+      <source>
+        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-spql/target/pinot-timeseries-spql-${project.version}-shaded.jar
+      </source>
+      <destName>
+        plugins/pinot-timeseries-lang/pinot-timeseries-spql/pinot-timeseries-spql-${project.version}-shaded.jar
+      </destName>
+    </file>
+    <!-- End Include Pinot Time Series Plugins -->
     <!-- End Include Pinot Plugins-->
   </files>
   <fileSets>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -230,10 +230,10 @@
     <!-- Start Include Pinot Time Series Plugins -->
     <file>
       <source>
-        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-spql/target/pinot-timeseries-spql-${project.version}-shaded.jar
+        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}.jar
       </source>
       <destName>
-        plugins/pinot-timeseries-lang/pinot-timeseries-spql/pinot-timeseries-spql-${project.version}-shaded.jar
+        plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}.jar
       </destName>
     </file>
     <!-- End Include Pinot Time Series Plugins -->

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -230,10 +230,10 @@
     <!-- Start Include Pinot Time Series Plugins -->
     <file>
       <source>
-        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}.jar
+        ${pinot.root}/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/target/pinot-timeseries-m3ql-${project.version}-shaded.jar
       </source>
       <destName>
-        plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}.jar
+        plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pinot-timeseries-m3ql-${project.version}-shaded.jar
       </destName>
     </file>
     <!-- End Include Pinot Time Series Plugins -->

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -55,46 +55,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-        </configuration>
-        <executions>
-          <execution>
-            <id>assemble-all</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>org.apache.pinot.shaded.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot-timeseries-lang</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pinot-timeseries-m3ql</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>assemble-all</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>org.apache.pinot.shaded.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot-timeseries-lang</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-timeseries-m3ql</artifactId>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -55,4 +55,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/Aggregations.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/Aggregations.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql;
+
+public class Aggregations {
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/Constants.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/Constants.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql;
+
+import java.time.Duration;
+
+
+public class Constants {
+  public static final String LANGUAGE = "m3ql";
+  public static final Duration DEFAULT_RESOLUTION = Duration.ofMinutes(1);
+
+  private Constants() {
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/M3TimeSeriesPlanner.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/M3TimeSeriesPlanner.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.pinot.tsdb.m3ql.parser.Tokenizer;
+import org.apache.pinot.tsdb.m3ql.plan.KeepLastValuePlanNode;
+import org.apache.pinot.tsdb.m3ql.plan.TransformNullPlanNode;
+import org.apache.pinot.tsdb.m3ql.time.TimeBucketComputer;
+import org.apache.pinot.tsdb.spi.AggInfo;
+import org.apache.pinot.tsdb.spi.RangeTimeSeriesRequest;
+import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanResult;
+import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanner;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.ScanFilterAndProjectPlanNode;
+
+
+public class M3TimeSeriesPlanner implements TimeSeriesLogicalPlanner {
+  @Override
+  public void init(Map<String, Object> config) {
+  }
+
+  @Override
+  public TimeSeriesLogicalPlanResult plan(RangeTimeSeriesRequest request) {
+    if (!request.getLanguage().equals(Constants.LANGUAGE)) {
+      throw new IllegalArgumentException(String.format("Invalid engine id: %s. Expected: %s", request.getLanguage(),
+          Constants.LANGUAGE));
+    }
+    // Step-1: Parse and create a logical plan tree.
+    BaseTimeSeriesPlanNode planNode = planQuery(request);
+    // Step-2: Compute the time-buckets.
+    TimeBuckets timeBuckets = TimeBucketComputer.compute(planNode, request);
+    return new TimeSeriesLogicalPlanResult(planNode, timeBuckets);
+  }
+
+  public BaseTimeSeriesPlanNode planQuery(RangeTimeSeriesRequest request) {
+    PlanIdGenerator planIdGenerator = new PlanIdGenerator();
+    Tokenizer tokenizer = new Tokenizer(request.getQuery());
+    List<List<String>> commands = tokenizer.tokenize();
+    Preconditions.checkState(commands.size() > 1, "At least two commands required. "
+        + "Query should start with a fetch followed by an aggregation.");
+    BaseTimeSeriesPlanNode lastNode = null;
+    AggInfo aggInfo = null;
+    List<String> groupByColumns = new ArrayList<>();
+    BaseTimeSeriesPlanNode rootNode = null;
+    for (int commandId = commands.size() - 1; commandId >= 0; commandId--) {
+      String command = commands.get(commandId).get(0);
+      Preconditions.checkState((command.equals("fetch") && commandId == 0)
+              || (!command.equals("fetch") && commandId > 0),
+          "fetch should be the first command");
+      List<BaseTimeSeriesPlanNode> children = new ArrayList<>();
+      BaseTimeSeriesPlanNode currentNode = null;
+      switch (command) {
+        case "fetch":
+          List<String> tokens = commands.get(commandId).subList(1, commands.get(commandId).size());
+          currentNode = handleFetchNode(planIdGenerator.generateId(), tokens, children, aggInfo, groupByColumns);
+          break;
+        case "sum":
+        case "min":
+        case "max":
+          Preconditions.checkState(commandId == 1,
+              "Aggregation should be the second command (fetch should be first)");
+          Preconditions.checkState(aggInfo == null, "Aggregation already set. Only single agg allowed.");
+          aggInfo = new AggInfo(command.toUpperCase(Locale.ENGLISH));
+          if (commands.get(commandId).size() > 1) {
+            String[] cols = commands.get(commandId).get(1).split(",");
+            groupByColumns = Stream.of(cols).map(String::trim).collect(Collectors.toList());
+          }
+          break;
+        case "keepLastValue":
+          currentNode = new KeepLastValuePlanNode(planIdGenerator.generateId(), children);
+          break;
+        case "transformNull":
+          Double defaultValue = TransformNullPlanNode.DEFAULT_VALUE;
+          if (commands.get(commandId).size() > 1) {
+            defaultValue = Double.parseDouble(commands.get(commandId).get(1));
+          }
+          currentNode = new TransformNullPlanNode(planIdGenerator.generateId(), defaultValue, children);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown function: " + command);
+      }
+      if (currentNode != null) {
+        if (rootNode == null) {
+          rootNode = currentNode;
+        }
+        if (lastNode != null) {
+          lastNode.addChildNode(currentNode);
+        }
+        lastNode = currentNode;
+      }
+    }
+    return rootNode;
+  }
+
+  public BaseTimeSeriesPlanNode handleFetchNode(String planId, List<String> tokens,
+      List<BaseTimeSeriesPlanNode> children, AggInfo aggInfo, List<String> groupByColumns) {
+    Preconditions.checkState(tokens.size() % 2 == 0, "Mismatched args");
+    String tableName = null;
+    String timeColumn = null;
+    TimeUnit timeUnit = null;
+    String filter = "";
+    String valueExpr = null;
+    for (int idx = 0; idx < tokens.size(); idx += 2) {
+      String key = tokens.get(idx);
+      String value = tokens.get(idx + 1);
+      switch (key) {
+        case "table":
+          tableName = value.replaceAll("\"", "");
+          break;
+        case "ts_column":
+          timeColumn = value.replaceAll("\"", "");
+          break;
+        case "ts_unit":
+          timeUnit = TimeUnit.valueOf(value.replaceAll("\"", "").toUpperCase(Locale.ENGLISH));
+          break;
+        case "filter":
+          filter = value.replaceAll("\"", "");
+          break;
+        case "value":
+          valueExpr = value.replaceAll("\"", "");
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown key: " + key);
+      }
+    }
+    Preconditions.checkNotNull(tableName, "Table name not set. Set via table=");
+    Preconditions.checkNotNull(timeColumn, "Time column not set. Set via time_col=");
+    Preconditions.checkNotNull(timeUnit, "Time unit not set. Set via time_unit=");
+    Preconditions.checkNotNull(valueExpr, "Value expression not set. Set via value=");
+    return new ScanFilterAndProjectPlanNode(planId, children, tableName, timeColumn, timeUnit, 0L, filter, valueExpr,
+        aggInfo, groupByColumns);
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/PlanIdGenerator.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/PlanIdGenerator.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql;
+
+public class PlanIdGenerator {
+  private Integer _id = 0;
+
+  public PlanIdGenerator() {
+  }
+
+  public String generateId() {
+    return "plan_" + (_id++);
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/operator/KeepLastValueOperator.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/operator/KeepLastValueOperator.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.operator;
+
+import java.util.List;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.series.TimeSeries;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+
+
+public class KeepLastValueOperator extends BaseTimeSeriesOperator {
+  public KeepLastValueOperator(List<BaseTimeSeriesOperator> childOperators) {
+    super(childOperators);
+  }
+
+  @Override
+  public TimeSeriesBlock getNextBlock() {
+    TimeSeriesBlock seriesBlock = _childOperators.get(0).nextBlock();
+    seriesBlock.getSeriesMap().values().parallelStream().forEach(unionOfSeries -> {
+      for (TimeSeries series : unionOfSeries) {
+        Double[] values = series.getValues();
+        Double lastValue = null;
+        for (int index = 0; index < values.length; index++) {
+          if (values[index] != null) {
+            lastValue = values[index];
+          } else {
+            values[index] = lastValue;
+          }
+        }
+      }
+    });
+    return seriesBlock;
+  }
+
+  @Override
+  public String getExplainName() {
+    return "KEEP_LAST_VALUE";
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/operator/TransformNullOperator.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/operator/TransformNullOperator.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.operator;
+
+import java.util.List;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.series.TimeSeries;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+
+
+public class TransformNullOperator extends BaseTimeSeriesOperator {
+  private final Double _defaultValue;
+
+  public TransformNullOperator(Double defaultValue, List<BaseTimeSeriesOperator> childOperators) {
+    super(childOperators);
+    _defaultValue = defaultValue;
+  }
+
+  @Override
+  public TimeSeriesBlock getNextBlock() {
+    TimeSeriesBlock seriesBlock = _childOperators.get(0).nextBlock();
+    seriesBlock.getSeriesMap().values().parallelStream().forEach(unionOfSeries -> {
+      for (TimeSeries series : unionOfSeries) {
+        Double[] values = series.getValues();
+        for (int index = 0; index < values.length; index++) {
+          values[index] = values[index] == null ? _defaultValue : values[index];
+        }
+      }
+    });
+    return seriesBlock;
+  }
+
+  @Override
+  public String getExplainName() {
+    return "TRANSFORM_NULL";
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/parser/Tokenizer.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/parser/Tokenizer.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+/**
+* TODO: Dummy implementation. Will be switched out with a proper implementation soon.
+*/
 public class Tokenizer {
   private final String _query;
 

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/parser/Tokenizer.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/parser/Tokenizer.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.parser;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class Tokenizer {
+  private final String _query;
+
+  public Tokenizer(String query) {
+    _query = query;
+  }
+
+  public List<List<String>> tokenize() {
+    String[] pipelines = _query.split("\\|");
+    List<List<String>> result = new ArrayList<>();
+    for (String pipeline : pipelines) {
+      String command = pipeline.trim().substring(0, pipeline.indexOf("{"));
+      if (command.equals("fetch")) {
+        result.add(consumeFetch(pipeline.trim()));
+      } else {
+        result.add(consumeGeneric(pipeline.trim()));
+      }
+    }
+    return result;
+  }
+
+  private List<String> consumeFetch(String pipeline) {
+    pipeline = pipeline.trim();
+    String command = pipeline.substring(0, 5);
+    Preconditions.checkState(command.equals("fetch"), "Invalid command: %s", command);
+    pipeline = pipeline.substring(5).trim();
+    int start = pipeline.indexOf("{");
+    int end = pipeline.indexOf("}");
+    String args = pipeline.substring(start + 1, end);
+    List<String> result = new ArrayList<>();
+    result.add("fetch");
+    int indexOfEquals = args.indexOf("=");
+    while (indexOfEquals != -1) {
+      args = args.strip();
+      int equalIndex = args.indexOf("=");
+      int indexOfQuotes = args.indexOf("\"");
+      int lastQuote = indexOfQuotes + 1 + args.substring(indexOfQuotes + 1).indexOf("\"");
+      String key = args.substring(0, equalIndex);
+      String value = args.substring(indexOfQuotes + 1, lastQuote);
+      args = args.substring(lastQuote + 1);
+      result.add(key);
+      result.add(value);
+      if (args.strip().startsWith(",")) {
+        args = args.strip().substring(1);
+      }
+      indexOfEquals = args.indexOf("=");
+    }
+    return result;
+  }
+
+  private List<String> consumeGeneric(String pipeline) {
+    List<String> result = new ArrayList<>();
+    int indexOfOpenBracket = pipeline.indexOf("{");
+    int indexOfClosedBracket = pipeline.indexOf("}");
+    result.add(pipeline.substring(0, indexOfOpenBracket));
+    result.add(pipeline.substring(indexOfOpenBracket + 1, indexOfClosedBracket));
+    return result;
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/KeepLastValuePlanNode.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/KeepLastValuePlanNode.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.apache.pinot.tsdb.m3ql.operator.KeepLastValueOperator;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+
+
+public class KeepLastValuePlanNode extends BaseTimeSeriesPlanNode {
+  @JsonCreator
+  public KeepLastValuePlanNode(@JsonProperty("id") String id,
+      @JsonProperty("children") List<BaseTimeSeriesPlanNode> children) {
+    super(id, children);
+  }
+
+  @Override
+  public String getKlass() {
+    return KeepLastValuePlanNode.class.getName();
+  }
+
+  @Override
+  public String getExplainName() {
+    return "KEEP_LAST_VALUE";
+  }
+
+  @Override
+  public BaseTimeSeriesOperator run() {
+    BaseTimeSeriesOperator childOperator = _children.get(0).run();
+    return new KeepLastValueOperator(List.of(childOperator));
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.pinot.tsdb.m3ql.operator.TransformNullOperator;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+
+
+public class TransformNullPlanNode extends BaseTimeSeriesPlanNode {
+  public static final Double DEFAULT_VALUE = 0.0;
+  private final Double _defaultValue;
+
+  @JsonCreator
+  public TransformNullPlanNode(@JsonProperty("id") String id, @JsonProperty("defaultValue") Double defaultValue,
+      @JsonProperty("children") List<BaseTimeSeriesPlanNode> children) {
+    super(id, children);
+    _defaultValue = defaultValue;
+  }
+
+  public Double getDefaultValue() {
+    return _defaultValue;
+  }
+
+  @Override
+  public String getKlass() {
+    return TransformNullPlanNode.class.getName();
+  }
+
+  @Override
+  public String getExplainName() {
+    return "TRANSFORM_NULL";
+  }
+
+  @Override
+  public BaseTimeSeriesOperator run() {
+    Preconditions.checkState(_children.size() == 1,
+        "TransformNullPlanNode should have only 1 child, got: %s", _children.size());
+    BaseTimeSeriesOperator childOperator = _children.get(0).run();
+    return new TransformNullOperator(_defaultValue, ImmutableList.of(childOperator));
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/QueryTimeBoundaryConstraints.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/QueryTimeBoundaryConstraints.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.time;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class QueryTimeBoundaryConstraints {
+  private final Set<Long> _divisors = new HashSet<>();
+  private long _leftExtensionSeconds = 0;
+  private long _rightExtensionSeconds = 0;
+  private boolean _leftAligned = false;
+
+  public Set<Long> getDivisors() {
+    return _divisors;
+  }
+
+  public long getLeftExtensionSeconds() {
+    return _leftExtensionSeconds;
+  }
+
+  public void setLeftExtensionSeconds(long leftExtensionSeconds) {
+    _leftExtensionSeconds = leftExtensionSeconds;
+  }
+
+  public long getRightExtensionSeconds() {
+    return _rightExtensionSeconds;
+  }
+
+  public void setRightExtensionSeconds(long rightExtensionSeconds) {
+    _rightExtensionSeconds = rightExtensionSeconds;
+  }
+
+  public boolean isLeftAligned() {
+    return _leftAligned;
+  }
+
+  public void setLeftAligned(boolean leftAligned) {
+    _leftAligned = leftAligned;
+  }
+
+  public static QueryTimeBoundaryConstraints merge(QueryTimeBoundaryConstraints left,
+      QueryTimeBoundaryConstraints right) {
+    QueryTimeBoundaryConstraints merged = new QueryTimeBoundaryConstraints();
+    merged._divisors.addAll(left._divisors);
+    merged._divisors.addAll(right._divisors);
+    merged._leftExtensionSeconds = Math.max(left._leftExtensionSeconds, right._leftExtensionSeconds);
+    merged._rightExtensionSeconds = Math.max(left._rightExtensionSeconds, right._rightExtensionSeconds);
+    if (left._leftAligned != right._leftAligned) {
+      throw new IllegalArgumentException(String.format("Cannot merge constraints with different alignments. "
+              + "Alignment from plan node on the left and right are %s and %s respectively",
+          left._leftAligned, right._leftAligned));
+    }
+    merged._leftAligned = left._leftAligned;
+    return merged;
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/TimeBucketComputer.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/TimeBucketComputer.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.m3ql.time;
+
+import java.time.Duration;
+import java.util.Collection;
+import org.apache.pinot.tsdb.spi.RangeTimeSeriesRequest;
+import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.ScanFilterAndProjectPlanNode;
+
+
+public class TimeBucketComputer {
+  private TimeBucketComputer() {
+  }
+
+  public static TimeBuckets compute(BaseTimeSeriesPlanNode planNode, RangeTimeSeriesRequest request) {
+    QueryTimeBoundaryConstraints constraints = process(planNode, request);
+    long newStartTime = request.getStartSeconds() - constraints.getLeftExtensionSeconds();
+    long newEndTime = request.getEndSeconds() + constraints.getRightExtensionSeconds();
+    long lcmOfDivisors = lcm(constraints.getDivisors());
+    long roundStartTimeDelta = (lcmOfDivisors - (newEndTime - newStartTime) % lcmOfDivisors) % lcmOfDivisors;
+    newStartTime -= roundStartTimeDelta;
+    int numItems = (int) ((newEndTime - newStartTime) / request.getStepSeconds());
+    return TimeBuckets.ofSeconds(newStartTime, Duration.ofSeconds(request.getStepSeconds()), numItems);
+  }
+
+  public static QueryTimeBoundaryConstraints process(BaseTimeSeriesPlanNode planNode, RangeTimeSeriesRequest request) {
+    if (planNode instanceof ScanFilterAndProjectPlanNode) {
+      QueryTimeBoundaryConstraints constraints = new QueryTimeBoundaryConstraints();
+      constraints.getDivisors().add(request.getStepSeconds());
+      return constraints;
+    }
+    QueryTimeBoundaryConstraints constraints = new QueryTimeBoundaryConstraints();
+    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+      QueryTimeBoundaryConstraints childConstraints = process(childNode, request);
+      constraints = QueryTimeBoundaryConstraints.merge(constraints, childConstraints);
+    }
+    return constraints;
+  }
+
+  public static long lcm(Collection<Long> values) {
+    long result = 1;
+    for (long value : values) {
+      result = lcm(result, value);
+    }
+    return result;
+  }
+
+  public static long lcm(long a, long b) {
+    return a * b / gcd(a, b);
+  }
+
+  public static long gcd(long a, long b) {
+    if (a < b) {
+      return gcd(b, a);
+    }
+    if (b == 0) {
+      return a;
+    }
+    return gcd(b, a % b);
+  }
+}

--- a/pinot-plugins/pinot-timeseries-lang/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot-plugins</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pinot-timeseries-lang</artifactId>

--- a/pinot-plugins/pinot-timeseries-lang/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pom.xml
@@ -25,21 +25,22 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pinot</groupId>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-plugins</artifactId>
     <version>1.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <packaging>pom</packaging>
 
-  <artifactId>pinot-timeseries</artifactId>
+  <artifactId>pinot-timeseries-lang</artifactId>
+  <packaging>pom</packaging>
+  <name>Pluggable Pinot Time Series Languages</name>
 
   <properties>
-    <pinot.root>${basedir}/..</pinot.root>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <plugin.type>pinot-ts-languages</plugin.type>
   </properties>
 
   <modules>
-    <module>pinot-timeseries-spi</module>
-    <module>pinot-timeseries-planner</module>
+    <module>pinot-timeseries-m3ql</module>
   </modules>
 
 </project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -48,6 +48,7 @@
     <module>pinot-segment-uploader</module>
     <module>pinot-environment</module>
     <module>assembly-descriptor</module>
+    <module>pinot-timeseries-lang</module>
   </modules>
 
   <build>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>pinot</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>pinot-plugins</artifactId>
   <packaging>pom</packaging>

--- a/pinot-query-runtime/pom.xml
+++ b/pinot-query-runtime/pom.xml
@@ -40,6 +40,14 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-query-planner</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-planner</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -68,11 +69,13 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerRequestMetadataKeys;
 import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerResponseMetadataKeys;
+import org.apache.pinot.tsdb.spi.PinotTimeSeriesConfiguration;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
 import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
 import org.apache.pinot.tsdb.spi.plan.serde.TimeSeriesPlanSerde;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactoryProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,6 +148,10 @@ public class QueryRunner {
           serverMetrics);
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+    if (StringUtils.isNotBlank(config.getProperty(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey()))) {
+      PhysicalTimeSeriesPlanVisitor.INSTANCE.init(_leafQueryExecutor, _executorService, serverMetrics);
+      TimeSeriesBuilderFactoryProvider.init(config);
     }
 
     LOGGER.info("Initialized QueryRunner with hostname: {}, port: {}", hostname, port);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/LeafTimeSeriesOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/LeafTimeSeriesOperator.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.timeseries;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.operator.blocks.results.TimeSeriesResultsBlock;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+
+
+public class LeafTimeSeriesOperator extends BaseTimeSeriesOperator {
+  private final ServerQueryRequest _request;
+  private final QueryExecutor _queryExecutor;
+  private final ExecutorService _executorService;
+
+  public LeafTimeSeriesOperator(ServerQueryRequest serverQueryRequest, QueryExecutor queryExecutor,
+      ExecutorService executorService) {
+    super(Collections.emptyList());
+    _request = serverQueryRequest;
+    _queryExecutor = queryExecutor;
+    _executorService = executorService;
+  }
+
+  @Override
+  public TimeSeriesBlock getNextBlock() {
+    Preconditions.checkNotNull(_queryExecutor, "Leaf time series operator has not been initialized");
+    InstanceResponseBlock instanceResponseBlock = _queryExecutor.execute(_request, _executorService);
+    assert instanceResponseBlock.getResultsBlock() instanceof TimeSeriesResultsBlock;
+    if (MapUtils.isNotEmpty(instanceResponseBlock.getExceptions())) {
+      // TODO: Return error in the TimeSeriesBlock instead?
+      String oneException = instanceResponseBlock.getExceptions().values().iterator().next();
+      throw new RuntimeException(oneException);
+    }
+    return ((TimeSeriesResultsBlock) instanceResponseBlock.getResultsBlock()).getTimeSeriesBlock();
+  }
+
+  @Override
+  public String getExplainName() {
+    return "TIME_SERIES_LEAF_STAGE_OPERATOR";
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.timeseries;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.common.request.context.TimeSeriesContext;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.ScanFilterAndProjectPlanNode;
+
+
+public class PhysicalTimeSeriesPlanVisitor {
+  public static final PhysicalTimeSeriesPlanVisitor INSTANCE = new PhysicalTimeSeriesPlanVisitor();
+
+  private QueryExecutor _queryExecutor;
+  private ExecutorService _executorService;
+  private ServerMetrics _serverMetrics;
+
+  private PhysicalTimeSeriesPlanVisitor() {
+  }
+
+  public void init(QueryExecutor queryExecutor, ExecutorService executorService, ServerMetrics serverMetrics) {
+    _queryExecutor = queryExecutor;
+    _executorService = executorService;
+    _serverMetrics = serverMetrics;
+  }
+
+  public BaseTimeSeriesOperator compile(BaseTimeSeriesPlanNode rootNode, TimeSeriesExecutionContext context) {
+    // Step-1: Replace scan filter project with our physical plan node with Pinot Core and Runtime context
+    initLeafPlanNode(rootNode, context);
+    // Step-2: Trigger recursive operator generation
+    return rootNode.run();
+  }
+
+  public void initLeafPlanNode(BaseTimeSeriesPlanNode planNode, TimeSeriesExecutionContext context) {
+    for (int index = 0; index < planNode.getChildren().size(); index++) {
+      BaseTimeSeriesPlanNode childNode = planNode.getChildren().get(index);
+      if (childNode instanceof ScanFilterAndProjectPlanNode) {
+        ScanFilterAndProjectPlanNode sfpNode = (ScanFilterAndProjectPlanNode) childNode;
+        List<String> segments = context.getPlanIdToSegmentsMap().get(sfpNode.getId());
+        ServerQueryRequest serverQueryRequest = compileLeafServerQueryRequest(sfpNode, segments, context);
+        TimeSeriesPhysicalTableScan physicalTableScan = new TimeSeriesPhysicalTableScan(childNode.getId(),
+            serverQueryRequest, _queryExecutor, _executorService);
+        planNode.getChildren().set(index, physicalTableScan);
+      } else {
+        initLeafPlanNode(childNode, context);
+      }
+    }
+  }
+
+  public ServerQueryRequest compileLeafServerQueryRequest(ScanFilterAndProjectPlanNode sfpNode, List<String> segments,
+      TimeSeriesExecutionContext context) {
+    return new ServerQueryRequest(compileQueryContext(sfpNode, context),
+        segments, /* TODO: Pass metadata from request */ Collections.emptyMap(), _serverMetrics);
+  }
+
+  public QueryContext compileQueryContext(ScanFilterAndProjectPlanNode sfpNode, TimeSeriesExecutionContext context) {
+    FilterContext filterContext =
+        RequestContextUtils.getFilter(CalciteSqlParser.compileToExpression(
+            sfpNode.getEffectiveFilter(context.getInitialTimeBuckets())));
+    List<ExpressionContext> groupByExpressions = sfpNode.getGroupByColumns().stream()
+        .map(ExpressionContext::forIdentifier).collect(Collectors.toList());
+    ExpressionContext valueExpression = RequestContextUtils.getExpression(sfpNode.getValueExpression());
+    TimeSeriesContext timeSeriesContext = new TimeSeriesContext(context.getLanguage(),
+        sfpNode.getTimeColumn(),
+        sfpNode.getTimeUnit(), context.getInitialTimeBuckets(), sfpNode.getOffset(),
+        valueExpression,
+        sfpNode.getAggInfo());
+    return new QueryContext.Builder()
+        .setTableName(sfpNode.getTableName())
+        .setFilter(filterContext)
+        .setGroupByExpressions(groupByExpressions)
+        .setSelectExpressions(Collections.emptyList())
+        .setQueryOptions(Collections.emptyMap())
+        .setAliasList(Collections.emptyList())
+        .setTimeSeriesContext(timeSeriesContext)
+        .setLimit(Integer.MAX_VALUE)
+        .build();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
@@ -16,35 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.tsdb.spi.series;
+package org.apache.pinot.query.runtime.timeseries;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 
 
-/**
- * Block used by time series operators. We store the series data in a map keyed by the series' ID. The value is a
- * list of series, because some query languages support "union" operations which allow series with the same tags/labels
- * to exist either in the query response or temporarily during execution before some n-ary series function
- * is applied.
- */
-public class TimeSeriesBlock {
-  private final TimeBuckets _timeBuckets;
-  private final Map<Long, List<TimeSeries>> _seriesMap;
+public class TimeSeriesExecutionContext {
+  private final String _language;
+  private final TimeBuckets _initialTimeBuckets;
+  private final Map<String, List<String>> _planIdToSegmentsMap;
 
-  public TimeSeriesBlock(@Nullable TimeBuckets timeBuckets, Map<Long, List<TimeSeries>> seriesMap) {
-    _timeBuckets = timeBuckets;
-    _seriesMap = seriesMap;
+  public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets,
+      Map<String, List<String>> planIdToSegmentsMap) {
+    _language = language;
+    _initialTimeBuckets = initialTimeBuckets;
+    _planIdToSegmentsMap = planIdToSegmentsMap;
   }
 
-  @Nullable
-  public TimeBuckets getTimeBuckets() {
-    return _timeBuckets;
+  public String getLanguage() {
+    return _language;
   }
 
-  public Map<Long, List<TimeSeries>> getSeriesMap() {
-    return _seriesMap;
+  public TimeBuckets getInitialTimeBuckets() {
+    return _initialTimeBuckets;
+  }
+
+  public Map<String, List<String>> getPlanIdToSegmentsMap() {
+    return _planIdToSegmentsMap;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.timeseries;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+
+
+public class TimeSeriesPhysicalTableScan extends BaseTimeSeriesPlanNode {
+  private final ServerQueryRequest _request;
+  private final QueryExecutor _queryExecutor;
+  private final ExecutorService _executorService;
+
+  public TimeSeriesPhysicalTableScan(
+      String id,
+      ServerQueryRequest serverQueryRequest,
+      QueryExecutor queryExecutor,
+      ExecutorService executorService) {
+    super(id, Collections.emptyList());
+    _request = serverQueryRequest;
+    _queryExecutor = queryExecutor;
+    _executorService = executorService;
+  }
+
+  public ServerQueryRequest getServerQueryRequest() {
+    return _request;
+  }
+
+  public QueryExecutor getQueryExecutor() {
+    return _queryExecutor;
+  }
+
+  public ExecutorService getExecutorService() {
+    return _executorService;
+  }
+
+  public String getKlass() {
+    return TimeSeriesPhysicalTableScan.class.getName();
+  }
+
+  @Override
+  public String getExplainName() {
+    return "PHYSICAL_TABLE_SCAN";
+  }
+
+  @Override
+  public BaseTimeSeriesOperator run() {
+    return new LeafTimeSeriesOperator(_request, _queryExecutor, _executorService);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/AsyncQueryTimeSeriesDispatchResponse.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/AsyncQueryTimeSeriesDispatchResponse.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch.timeseries;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.query.routing.QueryServerInstance;
+
+
+/**
+ * Response of the broker dispatch to the server.
+ * TODO: This shouldn't exist and we should re-use AsyncQueryDispatchResponse. TBD as part of multi-stage
+ *   engine integration.
+ */
+public class AsyncQueryTimeSeriesDispatchResponse {
+  private final QueryServerInstance _serverInstance;
+  private final Worker.TimeSeriesResponse _queryResponse;
+  private final Throwable _throwable;
+
+  public AsyncQueryTimeSeriesDispatchResponse(QueryServerInstance serverInstance,
+      @Nullable Worker.TimeSeriesResponse queryResponse,
+      @Nullable Throwable throwable) {
+    _serverInstance = serverInstance;
+    _queryResponse = queryResponse;
+    _throwable = throwable;
+  }
+
+  public QueryServerInstance getServerInstance() {
+    return _serverInstance;
+  }
+
+  @Nullable
+  public Worker.TimeSeriesResponse getQueryResponse() {
+    return _queryResponse;
+  }
+
+  @Nullable
+  public Throwable getThrowable() {
+    return _throwable;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch.timeseries;
+
+import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.util.function.Consumer;
+import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.query.routing.QueryServerInstance;
+
+
+/**
+ * Dispatch client used to dispatch a runnable plan to the server.
+ * TODO: This shouldn't exist and we should re-use DispatchClient. TBD as part of multi-stage
+ *   engine integration.
+ */
+public class TimeSeriesDispatchClient {
+  private final ManagedChannel _channel;
+  private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
+
+  public TimeSeriesDispatchClient(String host, int port) {
+    _channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+    _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);
+  }
+
+  public ManagedChannel getChannel() {
+    return _channel;
+  }
+
+  public void submit(Worker.TimeSeriesQueryRequest request, QueryServerInstance virtualServer, Deadline deadline,
+      Consumer<AsyncQueryTimeSeriesDispatchResponse> callback) {
+    _dispatchStub.withDeadline(deadline).submitTimeSeries(
+        request, new TimeSeriesDispatchObserver(virtualServer, callback));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchObserver.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch.timeseries;
+
+import io.grpc.stub.StreamObserver;
+import java.util.function.Consumer;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.query.routing.QueryServerInstance;
+
+
+/**
+ * Response observer for a time-series query request.
+ * TODO: This shouldn't exist and we should re-use DispatchObserver. TBD as part of multi-stage
+ *   engine integration.
+ */
+public class TimeSeriesDispatchObserver implements StreamObserver<Worker.TimeSeriesResponse> {
+  private final QueryServerInstance _serverInstance;
+  private final Consumer<AsyncQueryTimeSeriesDispatchResponse> _callback;
+
+  private Worker.TimeSeriesResponse _timeSeriesResponse;
+
+  public TimeSeriesDispatchObserver(QueryServerInstance serverInstance,
+      Consumer<AsyncQueryTimeSeriesDispatchResponse> callback) {
+    _serverInstance = serverInstance;
+    _callback = callback;
+  }
+
+  @Override
+  public void onNext(Worker.TimeSeriesResponse timeSeriesResponse) {
+    _timeSeriesResponse = timeSeriesResponse;
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    _callback.accept(
+        new AsyncQueryTimeSeriesDispatchResponse(
+            _serverInstance,
+            Worker.TimeSeriesResponse.getDefaultInstance(),
+            throwable));
+  }
+
+  @Override
+  public void onCompleted() {
+    _callback.accept(
+        new AsyncQueryTimeSeriesDispatchResponse(
+            _serverInstance,
+            _timeSeriesResponse,
+            null));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.service.server;
 
+import com.google.protobuf.ByteString;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
@@ -190,6 +191,13 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
         Worker.QueryResponse.newBuilder().putMetadata(CommonConstants.Query.Response.ServerResponseStatus.STATUS_OK, "")
             .build());
     responseObserver.onCompleted();
+  }
+
+  @Override
+  public void submitTimeSeries(Worker.TimeSeriesQueryRequest request,
+      StreamObserver<Worker.TimeSeriesResponse> responseObserver) {
+    ByteString bytes = request.getDispatchPlan();
+    _queryRunner.processTimeSeriesQuery(bytes.toStringUtf8(), request.getMetadataMap(), responseObserver);
   }
 
   @Override

--- a/pinot-timeseries/pinot-timeseries-planner/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-planner/pom.xml
@@ -27,19 +27,32 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
-  <packaging>pom</packaging>
 
-  <artifactId>pinot-timeseries</artifactId>
+  <artifactId>pinot-timeseries-planner</artifactId>
 
   <properties>
-    <pinot.root>${basedir}/..</pinot.root>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <modules>
-    <module>pinot-timeseries-spi</module>
-    <module>pinot-timeseries-planner</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-timeseries-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/pinot-timeseries/pinot-timeseries-planner/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-planner/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pinot</groupId>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-timeseries</artifactId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
 

--- a/pinot-timeseries/pinot-timeseries-planner/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-planner/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>pinot-timeseries-planner</artifactId>

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.planner;
+
+public class TimeSeriesPlanConstants {
+  private TimeSeriesPlanConstants() {
+  }
+
+  public static class WorkerRequestMetadataKeys {
+    private static final String SEGMENT_MAP_ENTRY_PREFIX = "$segmentMapEntry#";
+
+    private WorkerRequestMetadataKeys() {
+    }
+
+    public static final String LANGUAGE = "language";
+    public static final String START_TIME_SECONDS = "startTimeSeconds";
+    public static final String WINDOW_SECONDS = "windowSeconds";
+    public static final String NUM_ELEMENTS = "numElements";
+
+    public static boolean isKeySegmentList(String key) {
+      return key.startsWith(SEGMENT_MAP_ENTRY_PREFIX);
+    }
+
+    public static String encodeSegmentListKey(String planId) {
+      return SEGMENT_MAP_ENTRY_PREFIX + planId;
+    }
+
+    /**
+     * Returns the plan-id corresponding to the encoded key.
+     */
+    public static String decodeSegmentListKey(String key) {
+      return key.substring(SEGMENT_MAP_ENTRY_PREFIX.length());
+    }
+  }
+
+  public static class WorkerResponseMetadataKeys {
+    public static final String ERROR_TYPE = "errorType";
+    public static final String ERROR_MESSAGE = "error";
+  }
+}

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.planner;
+
+import com.google.common.base.Preconditions;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.DataSource;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.tsdb.planner.physical.TableScanVisitor;
+import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
+import org.apache.pinot.tsdb.planner.physical.TimeSeriesQueryServerInstance;
+import org.apache.pinot.tsdb.spi.PinotTimeSeriesConfiguration;
+import org.apache.pinot.tsdb.spi.RangeTimeSeriesRequest;
+import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanResult;
+import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanner;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.ScanFilterAndProjectPlanNode;
+import org.apache.pinot.tsdb.spi.plan.serde.TimeSeriesPlanSerde;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TimeSeriesQueryEnvironment {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesQueryEnvironment.class);
+  private final RoutingManager _routingManager;
+  private final TableCache _tableCache;
+  private final Map<String, TimeSeriesLogicalPlanner> _plannerMap = new HashMap<>();
+
+  public TimeSeriesQueryEnvironment(PinotConfiguration config, RoutingManager routingManager, TableCache tableCache) {
+    _routingManager = routingManager;
+    _tableCache = tableCache;
+  }
+
+  public void init(PinotConfiguration config) {
+    String[] languages = config.getProperty(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey(), "")
+        .split(",");
+    LOGGER.info("Found {} configured time series languages. List: {}", languages.length, languages);
+    for (String language : languages) {
+      String configPrefix = PinotTimeSeriesConfiguration.getLogicalPlannerConfigKey(language);
+      String klassName =
+          config.getProperty(PinotTimeSeriesConfiguration.getLogicalPlannerConfigKey(language));
+      Preconditions.checkNotNull(klassName, "Logical planner class not found for language: " + language);
+      // Create the planner with empty constructor
+      try {
+        Class<?> klass = TimeSeriesQueryEnvironment.class.getClassLoader().loadClass(klassName);
+        Constructor<?> constructor = klass.getConstructor();
+        TimeSeriesLogicalPlanner planner = (TimeSeriesLogicalPlanner) constructor.newInstance();
+        planner.init(config.subset(configPrefix).toMap());
+        _plannerMap.put(language, planner);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to instantiate logical planner for language: " + language, e);
+      }
+    }
+    TableScanVisitor.INSTANCE.init(_routingManager);
+  }
+
+  public TimeSeriesLogicalPlanResult buildLogicalPlan(RangeTimeSeriesRequest request) {
+    Preconditions.checkState(_plannerMap.containsKey(request.getLanguage()),
+        "No logical planner found for engine: %s. Available: %s", request.getLanguage(),
+        _plannerMap.keySet());
+    return _plannerMap.get(request.getLanguage()).plan(request);
+  }
+
+  public TimeSeriesDispatchablePlan buildPhysicalPlan(RangeTimeSeriesRequest timeSeriesRequest,
+      RequestContext requestContext, TimeSeriesLogicalPlanResult logicalPlan) {
+    // Step-1: Find tables in the query.
+    final Set<String> tableNames = new HashSet<>();
+    findTableNames(logicalPlan.getPlanNode(), tableNames::add);
+    Preconditions.checkState(tableNames.size() == 1,
+        "Expected exactly one table name in the logical plan, got: %s",
+        tableNames);
+    String tableName = tableNames.iterator().next();
+    // Step-2: Compute routing table assuming all segments are selected. This is to perform the check to reject tables
+    //         that span across multiple servers.
+    RoutingTable routingTable = _routingManager.getRoutingTable(compileBrokerRequest(tableName),
+        requestContext.getRequestId());
+    Preconditions.checkState(routingTable != null,
+        "Failed to get routing table for table: %s", tableName);
+    Preconditions.checkState(routingTable.getServerInstanceToSegmentsMap().size() == 1,
+        "Only support routing to a single server. Computed: %s",
+        routingTable.getServerInstanceToSegmentsMap().size());
+    var entry = routingTable.getServerInstanceToSegmentsMap().entrySet().iterator().next();
+    ServerInstance serverInstance = entry.getKey();
+    // Step-3: Assign segments to the leaf plan nodes.
+    TableScanVisitor.Context scanVisitorContext = TableScanVisitor.createContext(requestContext.getRequestId());
+    TableScanVisitor.INSTANCE.assignSegmentsToPlan(logicalPlan.getPlanNode(), logicalPlan.getTimeBuckets(),
+        scanVisitorContext);
+    return new TimeSeriesDispatchablePlan(timeSeriesRequest.getLanguage(),
+        new TimeSeriesQueryServerInstance(serverInstance),
+        TimeSeriesPlanSerde.serialize(logicalPlan.getPlanNode()), logicalPlan.getTimeBuckets(),
+        scanVisitorContext.getPlanIdToSegmentMap());
+  }
+
+  public static void findTableNames(BaseTimeSeriesPlanNode planNode, Consumer<String> tableNameConsumer) {
+    if (planNode instanceof ScanFilterAndProjectPlanNode) {
+      ScanFilterAndProjectPlanNode scanNode = (ScanFilterAndProjectPlanNode) planNode;
+      tableNameConsumer.accept(scanNode.getTableName());
+      return;
+    }
+    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+      findTableNames(childNode, tableNameConsumer);
+    }
+  }
+
+  private BrokerRequest compileBrokerRequest(String tableName) {
+    DataSource dataSource = new DataSource();
+    dataSource.setTableName(tableName);
+    PinotQuery pinotQuery = new PinotQuery();
+    pinotQuery.setDataSource(dataSource);
+    QuerySource querySource = new QuerySource();
+    querySource.setTableName(tableName);
+    BrokerRequest dummyRequest = new BrokerRequest();
+    dummyRequest.setPinotQuery(pinotQuery);
+    dummyRequest.setQuerySource(querySource);
+    return dummyRequest;
+  }
+}

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.planner.physical;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.DataSource;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.ScanFilterAndProjectPlanNode;
+
+
+public class TableScanVisitor {
+  public static final TableScanVisitor INSTANCE = new TableScanVisitor();
+  private RoutingManager _routingManager;
+
+  private TableScanVisitor() {
+  }
+
+  public void init(RoutingManager routingManager) {
+    _routingManager = routingManager;
+  }
+
+  public void assignSegmentsToPlan(BaseTimeSeriesPlanNode planNode, TimeBuckets timeBuckets, Context context) {
+    if (planNode instanceof ScanFilterAndProjectPlanNode) {
+      ScanFilterAndProjectPlanNode sfpNode = (ScanFilterAndProjectPlanNode) planNode;
+      Expression filterExpression = CalciteSqlParser.compileToExpression(sfpNode.getEffectiveFilter(timeBuckets));
+      RoutingTable routingTable = _routingManager.getRoutingTable(
+          compileBrokerRequest(sfpNode.getTableName(), filterExpression),
+          context._requestId);
+      Preconditions.checkNotNull(routingTable, "Failed to get routing table for table: " + sfpNode.getTableName());
+      Preconditions.checkState(routingTable.getServerInstanceToSegmentsMap().size() == 1,
+          "Only support routing to a single server. Computed: %s",
+          routingTable.getServerInstanceToSegmentsMap().size());
+      var entry = routingTable.getServerInstanceToSegmentsMap().entrySet().iterator().next();
+      List<String> segments = entry.getValue().getLeft();
+      context.getPlanIdToSegmentMap().put(sfpNode.getId(), segments);
+    }
+    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+      assignSegmentsToPlan(childNode, timeBuckets, context);
+    }
+  }
+
+  public static Context createContext(Long requestId) {
+    return new Context(requestId);
+  }
+
+  public static class Context {
+    private final Map<String, List<String>> _planIdToSegmentMap = new HashMap<>();
+    private final Long _requestId;
+
+    public Context(Long requestId) {
+      _requestId = requestId;
+    }
+
+    public Map<String, List<String>> getPlanIdToSegmentMap() {
+      return _planIdToSegmentMap;
+    }
+  }
+
+  private BrokerRequest compileBrokerRequest(String tableName, Expression filterExpression) {
+    DataSource dataSource = new DataSource();
+    dataSource.setTableName(tableName);
+    PinotQuery pinotQuery = new PinotQuery();
+    pinotQuery.setDataSource(dataSource);
+    pinotQuery.setFilterExpression(filterExpression);
+    QuerySource querySource = new QuerySource();
+    querySource.setTableName(tableName);
+    BrokerRequest dummyRequest = new BrokerRequest();
+    dummyRequest.setPinotQuery(pinotQuery);
+    dummyRequest.setQuerySource(querySource);
+    return dummyRequest;
+  }
+}

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
@@ -16,35 +16,46 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.tsdb.spi.series;
+package org.apache.pinot.tsdb.planner.physical;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 
 
-/**
- * Block used by time series operators. We store the series data in a map keyed by the series' ID. The value is a
- * list of series, because some query languages support "union" operations which allow series with the same tags/labels
- * to exist either in the query response or temporarily during execution before some n-ary series function
- * is applied.
- */
-public class TimeSeriesBlock {
+public class TimeSeriesDispatchablePlan {
+  private final TimeSeriesQueryServerInstance _queryServerInstance;
+  private final String _language;
+  private final String _serializedPlan;
   private final TimeBuckets _timeBuckets;
-  private final Map<Long, List<TimeSeries>> _seriesMap;
+  private final Map<String, List<String>> _planIdToSegments;
 
-  public TimeSeriesBlock(@Nullable TimeBuckets timeBuckets, Map<Long, List<TimeSeries>> seriesMap) {
+  public TimeSeriesDispatchablePlan(String language, TimeSeriesQueryServerInstance queryServerInstance,
+      String serializedPlan, TimeBuckets timeBuckets, Map<String, List<String>> planIdToSegments) {
+    _language = language;
+    _queryServerInstance = queryServerInstance;
+    _serializedPlan = serializedPlan;
     _timeBuckets = timeBuckets;
-    _seriesMap = seriesMap;
+    _planIdToSegments = planIdToSegments;
   }
 
-  @Nullable
+  public String getLanguage() {
+    return _language;
+  }
+
+  public TimeSeriesQueryServerInstance getQueryServerInstance() {
+    return _queryServerInstance;
+  }
+
+  public String getSerializedPlan() {
+    return _serializedPlan;
+  }
+
   public TimeBuckets getTimeBuckets() {
     return _timeBuckets;
   }
 
-  public Map<Long, List<TimeSeries>> getSeriesMap() {
-    return _seriesMap;
+  public Map<String, List<String>> getPlanIdToSegments() {
+    return _planIdToSegments;
   }
 }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesQueryServerInstance.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesQueryServerInstance.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tsdb.planner.physical;
+
+import org.apache.pinot.core.transport.ServerInstance;
+
+
+public class TimeSeriesQueryServerInstance {
+  private final String _hostname;
+  private final int _queryServicePort;
+  private final int _queryMailboxPort;
+
+  public TimeSeriesQueryServerInstance(ServerInstance serverInstance) {
+    this(serverInstance.getHostname(), serverInstance.getQueryServicePort(), serverInstance.getQueryMailboxPort());
+  }
+
+  public TimeSeriesQueryServerInstance(String hostname, int queryServicePort, int queryMailboxPort) {
+    _hostname = hostname;
+    _queryServicePort = queryServicePort;
+    _queryMailboxPort = queryMailboxPort;
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public int getQueryServicePort() {
+    return _queryServicePort;
+  }
+
+  public int getQueryMailboxPort() {
+    return _queryMailboxPort;
+  }
+}

--- a/pinot-timeseries/pinot-timeseries-spi/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-spi/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pinot</groupId>
-    <artifactId>pinot</artifactId>
+    <artifactId>pinot-timeseries</artifactId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
 

--- a/pinot-timeseries/pinot-timeseries-spi/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-spi/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>pinot-timeseries-spi</artifactId>

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/RangeTimeSeriesRequest.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/RangeTimeSeriesRequest.java
@@ -63,9 +63,11 @@ public class RangeTimeSeriesRequest {
   private final long _stepSeconds;
   /** E2E timeout for the query. */
   private final Duration _timeout;
+  /** Full query string to allow language implementations to pass custom parameters. */
+  private final String _fullQueryString;
 
   public RangeTimeSeriesRequest(String language, String query, long startSeconds, long endSeconds, long stepSeconds,
-      Duration timeout) {
+      Duration timeout, String fullQueryString) {
     Preconditions.checkState(endSeconds >= startSeconds, "Invalid range. startSeconds "
         + "should be greater than or equal to endSeconds. Found startSeconds=%s and endSeconds=%s",
         startSeconds, endSeconds);
@@ -75,6 +77,7 @@ public class RangeTimeSeriesRequest {
     _endSeconds = endSeconds;
     _stepSeconds = stepSeconds;
     _timeout = timeout;
+    _fullQueryString = fullQueryString;
   }
 
   public String getLanguage() {
@@ -99,5 +102,9 @@ public class RangeTimeSeriesRequest {
 
   public Duration getTimeout() {
     return _timeout;
+  }
+
+  public String getFullQueryString() {
+    return _fullQueryString;
   }
 }

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/RangeTimeSeriesRequest.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/RangeTimeSeriesRequest.java
@@ -49,7 +49,7 @@ import java.time.Duration;
  */
 public class RangeTimeSeriesRequest {
   /** Engine allows a Pinot cluster to support multiple Time-Series Query Languages. */
-  private final String _engine;
+  private final String _language;
   /** Query is the raw query sent by the caller. */
   private final String _query;
   /** Start time of the time-window being queried. */
@@ -64,12 +64,12 @@ public class RangeTimeSeriesRequest {
   /** E2E timeout for the query. */
   private final Duration _timeout;
 
-  public RangeTimeSeriesRequest(String engine, String query, long startSeconds, long endSeconds, long stepSeconds,
+  public RangeTimeSeriesRequest(String language, String query, long startSeconds, long endSeconds, long stepSeconds,
       Duration timeout) {
     Preconditions.checkState(endSeconds >= startSeconds, "Invalid range. startSeconds "
         + "should be greater than or equal to endSeconds. Found startSeconds=%s and endSeconds=%s",
         startSeconds, endSeconds);
-    _engine = engine;
+    _language = language;
     _query = query;
     _startSeconds = startSeconds;
     _endSeconds = endSeconds;
@@ -77,8 +77,8 @@ public class RangeTimeSeriesRequest {
     _timeout = timeout;
   }
 
-  public String getEngine() {
-    return _engine;
+  public String getLanguage() {
+    return _language;
   }
 
   public String getQuery() {

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/SimpleTimeSeriesBuilderFactory.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/SimpleTimeSeriesBuilderFactory.java
@@ -28,9 +28,7 @@ import org.apache.pinot.tsdb.spi.series.builders.SummingTimeSeriesBuilder;
 
 
 public class SimpleTimeSeriesBuilderFactory extends TimeSeriesBuilderFactory {
-  public static final SimpleTimeSeriesBuilderFactory INSTANCE = new SimpleTimeSeriesBuilderFactory();
-
-  private SimpleTimeSeriesBuilderFactory() {
+  public SimpleTimeSeriesBuilderFactory() {
     super();
   }
 

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactoryProvider.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactoryProvider.java
@@ -42,7 +42,8 @@ public class TimeSeriesBuilderFactoryProvider {
       String seriesBuilderClass = pinotConfiguration
           .getProperty(PinotTimeSeriesConfiguration.getSeriesBuilderFactoryConfigKey(language));
       try {
-        Object untypedSeriesBuilderFactory = Class.forName(seriesBuilderClass).getConstructor().newInstance();
+        Class<?> klass = TimeSeriesBuilderFactoryProvider.class.getClassLoader().loadClass(seriesBuilderClass);
+        Object untypedSeriesBuilderFactory = klass.getConstructor().newInstance();
         if (!(untypedSeriesBuilderFactory instanceof TimeSeriesBuilderFactory)) {
           throw new RuntimeException("Series builder factory class " + seriesBuilderClass
               + " does not implement SeriesBuilderFactory");

--- a/pinot-timeseries/pom.xml
+++ b/pinot-timeseries/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pinot</groupId>
     <artifactId>pinot</artifactId>
     <version>1.3.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <packaging>pom</packaging>
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+import org.apache.pinot.tsdb.spi.PinotTimeSeriesConfiguration;
+import org.apache.pinot.tsdb.spi.series.SimpleTimeSeriesBuilderFactory;
+
+
+public class TimeSeriesEngineQuickStart extends Quickstart {
+  private static final String[] TIME_SERIES_TABLE_DIRECTORIES = new String[]{
+      "examples/batch/airlineStats",
+      "examples/batch/baseballStats",
+      "examples/batch/billing",
+      "examples/batch/dimBaseballTeams",
+      "examples/batch/githubEvents",
+      "examples/batch/githubComplexTypeEvents",
+      "examples/batch/ssb/customer",
+      "examples/batch/ssb/dates",
+      "examples/batch/ssb/lineorder",
+      "examples/batch/ssb/part",
+      "examples/batch/ssb/supplier",
+      "examples/batch/starbucksStores",
+      "examples/batch/fineFoodReviews",
+  };
+
+  @Override
+  public String[] getDefaultBatchTableDirectories() {
+    return TIME_SERIES_TABLE_DIRECTORIES;
+  }
+
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("TIME_SERIES");
+  }
+
+  @Override
+  protected Map<String, Object> getConfigOverrides() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey(), "spql");
+    configs.put(PinotTimeSeriesConfiguration.getLogicalPlannerConfigKey("spql"),
+        "org.apache.pinot.tsdb.planner.logical.TimeSeriesLogicalPlanner");
+    configs.put(PinotTimeSeriesConfiguration.getSeriesBuilderFactoryConfigKey("spql"),
+        SimpleTimeSeriesBuilderFactory.class);
+    return configs;
+  }
+
+  @Override
+  public void execute()
+      throws Exception {
+    File quickstartTmpDir =
+        _setCustomDataDir ? _dataDir : new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    File quickstartRunnerDir = new File(quickstartTmpDir, "quickstart");
+    Preconditions.checkState(quickstartRunnerDir.mkdirs());
+    List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);
+    final QuickstartRunner runner =
+        new QuickstartRunner(quickstartTableRequests, 1, 1, 1, 1, quickstartRunnerDir, getConfigOverrides());
+
+    startKafka();
+    startAllDataStreams(_kafkaStarter, quickstartTmpDir);
+
+    printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker, server and minion *****");
+    runner.startAll();
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        printStatus(Color.GREEN, "***** Shutting down realtime quick start *****");
+        runner.stop();
+        FileUtils.deleteDirectory(quickstartTmpDir);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }));
+
+    printStatus(Color.CYAN, "***** Bootstrap all tables *****");
+    runner.bootstrapTable();
+
+    printStatus(Color.CYAN, "***** Waiting for 5 seconds for a few events to get populated *****");
+    Thread.sleep(5000);
+
+    printStatus(Color.YELLOW, "***** Realtime quickstart setup complete *****");
+    runSampleQueries(runner);
+
+    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -60,11 +60,11 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
   @Override
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configs = new HashMap<>();
-    configs.put(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey(), "spql");
-    configs.put(PinotTimeSeriesConfiguration.getLogicalPlannerConfigKey("spql"),
-        "org.apache.pinot.tsdb.planner.logical.TimeSeriesLogicalPlanner");
-    configs.put(PinotTimeSeriesConfiguration.getSeriesBuilderFactoryConfigKey("spql"),
-        SimpleTimeSeriesBuilderFactory.class);
+    configs.put(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey(), "m3ql");
+    configs.put(PinotTimeSeriesConfiguration.getLogicalPlannerConfigKey("m3ql"),
+        "org.apache.pinot.tsdb.m3ql.M3TimeSeriesPlanner");
+    configs.put(PinotTimeSeriesConfiguration.getSeriesBuilderFactoryConfigKey("m3ql"),
+        SimpleTimeSeriesBuilderFactory.class.getName());
     return configs;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,11 @@
         <artifactId>pinot-timeseries-spi</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-timeseries-planner</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Pinot Plug-in Modules -->
       <!-- Batch Ingestion -->


### PR DESCRIPTION
Last PR to get us to a working Quickstart state. The PRs after this will be much smaller. Explaining the changes at a high-level below:

### Adds a Prometheus Like Pinot Broker HTTP API

Adds two new APIs to the broker: 1 for range queries and 1 for instant-vector queries. The API is [Prometheus Compatible](https://prometheus.io/docs/prometheus/latest/querying/api/), except that the top-level path is prefixed with `timeseries/api`.

### Changes to Receive a Time Series Query Request in Broker and Send to Server

After the broker receives the query, we use the new `TimeSeriesRequestHandler`, which uses the `pinot-timeseries-planner` module's `TimeSeriesQueryEnvironment` to plan the query. The plan is finally dispatched via the `QueryDispatcher`. The implementation mimics the MSE very closely, but of course the exact details are quite different.

**Code Duplication:** I had to create the dispatch related classes again: `AsyndTimeSeriesDispatchClient` and the like; ideally we should just use their MSE equivalents but that will require us to consolidate more stuff and I plan to take it up as part of phase-2.

### Executing Received Plan in Server

Once the plan is received in the server, we:

1. Deserialize the plan and compile the plan-tree to an operator-tree
2. Run the operator tree in `QueryRunner`'s `ExecutorService`. The same executor service is used by `OpChainSchedulerService` as well.

##### Converting ScanFilterAndProject to TimeSeriesPhysicalTableScan

This is done as part of the plan compilation in the server, because we need to generate the LeafTimeSeriesOperator, which is a pinot-query-runtime construct, and ScanFilterAndProject only has a dependency to pinot-spi.

### Dummy M3QL Implementation

For now I have added a dummy M3QL implementation so we can play with the Quickstart.

### Instructions for Starting Quickstart

You can start the "TIME_SERIES" quick start, wait a minute or so for some data to be populated, and then run:

```
➜  ~ cat script.py
import requests
import time
import urllib


with open('query.txt', 'r') as of:
    query = of.read()
    request = {
            'language': 'm3ql',
            'start': int(time.time()),
            'end': int(time.time()) + 3600,
            'query': query
    }
    query_params = urllib.urlencode(request)
    resp = requests.get('http://localhost:8000/timeseries/api/v1/query_range?' + query_params)
    print(resp.text)

➜  ~ cat query.txt
fetch{table="meetupRsvp_REALTIME",filter="",ts_column="__metadata$recordTimestamp",ts_unit="MILLISECONDS",value="1"}
  | max{group_city}
  | transformNull{0}
  | keepLastValue{}
```