### PR TITLE
Enabling JSON column for groupBy in time series and proper handling f…

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -148,15 +148,17 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
           break;
       }
     }
+    Long stepSeconds = getStepSeconds(step);
     Preconditions.checkNotNull(query, "Query cannot be null");
     Preconditions.checkNotNull(startTs, "Start time cannot be null");
     Preconditions.checkNotNull(endTs, "End time cannot be null");
+    Preconditions.checkState(stepSeconds != null && stepSeconds > 0, "Step must be a positive integer");
     Duration timeout = Duration.ofMillis(_brokerTimeoutMs);
     if (StringUtils.isNotBlank(timeoutStr)) {
       timeout = HumanReadableDuration.from(timeoutStr);
     }
     // TODO: Pass full raw query param string to the request
-    return new RangeTimeSeriesRequest(language, query, startTs, endTs, getStepSeconds(step), timeout, queryParamString);
+    return new RangeTimeSeriesRequest(language, query, startTs, endTs, stepSeconds, timeout, queryParamString);
   }
 
   public static Long getStepSeconds(@Nullable String step) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -94,6 +94,7 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
     for (int i = 0; i < _groupByExpressions.size(); i++) {
       blockValSet = transformBlock.getBlockValueSet(_groupByExpressions.get(i));
       switch (blockValSet.getValueType()) {
+        case JSON:
         case STRING:
           tagValues[i] = blockValSet.getStringValuesSV();
           break;


### PR DESCRIPTION
- Commit enables JSOn column in groupBy expressions. 
- Avoid divide by zero exception by checking step second for 0. 
- Validated the changes manually. 