### PR TITLE
Add a server level config for segment server upload to deep store.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -57,7 +57,7 @@ public class SegmentCommitterFactory {
       throws URISyntaxException {
     InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
 
-    boolean uploadToFs = instanceDataManagerConfig.getDefaultServerUploadToDeepStore();
+    boolean uploadToFs = instanceDataManagerConfig.isUploadSegmentToDeepStore();
     Boolean streamConfigServerUploadToDeepStore = _streamConfig.isServerUploadToDeepStore();
     if (streamConfigServerUploadToDeepStore != null) {
       uploadToFs = streamConfigServerUploadToDeepStore;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -23,8 +23,11 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 
@@ -54,7 +57,13 @@ public class SegmentCommitterFactory {
   public SegmentCommitter createSegmentCommitter(SegmentCompletionProtocol.Request.Params params,
       String controllerVipUrl)
       throws URISyntaxException {
-    boolean uploadToFs = _streamConfig.isServerUploadToDeepStore();
+    InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
+    PinotConfiguration config = instanceDataManagerConfig.getConfig();
+    boolean defaultSegmentUploadToDeepStore = config.getProperty(
+        CommonConstants.Segment.CONFIG_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE,
+        CommonConstants.Segment.DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE);
+
+    boolean uploadToFs = _streamConfig.isServerUploadToDeepStore(defaultSegmentUploadToDeepStore);
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -25,9 +25,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 
@@ -58,12 +56,13 @@ public class SegmentCommitterFactory {
       String controllerVipUrl)
       throws URISyntaxException {
     InstanceDataManagerConfig instanceDataManagerConfig = _indexLoadingConfig.getInstanceDataManagerConfig();
-    PinotConfiguration config = instanceDataManagerConfig.getConfig();
-    boolean defaultSegmentUploadToDeepStore = config.getProperty(
-        CommonConstants.Segment.CONFIG_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE,
-        CommonConstants.Segment.DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE);
 
-    boolean uploadToFs = _streamConfig.isServerUploadToDeepStore(defaultSegmentUploadToDeepStore);
+    boolean uploadToFs = instanceDataManagerConfig.getDefaultServerUploadToDeepStore();
+    Boolean streamConfigServerUploadToDeepStore = _streamConfig.isServerUploadToDeepStore();
+    if (streamConfigServerUploadToDeepStore != null) {
+      uploadToFs = streamConfigServerUploadToDeepStore;
+    }
+
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class SegmentCommitterFactoryTest {
 
   private Map<String, String> getMinimumStreamConfigMap() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
@@ -27,15 +27,16 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
 
 public class SegmentCommitterFactoryTest {
 
@@ -62,9 +63,10 @@ public class SegmentCommitterFactoryTest {
     ServerSegmentCompletionProtocolHandler protocolHandler =
         new ServerSegmentCompletionProtocolHandler(Mockito.mock(ServerMetrics.class), "test_REALTIME");
     String controllerVipUrl = "http://localhost:1234";
+    IndexLoadingConfig indexLoadingConfig = mockIndexLoadConfig();
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     SegmentCommitterFactory factory = new SegmentCommitterFactory(Mockito.mock(Logger.class), protocolHandler, config,
-        Mockito.mock(IndexLoadingConfig.class), Mockito.mock(ServerMetrics.class));
+        indexLoadingConfig, Mockito.mock(ServerMetrics.class));
     SegmentCommitter committer = factory.createSegmentCommitter(requestParams, controllerVipUrl);
     Assert.assertNotNull(committer);
     Assert.assertTrue(committer instanceof SplitSegmentCommitter);
@@ -83,9 +85,8 @@ public class SegmentCommitterFactoryTest {
     Map<String, String> streamConfigMap = new HashMap<>(getMinimumStreamConfigMap());
     streamConfigMap.put(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, "true");
     TableConfig config = createRealtimeTableConfig("testDeepStoreConfig", streamConfigMap).build();
-    IndexLoadingConfig indexLoadingConfig = Mockito.mock(IndexLoadingConfig.class);
-    Mockito.when(indexLoadingConfig.getSegmentStoreURI()).thenReturn("file:///path/to/segment/store.txt");
-
+    // Create and set up the mocked IndexLoadingConfig and InstanceDataManager
+    IndexLoadingConfig indexLoadingConfig = mockIndexLoadConfig();
     SegmentCommitterFactory factory = new SegmentCommitterFactory(Mockito.mock(Logger.class), protocolHandler, config,
         indexLoadingConfig, Mockito.mock(ServerMetrics.class));
     SegmentCommitter committer = factory.createSegmentCommitter(requestParams, controllerVipUrl);
@@ -106,5 +107,15 @@ public class SegmentCommitterFactoryTest {
     Assert.assertNotNull(committer);
     Assert.assertTrue(committer instanceof SplitSegmentCommitter);
     Assert.assertTrue(((SplitSegmentCommitter) committer).getSegmentUploader() instanceof PinotFSSegmentUploader);
+  }
+
+  private IndexLoadingConfig mockIndexLoadConfig() {
+    IndexLoadingConfig indexLoadingConfig = Mockito.mock(IndexLoadingConfig.class);
+    InstanceDataManagerConfig instanceDataManagerConfig = Mockito.mock(InstanceDataManagerConfig.class);
+    Mockito.when(indexLoadingConfig.getInstanceDataManagerConfig()).thenReturn(instanceDataManagerConfig);
+    PinotConfiguration pinotConfiguration = Mockito.mock(PinotConfiguration.class);
+    Mockito.when(instanceDataManagerConfig.getConfig()).thenReturn(pinotConfiguration);
+
+    return indexLoadingConfig;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -135,8 +135,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
   private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
-  public static final String SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
-  public static final boolean DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = false;
+  public static final String UPLOAD_SEGMENT_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
+  public static final boolean DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE = false;
 
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
@@ -335,8 +335,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public boolean getDefaultServerUploadToDeepStore() {
-    return _serverConfig.getProperty(SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE,
-        DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE);
+  public boolean isUploadSegmentToDeepStore() {
+    return _serverConfig.getProperty(UPLOAD_SEGMENT_TO_DEEP_STORE,
+        DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -135,6 +135,9 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
   private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
+  public static final String SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
+  public static final boolean DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = false;
+
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_SIZE = 10_000;
@@ -329,5 +332,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public Map<String, Map<String, String>> getTierConfigs() {
     return _tierConfigs;
+  }
+
+  @Override
+  public boolean getDefaultServerUploadToDeepStore() {
+    return _serverConfig.getProperty(SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE,
+        DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -135,7 +135,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
   private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
-  public static final String UPLOAD_SEGMENT_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
+  public static final String UPLOAD_SEGMENT_TO_DEEP_STORE = "segment.upload.to.deep.store";
   public static final boolean DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE = false;
 
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
@@ -336,7 +336,6 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   @Override
   public boolean isUploadSegmentToDeepStore() {
-    return _serverConfig.getProperty(UPLOAD_SEGMENT_TO_DEEP_STORE,
-        DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE);
+    return _serverConfig.getProperty(UPLOAD_SEGMENT_TO_DEEP_STORE, DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -78,4 +78,6 @@ public interface InstanceDataManagerConfig {
   PinotConfiguration getAuthConfig();
 
   Map<String, Map<String, String>> getTierConfigs();
+
+  boolean getDefaultServerUploadToDeepStore();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -79,5 +79,5 @@ public interface InstanceDataManagerConfig {
 
   Map<String, Map<String, String>> getTierConfigs();
 
-  boolean getDefaultServerUploadToDeepStore();
+  boolean isUploadSegmentToDeepStore();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -415,7 +415,7 @@ public class StreamConfig {
         && _flushThresholdSegmentSizeBytes == that._flushThresholdSegmentSizeBytes
         && _flushAutotuneInitialRows == that._flushAutotuneInitialRows
         && Double.compare(_topicConsumptionRateLimit, that._topicConsumptionRateLimit) == 0
-        && _serverUploadToDeepStore == that._serverUploadToDeepStore && Objects.equals(_type, that._type)
+        && Objects.equals(_serverUploadToDeepStore, that._serverUploadToDeepStore) && Objects.equals(_type, that._type)
         && Objects.equals(_topicName, that._topicName) && Objects.equals(_tableNameWithType, that._tableNameWithType)
         && Objects.equals(_consumerFactoryClassName, that._consumerFactoryClassName) && Objects.equals(_decoderClass,
         that._decoderClass) && Objects.equals(_decoderProperties, that._decoderProperties) && Objects.equals(_groupId,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
@@ -82,7 +83,7 @@ public class StreamConfig {
   // controller during the segment commit protocol. if config is not present in Table StreamConfig
   // _serverUploadToDeepStore is null and method isServerUploadToDeepStore() overrides the default value with Server
   // level config
-  private final String _serverUploadToDeepStore;
+  private final Boolean _serverUploadToDeepStore;
 
   /**
    * Initializes a StreamConfig using the map of stream configs from the table config
@@ -175,7 +176,9 @@ public class StreamConfig {
     _flushThresholdSegmentRows = extractFlushThresholdSegmentRows(streamConfigMap);
     _flushThresholdTimeMillis = extractFlushThresholdTimeMillis(streamConfigMap);
     _flushThresholdSegmentSizeBytes = extractFlushThresholdSegmentSize(streamConfigMap);
-    _serverUploadToDeepStore = streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE);
+    _serverUploadToDeepStore = streamConfigMap.containsKey(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE)
+        ? Boolean.valueOf(streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
+        : null;
 
     int autotuneInitialRows = 0;
     String initialRowsValue = streamConfigMap.get(StreamConfigProperties.SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS);
@@ -212,9 +215,9 @@ public class StreamConfig {
     }
   }
 
-  public boolean isServerUploadToDeepStore(boolean defaultServerUploadToDeepStore) {
-    return _serverUploadToDeepStore == null ? defaultServerUploadToDeepStore
-        : Boolean.parseBoolean(_serverUploadToDeepStore);
+  @Nullable
+  public Boolean isServerUploadToDeepStore() {
+    return _serverUploadToDeepStore;
   }
 
   private long extractFlushThresholdSegmentSize(Map<String, String> streamConfigMap) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1071,6 +1071,9 @@ public class CommonConstants {
      */
     public static final String SEGMENT_UPLOAD_START_TIME = "segment.upload.start.time";
 
+    public static final String CONFIG_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
+    public static final boolean DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = false;
+
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1071,9 +1071,6 @@ public class CommonConstants {
      */
     public static final String SEGMENT_UPLOAD_START_TIME = "segment.upload.start.time";
 
-    public static final String CONFIG_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = "segment.server.upload.to.deep.store";
-    public static final boolean DEFAULT_SEGMENT_SERVER_UPLOAD_TO_DEEP_STORE = false;
-
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";
 


### PR DESCRIPTION
Commit contains following changes.
1. Add a cluster level flag to provide default value server upload to deep store setting for tables which does not have stream config property serverUploadToDeepStore.
2. Validated the changes by running quick start locally. 