### PR TITLE
Fix behavior for distinct sum and distinct avg when all values are null

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
@@ -63,6 +63,10 @@ public class DistinctAvgAggregationFunction extends BaseDistinctAggregateAggrega
 
   @Override
   public Double extractFinalResult(Set intermediateResult) {
+    if (_nullHandlingEnabled && intermediateResult.isEmpty()) {
+      return null;
+    }
+
     Double distinctSum = 0.0;
 
     for (Object obj : intermediateResult) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
@@ -63,6 +63,10 @@ public class DistinctSumAggregationFunction extends BaseDistinctAggregateAggrega
 
   @Override
   public Double extractFinalResult(Set intermediateResult) {
+    if (_nullHandlingEnabled && intermediateResult.isEmpty()) {
+      return null;
+    }
+
     Double distinctSum = 0.0;
 
     for (Object obj : intermediateResult) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
@@ -143,6 +143,21 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
   }
 
   @Test(dataProvider = "scenarios")
+  void distinctSumAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select sum(distinct myField) from testTable")
+        .thenResultIs("INTEGER", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
   void distinctSumAggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
         .onFirstInstance("myField",
@@ -202,6 +217,21 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "2"
         ).whenQuery("select 'literal', sum(distinct myField) from testTable group by 'literal'")
         .thenResultIs("STRING | DOUBLE", "literal | 6");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void distinctAvgAggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select avg(distinct myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
   }
 
   @Test(dataProvider = "scenarios")


### PR DESCRIPTION
- Currently, if null handling is enabled, Pinot's distinct sum returns `0.0` if all input values are `null` and distinct avg returns `NaN` due to division by zero.
- This behavior is inconsistent with null handling behavior in other aggregation functions in Pinot and also with Postgres' behavior for distinct count / avg. These functions should return `null` if all input values are `null`. Note that distinct count, however, should (and does) return 0 when all input values are `null`.
- This patch fixes the behavior for distinct sum / avg.