### PR TITLE
Upgrade Avro and ORC to the latest compatible version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,9 @@
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
     <shade.phase.prop>none</shade.phase.prop>
 
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.11.4</avro.version>
     <parquet.version>1.14.2</parquet.version>
-    <orc.version>1.9.3</orc.version>
+    <orc.version>1.9.4</orc.version>
     <hive.version>2.8.1</hive.version>
     <helix.version>1.3.1</helix.version>
     <zkclient.version>0.11</zkclient.version>


### PR DESCRIPTION
Upgrade Avro to `1.11.4` and ORC to `1.9.4`

We cannot pick the latest versions of them for compatibility reason:
- Avro `1.12.0` has API change and bug, see #13764 
- ORC `2.*.*` drops the support of Java 11