### PR TITLE
update upsert TTL watermark in replaceSegment too

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -238,7 +238,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl segment =
         mockImmutableSegmentWithEndTime(1, new ThreadSafeMutableRoaringBitmap(), null, new ArrayList<>(),
             COMPARISON_COLUMNS, new Double(currentTimeMs + 1024), new MutableRoaringBitmap());
-    upsertMetadataManager.updateWatermark(segment);
+    upsertMetadataManager.setWatermark(currentTimeMs + 1024);
     assertEquals(upsertMetadataManager.getWatermark(), currentTimeMs + 1024);
 
     // Stop the metadata manager


### PR DESCRIPTION
As segment can be uploaded to upsert table to replace old segment, when TTL is enabled, we should update TTL watermark in replaceSegment() method too. But not like preload or add, we can't skip processing the new segment even if it's out of TTL as it doesn't have validDocIds bitmap yet. 

Meanwhile, extracted a few more util methods and consolidate the TTL logic a bit more to avoid redundant processing and for more clarity.