### PR TITLE
Rewrite BETWEEN to >= AND <=

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -161,6 +161,13 @@ public class CalciteSqlParser {
     return compileToPinotQuery(compileToSqlNodeAndOptions(sql));
   }
 
+  /**
+   * Should only be used for testing query rewriters.
+   */
+  public static PinotQuery compileToPinotQueryWithoutRewrites(String sql) {
+    return compileWithoutRewrite(compileToSqlNodeAndOptions(sql).getSqlNode());
+  }
+
   public static PinotQuery compileToPinotQuery(SqlNodeAndOptions sqlNodeAndOptions) {
     // Compile SqlNode into PinotQuery
     PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
@@ -416,6 +423,15 @@ public class CalciteSqlParser {
   }
 
   public static PinotQuery compileSqlNodeToPinotQuery(SqlNode sqlNode) {
+    PinotQuery pinotQuery = compileWithoutRewrite(sqlNode);
+    queryRewrite(pinotQuery);
+    return pinotQuery;
+  }
+
+  /**
+   * Should only be used for testing query rewriters.
+   */
+  private static PinotQuery compileWithoutRewrite(SqlNode sqlNode) {
     PinotQuery pinotQuery = new PinotQuery();
     if (sqlNode instanceof SqlExplain) {
       // Extract sql node for the query
@@ -482,7 +498,6 @@ public class CalciteSqlParser {
       pinotQuery.setOffset(((SqlNumericLiteral) offsetNode).intValue(false));
     }
 
-    queryRewrite(pinotQuery);
     return pinotQuery;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -322,10 +322,16 @@ public class CalciteSqlCompilerTest {
     {
       PinotQuery pinotQuery = compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
-      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 70);
-      Assert.assertEquals(func.getOperands().get(2).getLiteral().getIntValue(), 80);
+      // BETWEEN is rewritten to >= AND <=
+      Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
+      List<Expression> operands = func.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "e");
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 70);
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "e");
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 80);
     }
 
     {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+
+public class PredicateComparisonRewriterTest {
+  PredicateComparisonRewriter _predicateComparisonRewriter = new PredicateComparisonRewriter();
+
+  @Test
+  public void testIdentifierPredicateRewrite() {
+    // A query like "select * from table where col1" should be rewritten to "select * from table where col1 = true"
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites("SELECT * FROM mytable WHERE col1");
+    assertTrue(pinotQuery.getFilterExpression().isSetIdentifier());
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "col1");
+    Assert.assertTrue(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getBoolValue());
+    assertTrue(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getBoolValue());
+  }
+
+  @Test
+  public void testFunctionPredicateRewrite() {
+    // A query like "select col1 from table where startsWith(col1, 'myStr') AND col2 > 10" should be rewritten to
+    // "select col1 from table where startsWith(col1, 'myStr') = true AND col2 > 10"
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT col1 FROM mytable WHERE startsWith(col1, 'myStr') AND col2 > 10;");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "startswith");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "EQUALS");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .size(), 2);
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getFunctionCall().getOperator(), "startswith");
+    assertTrue(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(1).getLiteral().getBoolValue());
+  }
+
+  @Test
+  public void testFilterPredicateLiteralIdentifierSwap() {
+    // Filters like '10 = col1' should be rewritten to 'col1 = 10'
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE 10 = col1 AND 10 < col2 AND 10 > col3 AND 10 <= col4 AND 10 >= col5 AND 10 != "
+            + "col6;");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().size(), 6);
+    assertTrue(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).isSetFunctionCall());
+    assertEquals(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "EQUALS");
+    assertTrue(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .isSetLiteral());
+    assertTrue(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .isSetIdentifier());
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 6);
+
+    // Ensure that all filter predicates have been rewritten with LHS as identifier and RHS as literal
+    for (int i = 0; i < 5; i++) {
+      assertTrue(
+          pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(i).getFunctionCall().getOperands().get(0)
+              .isSetIdentifier());
+      assertTrue(
+          pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(i).getFunctionCall().getOperands().get(1)
+              .isSetLiteral());
+    }
+  }
+
+  @Test
+  public void testBetweenRewrite() {
+    // Filters like 'col1 BETWEEN col2 AND 20' should be rewritten to 'col1 - col2 >= 0 AND col1 <= 20'
+
+    PinotQuery pinotQuery =
+        CalciteSqlParser.compileToPinotQueryWithoutRewrites("SELECT * FROM mytable WHERE col1 BETWEEN col2 AND 20;");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "BETWEEN");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().size(), 3);
+    assertTrue(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).isSetIdentifier());
+    assertTrue(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).isSetIdentifier());
+    assertTrue(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(2).isSetLiteral());
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertTrue(rewrittenQuery.getFilterExpression().isSetFunctionCall());
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertTrue(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).isSetFunctionCall());
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "GREATER_THAN_OR_EQUAL");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getFunctionCall().getOperator(), "minus");
+    // Check that LHS of minus is col1 and RHS of minus is col2
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "col2");
+
+    assertTrue(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).isSetFunctionCall());
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
+        "LESS_THAN_OR_EQUAL");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperands()
+            .get(0).getIdentifier().getName(), "col1");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperands()
+            .get(1).getLiteral().getIntValue(), 20);
+  }
+}


### PR DESCRIPTION
- Pinot's `BETWEEN` filter predicate currently has a number of issues.
- A query like `SELECT * FROM mytable WHERE intCol BETWEEN 1.5 AND 2.5` fails because the optimizations in `NumericalFilterOptimizer` don't apply to `BETWEEN` and there's an error later on when casting the float values to an int (via a `String`, which is its own problem in itself, but a matter for separate discussion).
- A query like `SELECT * FROM mytable WHERE col1 BETWEEN col2 AND 100`, `SELECT * FROM mytable WHERE col1 BETWEEN 100 AND col2`, or `SELECT * FROM mytable WHERE col1 BETWEEN col2 AND col3` fail because Pinot's v1 query engine doesn't support filter predicates where the operands (other than the first one) are not literals and the query rewrites in `PredicateComparisonRewriter` don't apply to `BETWEEN`.
- Similarly, filter predicates like  `WHERE 1 BETWEEN col1 AND col2` also aren't supported currently.
- One option could be to add support for the `BETWEEN` filter predicate to all these optimization and rewrite paths, but since there could be more such unknown gaps it seems more straightforward to simply rewrite a `BETWEEN` filter predicate to `GREATER_THAN_OR_EQUAL AND LESS_THAN_OR_EQUAL` since there shouldn't really be much overhead (if any) and this is also what the Calcite planner does in the multi-stage query engine.