### PR TITLE
Do not allow setting TableConfig in IndexLoadingConfig after construction

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -35,7 +34,6 @@ import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
@@ -99,6 +97,7 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     FileUtils.deleteDirectory(indexDir);
 
     TableConfig tableConfig = tableConfig();
+    Schema schema = schema();
 
     List<GenericRow> records = new ArrayList<>(numRecords());
     records.add(createRecord(1, 1, "daffy duck",
@@ -142,10 +141,8 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
         "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"days\": 111}"));
     records.add(createRecord(14, 14, "top level array", "[{\"i1\":1,\"i2\":2}, {\"i1\":3,\"i2\":4}]"));
 
-    List<String> jsonIndexColumns = new ArrayList<>();
-    jsonIndexColumns.add("jsonColumn");
-    tableConfig.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema());
+    tableConfig.getIndexingConfig().setJsonIndexColumns(List.of("jsonColumn"));
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(indexDir.getPath());
@@ -154,11 +151,7 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
     driver.build();
 
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(tableConfig);
-    indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
     ImmutableSegment immutableSegment =
         ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), indexLoadingConfig);
     _indexSegment = immutableSegment;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +58,7 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
-import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -68,7 +67,6 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
@@ -131,15 +129,22 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
       .addMultiValueDimension(MV_COL1_NO_INDEX, DataType.INT)
       .build();
 
+  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+      .setNoDictionaryColumns(List.of(COL1_RAW, MV_COL1_RAW))
+      .setSortedColumn(COL1_SORTED_INDEX)
+      .setInvertedIndexColumns(List.of(COL1_INVERTED_INDEX, COL2_INVERTED_INDEX, COL3_INVERTED_INDEX))
+      .setRangeIndexColumns(List.of(COL1_RANGE_INDEX, COL2_RANGE_INDEX, COL3_RANGE_INDEX))
+      .setJsonIndexColumns(List.of(COL1_JSON_INDEX))
+      .setFieldConfigList(List.of(
+          new FieldConfig(COL1_TEXT_INDEX, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.TEXT),
+              null, null)))
+      .build();
+
   private static final DataSchema DATA_SCHEMA = new DataSchema(
       new String[]{"Operator", "Operator_Id", "Parent_Id"},
       new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.INT}
   );
   //@formatter:on
-
-  private static final TableConfig TABLE_CONFIG =
-      new TableConfigBuilder(TableType.OFFLINE).setNoDictionaryColumns(List.of(COL1_RAW, MV_COL1_RAW))
-          .setTableName(RAW_TABLE_NAME).build();
 
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
@@ -198,22 +203,6 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
   ImmutableSegment createImmutableSegment(List<GenericRow> records, String segmentName)
       throws Exception {
-    IndexingConfig indexingConfig = TABLE_CONFIG.getIndexingConfig();
-
-    List<String> invertedIndexColumns = List.of(COL1_INVERTED_INDEX, COL2_INVERTED_INDEX, COL3_INVERTED_INDEX);
-    indexingConfig.setInvertedIndexColumns(invertedIndexColumns);
-
-    List<String> rangeIndexColumns = List.of(COL1_RANGE_INDEX, COL2_RANGE_INDEX, COL3_RANGE_INDEX);
-    indexingConfig.setRangeIndexColumns(rangeIndexColumns);
-
-    List<String> sortedIndexColumns = List.of(COL1_SORTED_INDEX);
-    indexingConfig.setSortedColumn(sortedIndexColumns);
-
-    List<String> jsonIndexColumns = List.of(COL1_JSON_INDEX);
-    indexingConfig.setJsonIndexColumns(jsonIndexColumns);
-
-    List<String> textIndexColumns = List.of(COL1_TEXT_INDEX);
-
     File tableDataDir = new File(TEMP_DIR, OFFLINE_TABLE_NAME);
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
     segmentGeneratorConfig.setSegmentName(segmentName);
@@ -223,16 +212,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
     driver.build();
 
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(TABLE_CONFIG);
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(invertedIndexColumns));
-    indexLoadingConfig.setRangeIndexColumns(new HashSet<>(rangeIndexColumns));
-    indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
-    indexLoadingConfig.setTextIndexColumns(new HashSet<>(textIndexColumns));
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
     _segmentNames.add(segmentName);
-
     return ImmutableSegmentLoader.load(new File(tableDataDir, segmentName), indexLoadingConfig);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExprMinMaxTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExprMinMaxTest.java
@@ -45,14 +45,13 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.utils.CommonConstants.RewriterConstants.*;
+import static org.apache.pinot.spi.utils.CommonConstants.RewriterConstants.CHILD_AGGREGATION_NAME_PREFIX;
+import static org.apache.pinot.spi.utils.CommonConstants.RewriterConstants.PARENT_AGGREGATION_NAME_PREFIX;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -63,7 +62,6 @@ import static org.testng.Assert.fail;
  * Queries test for exprmin/exprmax functions.
  */
 public class ExprMinMaxTest extends BaseQueriesTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ExprMinMaxTest.class);
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ExprMinMaxTest");
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME = "testSegment";

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesTest.java
@@ -20,13 +20,8 @@ package org.apache.pinot.queries;
 
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
@@ -39,20 +34,15 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
-import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
-import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -78,127 +68,96 @@ import static org.testng.Assert.*;
  * </ul>
  */
 public class ForwardIndexDisabledMultiValueQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), ForwardIndexDisabledMultiValueQueriesTest.class.getSimpleName());
   private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
-  private static final String SEGMENT_NAME_1 = "testTable_1756015688_1756015688";
-  private static final String SEGMENT_NAME_2 = "testTable_1756015689_1756015689";
-  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(),
-      "ForwardIndexDisabledMultiValueQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
 
   private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
 
-  // Hard-coded query filter.
+  //@formatter:off
+  // Hard-coded query filter
   protected static final String FILTER = " WHERE column1 > 100000000"
       + " AND column2 BETWEEN 20000000 AND 1000000000"
       + " AND column3 <> 'w'"
       + " AND (column6 < 500000 OR column7 NOT IN (225, 407))"
       + " AND daysSinceEpoch = 1756015683";
+  //@formatter:on
 
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments.
   private List<IndexSegment> _indexSegments;
 
-  private TableConfig _tableConfig;
-  private List<String> _invertedIndexColumns;
-  private List<String> _forwardIndexDisabledColumns;
-
-  @BeforeMethod
-  public void buildSegment()
+  @BeforeClass
+  public void setUp()
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
 
-    // Get resource file path.
+    //@formatter:off
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addMetric("column1", DataType.INT)
+        .addMetric("column2", DataType.INT)
+        .addSingleValueDimension("column3", DataType.STRING)
+        .addSingleValueDimension("column5", DataType.STRING)
+        .addMultiValueDimension("column6", DataType.INT)
+        .addMultiValueDimension("column7", DataType.INT)
+        .addSingleValueDimension("column8", DataType.INT)
+        .addMetric("column9", DataType.INT)
+        .addMetric("column10", DataType.INT)
+        .addDateTime("daysSinceEpoch", DataType.INT, "EPOCH|DAYS", "1:DAYS")
+        .build();
+
+    List<FieldConfig> fieldConfigs = List.of(
+        new FieldConfig("column6", FieldConfig.EncodingType.DICTIONARY, List.of(), null,
+            Map.of(FieldConfig.FORWARD_INDEX_DISABLED, "true")),
+        new FieldConfig("column7", FieldConfig.EncodingType.DICTIONARY, List.of(), null,
+            Map.of(FieldConfig.FORWARD_INDEX_DISABLED, "true")));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setTimeColumnName("daysSinceEpoch")
+        .setNoDictionaryColumns(List.of("column5"))
+        .setInvertedIndexColumns(List.of("column3", "column6", "column7", "column8", "column9"))
+        .setCreateInvertedIndexDuringSegmentGeneration(true)
+        .setFieldConfigList(fieldConfigs)
+        .build();
+    //@formatter:on
+
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
     assertNotNull(resource);
-    String filePath = resource.getFile();
+    String avroFile = resource.getFile();
 
-    // Build the segment schema.
-    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
-        .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
-        .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
-        .addMultiValueDimension("column6", FieldSpec.DataType.INT)
-        .addMultiValueDimension("column7", FieldSpec.DataType.INT)
-        .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
-        .addMetric("column10", FieldSpec.DataType.INT)
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
-
-    createSegment(filePath, SEGMENT_NAME_1, schema);
-    createSegment(filePath, SEGMENT_NAME_2, schema);
-
-    ImmutableSegment immutableSegment1 = loadSegmentWithMetadataChecks(SEGMENT_NAME_1);
-    ImmutableSegment immutableSegment2 = loadSegmentWithMetadataChecks(SEGMENT_NAME_2);
-
-    _indexSegment = immutableSegment1;
-    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2);
-  }
-
-  private void createSegment(String filePath, String segmentName, Schema schema)
-      throws Exception {
-    // Create field configs for the no forward index columns
-    List<FieldConfig> fieldConfigList = new ArrayList<>();
-    fieldConfigList.add(new FieldConfig("column6", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(), null,
-        Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())));
-    if (segmentName.equals(SEGMENT_NAME_1)) {
-      fieldConfigList.add(new FieldConfig("column7", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          null, Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())));
-
-      // Build table config based on segment 1 as it contains both columns under no forward index
-      _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setNoDictionaryColumns(Arrays.asList("column5"))
-          .setTableName("testTable").setTimeColumnName("daysSinceEpoch").setFieldConfigList(fieldConfigList).build();
-    }
-
-    // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, schema);
-    segmentGeneratorConfig.setInputFilePath(filePath);
-    segmentGeneratorConfig.setTableName("testTable");
-    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
-    segmentGeneratorConfig.setSegmentName(segmentName);
-    _invertedIndexColumns = Arrays.asList("column3", "column6", "column7", "column8", "column9");
-    segmentGeneratorConfig.setIndexOn(StandardIndexes.inverted(), IndexConfig.ENABLED, _invertedIndexColumns);
-    _forwardIndexDisabledColumns = new ArrayList<>(Arrays.asList("column6", "column7"));
-    segmentGeneratorConfig.setIndexOn(StandardIndexes.forward(), ForwardIndexConfig.DISABLED,
-        _forwardIndexDisabledColumns);
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we first need to fix the input avro data
-    // to have the time column values in allowed range. Until then, the check
-    // is explicitly disabled
-    segmentGeneratorConfig.setSkipTimeValueCheck(true);
-
-    // Build the index segment.
+    SegmentGeneratorConfig generatorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    generatorConfig.setInputFilePath(avroFile);
+    generatorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    generatorConfig.setSegmentName(SEGMENT_NAME);
+    generatorConfig.setSkipTimeValueCheck(true);
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig);
+    driver.init(generatorConfig);
     driver.build();
-  }
 
-  private ImmutableSegment loadSegmentWithMetadataChecks(String segmentName)
-      throws Exception {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(_invertedIndexColumns));
-    indexLoadingConfig.setForwardIndexDisabledColumns(new HashSet<>(_forwardIndexDisabledColumns));
-    indexLoadingConfig.setReadMode(ReadMode.heap);
-
-    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName),
-        indexLoadingConfig);
-
-    Map<String, ColumnMetadata> columnMetadataMap1 = immutableSegment.getSegmentMetadata().getColumnMetadataMap();
-    columnMetadataMap1.forEach((column, metadata) -> {
+    ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME),
+        new IndexLoadingConfig(tableConfig, schema));
+    Map<String, ColumnMetadata> columnMetadataMap = segment.getSegmentMetadata().getColumnMetadataMap();
+    for (Map.Entry<String, ColumnMetadata> entry : columnMetadataMap.entrySet()) {
+      String column = entry.getKey();
+      ColumnMetadata metadata = entry.getValue();
       if (column.equals("column6") || column.equals("column7")) {
         assertTrue(metadata.hasDictionary());
         assertFalse(metadata.isSingleValue());
-        assertNull(immutableSegment.getForwardIndex(column));
+        assertNull(segment.getForwardIndex(column));
       } else {
-        assertNotNull(immutableSegment.getForwardIndex(column));
+        assertNotNull(segment.getForwardIndex(column));
       }
-    });
+    }
 
-    return immutableSegment;
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
   }
 
-  @AfterMethod
-  public void deleteAndDestroySegment() {
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
     FileUtils.deleteQuietly(INDEX_DIR);
-    _indexSegments.forEach((IndexSegment::destroy));
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesWithReloadTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesWithReloadTest.java
@@ -21,13 +21,10 @@ package org.apache.pinot.queries;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
@@ -40,16 +37,11 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
-import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
-import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -80,22 +72,25 @@ import static org.testng.Assert.*;
  * </ul>
  */
 public class ForwardIndexDisabledMultiValueQueriesWithReloadTest extends BaseQueriesTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), ForwardIndexDisabledMultiValueQueriesWithReloadTest.class.getSimpleName());
   private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
-  private static final String SEGMENT_NAME_1 = "testTable_1756015688_1756015688";
-  private static final String SEGMENT_NAME_2 = "testTable_1756015689_1756015689";
-  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(),
-      "ForwardIndexDisabledMultiValueQueriesWithReloadTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
 
-  // Build the segment schema.
-  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName("testTable")
-      .addMetric("column1", FieldSpec.DataType.INT)
-      .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
-      .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
-      .addMultiValueDimension("column6", FieldSpec.DataType.INT)
-      .addMultiValueDimension("column7", FieldSpec.DataType.INT)
-      .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
-      .addMetric("column10", FieldSpec.DataType.INT)
-      .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
+  //@formatter:off
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+      .addMetric("column1", DataType.INT)
+      .addMetric("column2", DataType.INT)
+      .addSingleValueDimension("column3", DataType.STRING)
+      .addSingleValueDimension("column5", DataType.STRING)
+      .addMultiValueDimension("column6", DataType.INT)
+      .addMultiValueDimension("column7", DataType.INT)
+      .addSingleValueDimension("column8", DataType.INT)
+      .addMetric("column9", DataType.INT)
+      .addMetric("column10", DataType.INT)
+      .addDateTime("daysSinceEpoch", DataType.INT, "EPOCH|DAYS", "1:DAYS")
+      .build();
 
   // Hard-coded query filter.
   protected static final String FILTER = " WHERE column1 > 100000000"
@@ -103,103 +98,69 @@ public class ForwardIndexDisabledMultiValueQueriesWithReloadTest extends BaseQue
       + " AND column3 <> 'w'"
       + " AND (column6 < 500000 OR column7 NOT IN (225, 407))"
       + " AND daysSinceEpoch = 1756015683";
+  //@formatter:on
 
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments.
   private List<IndexSegment> _indexSegments;
 
-  private TableConfig _tableConfig;
-  private List<String> _invertedIndexColumns;
-  private List<String> _forwardIndexDisabledColumns;
-  private List<String> _noDictionaryColumns;
-
   @BeforeMethod
-  public void buildSegment()
+  public void setUp()
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
 
-    // Get resource file path.
+    TableConfig tableConfig =
+        createTableConfig(List.of("column5", "column7"), List.of("column3", "column6", "column8", "column9"),
+            List.of("column6"));
+
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
     assertNotNull(resource);
-    String filePath = resource.getFile();
+    String avroFile = resource.getFile();
 
-    createSegment(filePath, SEGMENT_NAME_1);
-    createSegment(filePath, SEGMENT_NAME_2);
-
-    ImmutableSegment immutableSegment1 = loadSegmentWithMetadataChecks(SEGMENT_NAME_1);
-    ImmutableSegment immutableSegment2 = loadSegmentWithMetadataChecks(SEGMENT_NAME_2);
-
-    _indexSegment = immutableSegment1;
-    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2);
-  }
-
-  private void createSegment(String filePath, String segmentName)
-      throws Exception {
-    // Create field configs for the no forward index columns
-    List<FieldConfig> fieldConfigList = new ArrayList<>();
-    fieldConfigList.add(new FieldConfig("column6", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(), null,
-        Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())));
-    // Build table config based on segment 1 as it contains both columns under no forward index
-    _noDictionaryColumns = new ArrayList<>(Arrays.asList("column5", "column7"));
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
-        .setTimeColumnName("daysSinceEpoch").setNoDictionaryColumns(_noDictionaryColumns)
-        .setFieldConfigList(fieldConfigList).build();
-
-    // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, SCHEMA);
-    segmentGeneratorConfig.setInputFilePath(filePath);
-    segmentGeneratorConfig.setTableName("testTable");
-    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
-    segmentGeneratorConfig.setSegmentName(segmentName);
-    _invertedIndexColumns = Arrays.asList("column3", "column6", "column8", "column9");
-    segmentGeneratorConfig.setIndexOn(StandardIndexes.inverted(), IndexConfig.ENABLED, _invertedIndexColumns);
-    _forwardIndexDisabledColumns = new ArrayList<>(Arrays.asList("column6"));
-    segmentGeneratorConfig.setIndexOn(StandardIndexes.forward(), ForwardIndexConfig.DISABLED,
-        _forwardIndexDisabledColumns);
-    segmentGeneratorConfig.setRawIndexCreationColumns(_noDictionaryColumns);
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we first need to fix the input avro data
-    // to have the time column values in allowed range. Until then, the check
-    // is explicitly disabled
-    segmentGeneratorConfig.setSkipTimeValueCheck(true);
-
-    // Build the index segment.
+    SegmentGeneratorConfig generatorConfig = new SegmentGeneratorConfig(tableConfig, SCHEMA);
+    generatorConfig.setInputFilePath(avroFile);
+    generatorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    generatorConfig.setSegmentName(SEGMENT_NAME);
+    generatorConfig.setSkipTimeValueCheck(true);
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig);
+    driver.init(generatorConfig);
     driver.build();
-  }
 
-  private ImmutableSegment loadSegmentWithMetadataChecks(String segmentName)
-      throws Exception {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(_invertedIndexColumns));
-    indexLoadingConfig.setForwardIndexDisabledColumns(new HashSet<>(_forwardIndexDisabledColumns));
-    indexLoadingConfig.setNoDictionaryColumns(new HashSet<>(_noDictionaryColumns));
-    indexLoadingConfig.setReadMode(ReadMode.heap);
-
-    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName),
-        indexLoadingConfig);
-
-    Map<String, ColumnMetadata> columnMetadataMap1 = immutableSegment.getSegmentMetadata().getColumnMetadataMap();
-    columnMetadataMap1.forEach((column, metadata) -> {
+    ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME),
+        new IndexLoadingConfig(tableConfig, SCHEMA));
+    Map<String, ColumnMetadata> columnMetadataMap = segment.getSegmentMetadata().getColumnMetadataMap();
+    for (Map.Entry<String, ColumnMetadata> entry : columnMetadataMap.entrySet()) {
+      String column = entry.getKey();
+      ColumnMetadata metadata = entry.getValue();
       if (column.equals("column6")) {
         assertTrue(metadata.hasDictionary());
         assertFalse(metadata.isSingleValue());
-        assertNull(immutableSegment.getForwardIndex(column));
+        assertNull(segment.getForwardIndex(column));
       } else {
-        assertNotNull(immutableSegment.getForwardIndex(column));
+        assertNotNull(segment.getForwardIndex(column));
       }
-    });
+    }
 
-    return immutableSegment;
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
+  }
+
+  private TableConfig createTableConfig(List<String> noDictionaryColumns, List<String> invertedIndexColumns,
+      List<String> forwardIndexDisabledColumns) {
+    List<FieldConfig> fieldConfigs = new ArrayList<>(forwardIndexDisabledColumns.size());
+    for (String column : forwardIndexDisabledColumns) {
+      fieldConfigs.add(new FieldConfig(column, FieldConfig.EncodingType.DICTIONARY, List.of(), null,
+          Map.of(FieldConfig.FORWARD_INDEX_DISABLED, "true")));
+    }
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTimeColumnName("daysSinceEpoch")
+        .setNoDictionaryColumns(noDictionaryColumns).setInvertedIndexColumns(invertedIndexColumns)
+        .setCreateInvertedIndexDuringSegmentGeneration(true).setFieldConfigList(fieldConfigs).build();
   }
 
   @AfterMethod
-  public void deleteAndDestroySegment() {
+  public void tearDown() {
+    _indexSegment.destroy();
     FileUtils.deleteQuietly(INDEX_DIR);
-    _indexSegments.forEach((IndexSegment::destroy));
   }
 
   @Override
@@ -409,7 +370,8 @@ public class ForwardIndexDisabledMultiValueQueriesWithReloadTest extends BaseQue
     // Validate that the result row size before disabling the forward index matches the result row size after
     // re-enabling the forward index
     assertEquals(resultRowsAfterReenabling.size(), resultRowsBeforeDisabling.size());
-    for (int i = 0; i < resultRowsAfterReenabling.size(); i++) {
+    // Validate the first 10 rows
+    for (int i = 0; i < 10; i++) {
       Object[] resultRow = resultRowsAfterReenabling.get(i);
       assertEquals(resultRow.length, 1);
       int[] rowValuesAfterReenabling = (int[]) resultRow[0];
@@ -745,69 +707,45 @@ public class ForwardIndexDisabledMultiValueQueriesWithReloadTest extends BaseQue
 
   private void disableForwardIndexForSomeColumns()
       throws Exception {
-    // Now disable forward index for column7 in the index loading config.
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    Set<String> invertedIndexEnabledColumns = new HashSet<>(_invertedIndexColumns);
-    invertedIndexEnabledColumns.add("column7");
-    indexLoadingConfig.setInvertedIndexColumns(invertedIndexEnabledColumns);
-    Set<String> forwardIndexDisabledColumns = new HashSet<>(_forwardIndexDisabledColumns);
-    forwardIndexDisabledColumns.add("column7");
-    indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    indexLoadingConfig.removeNoDictionaryColumns("column7");
-    indexLoadingConfig.setReadMode(ReadMode.heap);
+    // Now disable forward index for column7 in the table config
+    TableConfig tableConfig =
+        createTableConfig(List.of("column5"), List.of("column3", "column6", "column7", "column8", "column9"),
+            List.of("column6", "column7"));
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, SCHEMA);
 
     // Reload the segments to pick up the new configs
-    File indexDir = new File(INDEX_DIR, SEGMENT_NAME_1);
-    ImmutableSegment immutableSegment1 = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
-    indexDir = new File(INDEX_DIR, SEGMENT_NAME_2);
-    ImmutableSegment immutableSegment2 = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
-    _indexSegment = immutableSegment1;
-    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2);
+    File indexDir = new File(INDEX_DIR, SEGMENT_NAME);
+    ImmutableSegment segment = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
+    _indexSegment.destroy();
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
 
-    assertNull(immutableSegment1.getForwardIndex("column7"));
-    assertNotNull(immutableSegment1.getInvertedIndex("column7"));
-    assertNotNull(immutableSegment1.getDictionary("column7"));
-
-    assertNull(immutableSegment2.getForwardIndex("column7"));
-    assertNotNull(immutableSegment2.getInvertedIndex("column7"));
-    assertNotNull(immutableSegment2.getDictionary("column7"));
+    assertNull(segment.getForwardIndex("column7"));
+    assertNotNull(segment.getInvertedIndex("column7"));
+    assertNotNull(segment.getDictionary("column7"));
   }
 
   private void reenableForwardIndexForSomeColumns()
       throws Exception {
-    // Now re-enable forward index for column7 in the index loading config.
+    // Now re-enable forward index for column7 in the table config
     // Also re-enable forward index for column6
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    Set<String> invertedIndexEnabledColumns = new HashSet<>(_invertedIndexColumns);
-    indexLoadingConfig.setInvertedIndexColumns(invertedIndexEnabledColumns);
-    Set<String> forwardIndexDisabledColumns = new HashSet<>(_forwardIndexDisabledColumns);
-    forwardIndexDisabledColumns.remove("column6");
-    indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    indexLoadingConfig.addNoDictionaryColumns("column7");
-    indexLoadingConfig.setReadMode(ReadMode.heap);
+    TableConfig tableConfig =
+        createTableConfig(List.of("column5", "column7"), List.of("column3", "column6", "column8", "column9"),
+            List.of());
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, SCHEMA);
 
     // Reload the segments to pick up the new configs
-    File indexDir = new File(INDEX_DIR, SEGMENT_NAME_1);
-    ImmutableSegment immutableSegment1 = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
-    indexDir = new File(INDEX_DIR, SEGMENT_NAME_2);
-    ImmutableSegment immutableSegment2 = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
-    _indexSegment = immutableSegment1;
-    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2);
+    File indexDir = new File(INDEX_DIR, SEGMENT_NAME);
+    ImmutableSegment segment = reloadSegment(indexDir, indexLoadingConfig, SCHEMA);
+    _indexSegment.destroy();
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
 
-    assertNotNull(immutableSegment1.getForwardIndex("column7"));
-    assertNull(immutableSegment1.getInvertedIndex("column7"));
-    assertNull(immutableSegment1.getDictionary("column7"));
-    assertNotNull(immutableSegment1.getForwardIndex("column6"));
-    assertNotNull(immutableSegment1.getInvertedIndex("column6"));
-    assertNotNull(immutableSegment1.getDictionary("column6"));
-
-    assertNotNull(immutableSegment2.getForwardIndex("column7"));
-    assertNull(immutableSegment2.getInvertedIndex("column7"));
-    assertNull(immutableSegment2.getDictionary("column7"));
-    assertNotNull(immutableSegment2.getForwardIndex("column6"));
-    assertNotNull(immutableSegment2.getInvertedIndex("column6"));
-    assertNotNull(immutableSegment2.getDictionary("column6"));
+    assertNotNull(segment.getForwardIndex("column7"));
+    assertNull(segment.getInvertedIndex("column7"));
+    assertNull(segment.getDictionary("column7"));
+    assertNotNull(segment.getForwardIndex("column6"));
+    assertNotNull(segment.getInvertedIndex("column6"));
+    assertNotNull(segment.getDictionary("column6"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -35,97 +34,90 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 public class JsonMalformedIndexTest extends BaseQueriesTest {
-    private static final String RAW_TABLE_NAME = "testTable";
-    private static final String SEGMENT_NAME = "testSegment";
-    private static final String STRING_COLUMN = "stringColumn";
-    private static final String JSON_COLUMN = "jsonColumn";
-    private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
-            .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
-            .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.STRING).build();
-    private static final TableConfig TABLE_CONFIG =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
-    private IndexSegment _indexSegment;
-    private List<IndexSegment> _indexSegments;
-    private final List<GenericRow> _records = new ArrayList<>();
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final String STRING_COLUMN = "stringColumn";
+  private static final String JSON_COLUMN = "jsonColumn";
+  //@formatter:off
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+      .addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+      .addSingleValueDimension(JSON_COLUMN, DataType.STRING)
+      .build();
+  //@formatter:on
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setJsonIndexColumns(List.of(JSON_COLUMN))
+          .build();
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+  private final List<GenericRow> _records = new ArrayList<>();
 
-    @BeforeClass
-    public void setUp()
-            throws Exception {
-        _records.add(createRecord("ludwik von drake",
-                "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, "
-                        + "\"data\": [\"l\", \"b\", \"c\", \"d\"]"));
-    }
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _records.add(createRecord("ludwik von drake",
+        "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, "
+            + "\"data\": [\"l\", \"b\", \"c\", \"d\"]"));
+  }
 
-    protected void checkResult(String query, Object[][] expectedResults) {
-        BrokerResponseNative brokerResponse = getBrokerResponseForOptimizedQuery(query, TABLE_CONFIG, SCHEMA);
-        QueriesTestUtils.testInterSegmentsResult(brokerResponse, Arrays.asList(expectedResults));
-    }
+  protected void checkResult(String query, Object[][] expectedResults) {
+    BrokerResponseNative brokerResponse = getBrokerResponseForOptimizedQuery(query, TABLE_CONFIG, SCHEMA);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, Arrays.asList(expectedResults));
+  }
 
-    File indexDir() {
-        return new File(FileUtils.getTempDirectory(), getClass().getSimpleName());
-    }
+  File indexDir() {
+    return new File(FileUtils.getTempDirectory(), getClass().getSimpleName());
+  }
 
-    GenericRow createRecord(String stringValue, String jsonValue) {
-        GenericRow record = new GenericRow();
-        record.putValue(STRING_COLUMN, stringValue);
-        record.putValue(JSON_COLUMN, jsonValue);
-        return record;
-    }
+  GenericRow createRecord(String stringValue, String jsonValue) {
+    GenericRow record = new GenericRow();
+    record.putValue(STRING_COLUMN, stringValue);
+    record.putValue(JSON_COLUMN, jsonValue);
+    return record;
+  }
 
-    @Test(expectedExceptions = ColumnJsonParserException.class,
-          expectedExceptionsMessageRegExp = "Column: jsonColumn.*")
-    public void testJsonIndexBuild()
-            throws Exception {
-        File indexDir = indexDir();
-        FileUtils.deleteDirectory(indexDir);
+  @Test(expectedExceptions = ColumnJsonParserException.class, expectedExceptionsMessageRegExp = "Column: jsonColumn.*")
+  public void testJsonIndexBuild()
+      throws Exception {
+    File indexDir = indexDir();
+    FileUtils.deleteDirectory(indexDir);
 
-        List<String> jsonIndexColumns = new ArrayList<>();
-        jsonIndexColumns.add("jsonColumn");
-        TABLE_CONFIG.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
-        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
-        segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
-        segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-        segmentGeneratorConfig.setOutDir(indexDir.getPath());
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setOutDir(indexDir.getPath());
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(_records));
+    driver.build();
 
-        SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(_records));
-        driver.build();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
+    ImmutableSegment segment = ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), indexLoadingConfig);
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
 
-        IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-        indexLoadingConfig.setTableConfig(TABLE_CONFIG);
-        indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
-        indexLoadingConfig.setReadMode(ReadMode.mmap);
+    Object[][] expected = {{"von drake"}, {"von drake"}, {"von drake"}, {"von drake"}};
+    checkResult("SELECT jsonextractscalar(jsonColumn, '$.name.last', 'STRING') FROM testTable", expected);
+  }
 
-        ImmutableSegment immutableSegment =
-                ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), indexLoadingConfig);
-        _indexSegment = immutableSegment;
-        _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  @Override
+  protected String getFilter() {
+    return "";
+  }
 
-        Object[][] expecteds1 = {{"von drake"}, {"von drake"}, {"von drake"}, {"von drake"}};
-        checkResult("SELECT jsonextractscalar(jsonColumn, '$.name.last', 'STRING') FROM testTable", expecteds1);
-    }
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
 
-    @Override
-    protected String getFilter() {
-        return "";
-    }
-
-    @Override
-    protected IndexSegment getIndexSegment() {
-        return _indexSegment;
-    }
-
-    @Override
-    protected List<IndexSegment> getIndexSegments() {
-        return _indexSegments;
-    }
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonUnnestIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonUnnestIngestionFromAvroQueriesTest.java
@@ -49,10 +49,9 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -76,25 +75,32 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
   private static final String JSON_COLUMN = "jsonColumn"; // for testing ARRAY of MAPS
   private static final String STRING_COLUMN = "stringColumn";
   private static final String EVENTTIME_JSON_COLUMN = "eventTimeColumn";
-  private static final org.apache.pinot.spi.data.Schema SCHEMA =
-      new org.apache.pinot.spi.data.Schema.SchemaBuilder()
-          .addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
-          .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
-          .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
-          .addSingleValueDimension("jsonColumn.timestamp", FieldSpec.DataType.TIMESTAMP)
-          .addSingleValueDimension("jsonColumn.data", FieldSpec.DataType.JSON)
-          .addSingleValueDimension("jsonColumn.data.a", FieldSpec.DataType.STRING)
-          .addSingleValueDimension("jsonColumn.data.b", FieldSpec.DataType.STRING)
-          .addSingleValueDimension(EVENTTIME_JSON_COLUMN, FieldSpec.DataType.TIMESTAMP)
-          .addSingleValueDimension("eventTimeColumn_10m", FieldSpec.DataType.TIMESTAMP)
-          .build();
-  private static final TableConfig TABLE_CONFIG =
-      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setIngestionConfig(
-          new IngestionConfig(null, null, null, null,
-              List.of(new TransformConfig("eventTimeColumn", "eventTimeColumn.seconds * 1000"),
-                  new TransformConfig("eventTimeColumn_10m", "round(eventTimeColumn, 60000)")),
-              new ComplexTypeConfig(List.of(JSON_COLUMN), null, null, null), null, null, null)
-      ).build();
+  //@formatter:off
+  private static final org.apache.pinot.spi.data.Schema SCHEMA = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+      .setSchemaName(RAW_TABLE_NAME)
+      .addSingleValueDimension(INT_COLUMN, DataType.INT)
+      .addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+      .addSingleValueDimension(JSON_COLUMN, DataType.JSON)
+      .addSingleValueDimension("jsonColumn.timestamp", DataType.TIMESTAMP)
+      .addSingleValueDimension("jsonColumn.data", DataType.JSON)
+      .addSingleValueDimension("jsonColumn.data.a", DataType.STRING)
+      .addSingleValueDimension("jsonColumn.data.b", DataType.STRING)
+      .addSingleValueDimension(EVENTTIME_JSON_COLUMN, DataType.TIMESTAMP)
+      .addSingleValueDimension("eventTimeColumn_10m", DataType.TIMESTAMP)
+      .build();
+  //@formatter:on
+  private static final TableConfig TABLE_CONFIG;
+
+  static {
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setTransformConfigs(
+        List.of(new TransformConfig("eventTimeColumn", "eventTimeColumn.seconds * 1000"),
+            new TransformConfig("eventTimeColumn_10m", "round(eventTimeColumn, 60000)")));
+    ingestionConfig.setComplexTypeConfig(new ComplexTypeConfig(List.of(JSON_COLUMN), null, null, null));
+    TABLE_CONFIG =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setIngestionConfig(ingestionConfig)
+            .setJsonIndexColumns(List.of(JSON_COLUMN)).build();
+  }
 
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
@@ -294,27 +300,19 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
     FileUtils.deleteDirectory(INDEX_DIR);
     createInputFile();
 
-    List<String> jsonIndexColumns = Arrays.asList(JSON_COLUMN);
-    TABLE_CONFIG.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
-    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
-    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
-    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
     segmentGeneratorConfig.setInputFilePath(AVRO_DATA_FILE.getPath());
-
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig, createRecordReader());
     driver.build();
 
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(TABLE_CONFIG);
-    indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-
-    ImmutableSegment immutableSegment =
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
+    ImmutableSegment segment =
         ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
-    _indexSegment = immutableSegment;
-    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+    _indexSegment = segment;
+    _indexSegments = List.of(segment, segment);
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -135,10 +135,14 @@ public class IndexLoadingConfig {
     this(instanceDataManagerConfig, tableConfig, null);
   }
 
+  @VisibleForTesting
   public IndexLoadingConfig(TableConfig tableConfig, @Nullable Schema schema) {
     extractFromTableConfigAndSchema(tableConfig, schema);
   }
 
+  /**
+   * NOTE: Can be used in production code when we want to load a segment as is without any modifications.
+   */
   public IndexLoadingConfig() {
   }
 
@@ -861,6 +865,7 @@ public class IndexLoadingConfig {
     return _realtimeAvgMultiValueCount;
   }
 
+  @Nullable
   public TableConfig getTableConfig() {
     return _tableConfig;
   }
@@ -868,12 +873,6 @@ public class IndexLoadingConfig {
   @Nullable
   public Schema getSchema() {
     return _schema;
-  }
-
-  @VisibleForTesting
-  public void setTableConfig(TableConfig tableConfig) {
-    _tableConfig = tableConfig;
-    _dirty = true;
   }
 
   public String getSegmentDirectoryLoader() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -189,8 +189,6 @@ public class SegmentPreProcessorTest {
     _indexLoadingConfig.setInvertedIndexColumns(
         Sets.newHashSet(COLUMN1_NAME, COLUMN7_NAME, COLUMN13_NAME, NO_SUCH_COLUMN_NAME));
 
-    _indexLoadingConfig.setTableConfig(_tableConfig);
-
     ClassLoader classLoader = getClass().getClassLoader();
     URL resourceUrl = classLoader.getResource(AVRO_DATA);
     assertNotNull(resourceUrl);
@@ -231,13 +229,12 @@ public class SegmentPreProcessorTest {
   }
 
   private IndexLoadingConfig getDefaultIndexLoadingConfig() {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(_tableConfig, null);
 
     // Set RAW columns. Otherwise, they will end up being converted to dict columns (default) during segment reload.
     indexLoadingConfig.setNoDictionaryColumns(
         Sets.newHashSet(EXISTING_STRING_COL_RAW, EXISTING_INT_COL_RAW_MV, EXISTING_INT_COL_RAW));
 
-    indexLoadingConfig.setTableConfig(_tableConfig);
     return indexLoadingConfig;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -82,13 +82,13 @@ public class FieldConfig extends BaseJsonConfig {
   private final TimestampConfig _timestampConfig;
 
   @Deprecated
-  public FieldConfig(String name, EncodingType encodingType, IndexType indexType, CompressionCodec compressionCodec,
-      Map<String, String> properties) {
+  public FieldConfig(String name, EncodingType encodingType, @Nullable IndexType indexType,
+      @Nullable CompressionCodec compressionCodec, @Nullable Map<String, String> properties) {
     this(name, encodingType, indexType, null, compressionCodec, null, null, properties, null);
   }
 
-  public FieldConfig(String name, EncodingType encodingType, List<IndexType> indexTypes,
-      CompressionCodec compressionCodec, Map<String, String> properties) {
+  public FieldConfig(String name, EncodingType encodingType, @Nullable List<IndexType> indexTypes,
+      @Nullable CompressionCodec compressionCodec, @Nullable Map<String, String> properties) {
     this(name, encodingType, null, indexTypes, compressionCodec, null, null, properties, null);
   }
 


### PR DESCRIPTION
We should not allow setting `TableConfig` into `IndexLoadingConfig` after it is constructed because the step of extracting index settings are not performed.
Ideally, we should not allow any setter in `IndexLoadingConfig`, and it should always honor table config and schema. That involves bigger change, and will be addressed in followup PRs