### PR TITLE
Rewrite BETWEEN to >= AND <= for SV columns in the v1 query engine

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -161,6 +161,13 @@ public class CalciteSqlParser {
     return compileToPinotQuery(compileToSqlNodeAndOptions(sql));
   }
 
+  /**
+   * Should only be used for testing query rewriters.
+   */
+  public static PinotQuery compileToPinotQueryWithoutRewrites(String sql) {
+    return compileWithoutRewrite(compileToSqlNodeAndOptions(sql).getSqlNode());
+  }
+
   public static PinotQuery compileToPinotQuery(SqlNodeAndOptions sqlNodeAndOptions) {
     // Compile SqlNode into PinotQuery
     PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
@@ -416,6 +423,15 @@ public class CalciteSqlParser {
   }
 
   public static PinotQuery compileSqlNodeToPinotQuery(SqlNode sqlNode) {
+    PinotQuery pinotQuery = compileWithoutRewrite(sqlNode);
+    queryRewrite(pinotQuery);
+    return pinotQuery;
+  }
+
+  /**
+   * Should only be used for testing query rewriters.
+   */
+  private static PinotQuery compileWithoutRewrite(SqlNode sqlNode) {
     PinotQuery pinotQuery = new PinotQuery();
     if (sqlNode instanceof SqlExplain) {
       // Extract sql node for the query
@@ -482,7 +498,6 @@ public class CalciteSqlParser {
       pinotQuery.setOffset(((SqlNumericLiteral) offsetNode).intValue(false));
     }
 
-    queryRewrite(pinotQuery);
     return pinotQuery;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -133,13 +133,11 @@ public class PredicateComparisonRewriter implements QueryRewriter {
            * Also check in {@link org.apache.pinot.sql.parsers.CalciteSqlParser#validateFilter(Expression)}}
            */
           if ((operands.get(1).getFunctionCall() != null && !operands.get(1).getFunctionCall().getOperator()
-              .equalsIgnoreCase("arrayvalueconstructor"))
-              || (operands.get(1).getLiteral() != null && !operands.get(1).getLiteral().isSetFloatArrayValue()
-                  && !operands.get(1).getLiteral().isSetDoubleArrayValue())) {
+              .equalsIgnoreCase("arrayvalueconstructor")) || (operands.get(1).getLiteral() != null && !operands.get(1)
+              .getLiteral().isSetFloatArrayValue() && !operands.get(1).getLiteral().isSetDoubleArrayValue())) {
             throw new SqlCompilationException(
                 String.format("For %s predicate, the second operand must be a float/double array literal, got: %s",
-                    filterKind,
-                    expression));
+                    filterKind, expression));
           }
           if (operands.size() == 3 && operands.get(2).getLiteral() == null) {
             throw new SqlCompilationException(

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+
+public class PredicateComparisonRewriterTest {
+  PredicateComparisonRewriter _predicateComparisonRewriter = new PredicateComparisonRewriter();
+
+  @Test
+  public void testIdentifierPredicateRewrite() {
+    // A query like "select * from table where col1" should be rewritten to "select * from table where col1 = true"
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites("SELECT * FROM mytable WHERE col1");
+    assertTrue(pinotQuery.getFilterExpression().isSetIdentifier());
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "col1");
+    Assert.assertTrue(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getBoolValue());
+    assertTrue(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getBoolValue());
+  }
+
+  @Test
+  public void testFunctionPredicateRewrite() {
+    // A query like "select col1 from table where startsWith(col1, 'myStr') AND col2 > 10" should be rewritten to
+    // "select col1 from table where startsWith(col1, 'myStr') = true AND col2 > 10"
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT col1 FROM mytable WHERE startsWith(col1, 'myStr') AND col2 > 10;");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "startswith");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 2);
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "EQUALS");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .size(), 2);
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getFunctionCall().getOperator(), "startswith");
+    assertTrue(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(1).getLiteral().getBoolValue());
+  }
+
+  @Test
+  public void testFilterPredicateLiteralIdentifierSwap() {
+    // Filters like '10 = col1' should be rewritten to 'col1 = 10'
+
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE 10 = col1 AND 10 < col2 AND 10 > col3 AND 10 <= col4 AND 10 >= col5 AND 10 != "
+            + "col6;");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().size(), 6);
+    assertTrue(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).isSetFunctionCall());
+    assertEquals(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "EQUALS");
+    assertTrue(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .isSetLiteral());
+    assertTrue(
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
+            .isSetIdentifier());
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "AND");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().size(), 6);
+
+    // Ensure that all filter predicates have been rewritten with LHS as identifier and RHS as literal
+    for (int i = 0; i < 5; i++) {
+      assertTrue(
+          pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(i).getFunctionCall().getOperands().get(0)
+              .isSetIdentifier());
+      assertTrue(
+          pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(i).getFunctionCall().getOperands().get(1)
+              .isSetLiteral());
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.query.optimizer.filter.BetweenFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.FilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.FlattenAndOrFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.IdenticalPredicateFilterOptimizer;
@@ -46,9 +47,9 @@ public class QueryOptimizer {
   // - TimePredicateFilterOptimizer and MergeRangeFilterOptimizer relies on NumericalFilterOptimizer to convert the
   //   values to the proper format so that they can be properly parsed
   private static final List<FilterOptimizer> FILTER_OPTIMIZERS =
-      Arrays.asList(new FlattenAndOrFilterOptimizer(), new IdenticalPredicateFilterOptimizer(),
-          new MergeEqInFilterOptimizer(), new NumericalFilterOptimizer(), new TimePredicateFilterOptimizer(),
-          new MergeRangeFilterOptimizer(), new TextMatchFilterOptimizer());
+      Arrays.asList(new BetweenFilterOptimizer(), new FlattenAndOrFilterOptimizer(),
+          new IdenticalPredicateFilterOptimizer(), new MergeEqInFilterOptimizer(), new NumericalFilterOptimizer(),
+          new TimePredicateFilterOptimizer(), new MergeRangeFilterOptimizer(), new TextMatchFilterOptimizer());
 
   private static final List<StatementOptimizer> STATEMENT_OPTIMIZERS =
       Collections.singletonList(new StringPredicateFilterOptimizer());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/BetweenFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/BetweenFilterOptimizer.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.sql.FilterKind;
+
+
+/**
+ * Rewrite a BETWEEN filter predicate to an AND of the equivalent GREATER_THAN_OR_EQUAL and LESS_THAN_OR_EQUAL filter
+ * predicates. This is done to make it easier to apply later range related optimizations (like in the
+ * NumericalFilterOptimizer) that might not be possible to do directly on BETWEEN.
+ * <p>
+ * Ideally, this would be done in PredicateComparisonRewriter (that would also allow for things like
+ * 'col1 BETWEEN col2 AND col3' which isn't currently supported), but we don't have access to the schema there, and
+ * we cannot apply this rewrite for MV columns since that changes the semantics of the filter predicate.
+ */
+public class BetweenFilterOptimizer implements FilterOptimizer {
+
+  @Override
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+    if (schema == null || filterExpression.getType() != ExpressionType.FUNCTION) {
+      return filterExpression;
+    }
+
+    Function function = filterExpression.getFunctionCall();
+    String operator = function.getOperator();
+    if (operator.equals(FilterKind.AND.name()) || operator.equals(FilterKind.OR.name()) || operator.equals(
+        FilterKind.NOT.name())) {
+      function.getOperands().replaceAll(expression -> optimize(expression, schema));
+    } else if (operator.equals(FilterKind.BETWEEN.name())) {
+      List<Expression> operands = function.getOperands();
+      Expression op1 = operands.get(0);
+      Expression op2 = operands.get(1);
+      Expression op3 = operands.get(2);
+
+      // Pinot currently only supports BETWEEN filter predicates where the first operand is a non-literal and the
+      // second and third operands are literals. The PredicateComparisonRewriter will throw an error during query
+      // compilation if the second or third argument is not a literal. If the first argument is also a literal, the
+      // CompileTimeFunctionsInvoker should reduce that altogether. So, we can safely assume that the first operand
+      // is not a literal, but we still handle this just in case.
+      if (op1.isSetLiteral()) {
+        return filterExpression;
+      }
+
+      // Don't apply this optimization to MV columns since that changes the semantics of the filter predicate
+      if (op1.isSetIdentifier() && !schema.getFieldSpecFor(op1.getIdentifier().getName()).isSingleValueField()) {
+        return filterExpression;
+      }
+
+      Expression greaterThanEqualExpression =
+          RequestUtils.getFunctionExpression(FilterKind.GREATER_THAN_OR_EQUAL.name(), op1, op2);
+      Expression lessThanEqualExpression =
+          RequestUtils.getFunctionExpression(FilterKind.LESS_THAN_OR_EQUAL.name(), op1, op3);
+
+      return RequestUtils.getFunctionExpression(FilterKind.AND.name(), greaterThanEqualExpression,
+          lessThanEqualExpression);
+    }
+
+    return filterExpression;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/BetweenFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/BetweenFilterOptimizerTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.query.optimizer.QueryOptimizer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BetweenFilterOptimizerTest {
+  private static final QueryOptimizer OPTIMIZER = new QueryOptimizer();
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName("testTable")
+      .addSingleValueDimension("intSVColumn", FieldSpec.DataType.INT)
+      .addMultiValueDimension("intMVColumn", FieldSpec.DataType.INT).build();
+
+  @Test
+  public void testBetweenRewriteOnSVColumn() {
+    Range expectedRange = new Range(5, false, 10, true);
+    // intSVColumn BETWEEN 5.5 AND 10.5 should be rewritten to intSVColumn > 5 AND intSVColumn <= 10 due to a
+    // combination of the BetweenFilterOptimizer and the NumericalFilterOptimizer
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE intSVColumn BETWEEN 5.5 AND 10.5"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:RANGE, operands:[Expression(type:IDENTIFIER, "
+            + "identifier:Identifier(name:intSVColumn)), Expression(type:LITERAL, literal:<Literal stringValue:"
+            + expectedRange.getRangeString() + ">)]))");
+  }
+
+  @Test
+  public void testBetweenNoRewriteOnMVColumn() {
+    // intMVColumn BETWEEN 5.5 AND 10.5 should not be rewritten
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE intMVColumn BETWEEN 5.5 AND 10.5"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:BETWEEN, operands:[Expression(type:IDENTIFIER, "
+            + "identifier:Identifier(name:intMVColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5"
+            + ".5>), Expression(type:LITERAL, literal:<Literal doubleValue:10.5>)]))");
+  }
+
+  private static String rewrite(String query) {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+    return pinotQuery.getFilterExpression().toString();
+  }
+}


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/14102 attempted to add this rewrite in the `PredicateComparisonRewriter` since that would fix at least two issues with the `BETWEEN` filter predicate - `WHERE intCol BETWEEN 1.5 AND 2.5` currently doesn't work (since the `NumericalFilterOptimizer` is not applied to `BETWEEN`) and `WHERE col1 BETWEEN col2 AND col3` also doesn't work (since Pinot's v1 query engine only supports filter predicates with literals as operands other than the LHS column identifier).
- However, the rewrite can't be applied to MV columns since that changes the semantics of the filter predicate. Since the query rewriters are applied during the query compilation phase in v1 which does not have access to the schema, we can't add the column type check there.
- This patch moves the rewrite to a new `FilterOptimizer` since the optimizers do have access to the schema. However, this won't be able to solve the `WHERE col1 BETWEEN col2 AND col3` kind of use case since that re-write is only applied to supported filter predicates in `PredicateComparisonRewriter` which happens before the optimizers are applied.
- We can't simply move that rewrite into this new optimizer (i.e., replacing `col1 BETWEEN col2 AND col3` with `col1 - col2 >= 0 AND col1 - col3 <= 0`) since the assumption that filter predicates only have literals in all operands (other than the LHS column identifier) is baked into multiple other places - see [here](https://github.com/apache/pinot/blob/ad1eda52ea3e9a040f87d0e0cabff1fba933f7bf/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java#L154-L158), [here](https://github.com/apache/pinot/blob/ad1eda52ea3e9a040f87d0e0cabff1fba933f7bf/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java#L295) for instance.
- Note that we can't apply the rewrites in `NumericalFilterOptimizer` without reducing the `BETWEEN` since `intCol BETWEEN 5.5 AND 10.5` / `intCol >= 5.5 AND intCol <= 10.5` / `intCol > 5 AND intCol <= 10` are not equivalent to `intCol BETWEEN 5 AND 10` (which would be `intCol >=5 AND intCol <= 10`).