### PR TITLE
Remove Calcite return type override for FROM_DATE_TIME scalar function in PinotOperatorTable

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
@@ -141,7 +141,8 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
         + "FROM %s\n"
         + "WHERE   CAST(DATETRUNC('DAY', CAST(FROMDATETIME(TODATETIME(FROMDATETIME(CAST(CAST(tsBase AS TIMESTAMP) AS "
         + "VARCHAR), 'yyyy-MM-dd HH:mm:ss.S'), 'yyyy-MM-dd'), 'yyyy-MM-dd') AS TIMESTAMP), 'MILLISECONDS') AS "
-        + "TIMESTAMP) = FROMDATETIME( '2019-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')\n", getTableName());
+        + "TIMESTAMP) = CAST(FROMDATETIME( '2019-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') AS TIMESTAMP)\n",
+        getTableName());
     JsonNode jsonNode = postQuery(query);
     assertEquals(jsonNode.get("resultTable").get("rows").size(), 1);
     assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asText(), "2019-01-01 00:00:00.0");
@@ -162,19 +163,11 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
         + "LIMIT 5", getTableName());
     JsonNode jsonNode = postQuery(query);
     assertEquals(jsonNode.get("resultTable").get("rows").size(), 5);
-    if (useMultiStageQueryEngine) {
-      assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asText(), "2018-12-31 23:00:00.0");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(1).get(0).asText(), "2019-01-01 23:00:00.0");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(2).get(0).asText(), "2019-01-02 23:00:00.0");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(3).get(0).asText(), "2019-01-03 23:00:00.0");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(4).get(0).asText(), "2019-01-04 23:00:00.0");
-    } else {
-      assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asText(), "1546297200000");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(1).get(0).asText(), "1546383600000");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(2).get(0).asText(), "1546470000000");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(3).get(0).asText(), "1546556400000");
-      assertEquals(jsonNode.get("resultTable").get("rows").get(4).get(0).asText(), "1546642800000");
-    }
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asText(), "1546297200000");
+    assertEquals(jsonNode.get("resultTable").get("rows").get(1).get(0).asText(), "1546383600000");
+    assertEquals(jsonNode.get("resultTable").get("rows").get(2).get(0).asText(), "1546470000000");
+    assertEquals(jsonNode.get("resultTable").get("rows").get(3).get(0).asText(), "1546556400000");
+    assertEquals(jsonNode.get("resultTable").get("rows").get(4).get(0).asText(), "1546642800000");
   }
 
   @Test(dataProvider = "useBothQueryEngines")

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -254,13 +254,7 @@ public class PinotOperatorTable implements SqlOperatorTable {
       // SqlStdOperatorTable.COALESCE without rewrite
       new SqlFunction("COALESCE", SqlKind.COALESCE,
           ReturnTypes.LEAST_RESTRICTIVE.andThen(SqlTypeTransforms.LEAST_NULLABLE), null, OperandTypes.SAME_VARIADIC,
-          SqlFunctionCategory.SYSTEM),
-
-      // The scalar function version returns long instead of Timestamp
-      // TODO: Consider unifying the return type to Timestamp
-      new PinotSqlFunction("FROM_DATE_TIME", ReturnTypes.TIMESTAMP_NULLABLE, OperandTypes.family(
-          List.of(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY),
-          i -> i > 1))
+          SqlFunctionCategory.SYSTEM)
   );
 
   private static final List<Pair<SqlOperator, List<String>>> PINOT_OPERATORS_WITH_ALIASES = List.of(

--- a/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
@@ -25,7 +25,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT FROMDATETIME( '1997-02-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') FROM d",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(EXPR$0=[1997-02-01 00:00:00])",
+          "\nLogicalProject(EXPR$0=[854755200000:BIGINT])",
           "\n  LogicalTableScan(table=[[default, d]])",
           "\n"
         ]
@@ -52,10 +52,10 @@
       },
       {
         "description": "Select fromdatetime function in where clause",
-        "sql": "EXPLAIN PLAN FOR SELECT * FROM d WHERE CAST(ts AS TIMESTAMP) = FROMDATETIME('2019-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM d WHERE ts = FROMDATETIME('2019-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')",
         "output": [
           "Execution Plan",
-          "\nLogicalFilter(condition=[=(CAST($6):TIMESTAMP(0) NOT NULL, 2019-01-01 00:00:00)])",
+          "\nLogicalFilter(condition=[=($6, 1546300800000)])",
           "\n  LogicalTableScan(table=[[default, d]])",
           "\n"
         ]


### PR DESCRIPTION
- The `FROM_DATE_TIME` scalar function returns a long value representing milliseconds since epoch and is not a standard SQL function - https://github.com/apache/pinot/blob/49896eb3ba40ecc1494b1cc1783466c03aa7f832/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java#L488
- The return type was forced to `TIMESTAMP` in the multistage engine in https://github.com/apache/pinot/pull/11350 and carried forward in the refactoring in https://github.com/apache/pinot/pull/13573.
- This leads to an inconsistent experience for the same Pinot UDF across the two query engines:
![image](https://github.com/user-attachments/assets/cbf3f0ff-3207-4975-837e-e0421dc26584)

![image](https://github.com/user-attachments/assets/d9d2a76c-1e9c-497c-b673-be396ad99cc3)
- The `FROM_DATE_TIME` function only has a scalar implementation in Pinot (and no transform function equivalent) that returns a `long`, so it isn't too clear why the Calcite return type was forced to `TIMESTAMP`.