### PR TITLE
Fix incorrect semantics for BETWEEN on MV columns in the multi-stage query engine

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql2rel/PinotConvertletTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql2rel/PinotConvertletTable.java
@@ -116,6 +116,9 @@ public class PinotConvertletTable implements SqlRexConvertletTable {
             List.of(cx.convertExpression(call.operand(0)), cx.convertExpression(call.operand(1)),
                 cx.convertExpression(call.operand(2))));
 
+        // Since Pinot only has support for ASYMMETRIC BETWEEN, we need to rewrite SYMMETRIC BETWEEN, ASYMMETRIC NOT
+        // BETWEEN, and SYMMETRIC NOT BETWEEN to the equivalent BETWEEN expressions.
+
         // (val BETWEEN SYMMETRIC x AND y) is equivalent to (val BETWEEN x AND y OR val BETWEEN y AND x)
         if (betweenOperator.flag == SqlBetweenOperator.Flag.SYMMETRIC) {
           RexNode flipped = rexBuilder.makeCall(cx.getValidator().getValidatedNodeType(call), PINOT_BETWEEN,


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/14134.
- In the multi-stage query engine, Calcite converts `BETWEEN` filter predicates to the equivalent >= AND <= filter predicates.
- This happens in the `SqlToRelConverter` phase of the query compilation and is done via this Calcite conversion rule in the standard convertlet table - https://github.com/apache/calcite/blob/a8802c721a2805159d166e45044c00364d1cb6c3/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java#L1321-L1368
- In general, this is a good thing since it allows for Pinot's optimizations on >=, <= to kick in (many of which aren't currently applied to `BETWEEN`) like predicate comparison rewrite (allows for things `col1 <= col2` and hence `col1 BETWEEN col2 AND col3`) and numerical filter optimizer.
- However, this conversion breaks the filter predicate's semantics for MV columns. The filter predicate `ARRAY_TO_MV(mvCol) BETWEEN 0 AND 10` should return `false` if applied to `[-5, 15]`. But if the filter predicate is rewritten to `ARRAY_TO_MV(mvCol) >=0 AND ARRAY_TO_MV(mvCol) <= 10`, then it will return `true` if applied to `[-5, 15]` due to MV column semantics (where a predicate is true if any one value matches).
- Similarly, predicates like `ARRAY_TO_MV(mvCol) BETWEEN 10 AND 0` which should always be `false` can still return `true` for values like `[-5, 15]` due to the rewrite.
- This patch disables this conversion rule for MV columns by adding a new convertlet implementation in `PinotConvertletTable`.