### PR TITLE
Add watermark for dedup TTL

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -207,8 +207,7 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       try {
         byte[] bytes = FileUtils.readFileToByteArray(watermarkFile);
         double watermark = ByteBuffer.wrap(bytes).getDouble();
-        _logger.info("Loaded watermark: {} from file for table: {} partition_id: {}", watermark, _tableNameWithType,
-            _partitionId);
+        _logger.info("Loaded watermark: {} from file: {}", watermark, watermarkFile);
         return watermark;
       } catch (Exception e) {
         _logger.warn("Caught exception while loading watermark file: {}, skipping", watermarkFile);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapTableDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapTableDedupMetadataManager.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.dedup;
 
-
 class ConcurrentMapTableDedupMetadataManager extends BaseTableDedupMetadataManager {
   protected PartitionDedupMetadataManager createPartitionDedupMetadataManager(Integer partitionId) {
     return new ConcurrentMapPartitionDedupMetadataManager(_tableNameWithType, partitionId, _dedupContext);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -1039,8 +1039,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       try {
         byte[] bytes = FileUtils.readFileToByteArray(watermarkFile);
         double watermark = ByteBuffer.wrap(bytes).getDouble();
-        _logger.info("Loaded watermark: {} from file for table: {} partition_id: {}", watermark, _tableNameWithType,
-            _partitionId);
+        _logger.info("Loaded watermark: {} from file: {}", watermark, watermarkFile);
         return watermark;
       } catch (Exception e) {
         _logger.warn("Caught exception while loading watermark file: {}, skipping", watermarkFile);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -21,12 +21,8 @@ package org.apache.pinot.segment.local.upsert;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AtomicDouble;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,7 +41,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.Utils;
@@ -66,6 +61,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.local.segment.readers.PrimaryKeyReader;
 import org.apache.pinot.segment.local.utils.HashUtils;
+import org.apache.pinot.segment.local.utils.WatermarkUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
@@ -184,10 +180,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       Preconditions.checkState(_comparisonColumns.size() == 1,
           "Upsert TTL does not work with multiple comparison columns");
       Preconditions.checkState(_metadataTTL <= 0 || _enableSnapshot, "Upsert metadata TTL must have snapshot enabled");
-      _largestSeenComparisonValue = new AtomicDouble(loadWatermark());
+      _largestSeenComparisonValue =
+          new AtomicDouble(WatermarkUtils.loadWatermark(getWatermarkFile(), TTL_WATERMARK_NOT_SET));
     } else {
       _largestSeenComparisonValue = new AtomicDouble(TTL_WATERMARK_NOT_SET);
-      deleteWatermark();
+      WatermarkUtils.deleteWatermark(getWatermarkFile());
     }
   }
 
@@ -1013,7 +1010,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // updated validDocIds bitmaps. If the TTL watermark is persisted first, segments out of TTL may get loaded with
     // stale bitmaps or even no bitmap snapshots to use.
     if (isTTLEnabled()) {
-      persistWatermark(_largestSeenComparisonValue.get());
+      WatermarkUtils.persistWatermark(_largestSeenComparisonValue.get(), getWatermarkFile());
     }
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
         ServerGauge.UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT, numImmutableSegments);
@@ -1028,58 +1025,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _logger.info("Finished taking snapshot for {} immutable segments with {} primary keys (out of {} total segments, "
             + "{} are consuming segments) in {} ms", numImmutableSegments, numPrimaryKeysInSnapshot, numTrackedSegments,
         numConsumingSegments, System.currentTimeMillis() - startTimeMs);
-  }
-
-  /**
-   * Loads watermark from the file if exists.
-   */
-  protected double loadWatermark() {
-    File watermarkFile = getWatermarkFile();
-    if (watermarkFile.exists()) {
-      try {
-        byte[] bytes = FileUtils.readFileToByteArray(watermarkFile);
-        double watermark = ByteBuffer.wrap(bytes).getDouble();
-        _logger.info("Loaded watermark: {} from file: {}", watermark, watermarkFile);
-        return watermark;
-      } catch (Exception e) {
-        _logger.warn("Caught exception while loading watermark file: {}, skipping", watermarkFile);
-      }
-    }
-    return TTL_WATERMARK_NOT_SET;
-  }
-
-  /**
-   * Persists watermark to the file.
-   */
-  protected void persistWatermark(double watermark) {
-    File watermarkFile = getWatermarkFile();
-    try {
-      if (watermarkFile.exists()) {
-        if (!FileUtils.deleteQuietly(watermarkFile)) {
-          _logger.warn("Cannot delete watermark file: {}, skipping", watermarkFile);
-          return;
-        }
-      }
-      try (OutputStream outputStream = new FileOutputStream(watermarkFile, false);
-          DataOutputStream dataOutputStream = new DataOutputStream(outputStream)) {
-        dataOutputStream.writeDouble(watermark);
-      }
-      _logger.info("Persisted watermark: {} to file: {}", watermark, watermarkFile);
-    } catch (Exception e) {
-      _logger.warn("Caught exception while persisting watermark file: {}, skipping", watermarkFile);
-    }
-  }
-
-  /**
-   * Deletes the watermark file.
-   */
-  protected void deleteWatermark() {
-    File watermarkFile = getWatermarkFile();
-    if (watermarkFile.exists()) {
-      if (!FileUtils.deleteQuietly(watermarkFile)) {
-        _logger.warn("Cannot delete watermark file: {}, skipping", watermarkFile);
-      }
-    }
   }
 
   protected File getWatermarkFile() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/WatermarkUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/WatermarkUtils.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utils methods to manage the TTL watermark for dedup and upsert tables, as both share very similar logic.
+ */
+public class WatermarkUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WatermarkUtils.class);
+
+  private WatermarkUtils() {
+  }
+
+  /**
+   * Loads watermark from the file if exists.
+   */
+  public static double loadWatermark(File watermarkFile, double defaultWatermark) {
+    if (watermarkFile.exists()) {
+      try {
+        byte[] bytes = FileUtils.readFileToByteArray(watermarkFile);
+        double watermark = ByteBuffer.wrap(bytes).getDouble();
+        LOGGER.info("Loaded watermark: {} from file: {}", watermark, watermarkFile);
+        return watermark;
+      } catch (Exception e) {
+        LOGGER.warn("Failed to load watermark from file: {}, skipping", watermarkFile);
+      }
+    }
+    return defaultWatermark;
+  }
+
+  /**
+   * Persists watermark to the file.
+   */
+  public static void persistWatermark(double watermark, File watermarkFile) {
+    try {
+      if (watermarkFile.exists()) {
+        if (!FileUtils.deleteQuietly(watermarkFile)) {
+          LOGGER.warn("Cannot delete watermark file: {} to persist watermark: {}, skipping", watermarkFile, watermark);
+          return;
+        }
+      }
+      try (OutputStream outputStream = new FileOutputStream(watermarkFile, false);
+          DataOutputStream dataOutputStream = new DataOutputStream(outputStream)) {
+        dataOutputStream.writeDouble(watermark);
+      }
+      LOGGER.info("Persisted watermark: {} to file: {}", watermark, watermarkFile);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to persist watermark: {} to file: {}, skipping", watermark, watermarkFile);
+    }
+  }
+
+  /**
+   * Deletes the watermark file.
+   */
+  public static void deleteWatermark(File watermarkFile) {
+    if (watermarkFile.exists()) {
+      if (!FileUtils.deleteQuietly(watermarkFile)) {
+        LOGGER.warn("Cannot delete watermark file: {}, skipping", watermarkFile);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -38,6 +39,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -50,17 +52,27 @@ import static org.testng.Assert.assertTrue;
 
 
 public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(),
+      ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.class.getSimpleName());
   private static final int METADATA_TTL = 10000;
   private static final String DEDUP_TIME_COLUMN_NAME = "dedupTimeColumn";
   private DedupContext.Builder _dedupContextBuilder;
 
   @BeforeMethod
-  public void setUpContextBuilder() {
+  public void setUpContextBuilder()
+      throws IOException {
+    FileUtils.forceMkdir(TEMP_DIR);
     _dedupContextBuilder = new DedupContext.Builder();
     _dedupContextBuilder.setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
         .setPrimaryKeyColumns(List.of("primaryKeyColumn")).setMetadataTTL(METADATA_TTL)
         .setDedupTimeColumn(DEDUP_TIME_COLUMN_NAME).setTableIndexDir(mock(File.class))
-        .setTableDataManager(mock(TableDataManager.class)).setServerMetrics(mock(ServerMetrics.class));
+        .setTableDataManager(mock(TableDataManager.class)).setServerMetrics(mock(ServerMetrics.class))
+        .setTableIndexDir(TEMP_DIR);
+  }
+
+  @AfterMethod
+  public void cleanup() {
+    FileUtils.deleteQuietly(TEMP_DIR);
   }
 
   @Test
@@ -134,7 +146,6 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     dedupRecordInfoIterator = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader, 10);
     metadataManager.doRemoveSegment(segment, dedupRecordInfoIterator);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 0);
-    assertEquals(metadataManager._largestSeenTime.get(), 9000);
 
     metadataManager.stop();
     metadataManager.close();
@@ -204,7 +215,6 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
 
   private void verifyInitialSegmentAddition(ConcurrentMapPartitionDedupMetadataManager metadataManager,
       IndexSegment segment, HashFunction hashFunction) {
-    assertEquals(metadataManager._largestSeenTime.get(), 9000);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 10);
     verifyInMemoryState(metadataManager, 0, 10, segment, hashFunction);
   }
@@ -245,23 +255,23 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     Iterator<DedupRecordInfo> dedupRecordInfoIterator2 =
         DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader2, 10);
     metadataManager.doAddOrReplaceSegment(null, segment2, dedupRecordInfoIterator2);
+
+    metadataManager._largestSeenTime.set(19000);
     metadataManager.removeExpiredPrimaryKeys();
     assertEquals(metadataManager.getNumPrimaryKeys(), 11);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 11);
     verifyInMemoryState(metadataManager, 9, 1, segment1, hashFunction);
     verifyInMemoryState(metadataManager, 10, 10, segment2, hashFunction);
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
+    assertEquals(metadataManager.loadWatermark(), 19000);
 
     dedupRecordInfoIterator1 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader1, 10);
     metadataManager.doRemoveSegment(segment1, dedupRecordInfoIterator1);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 10);
     verifyInMemoryState(metadataManager, 10, 10, segment2, hashFunction);
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
 
     dedupRecordInfoIterator2 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader2, 10);
     metadataManager.doRemoveSegment(segment2, dedupRecordInfoIterator2);
     assertTrue(metadataManager._primaryKeyToSegmentAndTimeMap.isEmpty());
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
 
     metadataManager.stop();
     metadataManager.close();
@@ -294,22 +304,21 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     Iterator<DedupRecordInfo> dedupRecordInfoIterator2 =
         DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader2, 10);
     metadataManager.doAddOrReplaceSegment(null, segment2, dedupRecordInfoIterator2);
+    metadataManager._largestSeenTime.set(19000);
     metadataManager.removeExpiredPrimaryKeys();
     assertEquals(metadataManager.getNumPrimaryKeys(), 11);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 11);
     verifyInMemoryState(metadataManager, 10, 10, segment2, hashFunction);
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
+    assertEquals(metadataManager.loadWatermark(), 19000);
 
     dedupRecordInfoIterator2 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader2, 10);
     metadataManager.doRemoveSegment(segment2, dedupRecordInfoIterator2);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 1);
     verifyInMemoryState(metadataManager, 9, 1, segment1, hashFunction);
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
 
     dedupRecordInfoIterator1 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader1, 10);
     metadataManager.doRemoveSegment(segment1, dedupRecordInfoIterator1);
     assertTrue(metadataManager._primaryKeyToSegmentAndTimeMap.isEmpty());
-    assertEquals(metadataManager._largestSeenTime.get(), 19000);
 
     metadataManager.stop();
     metadataManager.close();
@@ -351,7 +360,6 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 1);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.get(primaryKeyHash),
         Pair.of(immutableSegment, 25000.0));
-    assertEquals(metadataManager._largestSeenTime.get(), 25000);
 
     metadataManager.stop();
     metadataManager.close();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImp
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.local.segment.readers.PrimaryKeyReader;
 import org.apache.pinot.segment.local.utils.HashUtils;
+import org.apache.pinot.segment.local.utils.WatermarkUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -262,7 +263,7 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 11);
     verifyInMemoryState(metadataManager, 9, 1, segment1, hashFunction);
     verifyInMemoryState(metadataManager, 10, 10, segment2, hashFunction);
-    assertEquals(metadataManager.loadWatermark(), 19000);
+    assertEquals(WatermarkUtils.loadWatermark(metadataManager.getWatermarkFile(), -1), 19000);
 
     dedupRecordInfoIterator1 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader1, 10);
     metadataManager.doRemoveSegment(segment1, dedupRecordInfoIterator1);
@@ -309,7 +310,7 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
     assertEquals(metadataManager.getNumPrimaryKeys(), 11);
     assertEquals(metadataManager._primaryKeyToSegmentAndTimeMap.size(), 11);
     verifyInMemoryState(metadataManager, 10, 10, segment2, hashFunction);
-    assertEquals(metadataManager.loadWatermark(), 19000);
+    assertEquals(WatermarkUtils.loadWatermark(metadataManager.getWatermarkFile(), -1), 19000);
 
     dedupRecordInfoIterator2 = DedupUtils.getDedupRecordInfoIterator(dedupRecordInfoReader2, 10);
     metadataManager.doRemoveSegment(segment2, dedupRecordInfoIterator2);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -36,6 +37,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -45,14 +47,24 @@ import static org.testng.Assert.assertSame;
 
 
 public class ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(),
+      ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest.class.getSimpleName());
   private DedupContext.Builder _dedupContextBuilder;
 
   @BeforeMethod
-  public void setUpContextBuilder() {
+  public void setUpContextBuilder()
+      throws IOException {
+    FileUtils.forceMkdir(TEMP_DIR);
     _dedupContextBuilder = new DedupContext.Builder();
     _dedupContextBuilder.setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
         .setPrimaryKeyColumns(List.of("primaryKeyColumn")).setTableIndexDir(mock(File.class))
-        .setTableDataManager(mock(TableDataManager.class)).setServerMetrics(mock(ServerMetrics.class));
+        .setTableDataManager(mock(TableDataManager.class)).setServerMetrics(mock(ServerMetrics.class))
+        .setTableIndexDir(TEMP_DIR);
+  }
+
+  @AfterMethod
+  public void cleanup() {
+    FileUtils.deleteQuietly(TEMP_DIR);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentDedupeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentDedupeTest.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
@@ -49,6 +50,8 @@ import org.testng.annotations.Test;
 
 
 public class MutableSegmentDedupeTest {
+  private static final File TEMP_DIR =
+      new File(FileUtils.getTempDirectory(), MutableSegmentDedupeTest.class.getSimpleName());
   private static final String SCHEMA_FILE_PATH = "data/test_dedup_schema.json";
   private static final String DATA_FILE_PATH = "data/test_dedup_data.json";
   private MutableSegmentImpl _mutableSegmentImpl;
@@ -88,17 +91,18 @@ public class MutableSegmentDedupeTest {
     TableConfig tableConfig = Mockito.mock(TableConfig.class);
     Mockito.when(tableConfig.getTableName()).thenReturn("testTable_REALTIME");
     Mockito.when(tableConfig.getDedupConfig()).thenReturn(dedupConfig);
-    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig
-        = Mockito.mock(SegmentsValidationAndRetentionConfig.class);
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
+        Mockito.mock(SegmentsValidationAndRetentionConfig.class);
     Mockito.when(tableConfig.getValidationConfig()).thenReturn(segmentsValidationAndRetentionConfig);
     Mockito.when(segmentsValidationAndRetentionConfig.getTimeColumnName()).thenReturn("secondsSinceEpoch");
     TableDataManager tableDataManager = Mockito.mock(TableDataManager.class);
-    Mockito.when(tableDataManager.getTableDataDir()).thenReturn(Mockito.mock(File.class));
+    Mockito.when(tableDataManager.getTableDataDir()).thenReturn(TEMP_DIR);
     return TableDedupMetadataManagerFactory.create(tableConfig, schema, tableDataManager,
         Mockito.mock(ServerMetrics.class));
   }
 
-  public List<Map<String, String>> loadJsonFile(String filePath) throws IOException {
+  public List<Map<String, String>> loadJsonFile(String filePath)
+      throws IOException {
     URL resourceUrl = this.getClass().getClassLoader().getResource(filePath);
     if (resourceUrl == null) {
       throw new IllegalArgumentException("File not found: " + filePath);
@@ -165,8 +169,8 @@ public class MutableSegmentDedupeTest {
     }
   }
 
-  private void verifyGeneratedSegmentDataAgainstRawData(
-      int docId, int rawDataIndex, List<Map<String, String>> rawData) {
+  private void verifyGeneratedSegmentDataAgainstRawData(int docId, int rawDataIndex,
+      List<Map<String, String>> rawData) {
     for (String columnName : rawData.get(0).keySet()) {
       Assert.assertEquals(String.valueOf(_mutableSegmentImpl.getValue(docId, columnName)),
           String.valueOf(rawData.get(rawDataIndex).get(columnName)));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImp
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager.RecordLocation;
 import org.apache.pinot.segment.local.utils.HashUtils;
+import org.apache.pinot.segment.local.utils.WatermarkUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
@@ -228,10 +229,10 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
 
     double currentTimeMs = System.currentTimeMillis();
-    upsertMetadataManager.persistWatermark(currentTimeMs);
+    WatermarkUtils.persistWatermark(currentTimeMs, upsertMetadataManager.getWatermarkFile());
     assertTrue(new File(INDEX_DIR, V1Constants.TTL_WATERMARK_TABLE_PARTITION + 0).exists());
 
-    double watermark = upsertMetadataManager.loadWatermark();
+    double watermark = WatermarkUtils.loadWatermark(upsertMetadataManager.getWatermarkFile(), -1);
     assertEquals(watermark, currentTimeMs);
 
     ImmutableSegmentImpl segment =


### PR DESCRIPTION
Dedup feature has TTL but it didn't store/load TTL watermark as done in upsert feature, so this PR adds this, to avoid the waste of adding stale dedup metadata into store when loading segments.