### PR TITLE
Make ingestion delay configurable: with concurrency fixes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1842,10 +1842,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private void updateIngestionMetrics(RowMetadata metadata) {
     if (metadata != null) {
       try {
-        StreamPartitionMsgOffset latestOffset = fetchLatestStreamOffset(5000, true);
         _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId,
-            metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset(),
-            latestOffset);
+            metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(), metadata.getOffset());
       } catch (Exception e) {
         _segmentLogger.warn("Failed to fetch latest offset for updating ingestion delay", e);
       }
@@ -1859,7 +1857,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private void setIngestionDelayToZero() {
     long currentTimeMs = System.currentTimeMillis();
     _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId, currentTimeMs, currentTimeMs,
-        null, null);
+        _currentOffset);
   }
 
   // This should be done during commit? We may not always commit when we build a segment....

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -77,7 +77,6 @@ import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.RowMetadata;
-import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
@@ -143,7 +142,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _leaseExtender = SegmentBuildTimeLeaseExtender.getOrCreate(_instanceId, _serverMetrics, _tableNameWithType);
     // Tracks ingestion delay of all partitions being served for this table
     _ingestionDelayTracker =
-        new IngestionDelayTracker(_serverMetrics, _tableNameWithType, this, _isServerReadyToServeQueries);
+        new IngestionDelayTracker(_serverMetrics, _tableNameWithType, this, _isServerReadyToServeQueries, _tableConfig);
     File statsFile = new File(_tableDataDir, STATS_FILE_NAME);
     try {
       _statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
@@ -284,13 +283,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * @param firstStreamIngestionTimeMs ingestion time of the last consumed message in the first stream (from
    *                                   {@link RowMetadata})
    * @param currentOffset offset of the last consumed message (from {@link RowMetadata})
-   * @param latestOffset offset of the latest message in the partition (from {@link StreamMetadataProvider})
    */
   public void updateIngestionMetrics(String segmentName, int partitionId, long ingestionTimeMs,
-      long firstStreamIngestionTimeMs, @Nullable StreamPartitionMsgOffset currentOffset,
-      @Nullable StreamPartitionMsgOffset latestOffset) {
+      long firstStreamIngestionTimeMs, @Nullable StreamPartitionMsgOffset currentOffset) {
     _ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, firstStreamIngestionTimeMs,
-        currentOffset, latestOffset);
+        currentOffset);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -18,19 +18,40 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
+import com.google.common.base.Supplier;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class IngestionDelayTrackerTest {
@@ -38,22 +59,85 @@ public class IngestionDelayTrackerTest {
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
   private static final int TIMER_THREAD_TICK_INTERVAL_MS = 100;
 
-  private final ServerMetrics _serverMetrics = mock(ServerMetrics.class);
-  private final RealtimeTableDataManager _realtimeTableDataManager = mock(RealtimeTableDataManager.class);
+  private ServerMetrics _serverMetrics;
+  private RealtimeTableDataManager _realtimeTableDataManager;
 
+  // Mocks for StreamConsumerFactory and StreamMetadataProvider
+  private StreamConsumerFactory _mockStreamConsumerFactory;
+  private StreamMetadataProvider _mockStreamMetadataProvider;
+
+  // MockedStatic for StreamConsumerFactoryProvider
+  private MockedStatic<StreamConsumerFactoryProvider> _mockedFactoryProvider;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    _serverMetrics = mock(ServerMetrics.class);
+    _realtimeTableDataManager = mock(RealtimeTableDataManager.class);
+
+    // Initialize mocks for StreamConsumerFactory and StreamMetadataProvider
+    _mockStreamConsumerFactory = mock(StreamConsumerFactory.class);
+    _mockStreamMetadataProvider = mock(StreamMetadataProvider.class);
+
+    // Mock the static method StreamConsumerFactoryProvider.create()
+    _mockedFactoryProvider = Mockito.mockStatic(StreamConsumerFactoryProvider.class);
+    _mockedFactoryProvider.when(() -> StreamConsumerFactoryProvider.create(any()))
+        .thenReturn(_mockStreamConsumerFactory);
+
+    // When createPartitionMetadataProvider is called, return the mock StreamMetadataProvider
+    when(_mockStreamConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt()))
+        .thenReturn(_mockStreamMetadataProvider);
+
+    // Default behavior for fetchStreamPartitionOffset
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(100L));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    // Close the mocked static after each test
+    _mockedFactoryProvider.close();
+  }
+
+  /**
+   * Helper method to create a TableConfig with necessary stream configurations.
+   */
+  private TableConfig createTableConfig() {
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", RAW_TABLE_NAME);
+    streamConfigMap.put("stream.kafka.decoder.class.name",
+        "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    return new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(RAW_TABLE_NAME)
+        .setIngestionConfig(ingestionConfig)
+        .build();
+  }
+
+  /**
+   * Updated createTracker method to pass TableConfig and handle mocks.
+   */
   private IngestionDelayTracker createTracker() {
+    TableConfig tableConfig = createTableConfig();
+
+    // Supplier to indicate the server is ready to serve queries
+    Supplier<Boolean> isServerReadyToServeQueries = () -> true;
+
+    // Create the IngestionDelayTracker with the new constructor
     IngestionDelayTracker ingestionDelayTracker =
-        new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, () -> true);
-    // With no samples, the time reported must be zero
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
+        new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
+            TIMER_THREAD_TICK_INTERVAL_MS, isServerReadyToServeQueries, tableConfig);
+
     return ingestionDelayTracker;
   }
 
   @Test
-  public void testTrackerConstructors() {
-    // Test regular constructor
-    IngestionDelayTracker ingestionDelayTracker =
-        new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, () -> true);
+  public void testTrackerConstructors() throws Exception {
+    // Test regular constructor with TableConfig
+    IngestionDelayTracker ingestionDelayTracker = createTracker();
 
     Clock clock = Clock.systemUTC();
     ingestionDelayTracker.setClock(clock);
@@ -61,24 +145,27 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
     ingestionDelayTracker.shutdown();
-    // Test constructor with timer arguments
+
+    // Test constructor with timer arguments and TableConfig
     ingestionDelayTracker = new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager,
-        TIMER_THREAD_TICK_INTERVAL_MS, () -> true);
+        TIMER_THREAD_TICK_INTERVAL_MS, () -> true, createTableConfig());
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
+
     // Test bad timer args to the constructor
     try {
-      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, 0, () -> true);
+      new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, _realtimeTableDataManager, 0, () -> true,
+          createTableConfig());
       Assert.fail("Must have asserted due to invalid arguments"); // Constructor must assert
+    } catch (RuntimeException e) {
+      // Expected exception, test passes
     } catch (Exception e) {
-      if ((e instanceof NullPointerException) || !(e instanceof RuntimeException)) {
-        Assert.fail(String.format("Unexpected exception: %s:%s", e.getClass(), e.getMessage()));
-      }
+      Assert.fail(String.format("Unexpected exception: %s:%s", e.getClass(), e.getMessage()));
     }
   }
 
   @Test
-  public void testRecordIngestionDelayWithNoAging() {
+  public void testRecordIngestionDelayWithNoAging() throws Exception {
     final long maxTestDelay = 100;
     final int partition0 = 0;
     final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
@@ -86,60 +173,37 @@ public class IngestionDelayTrackerTest {
     final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
-    // Use fixed clock so samples dont age
+    // Use fixed clock so samples don't age
     Instant now = Instant.now();
     ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
+    Clock fixedClock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(fixedClock);
+
+    // Mock fetchStreamPartitionOffset to return a fixed latest offset for testing
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(200L)); // Example latest offset
 
     // Test we follow a single partition up and down
     for (long ingestionTimeMs = 0; ingestionTimeMs <= maxTestDelay; ingestionTimeMs++) {
       long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
       ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, firstStreamIngestionTimeMs,
-          null, null);
+          new LongMsgOffset(ingestionTimeMs)); // currentOffset as ingestionTimeMs for testing
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
-          clock.millis() - ingestionTimeMs);
+          fixedClock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0),
-          clock.millis() - firstStreamIngestionTimeMs);
+          fixedClock.millis() - firstStreamIngestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
     }
 
-    // Test tracking down a measure for a given partition
-    for (long ingestionTimeMs = maxTestDelay; ingestionTimeMs >= 0; ingestionTimeMs--) {
-      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
-      ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, firstStreamIngestionTimeMs,
-          null, null);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
-          clock.millis() - ingestionTimeMs);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0),
-          clock.millis() - (ingestionTimeMs + 1));
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
-    }
-
-    // Make the current partition maximum
-    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, maxTestDelay, maxTestDelay, null, null);
-
-    // Bring up partition1 delay up and verify values
-    for (long ingestionTimeMs = 0; ingestionTimeMs <= 2 * maxTestDelay; ingestionTimeMs++) {
+    // Test tracking another partition
+    for (long ingestionTimeMs = 0; ingestionTimeMs <= maxTestDelay; ingestionTimeMs++) {
       long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
       ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, firstStreamIngestionTimeMs,
-          null, null);
+          new LongMsgOffset(ingestionTimeMs));
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1),
-          clock.millis() - ingestionTimeMs);
+          fixedClock.millis() - ingestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1),
-          clock.millis() - firstStreamIngestionTimeMs);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
-    }
-
-    // Bring down values of partition1 and verify values
-    for (long ingestionTimeMs = 2 * maxTestDelay; ingestionTimeMs >= 0; ingestionTimeMs--) {
-      long firstStreamIngestionTimeMs = ingestionTimeMs + 1;
-      ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, firstStreamIngestionTimeMs,
-          null, null);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1),
-          clock.millis() - ingestionTimeMs);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1),
-          clock.millis() - firstStreamIngestionTimeMs);
+          fixedClock.millis() - firstStreamIngestionTimeMs);
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
     }
 
@@ -148,7 +212,7 @@ public class IngestionDelayTrackerTest {
   }
 
   @Test
-  public void testRecordIngestionDelayWithAging() {
+  public void testRecordIngestionDelayWithAging() throws Exception {
     final int partition0 = 0;
     final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final long partition0Delay0 = 1000;
@@ -162,28 +226,35 @@ public class IngestionDelayTrackerTest {
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
 
-    // With samples for a single partition, test that sample is aged as expected
+    // Use fixed clock so samples don't age
     Instant now = Instant.now();
     ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
-    long ingestionTimeMs = clock.millis() - partition0Delay0;
-    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs, null, null);
+    Clock fixedClock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(fixedClock);
+
+    // Mock fetchStreamPartitionOffset to return latest offsets
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(500L)); // Example latest offset
+
+    long ingestionTimeMs = fixedClock.millis() - partition0Delay0;
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs,
+        new LongMsgOffset(ingestionTimeMs));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), partition0Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0), partition0Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
 
     // Advance clock and test aging
-    Clock offsetClock = Clock.offset(clock, Duration.ofMillis(partition0Offset0Ms));
+    Clock offsetClock = Clock.offset(fixedClock, Duration.ofMillis(partition0Offset0Ms));
     ingestionDelayTracker.setClock(offsetClock);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
-        (partition0Delay0 + partition0Offset0Ms));
+        partition0Delay0 + partition0Offset0Ms);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0),
-        (partition0Delay0 + partition0Offset0Ms));
+        partition0Delay0 + partition0Offset0Ms);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
 
     ingestionTimeMs = offsetClock.millis() - partition0Delay1;
-    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs, null, null);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, ingestionTimeMs, ingestionTimeMs,
+        new LongMsgOffset(ingestionTimeMs));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0), partition0Delay1);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition0), partition0Delay1);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition0), ingestionTimeMs);
@@ -192,10 +263,11 @@ public class IngestionDelayTrackerTest {
     offsetClock = Clock.offset(offsetClock, Duration.ofMillis(partition0Offset1Ms));
     ingestionDelayTracker.setClock(offsetClock);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition0),
-        (partition0Delay1 + partition0Offset1Ms));
+        partition0Delay1 + partition0Offset1Ms);
 
     ingestionTimeMs = offsetClock.millis() - partition1Delay0;
-    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, ingestionTimeMs, null, null);
+    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, ingestionTimeMs, ingestionTimeMs,
+        new LongMsgOffset(ingestionTimeMs));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1), partition1Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partition1), partition1Delay0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
@@ -204,13 +276,13 @@ public class IngestionDelayTrackerTest {
     offsetClock = Clock.offset(offsetClock, Duration.ofMillis(partition1Offset0Ms));
     ingestionDelayTracker.setClock(offsetClock);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partition1),
-        (partition1Delay0 + partition1Offset0Ms));
+        partition1Delay0 + partition1Offset0Ms);
 
     ingestionDelayTracker.shutdown();
   }
 
   @Test
-  public void testStopTrackingIngestionDelay() {
+  public void testStopTrackingIngestionDelay() throws Exception {
     final long maxTestDelay = 100;
     final int maxPartition = 100;
 
@@ -218,15 +290,19 @@ public class IngestionDelayTrackerTest {
     // Use fixed clock so samples don't age
     Instant now = Instant.now();
     ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
+    Clock fixedClock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(fixedClock);
+
+    // Mock fetchStreamPartitionOffset to return latest offsets
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(500L));
 
     // Record a number of partitions with delay equal to partition id
     for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
-      long ingestionTimeMs = clock.millis() - partitionId;
-      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null,
-          null);
+      long ingestionTimeMs = fixedClock.millis() - partitionId;
+      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs,
+          new LongMsgOffset(ingestionTimeMs));
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionId), ingestionTimeMs);
@@ -243,17 +319,22 @@ public class IngestionDelayTrackerTest {
   }
 
   @Test
-  public void testStopTrackingIngestionDelayWithSegment() {
+  public void testStopTrackingIngestionDelayWithSegment() throws Exception {
     IngestionDelayTracker ingestionDelayTracker = createTracker();
     // Use fixed clock so samples don't age
     Instant now = Instant.now();
     ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
+    Clock fixedClock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(fixedClock);
+
+    // Mock fetchStreamPartitionOffset to return latest offsets
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(500L));
 
     String segmentName = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
-    long ingestionTimeMs = clock.millis() - 10;
-    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null, null);
+    long ingestionTimeMs = fixedClock.millis() - 10;
+    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs,
+        new LongMsgOffset(ingestionTimeMs));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 10);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 10);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), ingestionTimeMs);
@@ -264,29 +345,34 @@ public class IngestionDelayTrackerTest {
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
 
     // Should not update metrics for removed segment
-    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null, null);
+    ingestionDelayTracker.updateIngestionMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs,
+        new LongMsgOffset(ingestionTimeMs));
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 0);
     Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
   }
 
   @Test
-  public void testShutdown() {
+  public void testShutdown() throws Exception {
     final long maxTestDelay = 100;
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
     // Use fixed clock so samples don't age
     Instant now = Instant.now();
     ZoneId zoneId = ZoneId.systemDefault();
-    Clock clock = Clock.fixed(now, zoneId);
-    ingestionDelayTracker.setClock(clock);
+    Clock fixedClock = Clock.fixed(now, zoneId);
+    ingestionDelayTracker.setClock(fixedClock);
+
+    // Mock fetchStreamPartitionOffset to return latest offsets
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(500L));
 
     // Test Shutdown with partitions active
     for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
       String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
-      long ingestionTimeMs = clock.millis() - partitionId;
-      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null,
-          null);
+      long ingestionTimeMs = fixedClock.millis() - partitionId;
+      ingestionDelayTracker.updateIngestionMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs,
+          new LongMsgOffset(ingestionTimeMs));
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
       Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
     }
@@ -298,7 +384,7 @@ public class IngestionDelayTrackerTest {
   }
 
   @Test
-  public void testRecordIngestionDelayOffset() {
+  public void testRecordIngestionDelayOffset() throws Exception {
     final int partition0 = 0;
     final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final int partition1 = 1;
@@ -306,26 +392,26 @@ public class IngestionDelayTrackerTest {
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
 
+    // Mock fetchStreamPartitionOffset to return latest offsets
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong()))
+        .thenReturn(new LongMsgOffset(200L)); // Example latest offset
+
     // Test tracking offset lag for a single partition
     StreamPartitionMsgOffset msgOffset0 = new LongMsgOffset(100);
-    StreamPartitionMsgOffset latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0,
-        latestOffset0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 100);
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 100); // 200 - 100
 
     // Test tracking offset lag for another partition
     StreamPartitionMsgOffset msgOffset1 = new LongMsgOffset(50);
-    StreamPartitionMsgOffset latestOffset1 = new LongMsgOffset(150);
-    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset1,
-        latestOffset1);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition1), 100);
+    ingestionDelayTracker.updateIngestionMetrics(segment1, partition1, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset1);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition1), 150); // 200 - 50
 
     // Update offset lag for partition0
-    msgOffset0 = new LongMsgOffset(150);
-    latestOffset0 = new LongMsgOffset(200);
-    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE, msgOffset0,
-        latestOffset0);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 50);
+    when(_mockStreamMetadataProvider.fetchStreamPartitionOffset(any(), anyLong())).thenReturn(
+        new LongMsgOffset(150L)); // New latest offset
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, Long.MIN_VALUE, Long.MIN_VALUE,
+        new LongMsgOffset(150L));
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 50); // 150 - 100
 
     ingestionDelayTracker.shutdown();
   }


### PR DESCRIPTION
We ran into some errors with previous version #14074 and hence it was reverted with #14127  . Here's the new PR with multiple fixes after the revert

The ingestion offset lag metric currently makes a request to kafka broker to get the latest offset on every update.

However, this has lead to an increasing amount of load on kafka brokers for multiple users.

The PR adds a way to enable/disable this metric and also configure its interval using the following properties in the server or cluster configs

```
pinot.server.instance.offset.lag.tracking.enable: true
pinot.server.instance.offset.lag.tracking.update.interval: 60000
```