### PR TITLE
[Multi-stage] Clean up unnecessary checks in rules

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -88,6 +88,8 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
       new PinotAggregateExchangeNodeInsertRule(PinotRuleUtils.PINOT_REL_FACTORY);
 
   public PinotAggregateExchangeNodeInsertRule(RelBuilderFactory factory) {
+    // NOTE: Explicitly match for LogicalAggregate because after applying the rule, LogicalAggregate is replaced with
+    //       PinotLogicalAggregate, and the rule won't be applied again.
     super(operand(LogicalAggregate.class, any()), factory, null);
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateToSemiJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateToSemiJoinRule.java
@@ -29,7 +29,6 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinInfo;
-import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
@@ -40,8 +39,7 @@ import org.apache.calcite.util.ImmutableIntList;
 
 
 /**
- * SemiJoinRule that matches an Aggregate on top of a Join with an Aggregate
- * as its right child.
+ * SemiJoinRule that matches an Aggregate on top of a Join with an Aggregate as its right child.
  *
  * @see CoreRules#PROJECT_TO_SEMI_JOIN
  */
@@ -50,18 +48,9 @@ public class PinotAggregateToSemiJoinRule extends RelOptRule {
       new PinotAggregateToSemiJoinRule(PinotRuleUtils.PINOT_REL_FACTORY);
 
   public PinotAggregateToSemiJoinRule(RelBuilderFactory factory) {
-    super(operand(LogicalAggregate.class, any()), factory, null);
-  }
-
-  @Override
-  @SuppressWarnings("rawtypes")
-  public boolean matches(RelOptRuleCall call) {
-    final Aggregate topAgg = call.rel(0);
-    if (!PinotRuleUtils.isJoin(topAgg.getInput())) {
-      return false;
-    }
-    final Join join = (Join) PinotRuleUtils.unboxRel(topAgg.getInput());
-    return PinotRuleUtils.isAggregate(join.getInput(1));
+    super(operand(Aggregate.class,
+            some(operand(Join.class, some(operand(RelNode.class, any()), operand(Aggregate.class, any()))))), factory,
+        null);
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotEvaluateLiteralRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotEvaluateLiteralRule.java
@@ -97,7 +97,7 @@ public class PinotEvaluateLiteralRule {
       }
       castedNewProjects.add(newNode);
     }
-    return needCast ? LogicalProject.create(oldProject.getInput(), oldProject.getHints(), castedNewProjects,
+    return needCast ? oldProject.copy(oldProject.getTraitSet(), oldProject.getInput(), castedNewProjects,
         oldProject.getRowType()) : newProject;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotExchangeEliminationRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotExchangeEliminationRule.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
-import java.util.Collections;
+import java.util.List;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 
@@ -36,17 +37,14 @@ public class PinotExchangeEliminationRule extends RelOptRule {
       new PinotExchangeEliminationRule(PinotRuleUtils.PINOT_REL_FACTORY);
 
   public PinotExchangeEliminationRule(RelBuilderFactory factory) {
-    super(operand(PinotLogicalExchange.class,
-        some(operand(PinotLogicalExchange.class, some(operand(RelNode.class, any()))))), factory, null);
+    super(operand(Exchange.class, some(operand(Exchange.class, some(operand(RelNode.class, any()))))), factory, null);
   }
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    PinotLogicalExchange exchange0 = call.rel(0);
-    PinotLogicalExchange exchange1 = call.rel(1);
+    Exchange exchange0 = call.rel(0);
     RelNode input = call.rel(2);
     // convert the call to skip the exchange.
-    RelNode rel = exchange0.copy(input.getTraitSet(), Collections.singletonList(input));
-    call.transformTo(rel);
+    call.transformTo(exchange0.copy(input.getTraitSet(), List.of(input)));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
@@ -69,11 +69,6 @@ public class PinotRelDistributionTraitRule extends RelOptRule {
   }
 
   @Override
-  public boolean matches(RelOptRuleCall call) {
-    return call.rels.length >= 1;
-  }
-
-  @Override
   public void onMatch(RelOptRuleCall call) {
     RelNode current = call.rel(0);
     List<RelNode> inputs = current.getInputs();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotSingleValueAggregateRemoveRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotSingleValueAggregateRemoveRule.java
@@ -18,13 +18,12 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
+import java.util.List;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.hep.HepRelVertex;
-import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
-import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 
@@ -37,23 +36,22 @@ public class PinotSingleValueAggregateRemoveRule extends RelOptRule {
       new PinotSingleValueAggregateRemoveRule(PinotRuleUtils.PINOT_REL_FACTORY);
 
   public PinotSingleValueAggregateRemoveRule(RelBuilderFactory factory) {
-    super(operand(LogicalAggregate.class, any()), factory, null);
+    super(operand(Aggregate.class, any()), factory, null);
   }
 
   @Override
   public boolean matches(RelOptRuleCall call) {
-    final Aggregate agg = call.rel(0);
-    if (agg.getAggCallList().size() != 1) {
+    Aggregate agg = call.rel(0);
+    List<AggregateCall> aggCalls = agg.getAggCallList();
+    if (aggCalls.size() != 1) {
       return false;
     }
-    final AggregateCall aggCall = agg.getAggCallList().get(0);
-    return aggCall.getAggregation().getName().equals("SINGLE_VALUE");
+    return aggCalls.get(0).getAggregation().getName().equals("SINGLE_VALUE");
   }
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    final Aggregate agg = call.rel(0);
-    final RelNode input = ((HepRelVertex) agg.getInput()).getCurrentRel();
-    call.transformTo(input);
+    Aggregate agg = call.rel(0);
+    call.transformTo(((HepRelVertex) agg.getInput()).getCurrentRel());
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotWindowExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotWindowExchangeNodeInsertRule.java
@@ -20,7 +20,6 @@ package org.apache.pinot.calcite.rel.rules;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -32,6 +31,7 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -65,66 +65,59 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
 
   // Supported window functions
   // OTHER_FUNCTION supported are: BOOL_AND, BOOL_OR
-  private static final Set<SqlKind> SUPPORTED_WINDOW_FUNCTION_KIND = ImmutableSet.of(SqlKind.SUM, SqlKind.SUM0,
-      SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT, SqlKind.ROW_NUMBER, SqlKind.RANK, SqlKind.DENSE_RANK,
-      SqlKind.LAG, SqlKind.LEAD, SqlKind.FIRST_VALUE, SqlKind.LAST_VALUE, SqlKind.OTHER_FUNCTION);
+  private static final Set<SqlKind> SUPPORTED_WINDOW_FUNCTION_KIND =
+      Set.of(SqlKind.SUM, SqlKind.SUM0, SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT, SqlKind.ROW_NUMBER, SqlKind.RANK,
+          SqlKind.DENSE_RANK, SqlKind.LAG, SqlKind.LEAD, SqlKind.FIRST_VALUE, SqlKind.LAST_VALUE,
+          SqlKind.OTHER_FUNCTION);
 
   public PinotWindowExchangeNodeInsertRule(RelBuilderFactory factory) {
-    super(operand(LogicalWindow.class, any()), factory, null);
+    super(operand(Window.class, any()), factory, null);
   }
 
   @Override
   public boolean matches(RelOptRuleCall call) {
-    if (call.rels.length < 1) {
-      return false;
-    }
-    if (call.rel(0) instanceof Window) {
-      Window window = call.rel(0);
-      // Only run the rule if the input isn't already an exchange node
-      return !PinotRuleUtils.isExchange(window.getInput());
-    }
-    return false;
+    Window window = call.rel(0);
+    return !PinotRuleUtils.isExchange(window.getInput());
   }
 
   @Override
   public void onMatch(RelOptRuleCall call) {
     Window window = call.rel(0);
-    RelNode windowInput = window.getInput();
-
     // Perform all validations
     validateWindows(window);
 
+    RelNode input = window.getInput();
     Window.Group windowGroup = updateLiteralArgumentsInWindowGroup(window);
-    if (windowGroup.keys.isEmpty() && windowGroup.orderKeys.getKeys().isEmpty()) {
+    Exchange exchange;
+    if (windowGroup.keys.isEmpty()) {
       // Empty OVER()
-      // Add a single Exchange for empty OVER() since no sort is required
+      if (windowGroup.orderKeys.getKeys().isEmpty()) {
+        // Add a single Exchange for empty OVER() if sort is not required
 
-      if (PinotRuleUtils.isProject(windowInput)) {
-        // Check for empty LogicalProject below LogicalWindow. If present modify it to be a Literal only project and add
-        // a project above
-        Project project = (Project) ((HepRelVertex) windowInput).getCurrentRel();
-        if (project.getProjects().isEmpty()) {
-          RelNode returnedRelNode = handleEmptyProjectBelowWindow(window, project);
-          call.transformTo(returnedRelNode);
-          return;
+        if (PinotRuleUtils.isProject(input)) {
+          // Check for empty LogicalProject below LogicalWindow. If present, modify it to be a Literal only project and
+          // add a project above.
+          Project project = (Project) ((HepRelVertex) input).getCurrentRel();
+          if (project.getProjects().isEmpty()) {
+            RelNode returnedRelNode = handleEmptyProjectBelowWindow(window, project);
+            call.transformTo(returnedRelNode);
+            return;
+          }
         }
-      }
 
-      PinotLogicalExchange exchange = PinotLogicalExchange.create(windowInput,
-          RelDistributions.hash(Collections.emptyList()));
-      call.transformTo(
-          LogicalWindow.create(window.getTraitSet(), exchange, window.constants, window.getRowType(),
-              List.of(windowGroup)));
-    } else if (windowGroup.keys.isEmpty() && !windowGroup.orderKeys.getKeys().isEmpty()) {
-      // Only ORDER BY
-      // Add a LogicalSortExchange with collation on the order by key(s) and an empty hash partition key
-      // TODO: ORDER BY only type queries need to be sorted on both sender and receiver side for better performance.
-      //       Sorted input data can use a k-way merge instead of a PriorityQueue for sorting. For now support to
-      //       sort on the sender side is not available thus setting this up to only sort on the receiver.
-      PinotLogicalSortExchange sortExchange = PinotLogicalSortExchange.create(windowInput,
-          RelDistributions.hash(Collections.emptyList()), windowGroup.orderKeys, false, true);
-      call.transformTo(LogicalWindow.create(window.getTraitSet(), sortExchange, window.constants, window.getRowType(),
-          List.of(windowGroup)));
+        // TODO: Revisit whether we should use hash distribution
+        exchange = PinotLogicalExchange.create(input, RelDistributions.hash(List.of()));
+      } else {
+        // Only ORDER BY
+        // Add a LogicalSortExchange with collation on the order by key(s) and an empty hash partition key
+        // TODO: ORDER BY only type queries need to be sorted on both sender and receiver side for better performance.
+        //       Sorted input data can use a k-way merge instead of a PriorityQueue for sorting. For now support to
+        //       sort on the sender side is not available thus setting this up to only sort on the receiver.
+        // TODO: Revisit whether we should use hash distribution
+        exchange =
+            PinotLogicalSortExchange.create(input, RelDistributions.hash(List.of()), windowGroup.orderKeys, false,
+                true);
+      }
     } else {
       // All other variants
       // Assess whether this is a PARTITION BY only query or not (includes queries of the type where PARTITION BY and
@@ -134,10 +127,7 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
       if (isPartitionByOnly) {
         // Only PARTITION BY or PARTITION BY and ORDER BY on the same key(s)
         // Add an Exchange hashed on the partition by keys
-        PinotLogicalExchange exchange = PinotLogicalExchange.create(windowInput,
-            RelDistributions.hash(windowGroup.keys.toList()));
-        call.transformTo(LogicalWindow.create(window.getTraitSet(), exchange, window.constants, window.getRowType(),
-            List.of(windowGroup)));
+        exchange = PinotLogicalExchange.create(input, RelDistributions.hash(windowGroup.keys.toList()));
       } else {
         // PARTITION BY and ORDER BY on different key(s)
         // Add a LogicalSortExchange hashed on the partition by keys and collation based on order by keys
@@ -145,12 +135,13 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
         //       that the data is already partitioned and sorting can be done on the sender side instead. This way
         //       sorting on the receiver side can be a no-op. Add support for this hint and pass it on. Until sender
         //       side sorting is implemented, setting this hint will throw an error on execution.
-        PinotLogicalSortExchange sortExchange = PinotLogicalSortExchange.create(windowInput,
-            RelDistributions.hash(windowGroup.keys.toList()), windowGroup.orderKeys, false, true);
-        call.transformTo(LogicalWindow.create(window.getTraitSet(), sortExchange, window.constants, window.getRowType(),
-            List.of(windowGroup)));
+        exchange = PinotLogicalSortExchange.create(input, RelDistributions.hash(windowGroup.keys.toList()),
+            windowGroup.orderKeys, false, true);
       }
     }
+    // NOTE: Need to create a new LogicalWindow to use the modified window group.
+    call.transformTo(LogicalWindow.create(window.getTraitSet(), exchange, window.constants, window.getRowType(),
+        List.of(windowGroup)));
   }
 
   private Window.Group updateLiteralArgumentsInWindowGroup(Window window) {
@@ -288,8 +279,9 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
     final List<RexNode> expsForProjectBelowWindow = Collections.singletonList(
         rexBuilder.makeLiteral(0, cluster.getTypeFactory().createSqlType(SqlTypeName.INTEGER)));
     final List<String> expsFieldNamesBelowWindow = Collections.singletonList("winLiteral");
-    Project projectBelowWindow = LogicalProject.create(project.getInput(), project.getHints(),
-        expsForProjectBelowWindow, expsFieldNamesBelowWindow);
+    Project projectBelowWindow =
+        LogicalProject.create(project.getInput(), project.getHints(), expsForProjectBelowWindow,
+            expsFieldNamesBelowWindow);
 
     // Fix up the inputs to the Window to include the literal column and add an exchange
     final RelDataTypeFactory.Builder outputBuilder = cluster.getTypeFactory().builder();
@@ -300,8 +292,8 @@ public class PinotWindowExchangeNodeInsertRule extends RelOptRule {
     // ROW_NUMBER(). Add an Exchange with empty hash distribution list
     PinotLogicalExchange exchange =
         PinotLogicalExchange.create(projectBelowWindow, RelDistributions.hash(Collections.emptyList()));
-    Window newWindow = new LogicalWindow(window.getCluster(), window.getTraitSet(), exchange,
-        window.getConstants(), outputBuilder.build(), window.groups);
+    Window newWindow = new LogicalWindow(window.getCluster(), window.getTraitSet(), exchange, window.getConstants(),
+        outputBuilder.build(), window.groups);
 
     // Create the LogicalProject above window to remove the literal column
     final List<RexNode> expsForProjectAboveWindow = new ArrayList<>();


### PR DESCRIPTION
- Remove unnecessary checks in `matches()`
- Use `copy()` instead of `create()` if we are modifying a `RelNode` to preserve the hints