### PR TITLE
Add Default RecordReader Next Implementation

### DIFF
--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotBufferedRecordReader.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotBufferedRecordReader.scala
@@ -47,7 +47,7 @@ class PinotBufferedRecordReader extends RecordReader {
     readCursor < recordBuffer.size()
   }
 
-  def next(): GenericRow = {
+  override def next(): GenericRow = {
     readCursor += 1
     recordBuffer.get(readCursor - 1)
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -184,11 +184,6 @@ public class SegmentPurger {
     }
 
     @Override
-    public GenericRow next() {
-      return next(new GenericRow());
-    }
-
-    @Override
     public GenericRow next(GenericRow reuse) {
       if (_recordPurger == null) {
         reuse = _pinotSegmentRecordReader.next(reuse);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileRecordReader.java
@@ -105,11 +105,6 @@ public class GenericRowFileRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next() {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse) {
     int rowId = _sortedRowIds != null ? _sortedRowIds[_nextRowId++] : _nextRowId++;
     _fileReader.read(rowId, reuse);

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReader.java
@@ -62,12 +62,6 @@ public class AvroRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     _reusableAvroRecord = _avroReader.next(_reusableAvroRecord);

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -208,12 +208,6 @@ public class CSVRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     CSVRecord record = _iterator.next();

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordReader.java
@@ -78,11 +78,6 @@ public class JSONRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next() {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse) {
     Map<String, Object> record = _iterator.next();
     _recordExtractor.extract(record, reuse);

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -178,12 +178,6 @@ public class ORCRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     int numFields = _orcFields.size();

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
@@ -63,12 +63,6 @@ public class ParquetAvroRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     _recordExtractor.extract(_nextRecord, reuse);

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
@@ -112,12 +112,6 @@ public class ParquetNativeRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     _nextRecord = _parquetRecordReader.read();

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
@@ -67,12 +67,6 @@ public class ParquetRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     return _internalParquetRecordReader.next(reuse);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReader.java
@@ -96,12 +96,6 @@ public class ProtoBufRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     Message message;

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReader.java
@@ -103,12 +103,6 @@ public class ThriftRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     TBase tObject;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
@@ -94,12 +94,6 @@ public class CompactedPinotSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next()
-      throws IOException {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
     Preconditions.checkState(!_nextRowReturned);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/GenericRowRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/GenericRowRecordReader.java
@@ -51,11 +51,6 @@ public class GenericRowRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next() {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse) {
     reuse.init(_rows.get(_nextRowId++));
     return reuse;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/MultiplePinotSegmentRecordReader.java
@@ -109,11 +109,6 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next() {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse) {
     if (_sortOrder != null) {
       GenericRowWithReader genericRowComparable = _priorityQueue.poll();
@@ -144,7 +139,8 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public void rewind() {
+  public void rewind()
+      throws IOException {
     for (PinotSegmentRecordReader recordReader : _recordReaders) {
       recordReader.rewind();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -200,11 +200,6 @@ public class PinotSegmentRecordReader implements RecordReader {
   }
 
   @Override
-  public GenericRow next() {
-    return next(new GenericRow());
-  }
-
-  @Override
   public GenericRow next(GenericRow reuse) {
     if (_sortedDocIds == null) {
       getRecord(_nextDocId, reuse);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
@@ -51,8 +51,6 @@ public interface RecordReader extends Closeable, Serializable {
 
   /**
    * Get the next record.
-   *
-   * TODO: Add default implementation because all the override implementations are the same
    */
   default GenericRow next()
       throws IOException {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
@@ -54,8 +54,10 @@ public interface RecordReader extends Closeable, Serializable {
    *
    * TODO: Add default implementation because all the override implementations are the same
    */
-  GenericRow next()
-      throws IOException;
+  default GenericRow next()
+      throws IOException {
+    return next(new GenericRow());
+  }
 
   /**
    * Get the next record. Re-use the given row to reduce garbage.


### PR DESCRIPTION
- Adds default implementation for `RecordReader` interface `next()` function
- Deletes redundant `next` function implementations
- Adds override to scala function redefinition