### PR TITLE
Use fixed thread pool in Pinot Controller

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
@@ -200,7 +201,6 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected ExecutorService _tenantRebalanceExecutorService;
   protected TableSizeReader _tableSizeReader;
   protected StorageQuotaChecker _storageQuotaChecker;
-  protected int _numThreadPool;
 
   @Override
   public void init(PinotConfiguration pinotConfiguration)
@@ -253,13 +253,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       // ControllerStarter::start()}
       _helixResourceManager = createHelixResourceManager();
       // This executor service is used to do async tasks from multiget util or table rebalancing.
-      _numThreadPool = _config.getControllerNumThreadPool();
-      _executorService =
-          Executors.newFixedThreadPool(_numThreadPool, new ThreadFactoryBuilder()
-                  .setNameFormat("async-task-thread-%d").build());
-      _tenantRebalanceExecutorService =
-          Executors.newFixedThreadPool(_numThreadPool, new ThreadFactoryBuilder()
-                  .setNameFormat("tenant-rebalance-thread-%d").build());
+      _executorService = createExecutorService(_config.getControllerExecutorNumThreads(), "async-task-thread-%d");
+      _tenantRebalanceExecutorService = createExecutorService(_config.getControllerExecutorRebalanceNumThreads(),
+              "tenant-rebalance-thread-%d");
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
 
@@ -268,6 +264,13 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
     TableConfigUtils.setDisableGroovy(_config.isDisableIngestionGroovy());
     TableConfigUtils.setEnforcePoolBasedAssignment(_config.isEnforcePoolBasedAssignmentEnabled());
+  }
+
+  // If thread pool size is not configured executor will use cached thread pool
+  private ExecutorService createExecutorService(int numThreadPool, String threadNameFormat) {
+    ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(threadNameFormat).build();
+    return (numThreadPool <= 0) ? Executors.newCachedThreadPool(threadFactory)
+            : Executors.newFixedThreadPool(numThreadPool, threadFactory);
   }
 
   private void inferHostnameIfNeeded(ControllerConf config) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -200,6 +200,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected ExecutorService _tenantRebalanceExecutorService;
   protected TableSizeReader _tableSizeReader;
   protected StorageQuotaChecker _storageQuotaChecker;
+  protected int _numThreadPool;
 
   @Override
   public void init(PinotConfiguration pinotConfiguration)
@@ -252,10 +253,13 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       // ControllerStarter::start()}
       _helixResourceManager = createHelixResourceManager();
       // This executor service is used to do async tasks from multiget util or table rebalancing.
+      _numThreadPool = _config.getControllerNumThreadPool();
       _executorService =
-          Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
+          Executors.newFixedThreadPool(_numThreadPool, new ThreadFactoryBuilder()
+                  .setNameFormat("async-task-thread-%d").build());
       _tenantRebalanceExecutorService =
-          Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("tenant-rebalance-thread-%d").build());
+          Executors.newFixedThreadPool(_numThreadPool, new ThreadFactoryBuilder()
+                  .setNameFormat("tenant-rebalance-thread-%d").build());
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -278,6 +278,7 @@ public class ControllerConf extends PinotConfiguration {
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
   private static final String MINION_ADMIN_REQUEST_TIMEOUT_SECONDS = "minion.request.timeoutSeconds";
   private static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "controller.realtime.segment.commit.timeoutSeconds";
+  private static final String CONTROLLER_NUM_THREAD_POOL = "controller.numThreadPool";
   private static final String DELETED_SEGMENTS_RETENTION_IN_DAYS = "controller.deleted.segments.retentionInDays";
   public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
   private static final String JERSEY_ADMIN_API_PORT = "jersey.admin.api.port";
@@ -321,6 +322,7 @@ public class ControllerConf extends PinotConfiguration {
       AutoRebalanceStrategy.class.getName();
   private static final int DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_DELAY_MS = 300_000; // 5 minutes
   private static final String DEFAULT_DIM_TABLE_MAX_SIZE = "200M";
+  private static final int DEFAULT_CONTROLLER_NUM_THREAD_POOL = 500;
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
@@ -408,6 +410,10 @@ public class ControllerConf extends PinotConfiguration {
     setProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS, Integer.toString(timeoutSec));
   }
 
+  public void setControllerNumThreadPool(int numThreadPool) {
+    setProperty(CONTROLLER_NUM_THREAD_POOL, Integer.toString(numThreadPool));
+  }
+
   public void setUpdateSegmentStateModel(String updateStateModel) {
     setProperty(UPDATE_SEGMENT_STATE_MODEL, updateStateModel);
   }
@@ -474,6 +480,10 @@ public class ControllerConf extends PinotConfiguration {
   public int getSegmentCommitTimeoutSeconds() {
     return getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS,
         SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
+  }
+
+  public int getControllerNumThreadPool() {
+    return getProperty(CONTROLLER_NUM_THREAD_POOL, DEFAULT_CONTROLLER_NUM_THREAD_POOL);
   }
 
   public boolean isUpdateSegmentStateModel() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -278,7 +278,9 @@ public class ControllerConf extends PinotConfiguration {
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
   private static final String MINION_ADMIN_REQUEST_TIMEOUT_SECONDS = "minion.request.timeoutSeconds";
   private static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "controller.realtime.segment.commit.timeoutSeconds";
-  private static final String CONTROLLER_NUM_THREAD_POOL = "controller.numThreadPool";
+  private static final String CONTROLLER_EXECUTOR_NUM_THREADS = "controller.executor.numThreads";
+  public static final String CONTROLLER_EXECUTOR_REBALANCE_NUM_THREADS = "controller.executor.rebalance.numThreads";
+
   private static final String DELETED_SEGMENTS_RETENTION_IN_DAYS = "controller.deleted.segments.retentionInDays";
   public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
   private static final String JERSEY_ADMIN_API_PORT = "jersey.admin.api.port";
@@ -322,7 +324,7 @@ public class ControllerConf extends PinotConfiguration {
       AutoRebalanceStrategy.class.getName();
   private static final int DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_DELAY_MS = 300_000; // 5 minutes
   private static final String DEFAULT_DIM_TABLE_MAX_SIZE = "200M";
-  private static final int DEFAULT_CONTROLLER_NUM_THREAD_POOL = 500;
+  private static final int UNSPECIFIED_THREAD_POOL = -1;
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
@@ -410,8 +412,12 @@ public class ControllerConf extends PinotConfiguration {
     setProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS, Integer.toString(timeoutSec));
   }
 
-  public void setControllerNumThreadPool(int numThreadPool) {
-    setProperty(CONTROLLER_NUM_THREAD_POOL, Integer.toString(numThreadPool));
+  public void setControllerExecutorNumThreads(int numThreads) {
+    setProperty(CONTROLLER_EXECUTOR_NUM_THREADS, Integer.toString(numThreads));
+  }
+
+  public void setControllerExecutorRebalanceNumThreads(int numThreads) {
+    setProperty(CONTROLLER_EXECUTOR_REBALANCE_NUM_THREADS, Integer.toString(numThreads));
   }
 
   public void setUpdateSegmentStateModel(String updateStateModel) {
@@ -482,8 +488,12 @@ public class ControllerConf extends PinotConfiguration {
         SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
   }
 
-  public int getControllerNumThreadPool() {
-    return getProperty(CONTROLLER_NUM_THREAD_POOL, DEFAULT_CONTROLLER_NUM_THREAD_POOL);
+  public int getControllerExecutorNumThreads() {
+    return getProperty(CONTROLLER_EXECUTOR_NUM_THREADS, UNSPECIFIED_THREAD_POOL);
+  }
+
+  public int getControllerExecutorRebalanceNumThreads() {
+    return getProperty(CONTROLLER_EXECUTOR_REBALANCE_NUM_THREADS, UNSPECIFIED_THREAD_POOL);
   }
 
   public boolean isUpdateSegmentStateModel() {


### PR DESCRIPTION
Replaces `CachedThreadPool` with `FixedThreadPool` in Pinot Controller. 

We've observed the max thread count in prod controller over a 7 day period to be ~500 which is set as the default thread pool size. The thread pool size is kept configurable.
![image (7)](https://github.com/user-attachments/assets/8b7ce7d7-a98d-46a1-b081-ba43c18c3bdb)

Fixes #13990
