### PR TITLE
Add support for configuring Theta and Tuple aggregation functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -422,16 +422,18 @@ public class DistinctCountCPCSketchAggregationFunction
 
   @Override
   public boolean canUseStarTree(Map<String, Object> functionParameters) {
-    Object lgK = functionParameters.get(Constants.CPCSKETCH_LGK_KEY);
+    Object lgKParam = functionParameters.get(Constants.CPCSKETCH_LGK_KEY);
+    int starTreeLgK;
 
-    // Check if lgK values match
-    if (lgK != null) {
-      return _lgNominalEntries == Integer.parseInt(String.valueOf(lgK));
+    if (lgKParam != null) {
+      starTreeLgK = Integer.parseInt(String.valueOf(lgKParam));
     } else {
       // If the functionParameters don't have an explicit lgK set, it means that the star-tree index was built with
       // the default value for lgK
-      return _lgNominalEntries == CommonConstants.Helix.DEFAULT_CPC_SKETCH_LGK;
+      starTreeLgK = CommonConstants.Helix.DEFAULT_CPC_SKETCH_LGK;
     }
+    // Check if the query lgK param is less than or equal to that of the StarTree aggregation
+    return _lgNominalEntries <= starTreeLgK;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -432,7 +432,10 @@ public class DistinctCountCPCSketchAggregationFunction
       // the default value for lgK
       starTreeLgK = CommonConstants.Helix.DEFAULT_CPC_SKETCH_LGK;
     }
-    // Check if the query lgK param is less than or equal to that of the StarTree aggregation
+    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation.
+    // LEQ is used instead of direct equality because it allows the end user to use a single index to serve various
+    // query precisions depending on the use case.  Apache Datasketches sketches of higher precision can seamlessly
+    // adjust down to lower precision if desired.
     return _lgNominalEntries <= starTreeLgK;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1040,7 +1040,7 @@ public class DistinctCountThetaSketchAggregationFunction
 
   @Override
   public boolean canUseStarTree(Map<String, Object> functionParameters) {
-    Object nominalEntriesParam = functionParameters.get(Constants.THETASKETCH_NOMINAL_ENTRIES);
+    Object nominalEntriesParam = functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES);
     int starTreeNominalEntries;
 
     // Check if nominal entries values match

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1048,8 +1048,7 @@ public class DistinctCountThetaSketchAggregationFunction
       starTreeNominalEntries = Integer.parseInt(String.valueOf(nominalEntriesParam));
     } else {
       // If the functionParameters don't have an explicit nominal entries value set, it means that the star-tree
-      // index was built with
-      // the default value for nominal entries
+      // index was built with the default value for nominal entries
       starTreeNominalEntries = CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES;
     }
     // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1051,7 +1051,10 @@ public class DistinctCountThetaSketchAggregationFunction
       // index was built with the default value for nominal entries
       starTreeNominalEntries = CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES;
     }
-    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation
+    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation.
+    // LEQ is used instead of direct equality because it allows the end user to use a single index to serve various
+    // query precisions depending on the use case.  Apache Datasketches sketches of higher precision can seamlessly
+    // adjust down to lower precision if desired.
     return _nominalEntries <= starTreeNominalEntries;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1052,7 +1052,7 @@ public class DistinctCountThetaSketchAggregationFunction
       // the default value for nominal entries
       starTreeNominalEntries = CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES;
     }
-    // Check if the query lgK param is less than or equal to that of the StarTree aggregation
+    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation
     return _nominalEntries <= starTreeNominalEntries;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -289,7 +289,10 @@ public class IntegerTupleSketchAggregationFunction
       // index was built with the default value for nominal entries
       starTreeNominalEntries = (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
     }
-    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation
+    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation.
+    // LEQ is used instead of direct equality because it allows the end user to use a single index to serve various
+    // query precisions depending on the use case.  Apache Datasketches sketches of higher precision can seamlessly
+    // adjust down to lower precision if desired.
     return _nominalEntries <= starTreeNominalEntries;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -278,7 +278,7 @@ public class IntegerTupleSketchAggregationFunction
 
   @Override
   public boolean canUseStarTree(Map<String, Object> functionParameters) {
-    Object nominalEntriesParam = functionParameters.get(Constants.TUPLESKETCH_NOMINAL_ENTRIES);
+    Object nominalEntriesParam = functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES);
     int starTreeNominalEntries;
 
     // Check if nominal entries values match

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -286,8 +286,7 @@ public class IntegerTupleSketchAggregationFunction
       starTreeNominalEntries = Integer.parseInt(String.valueOf(nominalEntriesParam));
     } else {
       // If the functionParameters don't have an explicit nominal entries value set, it means that the star-tree
-      // index was built with
-      // the default value for nominal entries
+      // index was built with the default value for nominal entries
       starTreeNominalEntries = (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
     }
     // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -290,7 +290,7 @@ public class IntegerTupleSketchAggregationFunction
       // the default value for nominal entries
       starTreeNominalEntries = (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
     }
-    // Check if the query lgK param is less than or equal to that of the StarTree aggregation
+    // Check if the query nominalEntries param is less than or equal to that of the StarTree aggregation
     return _nominalEntries <= starTreeNominalEntries;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunctionTest.java
@@ -31,21 +31,21 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
 
   @Test
   public void testCanUseStarTreeDefaultLgK() {
-    DistinctCountCPCSketchAggregationFunction function = new DistinctCountCPCSketchAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+    DistinctCountCPCSketchAggregationFunction function =
+        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "12")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 12)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 16)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 11)));
 
-    function = new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.intValue(12))));
+    function = new DistinctCountCPCSketchAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(12))));
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "12")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 12)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 16)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 11)));
   }
 
   @Test
@@ -54,8 +54,9 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
         List.of(ExpressionContext.forIdentifier("col"),
             ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=8192"))));
 
+    // Default lgK = 12 / K=4096
     Assert.assertFalse(function.canUseStarTree(Map.of()));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "12")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "14")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 13)));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "13")));
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
@@ -39,14 +39,6 @@ public class DistinctCountThetaSketchAggregationFunctionTest {
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "4096")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 2048)));
-
-    function = new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=16384"))));
-
-    Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.segment.spi.Constants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DistinctCountThetaSketchAggregationFunctionTest {
+
+  @Test
+  public void testCanUseStarTreeDefaultK() {
+    // Default aggregation function lgK = 12 / K=4096
+    DistinctCountThetaSketchAggregationFunction function =
+        new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+
+    Assert.assertTrue(function.canUseStarTree(Map.of()));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "4096")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 4096)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 2048)));
+
+    function = new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
+        ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=16384"))));
+
+    Assert.assertTrue(function.canUseStarTree(Map.of()));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 8192)));
+  }
+
+  @Test
+  public void testCanUseCustomK() {
+    DistinctCountThetaSketchAggregationFunction function = new DistinctCountThetaSketchAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=32768"))));
+
+    // Default StarTree lgK = 14 / K=16384
+    Assert.assertFalse(function.canUseStarTree(Map.of()));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "65536")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 32768)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "32768")));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
@@ -36,17 +36,17 @@ public class DistinctCountThetaSketchAggregationFunctionTest {
         new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "4096")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 4096)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 2048)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "4096")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 2048)));
 
     function = new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
         ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=16384"))));
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 16384)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 8192)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
   }
 
   @Test
@@ -57,9 +57,9 @@ public class DistinctCountThetaSketchAggregationFunctionTest {
 
     // Default StarTree lgK = 14 / K=16384
     Assert.assertFalse(function.canUseStarTree(Map.of()));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "65536")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 32768)));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, "32768")));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "65536")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 32768)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "32768")));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
@@ -37,18 +37,18 @@ public class IntegerTupleSketchAggregationFunctionTest {
             IntegerSummary.Mode.Sum);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 16384)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 8192)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
 
     function = new IntegerTupleSketchAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16384))),
         IntegerSummary.Mode.Sum);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 16384)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 8192)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
   }
 
   @Test
@@ -59,9 +59,9 @@ public class IntegerTupleSketchAggregationFunctionTest {
 
     // Default StarTree lgK = 14 / K=16384
     Assert.assertFalse(function.canUseStarTree(Map.of()));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "65536")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 32768)));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "32768")));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "65536")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 32768)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "32768")));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
@@ -40,15 +40,6 @@ public class IntegerTupleSketchAggregationFunctionTest {
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
-
-    function = new IntegerTupleSketchAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16384))),
-        IntegerSummary.Mode.Sum);
-
-    Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 16384)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 8192)));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunctionTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.datasketches.tuple.aninteger.IntegerSummary;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.segment.spi.Constants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IntegerTupleSketchAggregationFunctionTest {
+
+  @Test
+  public void testCanUseStarTreeDefaultK() {
+    IntegerTupleSketchAggregationFunction function =
+        new IntegerTupleSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")),
+            IntegerSummary.Mode.Sum);
+
+    Assert.assertTrue(function.canUseStarTree(Map.of()));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 8192)));
+
+    function = new IntegerTupleSketchAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16384))),
+        IntegerSummary.Mode.Sum);
+
+    Assert.assertTrue(function.canUseStarTree(Map.of()));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 16384)));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 8192)));
+  }
+
+  @Test
+  public void testCanUseCustomK() {
+    IntegerTupleSketchAggregationFunction function = new IntegerTupleSketchAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(32768))),
+        IntegerSummary.Mode.Sum);
+
+    // Default StarTree lgK = 14 / K=16384
+    Assert.assertFalse(function.canUseStarTree(Map.of()));
+    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "16384")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "65536")));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 32768)));
+    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, "32768")));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountIntegerSumTupleSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountIntegerSumTupleSketchStarTreeV2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree.v2;
 
+import java.util.Collections;
 import java.util.Random;
 import org.apache.datasketches.tuple.Sketch;
 import org.apache.datasketches.tuple.Union;
@@ -35,7 +36,7 @@ public class DistinctCountIntegerSumTupleSketchStarTreeV2Test extends BaseStarTr
 
   @Override
   ValueAggregator<byte[], Object> getValueAggregator() {
-    return new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
+    return new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree.v2;
 
+import java.util.Collections;
 import java.util.Random;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.Union;
@@ -32,7 +33,7 @@ public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<O
 
   @Override
   ValueAggregator<Object, Object> getValueAggregator() {
-    return new DistinctCountThetaSketchValueAggregator();
+    return new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -69,7 +69,7 @@ public class ValueAggregatorFactory {
         return new PercentileTDigestValueAggregator(arguments);
       case DISTINCTCOUNTTHETASKETCH:
       case DISTINCTCOUNTRAWTHETASKETCH:
-        return new DistinctCountThetaSketchValueAggregator();
+        return new DistinctCountThetaSketchValueAggregator(arguments);
       case DISTINCTCOUNTHLLPLUS:
       case DISTINCTCOUNTRAWHLLPLUS:
         return new DistinctCountHLLPlusValueAggregator(arguments);
@@ -77,7 +77,7 @@ public class ValueAggregatorFactory {
       case DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH:
       case AVGVALUEINTEGERSUMTUPLESKETCH:
       case SUMVALUESINTEGERSUMTUPLESKETCH:
-        return new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
+        return new IntegerTupleSketchValueAggregator(arguments, IntegerSummary.Mode.Sum);
       case DISTINCTCOUNTCPCSKETCH:
       case DISTINCTCOUNTRAWCPCSKETCH:
         return new DistinctCountCPCSketchValueAggregator(arguments);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
@@ -383,17 +383,17 @@ public class StarTreeBuilderUtils {
       }
       case DISTINCTCOUNTTHETASKETCH:
       case DISTINCTCOUNTRAWTHETASKETCH: {
-        if (functionParameters.containsKey(Constants.THETASKETCH_NOMINAL_ENTRIES)) {
+        if (functionParameters.containsKey(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES)) {
           expressionContexts.add(ExpressionContext.forLiteral(Literal.intValue(
-              Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETASKETCH_NOMINAL_ENTRIES))))));
+              Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES))))));
         }
         break;
       }
       case DISTINCTCOUNTTUPLESKETCH:
       case DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH: {
-        if (functionParameters.containsKey(Constants.TUPLESKETCH_NOMINAL_ENTRIES)) {
+        if (functionParameters.containsKey(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES)) {
           expressionContexts.add(ExpressionContext.forLiteral(Literal.intValue(
-              Integer.parseInt(String.valueOf(functionParameters.get(Constants.TUPLESKETCH_NOMINAL_ENTRIES))))));
+              Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES))))));
         }
         break;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
@@ -384,8 +384,8 @@ public class StarTreeBuilderUtils {
       case DISTINCTCOUNTTHETASKETCH:
       case DISTINCTCOUNTRAWTHETASKETCH: {
         if (functionParameters.containsKey(Constants.THETASKETCH_NOMINAL_ENTRIES)) {
-          expressionContexts.add(ExpressionContext.forLiteral(
-              Literal.intValue(Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETASKETCH_NOMINAL_ENTRIES))))));
+          expressionContexts.add(ExpressionContext.forLiteral(Literal.intValue(
+              Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETASKETCH_NOMINAL_ENTRIES))))));
         }
         break;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
@@ -381,6 +381,22 @@ public class StarTreeBuilderUtils {
         }
         break;
       }
+      case DISTINCTCOUNTTHETASKETCH:
+      case DISTINCTCOUNTRAWTHETASKETCH: {
+        if (functionParameters.containsKey(Constants.THETASKETCH_NOMINAL_ENTRIES)) {
+          expressionContexts.add(ExpressionContext.forLiteral(
+              Literal.intValue(Integer.parseInt(String.valueOf(functionParameters.get(Constants.THETASKETCH_NOMINAL_ENTRIES))))));
+        }
+        break;
+      }
+      case DISTINCTCOUNTTUPLESKETCH:
+      case DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH: {
+        if (functionParameters.containsKey(Constants.TUPLESKETCH_NOMINAL_ENTRIES)) {
+          expressionContexts.add(ExpressionContext.forLiteral(Literal.intValue(
+              Integer.parseInt(String.valueOf(functionParameters.get(Constants.TUPLESKETCH_NOMINAL_ENTRIES))))));
+        }
+        break;
+      }
       default:
         break;
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import java.util.Collections;
 import java.util.stream.IntStream;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.Sketches;
@@ -36,7 +37,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
 
   @Test
   public void initialShouldCreateSingleItemSketch() {
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     assertEquals(toSketch(agg.getInitialAggregatedValue("hello world")).getEstimate(), 1.0);
   }
 
@@ -45,7 +46,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     UpdateSketch input = Sketches.updateSketchBuilder().build();
     IntStream.range(0, 1000).forEach(input::update);
     Sketch result = input.compact();
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     byte[] bytes = agg.serializeAggregatedValue(result);
     Sketch initSketch = toSketch(agg.getInitialAggregatedValue(bytes));
     Union union =
@@ -62,7 +63,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     input1.update("hello");
     UpdateSketch input2 = Sketches.updateSketchBuilder().build();
     input2.update("world");
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     byte[][] bytes = {agg.serializeAggregatedValue(input1), agg.serializeAggregatedValue(input2)};
     assertEquals(toSketch(agg.getInitialAggregatedValue(bytes)).getEstimate(), 2.0);
   }
@@ -75,7 +76,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     UpdateSketch input2 = Sketches.updateSketchBuilder().build();
     IntStream.range(0, 1000).forEach(input2::update);
     Sketch result2 = input2.compact();
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     Sketch result = toSketch(agg.applyAggregatedValue(result1, result2));
     Union union =
         Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
@@ -94,7 +95,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     UpdateSketch input2 = Sketches.updateSketchBuilder().build();
     IntStream.range(0, 1000).forEach(input2::update);
     Sketch result2 = input2.compact();
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     byte[] result2bytes = agg.serializeAggregatedValue(result2);
     Sketch result = toSketch(agg.applyRawValue(result1, result2bytes));
     Union union =
@@ -112,7 +113,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     UpdateSketch input1 = Sketches.updateSketchBuilder().build();
     input1.update("hello".hashCode());
     Sketch result1 = input1.compact();
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     Sketch result = toSketch(agg.applyRawValue(result1, "world"));
     Union union =
         Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
@@ -127,7 +128,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     UpdateSketch input1 = Sketches.updateSketchBuilder().build();
     input1.update("hello");
     Sketch result1 = input1.compact();
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     String[] strings = {"hello", "world", "this", "is", "some", "strings"};
     Sketch result = toSketch(agg.applyRawValue(result1, (Object) strings));
     Union union =
@@ -140,7 +141,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
 
   @Test
   public void getInitialValueShouldSupportDifferentTypes() {
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     assertEquals(toSketch(agg.getInitialAggregatedValue(12345)).getEstimate(), 1.0);
     assertEquals(toSketch(agg.getInitialAggregatedValue(12345L)).getEstimate(), 1.0);
     assertEquals(toSketch(agg.getInitialAggregatedValue(12.345f)).getEstimate(), 1.0);
@@ -150,7 +151,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
 
   @Test
   public void getInitialValueShouldSupportMultiValueTypes() {
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     Integer[] ints = {12345};
     assertEquals(toSketch(agg.getInitialAggregatedValue(ints)).getEstimate(), 1.0);
     Long[] longs = {12345L};
@@ -171,7 +172,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
     IntStream.range(0, 10).forEach(input::update);
     Sketch unordered = input.compact(false, null);
     Sketch ordered = input.compact(true, null);
-    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+    DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator(Collections.emptyList());
     assertTrue(toSketch(agg.cloneAggregatedValue(ordered)).isOrdered());
     assertFalse(toSketch(agg.cloneAggregatedValue(unordered)).isOrdered());
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import java.util.Collections;
 import org.apache.datasketches.tuple.Sketch;
 import org.apache.datasketches.tuple.Union;
 import org.apache.datasketches.tuple.aninteger.IntegerSketch;
@@ -37,7 +38,7 @@ public class IntegerTupleSketchValueAggregatorTest {
 
   @Test
   public void initialShouldParseASketch() {
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     assertEquals(toSketch(agg.getInitialAggregatedValue(sketchContaining("hello world", 1))).getEstimate(), 1.0);
   }
 
@@ -47,7 +48,7 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerSketch s2 = new IntegerSketch(16, IntegerSummary.Mode.Sum);
     s1.update("a", 1);
     s2.update("b", 1);
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyAggregatedValue(s1, s2));
     assertEquals(merged.getEstimate(), 2.0);
     assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);
@@ -59,7 +60,7 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerSketch s2 = new IntegerSketch(16, IntegerSummary.Mode.Sum);
     s1.update("a", 1);
     s2.update("b", 1);
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyRawValue(s1, agg.serializeAggregatedValue(s2)));
     assertEquals(merged.getEstimate(), 2.0);
     assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
@@ -38,7 +38,8 @@ public class IntegerTupleSketchValueAggregatorTest {
 
   @Test
   public void initialShouldParseASketch() {
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg =
+        new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     assertEquals(toSketch(agg.getInitialAggregatedValue(sketchContaining("hello world", 1))).getEstimate(), 1.0);
   }
 
@@ -48,7 +49,8 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerSketch s2 = new IntegerSketch(16, IntegerSummary.Mode.Sum);
     s1.update("a", 1);
     s2.update("b", 1);
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg =
+        new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyAggregatedValue(s1, s2));
     assertEquals(merged.getEstimate(), 2.0);
     assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);
@@ -60,7 +62,8 @@ public class IntegerTupleSketchValueAggregatorTest {
     IntegerSketch s2 = new IntegerSketch(16, IntegerSummary.Mode.Sum);
     s1.update("a", 1);
     s2.update("b", 1);
-    IntegerTupleSketchValueAggregator agg = new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
+    IntegerTupleSketchValueAggregator agg =
+        new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
     Sketch<IntegerSummary> merged = toSketch(agg.applyRawValue(s1, agg.serializeAggregatedValue(s2)));
     assertEquals(merged.getEstimate(), 2.0);
     assertEquals(agg.getMaxAggregatedValueByteSize(), 196632);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
@@ -308,7 +308,8 @@ public class StarTreeBuilderUtilsTest {
         (DistinctCountThetaSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
             AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
             StarTreeBuilderUtils.expressionContextFromFunctionParameters(
-                AggregationFunctionType.DISTINCTCOUNTTHETASKETCH, Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 4096)));
+                AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
+                Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
     assertEquals(4096, thetaSketchValueAggregator.getNominalEntries());
 
     thetaSketchValueAggregator = (DistinctCountThetaSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
@@ -323,7 +324,8 @@ public class StarTreeBuilderUtilsTest {
         (IntegerTupleSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
             AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
             StarTreeBuilderUtils.expressionContextFromFunctionParameters(
-                AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH, Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 4096)));
+                AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+                Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
     assertEquals(4096, tupleSketchValueAggregator.getNominalEntries());
 
     tupleSketchValueAggregator = (IntegerTupleSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeBuilderUtilsTest.java
@@ -35,7 +35,9 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.segment.local.aggregator.DistinctCountCPCSketchValueAggregator;
 import org.apache.pinot.segment.local.aggregator.DistinctCountHLLPlusValueAggregator;
 import org.apache.pinot.segment.local.aggregator.DistinctCountHLLValueAggregator;
+import org.apache.pinot.segment.local.aggregator.DistinctCountThetaSketchValueAggregator;
 import org.apache.pinot.segment.local.aggregator.DistinctCountULLValueAggregator;
+import org.apache.pinot.segment.local.aggregator.IntegerTupleSketchValueAggregator;
 import org.apache.pinot.segment.local.aggregator.ValueAggregatorFactory;
 import org.apache.pinot.segment.local.startree.StarTreeBuilderUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -300,6 +302,36 @@ public class StarTreeBuilderUtilsTest {
             Map.of()));
     // Verify default value used
     assertEquals(12, cpcSketchValueAggregator.getLgK());
+
+    // DISTINCTCOUNTTHETASKETCH
+    DistinctCountThetaSketchValueAggregator thetaSketchValueAggregator =
+        (DistinctCountThetaSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
+            AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
+            StarTreeBuilderUtils.expressionContextFromFunctionParameters(
+                AggregationFunctionType.DISTINCTCOUNTTHETASKETCH, Map.of(Constants.THETASKETCH_NOMINAL_ENTRIES, 4096)));
+    assertEquals(4096, thetaSketchValueAggregator.getNominalEntries());
+
+    thetaSketchValueAggregator = (DistinctCountThetaSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
+        AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
+        StarTreeBuilderUtils.expressionContextFromFunctionParameters(AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
+            Map.of()));
+    // Verify default value used
+    assertEquals(16384, thetaSketchValueAggregator.getNominalEntries());
+
+    // DISTINCTCOUNTUPLESKETCH
+    IntegerTupleSketchValueAggregator tupleSketchValueAggregator =
+        (IntegerTupleSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
+            AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+            StarTreeBuilderUtils.expressionContextFromFunctionParameters(
+                AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH, Map.of(Constants.TUPLESKETCH_NOMINAL_ENTRIES, 4096)));
+    assertEquals(4096, tupleSketchValueAggregator.getNominalEntries());
+
+    tupleSketchValueAggregator = (IntegerTupleSketchValueAggregator) ValueAggregatorFactory.getValueAggregator(
+        AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+        StarTreeBuilderUtils.expressionContextFromFunctionParameters(AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+            Map.of()));
+    // Verify default value used
+    assertEquals(16384, tupleSketchValueAggregator.getNominalEntries());
   }
 
   private ColumnMetadata getColumnMetadata(String column, boolean hasDictionary, int cardinality) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/Constants.java
@@ -29,6 +29,8 @@ public class Constants {
   public static final String HLLPLUS_ULL_P_KEY = "p";
   public static final String HLLPLUS_SP_KEY = "sp";
   public static final String CPCSKETCH_LGK_KEY = "lgK";
+  public static final String THETASKETCH_NOMINAL_ENTRIES = "K";
+  public static final String TUPLESKETCH_NOMINAL_ENTRIES = "K";
   public static final String PERCENTILETDIGEST_COMPRESSION_FACTOR_KEY = "compressionFactor";
   public static final String SUMPRECISION_PRECISION_KEY = "precision";
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/Constants.java
@@ -29,8 +29,7 @@ public class Constants {
   public static final String HLLPLUS_ULL_P_KEY = "p";
   public static final String HLLPLUS_SP_KEY = "sp";
   public static final String CPCSKETCH_LGK_KEY = "lgK";
-  public static final String THETASKETCH_NOMINAL_ENTRIES = "K";
-  public static final String TUPLESKETCH_NOMINAL_ENTRIES = "K";
+  public static final String THETA_TUPLE_SKETCH_NOMINAL_ENTRIES = "nominalEntries";
   public static final String PERCENTILETDIGEST_COMPRESSION_FACTOR_KEY = "compressionFactor";
   public static final String SUMPRECISION_PRECISION_KEY = "precision";
 }


### PR DESCRIPTION
Applies to StarTree Index

This patch introduces a mechanism to allow configuring the aggregation function parameters for a star-tree index for Tuple and Theta sketches.  Any existing aggregation that has a precision greater or equal to that of the query precision is selected as a candidate. The behaviour of the CPC aggregator has been changed accordingly.

This PR can be tagged as a feature.
 
`release-notes`:
- New function parameter `nominalEntries` for Theta Sketch StarTree value aggregator
- New function parameter `nominalEntries` for Tuple Sketch StarTree value aggregator
