### PR TITLE
Adding variation to segment flush size

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -112,6 +112,13 @@ public class StreamConfigProperties {
   public static final String SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE = "realtime.segment.flush.threshold.segment.size";
 
   /**
+   * The variance fraction allowed for the segment size auto tuning. The valid value is [0.0, 0.5].
+   * By default 0.0 is used.
+   */
+  public static final String FLUSH_THRESHOLD_VARIANCE_FRACTION =
+      "realtime.segment.flush.threshold.variance.fraction";
+
+  /**
    * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
    */
   public static final String SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS = "realtime.segment.flush.autotune.initialRows";


### PR DESCRIPTION
## Motivation
For realtime table with many partitions, the consumers have relatively same size which causes all the segments are committed at roughly same time. This causes the segment build time increases and ingestion delay increases more.

## Release Notes
```
Adds a new config: `realtime.segment.flush.threshold.variance.percentage` in stream config to allow set a variation for segment flush size. 
The valid value of `realtime.segment.flush.threshold.variance.percentage` is [0.0, 1.0)
```