### PR TITLE
Fix function call return type for IN / NOT IN created from SEARCH in the multistage engine

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -87,8 +87,8 @@ public class RexExpressionUtils {
     String functionName = rexExpression.getFunctionName();
     SqlIdentifier sqlIdentifier = new SqlIdentifier(functionName, SqlParserPos.ZERO);
     ArrayList<SqlOperator> operators = new ArrayList<>();
-    builder.getCluster().getRexBuilder().getOpTab().lookupOperatorOverloads(sqlIdentifier, null, SqlSyntax.FUNCTION,
-        operators, SqlNameMatchers.liberal());
+    builder.getCluster().getRexBuilder().getOpTab()
+        .lookupOperatorOverloads(sqlIdentifier, null, SqlSyntax.FUNCTION, operators, SqlNameMatchers.liberal());
 
     if (operators.isEmpty()) {
       throw new IllegalArgumentException("No operator found for function: " + functionName);
@@ -177,8 +177,8 @@ public class RexExpressionUtils {
     String functionName = functionCall.getFunctionName();
     SqlIdentifier sqlIdentifier = new SqlIdentifier(functionName, SqlParserPos.ZERO);
     ArrayList<SqlOperator> operators = new ArrayList<>();
-    cluster.getRexBuilder().getOpTab().lookupOperatorOverloads(sqlIdentifier, null, SqlSyntax.FUNCTION,
-        operators, SqlNameMatchers.liberal());
+    cluster.getRexBuilder().getOpTab()
+        .lookupOperatorOverloads(sqlIdentifier, null, SqlSyntax.FUNCTION, operators, SqlNameMatchers.liberal());
 
     ArrayList<SqlAggFunction> aggFunctions = new ArrayList<>(operators.size());
     for (SqlOperator operator : operators) {
@@ -322,10 +322,10 @@ public class RexExpressionUtils {
     Sarg sarg = rexLiteral.getValueAs(Sarg.class);
     assert sarg != null;
     if (sarg.isPoints()) {
-      return new RexExpression.FunctionCall(dataType, SqlKind.IN.name(),
+      return new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.IN.name(),
           toFunctionOperands(rexInputRef, sarg.rangeSet.asRanges(), dataType));
     } else if (sarg.isComplementedPoints()) {
-      return new RexExpression.FunctionCall(dataType, SqlKind.NOT_IN.name(),
+      return new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.NOT_IN.name(),
           toFunctionOperands(rexInputRef, sarg.rangeSet.complement().asRanges(), dataType));
     } else {
       Set<Range> ranges = sarg.rangeSet.asRanges();


### PR DESCRIPTION
- `IN` / `NOT IN` should have a return type of `BOOLEAN` and not the type of the search argument.
- Pinot doesn't have native support for a `SEARCH` operator, hence we convert any `SEARCH` calls generated by the Calcite plan in the v2 engine into an `IN`, a `NOT IN`, or a combination (`AND` / `OR`) of range predicates (>, >=, <, <=).
- The return type for the range predicate function call is correctly set to `BOOLEAN`, but the return type for `IN` / `NOT IN` is currently incorrectly set to the type of the search argument.
- This can cause errors if there is a function call on top of the search and the scalar function implementation requires a boolean argument. This patch fixes the return type of the converted `IN` / `NOT IN` function calls.