### PR TITLE
Update list of collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,12 +31,12 @@ github:
     rebase: false
   collaborators:
     - sullis
-    - shenyu0127
-    - tibrewalpratik17
+    - yashmayya
     - abhioncbr
-    - zhtaoxiang
     - shounakmk219
     - itschrispeck
+    - zhtaoxiang
     - soumitra-st
     - swaminathanmanish
-    - yashmayya
+    - suddendust
+    - vrajat


### PR DESCRIPTION
- The collaborator list was initially added a few months ago in https://github.com/apache/pinot/pull/13346.
- The list needs to be periodically updated (every release or so) to take into account changes in contribution activity as well as existing collaborators becoming committers.
- The new list was generated with the same method used previously:
```
> git shortlog --numbered --summary --since="1 year ago"

   440  dependabot[bot]
   166  Xiaotian (Jackie) Jiang
   108  Xiang Fu
    74  sullis
    57  Gonzalo Ortiz Jaureguizar
    55  Pratik Tibrewal
    55  Yash Mayya
    48  Abhishek Sharma
    43  Xiaobing
    40  Rong Rong
    37  Shounak kulkarni
    27  Christopher Peck
    20  Haitao Zhang
    18  Saurabh Dubey
    18  soumitra-st
    17  Ankit Sultana
    17  Kartik Khare
    14  Vivek Iyer Vaidyanathan
    14  swaminathanmanish
    12  Prashant Pandey
    12  Seunghyun Lee
    11  Rajat Venkatesh
```
- Committers were manually filtered out from the above list (using the source of truth here - https://projects.apache.org/committee.html?pinot)