### PR TITLE
fix checks on largest comparison value for upsert ttl and allow to add segments out of ttl

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -88,8 +88,8 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public abstract class BasePartitionUpsertMetadataManager implements PartitionUpsertMetadataManager {
   protected static final long OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS = TimeUnit.MINUTES.toNanos(1);
-  // The special value to indicate the largest comparison value is not set yet.
-  private static final double LARGEST_COMPARISON_VALUE_NOT_SET = Double.MIN_VALUE;
+  // The special value to indicate the largest comparison value is not set yet, and allow negative comparison values.
+  private static final double LARGEST_COMPARISON_VALUE_NOT_SET = Double.NEGATIVE_INFINITY;
 
   protected final String _tableNameWithType;
   protected final int _partitionId;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -394,11 +394,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, maxComparisonValue));
     }
 
-    if (_metadataTTL > 0 && _largestSeenComparisonValue.get() != LARGEST_COMPARISON_VALUE_NOT_SET) {
+    if (_metadataTTL > 0 && _largestSeenComparisonValue.get() != LARGEST_COMPARISON_VALUE_NOT_SET
+        && shouldSkipAddSegmentOutOfTTL()) {
       Preconditions.checkState(_enableSnapshot, "Upsert TTL must have snapshot enabled");
       Preconditions.checkState(_comparisonColumns.size() == 1,
           "Upsert TTL does not work with multiple comparison columns");
-      if (shouldSkipAddSegmentOutOfTTL() && isOutOfMetadataTTL(segment)) {
+      if (isOutOfMetadataTTL(segment)) {
         _logger.info("Skip adding segment: {} because it's out of TTL", segmentName);
         MutableRoaringBitmap validDocIdsSnapshot = immutableSegment.loadValidDocIdsFromSnapshot();
         if (validDocIdsSnapshot != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -216,9 +216,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
         }
       }
     });
-    if (_metadataTTL > 0) {
-      persistWatermark(largestSeenComparisonValue);
-    }
 
     // Update metrics
     updatePrimaryKeyGauge();
@@ -255,7 +252,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     Comparable newComparisonValue = recordInfo.getComparisonValue();
 
     // When TTL is enabled, update largestSeenComparisonValue when adding new record
-    if (_metadataTTL > 0 || _deletedKeysTTL > 0) {
+    if (isTTLEnabled()) {
       double comparisonValue = ((Number) newComparisonValue).doubleValue();
       _largestSeenComparisonValue.getAndUpdate(v -> Math.max(v, comparisonValue));
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -192,8 +192,10 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     AtomicInteger numTotalKeysMarkForDeletion = new AtomicInteger();
     AtomicInteger numDeletedKeysWithinTTLWindow = new AtomicInteger();
     double largestSeenComparisonValue = _largestSeenComparisonValue.get();
-    double metadataTTLKeysThreshold = _metadataTTL > 0 ? largestSeenComparisonValue - _metadataTTL : 0;
-    double deletedKeysThreshold = _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : 0;
+    double metadataTTLKeysThreshold =
+        _metadataTTL > 0 ? largestSeenComparisonValue - _metadataTTL : Double.NEGATIVE_INFINITY;
+    double deletedKeysThreshold =
+        _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : Double.NEGATIVE_INFINITY;
     _primaryKeyToRecordLocationMap.forEach((primaryKey, recordLocation) -> {
       double comparisonValue = ((Number) recordLocation.getComparisonValue()).doubleValue();
       if (_metadataTTL > 0 && comparisonValue < metadataTTLKeysThreshold) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -192,19 +192,8 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     AtomicInteger numTotalKeysMarkForDeletion = new AtomicInteger();
     AtomicInteger numDeletedKeysWithinTTLWindow = new AtomicInteger();
     double largestSeenComparisonValue = _largestSeenComparisonValue.get();
-    double metadataTTLKeysThreshold;
-    if (_metadataTTL > 0) {
-      metadataTTLKeysThreshold = largestSeenComparisonValue - _metadataTTL;
-    } else {
-      metadataTTLKeysThreshold = Double.MIN_VALUE;
-    }
-    double deletedKeysThreshold;
-    if (_deletedKeysTTL > 0) {
-      deletedKeysThreshold = largestSeenComparisonValue - _deletedKeysTTL;
-    } else {
-      deletedKeysThreshold = Double.MIN_VALUE;
-    }
-
+    double metadataTTLKeysThreshold = _metadataTTL > 0 ? largestSeenComparisonValue - _metadataTTL : 0;
+    double deletedKeysThreshold = _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : 0;
     _primaryKeyToRecordLocationMap.forEach((primaryKey, recordLocation) -> {
       double comparisonValue = ((Number) recordLocation.getComparisonValue()).doubleValue();
       if (_metadataTTL > 0 && comparisonValue < metadataTTLKeysThreshold) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -202,8 +202,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
         segment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, getNumPrimaryKeys());
     long startTimeMs = System.currentTimeMillis();
 
-    try (
-        PrimaryKeyReader primaryKeyReader = new PrimaryKeyReader(segment, _primaryKeyColumns)) {
+    try (PrimaryKeyReader primaryKeyReader = new PrimaryKeyReader(segment, _primaryKeyColumns)) {
       removeSegment(segment,
           UpsertUtils.getPrimaryKeyIterator(primaryKeyReader, segment.getSegmentMetadata().getTotalDocs()));
     } catch (Exception e) {
@@ -292,7 +291,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
     AtomicInteger numDeletedKeysWithinTTLWindow = new AtomicInteger();
     AtomicInteger numDeletedTTLKeysInMultipleSegments = new AtomicInteger();
     double largestSeenComparisonValue = _largestSeenComparisonValue.get();
-    double deletedKeysThreshold = _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : 0;
+    double deletedKeysThreshold =
+        _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : Double.NEGATIVE_INFINITY;
     _primaryKeyToRecordLocationMap.forEach((primaryKey, recordLocation) -> {
       double comparisonValue = ((Number) recordLocation.getComparisonValue()).doubleValue();
       // We need to verify that the record belongs to only one segment. If a record is part of multiple segments,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -292,13 +292,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
     AtomicInteger numDeletedKeysWithinTTLWindow = new AtomicInteger();
     AtomicInteger numDeletedTTLKeysInMultipleSegments = new AtomicInteger();
     double largestSeenComparisonValue = _largestSeenComparisonValue.get();
-    double deletedKeysThreshold;
-    if (_deletedKeysTTL > 0) {
-      deletedKeysThreshold = largestSeenComparisonValue - _deletedKeysTTL;
-    } else {
-      deletedKeysThreshold = Double.MIN_VALUE;
-    }
-
+    double deletedKeysThreshold = _deletedKeysTTL > 0 ? largestSeenComparisonValue - _deletedKeysTTL : 0;
     _primaryKeyToRecordLocationMap.forEach((primaryKey, recordLocation) -> {
       double comparisonValue = ((Number) recordLocation.getComparisonValue()).doubleValue();
       // We need to verify that the record belongs to only one segment. If a record is part of multiple segments,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -1170,7 +1170,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
-            _contextBuilder.setHashFunction(hashFunction).build());
+            _contextBuilder.setHashFunction(hashFunction).setEnableSnapshot(true).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -163,20 +163,88 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   @Test
-  public void testUpsertMetadataCleanupWithTTLConfig()
+  public void testRemoveExpiredPrimaryKeys()
       throws IOException {
     _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
     verifyRemoveExpiredPrimaryKeys(new Integer(80), new Integer(120));
     verifyRemoveExpiredPrimaryKeys(new Float(80), new Float(120));
     verifyRemoveExpiredPrimaryKeys(new Double(80), new Double(120));
     verifyRemoveExpiredPrimaryKeys(new Long(80), new Long(120));
-    verifyPersistAndLoadWatermark();
-    verifyAddSegmentForTTL(new Integer(80));
-    verifyAddSegmentForTTL(new Float(80));
-    verifyAddSegmentForTTL(new Double(80));
-    verifyAddSegmentForTTL(new Long(80));
-    verifyAddOutOfTTLSegment();
-    verifyAddOutOfTTLSegmentWithRecordDelete();
+  }
+
+  @Test
+  public void testAddSegmentOutOfTTL()
+      throws IOException {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
+    verifyAddSegmentOutOfTTL(new Integer(80));
+    verifyAddSegmentOutOfTTL(new Float(80));
+    verifyAddSegmentOutOfTTL(new Double(80));
+    verifyAddSegmentOutOfTTL(new Long(80));
+    verifyAddMultipleSegmentsWithOneOutOfTTL();
+    verifyAddSegmentOutOfTTLWithRecordDelete();
+  }
+
+  @Test
+  public void testTTLWithNegativeComparisonValues()
+      throws IOException {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+    Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
+        upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add record to update largestSeenTimestamp, largest seen timestamp: comparisonValue
+    ThreadSafeMutableRoaringBitmap validDocIds0 = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment segment0 = mockMutableSegment(1, validDocIds0, null);
+    upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(10), 1, -80, false));
+    checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, -80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), -80);
+
+    // add a segment with segmentEndTime = -200 so it will be skipped since it out-of-TTL
+    int numRecords = 4;
+    int[] primaryKeys = new int[]{0, 1, 2, 3};
+    ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
+    List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
+    ImmutableSegmentImpl segment1 =
+        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, -200, null);
+
+    // load segment1.
+    upsertMetadataManager.addSegment(segment1);
+    assertEquals(recordLocationMap.size(), 1);
+    checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, -80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), -80);
+
+    // Stop the metadata manager
+    upsertMetadataManager.stop();
+
+    // Close the metadata manager
+    upsertMetadataManager.close();
+  }
+
+  @Test
+  public void testManageWatermark()
+      throws IOException {
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+
+    double currentTimeMs = System.currentTimeMillis();
+    upsertMetadataManager.persistWatermark(currentTimeMs);
+    assertTrue(new File(INDEX_DIR, V1Constants.TTL_WATERMARK_TABLE_PARTITION + 0).exists());
+
+    double watermark = upsertMetadataManager.loadWatermark();
+    assertEquals(watermark, currentTimeMs);
+
+    ImmutableSegmentImpl segment =
+        mockImmutableSegmentWithEndTime(1, new ThreadSafeMutableRoaringBitmap(), null, new ArrayList<>(),
+            COMPARISON_COLUMNS, new Double(currentTimeMs + 1024), new MutableRoaringBitmap());
+    upsertMetadataManager.updateWatermark(segment);
+    assertEquals(upsertMetadataManager.getWatermark(), currentTimeMs + 1024);
+
+    // Stop the metadata manager
+    upsertMetadataManager.stop();
+
+    // Close the metadata manager
+    upsertMetadataManager.close();
   }
 
   @Test
@@ -1050,6 +1118,52 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   @Test
+  public void testPreloadSegmentOutOfTTL() {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
+    verifyPreloadSegmentOutOfTTL(HashFunction.NONE);
+    verifyPreloadSegmentOutOfTTL(HashFunction.MD5);
+    verifyPreloadSegmentOutOfTTL(HashFunction.MURMUR3);
+  }
+
+  private void verifyPreloadSegmentOutOfTTL(HashFunction hashFunction) {
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
+    Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    int numRecords = 3;
+    int[] primaryKeys = new int[]{0, 1, 2};
+    int[] docIds = new int[]{0, 1, 2};
+    ThreadSafeMutableRoaringBitmap validDocIds = new ThreadSafeMutableRoaringBitmap();
+    MutableRoaringBitmap snapshot = new MutableRoaringBitmap();
+    snapshot.add(docIds);
+    ImmutableSegmentImpl segment1 =
+        mockImmutableSegmentWithEndTime(1, validDocIds, null, getPrimaryKeyList(numRecords, primaryKeys),
+            COMPARISON_COLUMNS, 80, snapshot);
+
+    upsertMetadataManager.setWatermark(60);
+    upsertMetadataManager.doPreloadSegment(segment1);
+    assertEquals(recordLocationMap.keySet().size(), 3);
+    for (int key : primaryKeys) {
+      assertTrue(recordLocationMap.containsKey(HashUtils.hashPrimaryKey(makePrimaryKey(key), hashFunction)),
+          String.valueOf(key));
+    }
+
+    // Bump up the watermark, so that segment2 gets out of TTL and is skipped.
+    upsertMetadataManager.setWatermark(120);
+    primaryKeys = new int[]{10, 11, 12};
+    ImmutableSegmentImpl segment2 =
+        mockImmutableSegmentWithEndTime(1, validDocIds, null, getPrimaryKeyList(numRecords, primaryKeys),
+            COMPARISON_COLUMNS, 80, snapshot);
+    upsertMetadataManager.doPreloadSegment(segment2);
+    assertEquals(recordLocationMap.keySet().size(), 3);
+    for (int key : primaryKeys) {
+      assertFalse(recordLocationMap.containsKey(HashUtils.hashPrimaryKey(makePrimaryKey(key), hashFunction)),
+          String.valueOf(key));
+    }
+  }
+
+  @Test
   public void testAddRecordWithDeleteColumn()
       throws IOException {
     _contextBuilder.setDeleteRecordColumn(DELETE_RECORD_COLUMN);
@@ -1170,7 +1284,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
-            _contextBuilder.setHashFunction(hashFunction).setEnableSnapshot(true).build());
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -1260,6 +1374,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     MutableSegment segment0 = mockMutableSegment(1, validDocIds0, null);
     upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(10), 1, earlierComparisonValue, false));
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 80);
 
     // Add a segment with segmentEndTime = earlierComparisonValue, so it will not be skipped
     int numRecords = 4;
@@ -1271,10 +1386,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
         mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, earlierComparisonValue,
             null);
 
-    int[] docIds1 = new int[]{0, 1, 2, 3};
-    MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
-    validDocIdsSnapshot1.add(docIds1);
-
     // load segment1.
     upsertMetadataManager.addSegment(segment1, validDocIds1, null,
         getRecordInfoListForTTL(numRecords, primaryKeys, timestamps).iterator());
@@ -1284,6 +1395,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     checkRecordLocationForTTL(recordLocationMap, 2, segment1, 2, 120, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 3, segment1, 3, 80, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    // The watermark is updated by segment's max comparison value, although segment1 has a few docs with larger
+    // comparison values. This segment is created to simplify the tests here and it shouldn't exist in real world env.
+    assertEquals(upsertMetadataManager.getWatermark(), 80);
 
     // Add record to update largestSeenTimestamp, largest seen timestamp: largerComparisonValue
     upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(10), 0, largerComparisonValue, false));
@@ -1293,6 +1407,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     checkRecordLocationForTTL(recordLocationMap, 2, segment1, 2, 120, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 3, segment1, 3, 80, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 0, 120, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 120);
 
     // records before (largest seen timestamp - TTL) are expired and removed from upsertMetadata.
     upsertMetadataManager.removeExpiredPrimaryKeys();
@@ -1301,6 +1416,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     checkRecordLocationForTTL(recordLocationMap, 1, segment1, 1, 100, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 2, segment1, 2, 120, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 0, 120, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 120);
 
     // ValidDocIds for out-of-ttl records should not be removed.
     assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1, 2, 3});
@@ -1312,7 +1428,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     upsertMetadataManager.close();
   }
 
-  private void verifyAddOutOfTTLSegment()
+  private void verifyAddMultipleSegmentsWithOneOutOfTTL()
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
@@ -1334,10 +1450,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl segment1 =
         mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, new Double(80), null);
 
-    int[] docIds1 = new int[]{0, 1, 2, 3};
-    MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
-    validDocIdsSnapshot1.add(docIds1);
-
     // load segment1 with segmentEndTime: 80, largest seen timestamp: 80. the segment will be loaded.
     upsertMetadataManager.addSegment(segment1, validDocIds1, null,
         getRecordInfoListForTTL(numRecords, primaryKeys, timestamps).iterator());
@@ -1348,6 +1460,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     checkRecordLocationForTTL(recordLocationMap, 3, segment1, 3, 80, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
     assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1, 2, 3});
+    assertEquals(upsertMetadataManager.getWatermark(), 80);
 
     // Add record to update largestSeenTimestamp, largest seen timestamp: 120
     upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(0), 0, new Double(120), false));
@@ -1358,6 +1471,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     checkRecordLocationForTTL(recordLocationMap, 2, segment1, 2, 120, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 3, segment1, 3, 80, HashFunction.NONE);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 120);
 
     // Add an out-of-ttl segment, verify all the invalid docs should not show up again.
     // Add a segment with segmentEndTime: 80, largest seen timestamp: 120. the segment will be skipped.
@@ -1372,6 +1486,12 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     upsertMetadataManager.addSegment(segment2);
     // out of ttl segment should not be added to recordLocationMap
     assertEquals(recordLocationMap.size(), 5);
+    checkRecordLocationForTTL(recordLocationMap, 0, segment0, 0, 120, HashFunction.NONE);
+    checkRecordLocationForTTL(recordLocationMap, 1, segment1, 1, 100, HashFunction.NONE);
+    checkRecordLocationForTTL(recordLocationMap, 2, segment1, 2, 120, HashFunction.NONE);
+    checkRecordLocationForTTL(recordLocationMap, 3, segment1, 3, 80, HashFunction.NONE);
+    checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 120);
 
     // Stop the metadata manager
     upsertMetadataManager.stop();
@@ -1380,7 +1500,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     upsertMetadataManager.close();
   }
 
-  private void verifyAddOutOfTTLSegmentWithRecordDelete()
+  private void verifyAddSegmentOutOfTTLWithRecordDelete()
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
@@ -1489,7 +1609,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     }
   }
 
-  private void verifyAddSegmentForTTL(Comparable comparisonValue)
+  private void verifyAddSegmentOutOfTTL(Comparable comparisonValue)
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
@@ -1501,6 +1621,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     MutableSegment segment0 = mockMutableSegment(1, validDocIds0, null);
     upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(10), 1, comparisonValue, false));
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 80);
 
     // add a segment with segmentEndTime = -1 so it will be skipped since it out-of-TTL
     int numRecords = 4;
@@ -1510,14 +1631,11 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl segment1 =
         mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, -1, null);
 
-    int[] docIds1 = new int[]{0, 1, 2, 3};
-    MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
-    validDocIdsSnapshot1.add(docIds1);
-
     // load segment1.
     upsertMetadataManager.addSegment(segment1);
     assertEquals(recordLocationMap.size(), 1);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 80);
 
     // Stop the metadata manager
     upsertMetadataManager.stop();
@@ -1545,25 +1663,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     assertSame(recordLocation.getSegment(), segment);
     assertEquals(recordLocation.getDocId(), docId);
     assertEquals(((Number) recordLocation.getComparisonValue()).doubleValue(), comparisonValue.doubleValue());
-  }
-
-  private void verifyPersistAndLoadWatermark()
-      throws IOException {
-    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
-
-    double currentTimeMs = System.currentTimeMillis();
-    upsertMetadataManager.persistWatermark(currentTimeMs);
-    assertTrue(new File(INDEX_DIR, V1Constants.TTL_WATERMARK_TABLE_PARTITION + 0).exists());
-
-    double watermark = upsertMetadataManager.loadWatermark();
-    assertEquals(watermark, currentTimeMs);
-
-    // Stop the metadata manager
-    upsertMetadataManager.stop();
-
-    // Close the metadata manager
-    upsertMetadataManager.close();
   }
 
   @Test


### PR DESCRIPTION
This PR refines some checks on upsert TTL and the logic around updating watermark and skipping segments out of TTL, in particular:
1) _largestSeenComparisonValue can be negative so check it against special value Double.NEGATIVE_INFINITY instead of 0;
2) allow to add segments even outside TTL. This may be needed when one uploads segments to upsert table directly, but they are out of TTL. If they are skipped, then all their docs are treated as valid. The table data is not right unless docs in those uploaded segments are all valid.
3) persist TTL watermark after taking snapshot for more correctness
4) update TTL watermark and skip segments out of TTL for preloading as well