### PR TITLE
[SchemaConformingTransformer]Add one more json_data field

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
@@ -500,7 +500,7 @@ class ExtraFieldsContainer {
 
   ExtraFieldsContainer(boolean storeUnindexableExtras, List<String> indexableSpecialPrefix) {
     if (!indexableSpecialPrefix.isEmpty()) {
-      this._indexableSpecialPrefix = indexableSpecialPrefix;
+      _indexableSpecialPrefix = indexableSpecialPrefix;
     }
     _storeUnindexableExtras = storeUnindexableExtras;
   }
@@ -533,9 +533,9 @@ class ExtraFieldsContainer {
     Map<String, Object> indexables = isSpecials ? _indexableSpecials : _indexableExtras;
     if (indexables == null) {
       if (isSpecials) {
-        this._indexableSpecials = new HashMap<>();
+        _indexableSpecials = new HashMap<>();
       } else {
-        this._indexableExtras = new HashMap<>();
+        _indexableExtras = new HashMap<>();
       }
     }
     indexables = isSpecials ? _indexableSpecials : _indexableExtras;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
@@ -297,6 +297,8 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
       }
       putExtrasField(_transformerConfig.getIndexableExtrasField(), _indexableExtrasFieldType,
           extraFieldsContainer.getIndexableExtras(), outputRecord);
+      putExtrasField(_transformerConfig.getIndexableSpecialField(), _indexableExtrasFieldType,
+          extraFieldsContainer.getIndexableSpecials(), outputRecord);
       putExtrasField(_transformerConfig.getUnindexableExtrasField(), _unindexableExtrasFieldType,
           extraFieldsContainer.getUnindexableExtras(), outputRecord);
 
@@ -373,7 +375,8 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
     boolean storeIndexableExtras = _transformerConfig.getIndexableExtrasField() != null;
     boolean storeUnindexableExtras = _transformerConfig.getUnindexableExtrasField() != null;
     String key = jsonPath.peekLast();
-    ExtraFieldsContainer extraFieldsContainer = new ExtraFieldsContainer(storeUnindexableExtras);
+    ExtraFieldsContainer extraFieldsContainer = new ExtraFieldsContainer(
+        storeUnindexableExtras, _transformerConfig.getIndexableSpecialFieldPrefix());
 
     // Base case
     if (StreamDataDecoderImpl.isSpecialKeyType(key) || GenericRow.isSpecialKeyType(key)) {
@@ -409,13 +412,13 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
           // In schema
           outputRecord.putValue(currentNode.getColumnName(), currentNode.getValue(value));
           if (_transformerConfig.getFieldsToDoubleIngest().contains(keyJsonPath)) {
-            extraFieldsContainer.addIndexableEntry(key, value);
+            extraFieldsContainer.addIndexableEntry(key, value, keyJsonPath);
           }
           mergedTextIndexMap.put(keyJsonPath, value);
         } else {
           // Out of schema
           if (storeIndexableExtras) {
-            extraFieldsContainer.addIndexableEntry(key, value);
+            extraFieldsContainer.addIndexableEntry(key, value, keyJsonPath);
             mergedTextIndexMap.put(keyJsonPath, value);
           }
         }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2Test.java
@@ -112,9 +112,10 @@ public class SchemaConformingTransformerV2Test {
       String mergedTextIndexField) {
     IngestionConfig ingestionConfig = new IngestionConfig();
     SchemaConformingTransformerV2Config schemaConformingTransformerV2Config =
-        new SchemaConformingTransformerV2Config(indexableExtrasField != null, indexableExtrasField, INDEXABLE_SPECIA_FIELD_NAME, indexableExtraSpecialPrefix,
-            unindexableExtrasField != null, unindexableExtrasField, unindexableFieldSuffix, fieldPathsToDrop,
-            fieldPathsToPreserve, fieldPathToPreserverWithIndex, mergedTextIndexField, null, null, null, null, null);
+        new SchemaConformingTransformerV2Config(indexableExtrasField != null, indexableExtrasField,
+            INDEXABLE_SPECIA_FIELD_NAME, indexableExtraSpecialPrefix, unindexableExtrasField != null,
+            unindexableExtrasField, unindexableFieldSuffix, fieldPathsToDrop, fieldPathsToPreserve,
+            fieldPathToPreserverWithIndex, mergedTextIndexField, null, null, null, null, null);
     ingestionConfig.setSchemaConformingTransformerV2Config(schemaConformingTransformerV2Config);
     return new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setIngestionConfig(ingestionConfig)
         .build();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/SchemaConformingTransformerV2Config.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/SchemaConformingTransformerV2Config.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.config.table.ingestion;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,13 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
 
   @JsonPropertyDescription("Name of the field that should contain extra fields that are not part of the schema.")
   private String _indexableExtrasField = "json_data";
+
+  @JsonPropertyDescription("Name of the field that should contain special fields that are not part of the schema and "
+      + "whose prefix matches indexableSpecialFieldPrefix")
+  private String _indexableSpecialField = "json_data_inf_idx";
+
+  @JsonPropertyDescription("The list of prefixes of fields that must be stored in indexableSpecialField")
+  private List<String> _indexableSpecialFieldPrefix = new ArrayList<>();
 
   @JsonPropertyDescription("Enable unindexable extras")
   private boolean _enableUnindexableExtras = true;
@@ -94,6 +102,8 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   public SchemaConformingTransformerV2Config(
       @JsonProperty("enableIndexableExtras") @Nullable Boolean enableIndexableExtras,
       @JsonProperty("indexableExtrasField") String indexableExtrasField,
+      @JsonProperty("indexableSpecialField") String indexableSpecialField,
+      @JsonProperty("indexableSpecialFieldPrefix") List<String> indexableSpecialFieldPrefix,
       @JsonProperty("enableUnindexableExtras") @Nullable Boolean enableUnindexableExtras,
       @JsonProperty("unindexableExtrasField") @Nullable String unindexableExtrasField,
       @JsonProperty("unindexableFieldSuffix") @Nullable String unindexableFieldSuffix,
@@ -110,6 +120,8 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   ) {
     setEnableIndexableExtras(enableIndexableExtras);
     setIndexableExtrasField(indexableExtrasField);
+    setIndexableSpecialField(indexableSpecialField);
+    setIndexableSpecialFieldPrefix(indexableSpecialFieldPrefix);
     setEnableUnindexableExtras(enableUnindexableExtras);
     setUnindexableExtrasField(unindexableExtrasField);
     setUnindexableFieldSuffix(unindexableFieldSuffix);
@@ -136,6 +148,25 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
 
   public SchemaConformingTransformerV2Config setIndexableExtrasField(String indexableExtrasField) {
     _indexableExtrasField = indexableExtrasField == null ? _indexableExtrasField : indexableExtrasField;
+    return this;
+  }
+
+  public String getIndexableSpecialField() {
+    return _indexableSpecialFieldPrefix.isEmpty() ? null : _indexableSpecialField;
+  }
+
+  public SchemaConformingTransformerV2Config setIndexableSpecialField(String indexableSpecialField) {
+    _indexableSpecialField = indexableSpecialField == null ? _indexableSpecialField : indexableSpecialField;
+    return this;
+  }
+
+  public List<String> getIndexableSpecialFieldPrefix() {
+    return _indexableSpecialFieldPrefix;
+  }
+
+  public SchemaConformingTransformerV2Config setIndexableSpecialFieldPrefix(List<String> indexableSpecialFieldPrefix) {
+    _indexableSpecialFieldPrefix = indexableSpecialFieldPrefix == null ? _indexableSpecialFieldPrefix
+        : indexableSpecialFieldPrefix;
     return this;
   }
 


### PR DESCRIPTION
`feature` `ingestion`
To ingest json-like data through SchemaConformingTransformer, previously, we could only dump data to either dedicated column or a single json_data field. We may build json index on json_data field to serve queries.
However, in reality, users may e.g. dump data like request/response body to the json data and query them. For those special json field, they may want special treatment like more levels of json index.
With this patch, among the non-dedicated column data, we will be able to dump them to either default field or a special field filtered by its prefix. And in real use cases, users could choose to build more index or add other special treatments to it.

One example, user might set 3 levels json on the default `json_data` field but needs some part of json (e.g. `request` and `response`) has deeper level index, e.g. 5.
Then they could set `indexableSpecialFieldPrefix: ["request", "response"]` in the SchemaConformingTransformerV2 config, and add `json_data_inf_idx` as json index in the config with 5 levels.
```
"schemaConformingTransformerV2Config": {
        "enableIndexableExtras": true,
        "indexableExtrasField": "json_data",
        "enableUnindexableExtras": true,
        "indexableSpecialFieldPrefix": ["request", "response"],
        "indexableSpecialField": "json_data_inf_idx",
        "unindexableExtrasField": "json_data_no_idx",
        "unindexableFieldSuffix": "_noindex",
        "fieldPathsToDrop": [],
        "fieldPathsToSkipStorage": [
          "message"
        ],
        "columnNameToJsonKeyPathMap": {},
        "mergedTextIndexFields": [
          "__mergedTextIndex"
        ],
        "optimizeCaseInsensitiveSearch": false,
        "reverseTextIndexKeyValueOrder": true,
        "mergedTextIndexDocumentMaxLength": 32766,
        "mergedTextIndexBinaryDocumentDetectionMinLength": 512,
        "mergedTextIndexPathToExclude": [
          "_timestampMillisNegative",
          "__mergedTextIndex",
          "_timestampMillis"
        ],
        "fieldsToDoubleIngest": [],
        "jsonKeyValueSeparator": "\u001e",
        "mergedTextIndexBeginOfDocAnchor": "\u0002",
        "mergedTextIndexEndOfDocAnchor": "\u0003",
        "fieldPathsToPreserveInput": [],
        "fieldPathsToPreserveInputWithIndex": []
      },
"jsonIndexConfigs": {
        "json_data": {
          "disabled": false,
          "maxLevels": 3,
          "excludeArray": true,
          "disableCrossArrayUnnest": true,
          "maxValueLength": 1000,
          "skipInvalidJson": true
        },
      "json_data_inf_idx": {
          "disabled": false,
          "maxLevels": 5,
          "excludeArray": true,
          "disableCrossArrayUnnest": true,
          "maxValueLength": 1000,
          "skipInvalidJson": true
        }
      },
```
