### PR TITLE
Implement consistent data push for spark 3 segment generation and metadata push jobs

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -249,12 +249,12 @@
       <artifactId>annotations</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-core_2.12</artifactId>
-          <version>3.5.1</version>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-core_${scala.compat.version}</artifactId>
+        <version>${spark3.version}</version>
+        <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-batch-ingestion-spark-3</artifactId>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -258,7 +258,6 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-batch-ingestion-spark-3</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -19,7 +19,8 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>pinot</artifactId>
@@ -250,10 +251,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_${scala.compat.version}</artifactId>
-        <version>${spark3.version}</version>
-        <scope>test</scope>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.compat.version}</artifactId>
+      <version>${spark3.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -249,5 +249,17 @@
       <artifactId>annotations</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-core_2.12</artifactId>
+          <version>3.5.1</version>
+          <scope>test</scope>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-batch-ingestion-spark-3</artifactId>
+      <version>1.2.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
@@ -1,0 +1,383 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.plugin.ingestion.batch.spark3.SparkSegmentMetadataPushJobRunner;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTest {
+
+  private JavaSparkContext _sparkContext;
+
+  @Override
+  protected Map<String, String> getStreamConfigs() {
+    return null;
+  }
+
+  @Override
+  protected String getSortedColumn() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getInvertedIndexColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getNoDictionaryColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getRangeIndexColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getBloomFilterColumns() {
+    return null;
+  }
+
+  @BeforeMethod
+  public void setUpTest()
+          throws IOException {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+  }
+
+  @BeforeClass
+  public void setUp()
+          throws Exception {
+    // Start Zk and Kafka
+    startZk();
+
+    // Start the Pinot cluster
+    startController();
+    startBroker();
+    startServer();
+
+    // Setup Spark context
+    SparkConf sparkConf = new SparkConf()
+            .setAppName(SparkSegmentMetadataPushIntegrationTest.class.getName())
+            .setMaster("local[*]") // Use local master
+            .set("spark.driver.bindAddress", "127.0.0.1") // Set to localhost or appropriate IP
+            .set("spark.driver.port", "7077") // Choose any available port
+            .set("spark.port.maxRetries", "50"); // Increase retry attempts if needed
+
+    _sparkContext = new JavaSparkContext(sparkConf);
+  }
+
+  @Test
+  public void testSparkSegmentMetadataPushWithoutConsistentPush()
+          throws Exception {
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig offlineTableConfig = createOfflineTableConfig();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
+    addTableConfig(offlineTableConfig);
+
+    List<File> avroFiles = getAllAvroFiles();
+
+    // Create and push the segment using SparkSegmentMetadataPushJobRunner
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema,
+            "_no_consistent_push", _segmentDir, _tarDir);
+
+    SparkSegmentMetadataPushJobRunner runner = new SparkSegmentMetadataPushJobRunner();
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    jobSpec.setJobType("SegmentMetadataPush");
+    jobSpec.setInputDirURI(avroFiles.get(0).getParent());
+
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    pushJobSpec.setPushParallelism(5);
+    pushJobSpec.setPushAttempts(1);
+    pushJobSpec.setCopyToDeepStoreForMetadataPush(true);
+    jobSpec.setPushJobSpec(pushJobSpec);
+
+    PinotFSSpec fsSpec = new PinotFSSpec();
+    fsSpec.setScheme("file");
+    fsSpec.setClassName("org.apache.pinot.spi.filesystem.LocalPinotFS");
+    jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
+    jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
+
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    jobSpec.setTableSpec(tableSpec);
+
+    PinotClusterSpec clusterSpec = new PinotClusterSpec();
+    clusterSpec.setControllerURI(getControllerBaseApiUrl());
+    jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Check that the segment is pushed and loaded
+    JsonNode segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 1);
+    String segmentName = segmentsList.get(0).asText();
+    Assert.assertTrue(segmentName.endsWith("_no_consistent_push"));
+    long numDocs = getNumDocs(segmentName);
+    testCountStar(numDocs);
+  }
+
+  @Test
+  public void testSparkSegmentMetadataPushWithConsistentPushParallelism1()
+          throws Exception {
+    runMetadataPushWithConsistentDataPushTest(5, 1);
+  }
+
+  @Test
+  public void testSparkSegmentMetadataPushWithConsistentPushParallelism5()
+          throws Exception {
+    runMetadataPushWithConsistentDataPushTest(5, 5);
+  }
+
+  @Test
+  public void testSparkSegmentMetadataPushWithConsistentPushHigherParallelismThenSegments()
+          throws Exception {
+    runMetadataPushWithConsistentDataPushTest(1, 5);
+  }
+
+  // In an empty table with consistent push enabled, we:
+  // 1. Push numSegment segments and verify:
+  //    a. Lineage is created.
+  //    b. Segments are loaded successfully.
+  //    c. The total record count is correct by running a COUNT(*) query, with the result equal to the sum of the
+  //    total docs of each segment pushed.
+  // 2. Push a additional segment and verify:
+  //    a. The new segment is loaded successfully.
+  //    b. Only the record count of the additional segment is present by running a COUNT(*) query, confirming previous
+  //    segments are replaced and no longer queryable.
+  private void runMetadataPushWithConsistentDataPushTest(int numSegments, int parallelism) throws Exception {
+    int pushAttempts = 1;
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig offlineTableConfig = createOfflineTableConfigWithConsistentPush();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
+    addTableConfig(offlineTableConfig);
+
+    List<File> avroFiles = getAllAvroFiles();
+
+    String firstTimeStamp = Long.toString(System.currentTimeMillis());
+
+    // Create and push the segment using SparkSegmentMetadataPushJobRunner
+    for (int i = 0; i < numSegments; i++) {
+      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(i), offlineTableConfig, schema,
+              firstTimeStamp, _segmentDir, _tarDir);
+    }
+
+    SparkSegmentMetadataPushJobRunner runner = new SparkSegmentMetadataPushJobRunner();
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    jobSpec.setJobType("SegmentMetadataPush");
+
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    pushJobSpec.setPushParallelism(parallelism);
+    pushJobSpec.setPushAttempts(pushAttempts);
+    pushJobSpec.setCopyToDeepStoreForMetadataPush(true);
+    jobSpec.setPushJobSpec(pushJobSpec);
+
+    PinotFSSpec fsSpec = new PinotFSSpec();
+    fsSpec.setScheme("file");
+    fsSpec.setClassName("org.apache.pinot.spi.filesystem.LocalPinotFS");
+    jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
+    jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
+
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    jobSpec.setTableSpec(tableSpec);
+
+    PinotClusterSpec clusterSpec = new PinotClusterSpec();
+    clusterSpec.setControllerURI(getControllerBaseApiUrl());
+    jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Check that the segment is pushed and loaded
+    JsonNode segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), numSegments);
+    long numDocs = 0;
+    for (int i = 0; i < numSegments; i++) {
+      String segmentName = segmentsList.get(i).asText();
+      Assert.assertTrue(segmentName.endsWith(firstTimeStamp));
+      numDocs += getNumDocs(segmentName);
+    }
+    testCountStar(numDocs);
+
+    // Fetch segment lineage entry after running segment metadata push with consistent push enabled
+    String segmentLineageResponse = sendGetRequest(
+            ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
+                    .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+    // Segment lineage should be in completed state
+    Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
+    // SegmentsFrom should be empty as we started with a blank table
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[]"));
+    // SegmentsTo should contain uploaded segments
+    String segmentsTo = extractSegmentsFromLineageKey("segmentsTo", segmentLineageResponse);
+    for (int i = 0; i < numSegments; i++) {
+      String segmentName = segmentsList.get(i).asText();
+      Assert.assertTrue(segmentsTo.contains(segmentName));
+    }
+
+    // Keep track of the segment names so we can check that they are no longer queryable after
+    // the additional segment is pushed as part of a new push job
+    List<String> previousSegmentNames = Lists.newArrayList();
+    for (int i = 0; i < numSegments; i++) {
+      previousSegmentNames.add(segmentsList.get(i).asText());
+    }
+
+    // Create and push the additional segment using SparkSegmentMetadataPushJobRunner
+    for (File tarFile : _tarDir.listFiles()) {
+      FileUtils.deleteQuietly(tarFile);
+    }
+    String secondTimeStamp = Long.toString(System.currentTimeMillis());
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(numSegments), offlineTableConfig, schema,
+            secondTimeStamp, _segmentDir, _tarDir);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Check that the segment is pushed and loaded. We expect the initial push of segments + 1 additional
+    // but we expect only the 1 additional pushed to be queryable only.
+    segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), numSegments + 1);
+    String additionalSegmentName = segmentsList.get(numSegments).asText();
+    Assert.assertTrue(additionalSegmentName.endsWith(secondTimeStamp));
+
+    // Check that the count is now only the count of the additional segment
+    testCountStar(getNumDocs(additionalSegmentName));
+  }
+
+  /**
+   * Extracts a list of segments from a given lineage response based on a provided key.
+   *
+   * This method searches for the specified key within the lineage response and extracts the
+   * segment list enclosed in square brackets following the key. The list is returned as a substring.
+   *
+   * Example keys are "segmentsTo" and "segmentsFrom".
+   *
+   * @param key The key to search for within the lineage response. It is expected to be a JSON
+   *            key that maps to an array of segments, formatted as "key":[...].
+   * @param lineageResponse The JSON-formatted lineage response containing the key and segments.
+   * @return A substring containing the list of segments associated with the provided key. If the
+   *         key is not found, or if there are no segments, an empty string is returned.
+   */
+  private static String extractSegmentsFromLineageKey(String key, String lineageResponse) {
+    String segmentKey = "\"" + key + "\":[";
+    int startIndex = lineageResponse.indexOf(segmentKey);
+    if (startIndex == -1) {
+      return "";
+    }
+    startIndex += segmentKey.length();
+    int endIndex = lineageResponse.indexOf(']', startIndex);
+
+    if (endIndex != -1 && startIndex < endIndex) {
+      return lineageResponse.substring(startIndex, endIndex);
+    }
+
+    return "";
+  }
+
+  protected TableConfig createOfflineTableConfigWithConsistentPush() {
+    TableConfig offlineTableConfig = createOfflineTableConfig();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null,
+            "REFRESH", "DAILY", true));
+    offlineTableConfig.setIngestionConfig(ingestionConfig);
+    return offlineTableConfig;
+  }
+
+  private long getNumDocs(String segmentName)
+          throws IOException {
+    return JsonUtils.stringToJsonNode(
+                    sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(DEFAULT_TABLE_NAME, segmentName)))
+            .get("segment.total.docs").asLong();
+  }
+
+  private JsonNode getSegmentsList()
+          throws IOException {
+    return JsonUtils.stringToJsonNode(sendGetRequest(
+                    _controllerRequestURLBuilder.forSegmentListAPI(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString())))
+            .get(0).get("OFFLINE");
+  }
+
+  protected void testCountStar(final long countStarResult) {
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return getCurrentCountStarResult() == countStarResult;
+      } catch (Exception e) {
+        return null;
+      }
+    }, 100L, 300_000, "Failed to load " + countStarResult + " documents",
+            true);
+  }
+
+  @AfterMethod
+  public void tearDownTest()
+          throws IOException {
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
+    dropOfflineTable(offlineTableName);
+
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+  }
+
+  @AfterClass
+  public void tearDown()
+          throws Exception {
+    _sparkContext.close();
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
@@ -40,8 +40,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.SparkContext;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -52,7 +51,7 @@ import org.testng.annotations.Test;
 
 public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTest {
 
-  private JavaSparkContext _sparkContext;
+  private SparkContext _sparkContext;
   private final String _testTable = DEFAULT_TABLE_NAME;
   private final String _testTableWithType = _testTable + "_OFFLINE";
 
@@ -104,12 +103,7 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
     startServer();
 
     // Setup Spark context
-    SparkConf sparkConf = new SparkConf().setAppName(SparkSegmentMetadataPushIntegrationTest.class.getName())
-        .setMaster("local[*]") // For local test based development
-        .set("spark.driver.bindAddress", "127.0.0.1").set("spark.driver.port", "7077")
-        .set("spark.port.maxRetries", "50");
-
-    _sparkContext = new JavaSparkContext(sparkConf);
+    _sparkContext = new SparkContext("local", SparkSegmentMetadataPushIntegrationTest.class.getName());
   }
 
   @Test
@@ -397,7 +391,7 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
   @AfterClass
   public void tearDown()
       throws Exception {
-    _sparkContext.close();
+    _sparkContext.stop();
 
     stopServer();
     stopBroker();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
@@ -103,10 +103,10 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
     // Setup Spark context
     SparkConf sparkConf = new SparkConf()
             .setAppName(SparkSegmentMetadataPushIntegrationTest.class.getName())
-            .setMaster("local[*]") // Use local master
-            .set("spark.driver.bindAddress", "127.0.0.1") // Set to localhost or appropriate IP
-            .set("spark.driver.port", "7077") // Choose any available port
-            .set("spark.port.maxRetries", "50"); // Increase retry attempts if needed
+            .setMaster("local[*]") // For local test based development
+            .set("spark.driver.bindAddress", "127.0.0.1")
+            .set("spark.driver.port", "7077")
+            .set("spark.port.maxRetries", "50");
 
     _sparkContext = new JavaSparkContext(sparkConf);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SparkSegmentMetadataPushIntegrationTest.java
@@ -49,6 +49,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+
 public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTest {
 
   private JavaSparkContext _sparkContext;
@@ -85,13 +86,13 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
 
   @BeforeMethod
   public void setUpTest()
-          throws IOException {
+      throws IOException {
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
   }
 
   @BeforeClass
   public void setUp()
-          throws Exception {
+      throws Exception {
     // Start Zk and Kafka
     startZk();
 
@@ -101,19 +102,17 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
     startServer();
 
     // Setup Spark context
-    SparkConf sparkConf = new SparkConf()
-            .setAppName(SparkSegmentMetadataPushIntegrationTest.class.getName())
-            .setMaster("local[*]") // For local test based development
-            .set("spark.driver.bindAddress", "127.0.0.1")
-            .set("spark.driver.port", "7077")
-            .set("spark.port.maxRetries", "50");
+    SparkConf sparkConf = new SparkConf().setAppName(SparkSegmentMetadataPushIntegrationTest.class.getName())
+        .setMaster("local[*]") // For local test based development
+        .set("spark.driver.bindAddress", "127.0.0.1").set("spark.driver.port", "7077")
+        .set("spark.port.maxRetries", "50");
 
     _sparkContext = new JavaSparkContext(sparkConf);
   }
 
   @Test
   public void testSparkSegmentMetadataPushWithoutConsistentPush()
-          throws Exception {
+      throws Exception {
     // Create and upload the schema and table config
     Schema schema = createSchema();
     addSchema(schema);
@@ -125,7 +124,7 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
 
     // Create and push the segment using SparkSegmentMetadataPushJobRunner
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema,
-            "_no_consistent_push", _segmentDir, _tarDir);
+        "_no_consistent_push", _segmentDir, _tarDir);
 
     SparkSegmentMetadataPushJobRunner runner = new SparkSegmentMetadataPushJobRunner();
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -167,19 +166,19 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
 
   @Test
   public void testSparkSegmentMetadataPushWithConsistentPushParallelism1()
-          throws Exception {
+      throws Exception {
     runMetadataPushWithConsistentDataPushTest(5, 1);
   }
 
   @Test
   public void testSparkSegmentMetadataPushWithConsistentPushParallelism5()
-          throws Exception {
+      throws Exception {
     runMetadataPushWithConsistentDataPushTest(5, 5);
   }
 
   @Test
   public void testSparkSegmentMetadataPushWithConsistentPushHigherParallelismThenSegments()
-          throws Exception {
+      throws Exception {
     runMetadataPushWithConsistentDataPushTest(1, 5);
   }
 
@@ -193,7 +192,8 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
   //    a. The new segment is loaded successfully.
   //    b. Only the record count of the additional segment is present by running a COUNT(*) query, confirming previous
   //    segments are replaced and no longer queryable.
-  private void runMetadataPushWithConsistentDataPushTest(int numSegments, int parallelism) throws Exception {
+  private void runMetadataPushWithConsistentDataPushTest(int numSegments, int parallelism)
+      throws Exception {
     int pushAttempts = 1;
 
     // Create and upload the schema and table config
@@ -209,8 +209,8 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
 
     // Create and push the segment using SparkSegmentMetadataPushJobRunner
     for (int i = 0; i < numSegments; i++) {
-      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(i), offlineTableConfig, schema,
-              firstTimeStamp, _segmentDir, _tarDir);
+      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(i), offlineTableConfig, schema, firstTimeStamp,
+          _segmentDir, _tarDir);
     }
 
     SparkSegmentMetadataPushJobRunner runner = new SparkSegmentMetadataPushJobRunner();
@@ -253,9 +253,8 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
     testCountStar(numDocs);
 
     // Fetch segment lineage entry after running segment metadata push with consistent push enabled
-    String segmentLineageResponse = sendGetRequest(
-            ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
-                    .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+    String segmentLineageResponse = sendGetRequest(ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
+        .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
     // Segment lineage should be in completed state
     Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
     // SegmentsFrom should be empty as we started with a blank table
@@ -280,7 +279,7 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
     }
     String secondTimeStamp = Long.toString(System.currentTimeMillis());
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(numSegments), offlineTableConfig, schema,
-            secondTimeStamp, _segmentDir, _tarDir);
+        secondTimeStamp, _segmentDir, _tarDir);
     Assert.assertEquals(_tarDir.listFiles().length, 1);
 
     runner.init(jobSpec);
@@ -330,24 +329,23 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
   protected TableConfig createOfflineTableConfigWithConsistentPush() {
     TableConfig offlineTableConfig = createOfflineTableConfig();
     IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null,
-            "REFRESH", "DAILY", true));
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH", "DAILY", true));
     offlineTableConfig.setIngestionConfig(ingestionConfig);
     return offlineTableConfig;
   }
 
   private long getNumDocs(String segmentName)
-          throws IOException {
+      throws IOException {
     return JsonUtils.stringToJsonNode(
-                    sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(DEFAULT_TABLE_NAME, segmentName)))
-            .get("segment.total.docs").asLong();
+            sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(DEFAULT_TABLE_NAME, segmentName)))
+        .get("segment.total.docs").asLong();
   }
 
   private JsonNode getSegmentsList()
-          throws IOException {
+      throws IOException {
     return JsonUtils.stringToJsonNode(sendGetRequest(
-                    _controllerRequestURLBuilder.forSegmentListAPI(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString())))
-            .get(0).get("OFFLINE");
+            _controllerRequestURLBuilder.forSegmentListAPI(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()))).get(0)
+        .get("OFFLINE");
   }
 
   protected void testCountStar(final long countStarResult) {
@@ -357,13 +355,12 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
       } catch (Exception e) {
         return null;
       }
-    }, 100L, 300_000, "Failed to load " + countStarResult + " documents",
-            true);
+    }, 100L, 300_000, "Failed to load " + countStarResult + " documents", true);
   }
 
   @AfterMethod
   public void tearDownTest()
-          throws IOException {
+      throws IOException {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
     dropOfflineTable(offlineTableName);
 
@@ -372,7 +369,7 @@ public class SparkSegmentMetadataPushIntegrationTest extends BaseClusterIntegrat
 
   @AfterClass
   public void tearDown()
-          throws Exception {
+      throws Exception {
     _sparkContext.close();
 
     stopServer();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -142,7 +142,6 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
     boolean consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(tableConfig);
 
-    // If consistent push is enabled, configure segment postfix.
     if (consistentPushEnabled) {
       ConsistentDataPushUtils.configureSegmentPostfix(_spec);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -102,8 +102,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         throw new RuntimeException("Missing property 'schemaURI' in 'tableSpec'");
       }
       PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
-      String schemaURI = SegmentGenerationUtils
-          .generateSchemaURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
+      String schemaURI = SegmentGenerationUtils.generateSchemaURI(pinotClusterSpec.getControllerURI(),
+          _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setSchemaURI(schemaURI);
     }
     if (_spec.getTableSpec().getTableConfigURI() == null) {
@@ -111,8 +111,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
       }
       PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
-      String tableConfigURI = SegmentGenerationUtils
-          .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
+      String tableConfigURI = SegmentGenerationUtils.generateTableConfigURI(pinotClusterSpec.getControllerURI(),
+          _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
     if (_spec.getExecutionFrameworkSpec().getExtraConfigs() == null) {
@@ -163,8 +163,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         stagingDirURI = new File(stagingDir).toURI();
       }
       if (!outputDirURI.getScheme().equals(stagingDirURI.getScheme())) {
-        throw new RuntimeException(String
-            .format("The scheme of staging directory URI [%s] and output directory URI [%s] has to be same.",
+        throw new RuntimeException(
+            String.format("The scheme of staging directory URI [%s] and output directory URI [%s] has to be same.",
                 stagingDirURI, outputDirURI));
       }
       outputDirFS.mkdir(stagingDirURI);
@@ -226,8 +226,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
             throws Exception {
           PluginManager.get().init();
           for (PinotFSSpec pinotFSSpec : _spec.getPinotFSSpecs()) {
-            PinotFSFactory
-                .register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+                new PinotConfiguration(pinotFSSpec));
           }
           PinotFS finalOutputDirFS = PinotFSFactory.create(finalOutputDirURI.getScheme());
           String[] splits = pathAndIdx.split(" ");
@@ -278,8 +278,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
           taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
           taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
-          taskSpec
-              .setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+          taskSpec.setSchema(
+              SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
           taskSpec.setTableConfig(
               SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
           taskSpec.setSequenceId(idx);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
@@ -25,9 +25,11 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
@@ -46,6 +48,7 @@ import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.scheduler.JobFailed;
 import org.apache.spark.scheduler.JobResult;
 import org.apache.spark.scheduler.SparkListener;
@@ -88,147 +91,163 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
   public SparkSegmentMetadataPushJobRunner() {
   }
 
-  public SparkSegmentMetadataPushJobRunner(SegmentGenerationJobSpec spec) {
-    init(spec);
-  }
-
   @Override
   public void init(SegmentGenerationJobSpec spec) {
     _spec = spec;
   }
 
   @Override
-  public void run()
-      throws Exception {
-    //init all file systems
-    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
-    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
-    }
+  public void run() throws Exception {
+    // Initialize all file systems
+    setupFileSystems();
 
-    //Get outputFS for writing output pinot segments
-    URI outputDirURI;
-    try {
-      outputDirURI = new URI(_spec.getOutputDirURI());
-      if (outputDirURI.getScheme() == null) {
-        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
-      }
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
-    }
+    // Get outputFS for writing output pinot segments
+    URI outputDirURI = validateOutputDirURI(_spec.getOutputDirURI());
     PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
-    //Get list of files to process
-    String[] files;
-    try {
-      files = outputDirFS.listFiles(outputDirURI, true);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
-    }
 
-    List<String> segmentsToPush = new ArrayList<>();
-    for (String file : files) {
-      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
-        segmentsToPush.add(file);
-      }
-    }
-    Map<String, String> segmentsToPushUriToTarPathMap =
-            SegmentPushUtils.getSegmentUriToTarPathMap(
-                    outputDirURI,
-                    _spec.getPushJobSpec(),
-                    segmentsToPush.toArray(new String[0])
-            );
+    // Collect files to process
+    List<String> segmentsToPush = getSegmentsToPush(outputDirFS, outputDirURI);
 
-    if (_spec.getTableSpec().getTableConfigURI() == null) {
-      if (_spec.getPinotClusterSpecs() == null || _spec.getPinotClusterSpecs().length == 0) {
-        throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
-      }
-      PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
-      String tableConfigURI = SegmentGenerationUtils
-          .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
-      _spec.getTableSpec().setTableConfigURI(tableConfigURI);
-    }
+    // Ensure tableConfigURI is set if missing
+    setupTableConfigURI();
 
-    TableConfig tableConfig =
-        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
+    // Retrieve table config and check for consistent push
+    TableConfig tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(),
+            _spec.getAuthToken());
     boolean consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(tableConfig);
 
-    Map<URI, String> uriToLineageEntryIdMap = null;
-    if (consistentPushEnabled) {
-      List<String> segmentNames = getSegmentsToReplace(segmentsToPushUriToTarPathMap);
-      uriToLineageEntryIdMap = ConsistentDataPushUtils.preUpload(_spec, segmentNames);
-    }
-
+    // Determine push parallelism
     int pushParallelism = _spec.getPushJobSpec().getPushParallelism();
     if (pushParallelism < 1) {
       pushParallelism = segmentsToPush.size();
     }
 
+    // Call the appropriate push helper
+    if (consistentPushEnabled) {
+      handleConsistentPush(segmentsToPush, outputDirURI, pushParallelism);
+    } else {
+      handleNonConsistentPush(segmentsToPush, outputDirFS, outputDirURI, pushParallelism);
+    }
+  }
+
+  private void handleConsistentPush(List<String> segmentsToPush, URI outputDirURI, int pushParallelism)
+          throws Exception {
+    Map<String, String> segmentsToPushUriToTarPathMap =
+            SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(),
+                    segmentsToPush.toArray(new String[0]));
+    Map<URI, String> uriToLineageEntryIdMap = ConsistentDataPushUtils.preUpload(_spec,
+            getSegmentsToReplace(segmentsToPushUriToTarPathMap));
+
+    if (pushParallelism == 1) {
+      // Single push
+      SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()),
+              segmentsToPushUriToTarPathMap);
+      executePostUpload(uriToLineageEntryIdMap);
+    } else {
+      // Parallel push using Spark
+      JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
+      sparkContext.sc().addSparkListener(new ConsistentDataPushFailureHandler(_spec, uriToLineageEntryIdMap));
+      JavaRDD<String> pathRDD = sparkContext.parallelize(segmentsToPush, pushParallelism);
+
+      pathRDD.foreach(segmentTarPath -> {
+        setupFileSystems();
+        Map<String, String> segmentUriToTarPathMap =
+                SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(),
+                        new String[]{segmentTarPath});
+        SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()),
+                segmentUriToTarPathMap);
+      });
+
+      executePostUpload(uriToLineageEntryIdMap);
+    }
+  }
+
+  private void handleNonConsistentPush(List<String> segmentsToPush, PinotFS outputDirFS, URI outputDirURI,
+                                       int pushParallelism) throws Exception {
     if (pushParallelism == 1) {
       // Push from driver
-      if (consistentPushEnabled) {
-        SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()),
-                segmentsToPushUriToTarPathMap);
-        try {
-          ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
-        } catch (Exception e) {
-          ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
-          throw new RuntimeException(e);
-        }
-      } else {
-        try {
-          SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
-        } catch (RetriableOperationException | AttemptsExceededException e) {
-          throw new RuntimeException(e);
-        }
+      try {
+        SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
+      } catch (RetriableOperationException | AttemptsExceededException e) {
+        throw new RuntimeException(e);
       }
     } else {
-      // Push from Spark executors when pushParallelism > 1
       JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
       JavaRDD<String> pathRDD = sparkContext.parallelize(segmentsToPush, pushParallelism);
-      URI finalOutputDirURI = outputDirURI;
-
-      if (consistentPushEnabled) {
-        // Parallel upload tasks executed by Spark executors
-        // In this case, we need to handle the case where the Spark job fails
-        sparkContext.sc().addSparkListener(new ConsistentDataPushFailureHandler(_spec, uriToLineageEntryIdMap));
-
-        pathRDD.foreach(segmentTarPath -> {
+        // Prevent using lambda expression in Spark to avoid potential serialization exceptions, use inner function
+      // instead.
+      pathRDD.foreach(new VoidFunction<String>() {
+        @Override
+        public void call(String segmentTarPath)
+                throws Exception {
           PluginManager.get().init();
-          for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
-                new PinotConfiguration(pinotFSSpec));
-          }
-          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(finalOutputDirURI,
-              _spec.getPushJobSpec(), new String[]{segmentTarPath});
-          SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
-              segmentUriToTarPathMap);
-        });
-
-        // Once all segments are uploaded, execute post-upload
-        try {
-          ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
-        } catch (Exception e) {
-          ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
-          throw new RuntimeException(e);
-        }
-      } else {
-        // Non-consistent data push tasks executed by Spark executors
-        pathRDD.foreach(segmentTarPath -> {
-          PluginManager.get().init();
-          for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
-                new PinotConfiguration(pinotFSSpec));
-          }
+          setupFileSystems();
           try {
-            Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(finalOutputDirURI,
-                _spec.getPushJobSpec(), new String[]{segmentTarPath});
-            SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
-                segmentUriToTarPathMap);
+            Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
+                    .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(), new String[]{segmentTarPath});
+            SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()),
+                    segmentUriToTarPathMap);
           } catch (RetriableOperationException | AttemptsExceededException e) {
             throw new RuntimeException(e);
           }
-        });
+        }
+      });
+    }
+  }
+
+  private List<String> getSegmentsToPush(PinotFS outputDirFS, URI outputDirURI) {
+    String[] files = listFiles(outputDirFS, outputDirURI);
+    return Arrays.stream(files)
+            .filter(file -> file.endsWith(Constants.TAR_GZ_FILE_EXT))
+            .collect(Collectors.toList());
+  }
+
+  private void setupFileSystems() {
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+  }
+
+  private URI validateOutputDirURI(String outputDir) {
+    URI outputDirURI;
+    try {
+      outputDirURI = new URI(outputDir);
+      if (outputDirURI.getScheme() == null) {
+        outputDirURI = new File(outputDir).toURI();
       }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("outputDirURI is not valid - '" + outputDir + "'");
+    }
+    return outputDirURI;
+  }
+
+  private String[] listFiles(PinotFS outputDirFS, URI outputDirURI) throws RuntimeException {
+    try {
+      return outputDirFS.listFiles(outputDirURI, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
+    }
+  }
+
+  private void setupTableConfigURI() {
+    if (_spec.getTableSpec().getTableConfigURI() == null) {
+      if (_spec.getPinotClusterSpecs() == null || _spec.getPinotClusterSpecs().length == 0) {
+        throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
+      }
+      PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
+      String tableConfigURI = SegmentGenerationUtils.generateTableConfigURI(pinotClusterSpec.getControllerURI(),
+              _spec.getTableSpec().getTableName());
+      _spec.getTableSpec().setTableConfigURI(tableConfigURI);
+    }
+  }
+
+  private void executePostUpload(Map<URI, String> uriToLineageEntryIdMap) {
+    try {
+      ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
+    } catch (Exception e) {
+      ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
@@ -18,20 +18,26 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.spark3;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
@@ -40,10 +46,43 @@ import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.scheduler.JobFailed;
+import org.apache.spark.scheduler.JobResult;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
 
 
 public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Serializable {
+  // This listener is added to the SparkContext and is executed when the Spark job fails.
+  // It handles the failure by calling ConsistentDataPushUtils.handleUploadException.
+  // The listener is only added if consistent data push is enabled and the pushParallelism is greater than 1.
+  // This listener is not a required part of the implementation, as the start replace segments protocol
+  // will cleanup past failures as part of the fresh consistent data push, but it's still cleaner to handle
+  // the failure as soon as possible.
+  private static class ConsistentDataPushFailureHandler extends SparkListener {
+    private final SegmentGenerationJobSpec _spec;
+    private final Map<URI, String> _uriToLineageEntryIdMap;
+
+    public ConsistentDataPushFailureHandler(SegmentGenerationJobSpec spec,
+                                            Map<URI, String> uriToLineageEntryIdMap) {
+      _spec = spec;
+      _uriToLineageEntryIdMap = uriToLineageEntryIdMap;
+    }
+
+    @Override
+    public void onJobEnd(SparkListenerJobEnd jobEnd) {
+      JobResult jobResult = jobEnd.jobResult();
+      if (jobResult instanceof JobFailed) {
+        try {
+          ConsistentDataPushUtils.handleUploadException(_spec, _uriToLineageEntryIdMap,
+                  ((JobFailed) jobResult).exception());
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to handle upload exception", e);
+        }
+      }
+    }
+  }
+
   private SegmentGenerationJobSpec _spec;
 
   public SparkSegmentMetadataPushJobRunner() {
@@ -59,7 +98,8 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
   }
 
   @Override
-  public void run() {
+  public void run()
+      throws Exception {
     //init all file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
@@ -91,43 +131,123 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
         segmentsToPush.add(file);
       }
     }
+    Map<String, String> segmentsToPushUriToTarPathMap =
+            SegmentPushUtils.getSegmentUriToTarPathMap(
+                    outputDirURI,
+                    _spec.getPushJobSpec(),
+                    segmentsToPush.toArray(new String[0])
+            );
+
+    if (_spec.getTableSpec().getTableConfigURI() == null) {
+      if (_spec.getPinotClusterSpecs() == null || _spec.getPinotClusterSpecs().length == 0) {
+        throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
+      }
+      PinotClusterSpec pinotClusterSpec = _spec.getPinotClusterSpecs()[0];
+      String tableConfigURI = SegmentGenerationUtils
+          .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
+      _spec.getTableSpec().setTableConfigURI(tableConfigURI);
+    }
+
+    TableConfig tableConfig =
+        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
+    boolean consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(tableConfig);
+
+    Map<URI, String> uriToLineageEntryIdMap = null;
+    if (consistentPushEnabled) {
+      List<String> segmentNames = getSegmentsToReplace(segmentsToPushUriToTarPathMap);
+      uriToLineageEntryIdMap = ConsistentDataPushUtils.preUpload(_spec, segmentNames);
+    }
 
     int pushParallelism = _spec.getPushJobSpec().getPushParallelism();
     if (pushParallelism < 1) {
       pushParallelism = segmentsToPush.size();
     }
+
     if (pushParallelism == 1) {
       // Push from driver
-      try {
-        SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
-      } catch (RetriableOperationException | AttemptsExceededException e) {
-        throw new RuntimeException(e);
+      if (consistentPushEnabled) {
+        SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()),
+                segmentsToPushUriToTarPathMap);
+        try {
+          ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
+        } catch (Exception e) {
+          ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
+          throw new RuntimeException(e);
+        }
+      } else {
+        try {
+          SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
+        } catch (RetriableOperationException | AttemptsExceededException e) {
+          throw new RuntimeException(e);
+        }
       }
     } else {
+      // Push from Spark executors when pushParallelism > 1
       JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
       JavaRDD<String> pathRDD = sparkContext.parallelize(segmentsToPush, pushParallelism);
       URI finalOutputDirURI = outputDirURI;
-      // Prevent using lambda expression in Spark to avoid potential serialization exceptions, use inner function
-      // instead.
-      pathRDD.foreach(new VoidFunction<String>() {
-        @Override
-        public void call(String segmentTarPath)
-            throws Exception {
+
+      if (consistentPushEnabled) {
+        // Parallel upload tasks executed by Spark executors
+        // In this case, we need to handle the case where the Spark job fails
+        sparkContext.sc().addSparkListener(new ConsistentDataPushFailureHandler(_spec, uriToLineageEntryIdMap));
+
+        pathRDD.foreach(segmentTarPath -> {
           PluginManager.get().init();
           for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-            PinotFSFactory
-                .register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+                new PinotConfiguration(pinotFSSpec));
+          }
+          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(finalOutputDirURI,
+              _spec.getPushJobSpec(), new String[]{segmentTarPath});
+          SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
+              segmentUriToTarPathMap);
+        });
+
+        // Once all segments are uploaded, execute post-upload
+        try {
+          ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
+        } catch (Exception e) {
+          ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
+          throw new RuntimeException(e);
+        }
+      } else {
+        // Non-consistent data push tasks executed by Spark executors
+        pathRDD.foreach(segmentTarPath -> {
+          PluginManager.get().init();
+          for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+                new PinotConfiguration(pinotFSSpec));
           }
           try {
-            Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-                .getSegmentUriToTarPathMap(finalOutputDirURI, _spec.getPushJobSpec(), new String[]{segmentTarPath});
+            Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(finalOutputDirURI,
+                _spec.getPushJobSpec(), new String[]{segmentTarPath});
             SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
                 segmentUriToTarPathMap);
           } catch (RetriableOperationException | AttemptsExceededException e) {
             throw new RuntimeException(e);
           }
-        }
-      });
+        });
+      }
     }
+  }
+
+  /**
+   * Returns segment names, which will be supplied to the segment replacement protocol as the new set of segments to
+   * atomically update when consistent data push is enabled.
+   * @param segmentsUriToTarPathMap Map from segment URI to corresponding tar path. Either the URIs (keys), the
+   *                                tarPaths (values), or both may be used depending on upload mode.
+   */
+  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
+    Collection<String> tarFilePaths = segmentsUriToTarPathMap.values();
+    List<String> segmentNames = new ArrayList<>(tarFilePaths.size());
+    for (String tarFilePath : tarFilePaths) {
+      File tarFile = new File(tarFilePath);
+      String fileName = tarFile.getName();
+      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
+      String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
+      segmentNames.add(segmentName);
+    }
+    return segmentNames;
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
@@ -43,7 +43,6 @@ import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -55,12 +54,7 @@ public class SparkSegmentGenerationJobRunnerTest {
 
   @BeforeClass
   public void setup() {
-    SparkConf conf = new SparkConf().setAppName(SparkSegmentGenerationJobRunnerTest.class.getName())
-        .setMaster("local[*]") // For local test based development
-        .set("spark.driver.bindAddress", "127.0.0.1").set("spark.driver.port", "7077")
-        .set("spark.port.maxRetries", "50");
-
-    _sparkContext = new SparkContext(conf);
+    _sparkContext = new SparkContext("local", SparkSegmentGenerationJobRunnerTest.class.getName());
   }
 
   private SegmentGenerationJobSpec setupAppendTableSpec(File testDir)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
@@ -22,12 +22,17 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.Schema.SchemaBuilder;
@@ -38,6 +43,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -49,47 +55,43 @@ public class SparkSegmentGenerationJobRunnerTest {
 
   @BeforeClass
   public void setup() {
-    _sparkContext = new SparkContext("local", SparkSegmentGenerationJobRunnerTest.class.getName());
+    SparkConf conf = new SparkConf()
+        .setAppName(SparkSegmentGenerationJobRunnerTest.class.getName())
+        .setMaster("local[*]") // Use local master
+        .set("spark.driver.bindAddress", "127.0.0.1") // Set to localhost or appropriate IP
+        .set("spark.driver.port", "7077") // Choose any available port
+        .set("spark.port.maxRetries", "50"); // Increase retry attempts if needed
+
+    _sparkContext = new SparkContext(conf);
   }
 
-  @Test
-  public void testSegmentGeneration() throws Exception {
-    // TODO use common resource definitions & code shared with Hadoop unit test.
-    // So probably need a pinot-batch-ingestion-common tests jar that we depend on.
-
-    File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
-    testDir.delete();
-    testDir.mkdirs();
-
+  private SegmentGenerationJobSpec setupAppendTableSpec(File testDir)
+          throws Exception {
     File inputDir = new File(testDir, "input");
     inputDir.mkdirs();
     File inputFile = new File(inputDir, "input.csv");
     FileUtils.writeLines(inputFile, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
 
-    // Create an output directory, with two empty files in it. One we'll overwrite,
-    // and one we'll leave alone.
-    final String outputFilename = "myTable_OFFLINE_0.tar.gz";
-    final String existingFilename = "myTable_OFFLINE_100.tar.gz";
     File outputDir = new File(testDir, "output");
+    final String outputFilename = "myTable_OFFLINE_0.tar.gz";
     FileUtils.touch(new File(outputDir, outputFilename));
+    final String existingFilename = "myTable_OFFLINE_100.tar.gz";
     FileUtils.touch(new File(outputDir, existingFilename));
 
-    // Set up schema file.
     final String schemaName = "myTable";
     File schemaFile = new File(testDir, "myTable.schema");
     Schema schema = new SchemaBuilder()
-      .setSchemaName(schemaName)
-      .addSingleValueDimension("col1", DataType.STRING)
-      .addMetric("col2", DataType.INT)
-      .build();
+        .setSchemaName(schemaName)
+        .addSingleValueDimension("col1", DataType.STRING)
+        .addMetric("col2", DataType.INT)
+        .build();
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
-    // Set up table config file.
     File tableConfigFile = new File(testDir, "myTable.table");
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-      .setTableName("myTable")
-      .setNumReplicas(1)
-      .build();
+        .setTableName("myTable")
+        .setNumReplicas(1)
+        .build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
 
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -120,10 +122,87 @@ public class SparkSegmentGenerationJobRunnerTest {
     pfsSpec.setClassName(LocalPinotFS.class.getName());
     jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
 
+    return jobSpec;
+  }
+
+  private SegmentGenerationJobSpec setupRefreshTableSpec(File testDir)
+          throws Exception {
+    File inputDir = new File(testDir, "input");
+    inputDir.mkdirs();
+
+    // Create two input files
+    File inputFile1 = new File(inputDir, "input1.csv");
+    File inputFile2 = new File(inputDir, "input2.csv");
+    FileUtils.writeLines(inputFile1, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
+    FileUtils.writeLines(inputFile2, Lists.newArrayList("col1,col2", "value3,3", "value4,4"));
+
+    File outputDir = new File(testDir, "output");
+    final String schemaName = "myTable";
+    File schemaFile = new File(testDir, "myTable.schema");
+    Schema schema = new SchemaBuilder()
+            .setSchemaName(schemaName)
+            .addSingleValueDimension("col1", DataType.STRING)
+            .addMetric("col2", DataType.INT)
+            .build();
+    FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
+
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH",
+            "DAILY", true));
+    File tableConfigFile = new File(testDir, "myTable.table");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+            .setTableName("myTable")
+            .setNumReplicas(1)
+            .setIngestionConfig(ingestionConfig)
+            .build();
+    FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
+
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    jobSpec.setJobType("SegmentCreation");
+    jobSpec.setInputDirURI(inputDir.toURI().toString());
+    jobSpec.setOutputDirURI(outputDir.toURI().toString());
+    jobSpec.setOverwriteOutput(false);
+
+    RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
+    recordReaderSpec.setDataFormat("csv");
+    recordReaderSpec.setClassName(CSVRecordReader.class.getName());
+    recordReaderSpec.setConfigClassName(CSVRecordReaderConfig.class.getName());
+    jobSpec.setRecordReaderSpec(recordReaderSpec);
+
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName("myTable");
+    tableSpec.setSchemaURI(schemaFile.toURI().toString());
+    tableSpec.setTableConfigURI(tableConfigFile.toURI().toString());
+    jobSpec.setTableSpec(tableSpec);
+
+    ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
+    efSpec.setName("standalone");
+    efSpec.setSegmentGenerationJobRunnerClassName(SparkSegmentGenerationJobRunner.class.getName());
+    jobSpec.setExecutionFrameworkSpec(efSpec);
+
+    PinotFSSpec pfsSpec = new PinotFSSpec();
+    pfsSpec.setScheme("file");
+    pfsSpec.setClassName(LocalPinotFS.class.getName());
+    jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
+
+    return jobSpec;
+  }
+
+  @Test
+  public void testSegmentGeneration() throws Exception {
+    File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
+    testDir.delete();
+    testDir.mkdirs();
+
+    SegmentGenerationJobSpec jobSpec = setupAppendTableSpec(testDir);
+
     SparkSegmentGenerationJobRunner jobRunner = new SparkSegmentGenerationJobRunner(jobSpec);
     jobRunner.run();
 
-    // The output directory should still have the original file in it.
+    final String outputFilename = "myTable_OFFLINE_0.tar.gz";
+    final String existingFilename = "myTable_OFFLINE_100.tar.gz";
+    File outputDir = new File(testDir, "output");
+
     File oldSegmentFile = new File(outputDir, existingFilename);
     Assert.assertTrue(oldSegmentFile.exists());
 
@@ -146,6 +225,38 @@ public class SparkSegmentGenerationJobRunnerTest {
     Assert.assertTrue(newSegmentFile.length() > 0);
 
     // FUTURE - validate contents of file?
+  }
+
+  @Test
+  public void testSegmentGenerationWithConsistentPush() throws Exception {
+    File testDir = Files.createTempDirectory("testSegmentGenerationWithConsistentPush-").toFile();
+    testDir.delete();
+    testDir.mkdirs();
+
+    SegmentGenerationJobSpec jobSpec = setupRefreshTableSpec(testDir);
+    SparkSegmentGenerationJobRunner jobRunner = new SparkSegmentGenerationJobRunner(jobSpec);
+    jobRunner.run();
+
+    // Assert that the segment name generator spec is present and has the correct value
+    Assert.assertNotNull(jobSpec.getSegmentNameGeneratorSpec());
+    Assert.assertEquals(jobSpec.getSegmentNameGeneratorSpec().getConfigs().keySet().size(), 1);
+    Assert.assertTrue(jobSpec.getSegmentNameGeneratorSpec().getConfigs().containsKey("segment.name.postfix"));
+    // Value should be the current time but we can't predict it, so just check that it's a number
+    Assert.assertTrue(jobSpec.getSegmentNameGeneratorSpec().getConfigs().get("segment.name.postfix")
+            .matches("\\d+"));
+    String segmentNamePostfix = jobSpec.getSegmentNameGeneratorSpec().getConfigs().get("segment.name.postfix");
+
+    String expectedSegmentName0 = "myTable_OFFLINE_" + segmentNamePostfix + "_0.tar.gz";
+    String expectedSegmentName1 = "myTable_OFFLINE_" + segmentNamePostfix + "_1.tar.gz";
+
+    // Get list of files in the output directory and assert segment name
+    File outputDir = new File(testDir, "output");
+    File[] files = outputDir.listFiles();
+    Set<String> fileNames = Arrays.stream(files)
+            .map(File::getName)
+            .collect(Collectors.toSet());
+    Set<String> expectedNames = Set.of(expectedSegmentName0, expectedSegmentName1);
+    Assert.assertEquals(fileNames, expectedNames);
   }
 
   @Test

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
@@ -55,18 +55,16 @@ public class SparkSegmentGenerationJobRunnerTest {
 
   @BeforeClass
   public void setup() {
-    SparkConf conf = new SparkConf()
-        .setAppName(SparkSegmentGenerationJobRunnerTest.class.getName())
+    SparkConf conf = new SparkConf().setAppName(SparkSegmentGenerationJobRunnerTest.class.getName())
         .setMaster("local[*]") // For local test based development
-        .set("spark.driver.bindAddress", "127.0.0.1")
-        .set("spark.driver.port", "7077")
+        .set("spark.driver.bindAddress", "127.0.0.1").set("spark.driver.port", "7077")
         .set("spark.port.maxRetries", "50");
 
     _sparkContext = new SparkContext(conf);
   }
 
   private SegmentGenerationJobSpec setupAppendTableSpec(File testDir)
-          throws Exception {
+      throws Exception {
     File inputDir = new File(testDir, "input");
     inputDir.mkdirs();
     File inputFile = new File(inputDir, "input.csv");
@@ -80,18 +78,13 @@ public class SparkSegmentGenerationJobRunnerTest {
 
     final String schemaName = "myTable";
     File schemaFile = new File(testDir, "myTable.schema");
-    Schema schema = new SchemaBuilder()
-        .setSchemaName(schemaName)
-        .addSingleValueDimension("col1", DataType.STRING)
-        .addMetric("col2", DataType.INT)
-        .build();
+    Schema schema = new SchemaBuilder().setSchemaName(schemaName).addSingleValueDimension("col1", DataType.STRING)
+        .addMetric("col2", DataType.INT).build();
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     File tableConfigFile = new File(testDir, "myTable.table");
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("myTable")
-        .setNumReplicas(1)
-        .build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setNumReplicas(1).build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
 
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -126,7 +119,7 @@ public class SparkSegmentGenerationJobRunnerTest {
   }
 
   private SegmentGenerationJobSpec setupRefreshTableSpec(File testDir)
-          throws Exception {
+      throws Exception {
     File inputDir = new File(testDir, "input");
     inputDir.mkdirs();
 
@@ -139,22 +132,15 @@ public class SparkSegmentGenerationJobRunnerTest {
     File outputDir = new File(testDir, "output");
     final String schemaName = "myTable";
     File schemaFile = new File(testDir, "myTable.schema");
-    Schema schema = new SchemaBuilder()
-            .setSchemaName(schemaName)
-            .addSingleValueDimension("col1", DataType.STRING)
-            .addMetric("col2", DataType.INT)
-            .build();
+    Schema schema = new SchemaBuilder().setSchemaName(schemaName).addSingleValueDimension("col1", DataType.STRING)
+        .addMetric("col2", DataType.INT).build();
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH",
-            "DAILY", true));
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH", "DAILY", true));
     File tableConfigFile = new File(testDir, "myTable.table");
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-            .setTableName("myTable")
-            .setNumReplicas(1)
-            .setIngestionConfig(ingestionConfig)
-            .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setNumReplicas(1)
+        .setIngestionConfig(ingestionConfig).build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
 
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -189,7 +175,8 @@ public class SparkSegmentGenerationJobRunnerTest {
   }
 
   @Test
-  public void testSegmentGeneration() throws Exception {
+  public void testSegmentGeneration()
+      throws Exception {
     File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
     testDir.delete();
     testDir.mkdirs();
@@ -228,7 +215,8 @@ public class SparkSegmentGenerationJobRunnerTest {
   }
 
   @Test
-  public void testSegmentGenerationWithConsistentPush() throws Exception {
+  public void testSegmentGenerationWithConsistentPush()
+      throws Exception {
     File testDir = Files.createTempDirectory("testSegmentGenerationWithConsistentPush-").toFile();
     testDir.delete();
     testDir.mkdirs();
@@ -242,8 +230,7 @@ public class SparkSegmentGenerationJobRunnerTest {
     Assert.assertEquals(jobSpec.getSegmentNameGeneratorSpec().getConfigs().keySet().size(), 1);
     Assert.assertTrue(jobSpec.getSegmentNameGeneratorSpec().getConfigs().containsKey("segment.name.postfix"));
     // Value should be the current time but we can't predict it, so just check that it's a number
-    Assert.assertTrue(jobSpec.getSegmentNameGeneratorSpec().getConfigs().get("segment.name.postfix")
-            .matches("\\d+"));
+    Assert.assertTrue(jobSpec.getSegmentNameGeneratorSpec().getConfigs().get("segment.name.postfix").matches("\\d+"));
     String segmentNamePostfix = jobSpec.getSegmentNameGeneratorSpec().getConfigs().get("segment.name.postfix");
 
     String expectedSegmentName0 = "myTable_OFFLINE_" + segmentNamePostfix + "_0.tar.gz";
@@ -252,9 +239,7 @@ public class SparkSegmentGenerationJobRunnerTest {
     // Get list of files in the output directory and assert segment name
     File outputDir = new File(testDir, "output");
     File[] files = outputDir.listFiles();
-    Set<String> fileNames = Arrays.stream(files)
-            .map(File::getName)
-            .collect(Collectors.toSet());
+    Set<String> fileNames = Arrays.stream(files).map(File::getName).collect(Collectors.toSet());
     Set<String> expectedNames = Set.of(expectedSegmentName0, expectedSegmentName1);
     Assert.assertEquals(fileNames, expectedNames);
   }
@@ -283,19 +268,14 @@ public class SparkSegmentGenerationJobRunnerTest {
     // Set up schema file.
     final String schemaName = "mySchema";
     File schemaFile = new File(testDir, "schema");
-    Schema schema = new SchemaBuilder()
-        .setSchemaName(schemaName)
-        .addSingleValueDimension("col1", DataType.STRING)
-        .addMetric("col2", DataType.INT)
-        .build();
+    Schema schema = new SchemaBuilder().setSchemaName(schemaName).addSingleValueDimension("col1", DataType.STRING)
+        .addMetric("col2", DataType.INT).build();
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     // Set up table config file.
     File tableConfigFile = new File(testDir, "tableConfig");
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("myTable")
-        .setNumReplicas(1)
-        .build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setNumReplicas(1).build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
 
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
@@ -57,10 +57,10 @@ public class SparkSegmentGenerationJobRunnerTest {
   public void setup() {
     SparkConf conf = new SparkConf()
         .setAppName(SparkSegmentGenerationJobRunnerTest.class.getName())
-        .setMaster("local[*]") // Use local master
-        .set("spark.driver.bindAddress", "127.0.0.1") // Set to localhost or appropriate IP
-        .set("spark.driver.port", "7077") // Choose any available port
-        .set("spark.port.maxRetries", "50"); // Increase retry attempts if needed
+        .setMaster("local[*]") // For local test based development
+        .set("spark.driver.bindAddress", "127.0.0.1")
+        .set("spark.driver.port", "7077")
+        .set("spark.port.maxRetries", "50");
 
     _sparkContext = new SparkContext(conf);
   }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -177,7 +177,6 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     List<String> filteredFiles = SegmentGenerationUtils.listMatchedFilesWithRecursiveOption(_inputDirFS, _inputDirURI,
         _spec.getIncludeFileNamePattern(), _spec.getExcludeFileNamePattern(), _spec.isSearchRecursively());
 
-    // If consistent push is enabled, configure segment postfix.
     if (_consistentPushEnabled) {
       ConsistentDataPushUtils.configureSegmentPostfix(_spec);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -177,6 +177,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     List<String> filteredFiles = SegmentGenerationUtils.listMatchedFilesWithRecursiveOption(_inputDirFS, _inputDirURI,
         _spec.getIncludeFileNamePattern(), _spec.getExcludeFileNamePattern(), _spec.isSearchRecursively());
 
+    // If consistent push is enabled, configure segment postfix.
     if (_consistentPushEnabled) {
       ConsistentDataPushUtils.configureSegmentPostfix(_spec);
     }


### PR DESCRIPTION
In Stripe we will need consistent data push support but as it stands its not supported in spark jobs. This resolves https://github.com/apache/pinot/issues/12941

This brings the [consistent data push](https://docs.pinot.apache.org/operators/operating-pinot/consistent-push-and-rollback) feature to spark 3 segment generation & metadata push jobs.
- SparkSegmentGenerationJobRunner and SparkSegmentMetadataPushJobRunner

For SparkSegmentMetadataPushJobRunner, when parallelism is > 1, the executors are used but we run into edge cases about what to do if the tasks fail and the driver doesn't have a chance to handle the exceptions. We also run into interesting case if the driver dies. I added a listener that conditionally is added to the spark context and will run if the job is deemed to fail. It will call `ConsistentDataPushUtils.handleUploadException`. This is not a requirement though, as the segment replace protocal (API called at the _start_ of consistent data push) cleans up prior failed attempts before proceeding. The added listener here is a nice to have and keeps it clean earlier then later.

I have also added support for batch upload using new api added in https://github.com/apache/pinot/pull/13646.

I will update pinot docs to describe how consistent data push, batch upload, and push parallelism interact since there is few different combinations on what can happen depending on what type of parallelism you want to achieve 

**Testing**
- Added integration tests for SparkSegmentMetadataPushJobRunner that asserts:
    - pushing w/ consistent data push, 
    - checking the lineage entry, 
    - performing a count query, 
    - pushing an additional segment, 
    - and then verifying previous segments pushed are not queryable and performing another count query represative of the only new additional queryable segment
    - same tests but w/ batch segment upload also
- Added a standalone test for SparkSegmentGenerationJobRunner asserting on consistent push behaviour (the consistent push util is used to add a postfix w/ timestamp) and segments are generated
- Ran internally in Stripe's dev environment, but this asserts the same behaviour as above

I am not going to add support for spark 2 jobs in this PR and will clearly mark in the Pinot docs that support exists for spark 3 but not 2. 

