### PR TITLE
Allow usage of star-tree index with null handling enabled when no null values in segment columns

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -46,12 +46,16 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.apache.pinot.segment.spi.index.startree.AggregationSpec;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @SuppressWarnings("rawtypes")
 public class StarTreeUtils {
   private StarTreeUtils() {
   }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeUtils.class);
 
   /**
    * Extracts the {@link AggregationFunctionColumnPair}s from the given {@link AggregationFunction}s. Returns
@@ -354,7 +358,7 @@ public class StarTreeUtils {
       QueryContext queryContext, AggregationFunction[] aggregationFunctions, @Nullable FilterContext filter,
       List<Pair<Predicate, PredicateEvaluator>> predicateEvaluators) {
     List<StarTreeV2> starTrees = indexSegment.getStarTrees();
-    if (starTrees == null || queryContext.isSkipStarTree() || queryContext.isNullHandlingEnabled()) {
+    if (starTrees == null || queryContext.isSkipStarTree()) {
       return null;
     }
 
@@ -363,11 +367,39 @@ public class StarTreeUtils {
     if (aggregationFunctionColumnPairs == null) {
       return null;
     }
+
     Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
         extractPredicateEvaluatorsMap(indexSegment, filter, predicateEvaluators);
     if (predicateEvaluatorsMap == null) {
       return null;
     }
+
+    if (queryContext.isNullHandlingEnabled()) {
+      // We can still use the star-tree index if there aren't actually any null values in this segment for all the
+      // metrics being aggregated and all the dimensions being filtered on
+      for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
+        String column = aggregationFunctionColumnPair.getColumn();
+        if (column.equals(AggregationFunctionColumnPair.STAR)) {
+          // Null handling is irrelevant for COUNT(*)
+          continue;
+        }
+
+        DataSource dataSource = indexSegment.getDataSource(column);
+        if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
+          LOGGER.debug("Cannot use star-tree index because aggregation column: '{}' has null values", column);
+          return null;
+        }
+      }
+
+      for (String column : predicateEvaluatorsMap.keySet()) {
+        DataSource dataSource = indexSegment.getDataSource(column);
+        if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
+          LOGGER.debug("Cannot use star-tree index because filter column: '{}' has null values", column);
+          return null;
+        }
+      }
+    }
+
     ExpressionContext[] groupByExpressions =
         queryContext.getGroupByExpressions() != null ? queryContext.getGroupByExpressions()
             .toArray(new ExpressionContext[0]) : null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -382,12 +382,12 @@ public class StarTreeUtils {
       // We can still use the star-tree index if there aren't actually any null values in this segment for all the
       // metrics being aggregated, all the dimensions being filtered on / grouped by.
       for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
-        String column = aggregationFunctionColumnPair.getColumn();
-        if (column.equals(AggregationFunctionColumnPair.STAR)) {
+        if (aggregationFunctionColumnPair == AggregationFunctionColumnPair.COUNT_STAR) {
           // Null handling is irrelevant for COUNT(*)
           continue;
         }
 
+        String column = aggregationFunctionColumnPair.getColumn();
         DataSource dataSource = indexSegment.getDataSource(column);
         if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
           LOGGER.debug("Cannot use star-tree index because aggregation column: '{}' has null values", column);


### PR DESCRIPTION
- The star-tree index currently doesn't support null values (see https://github.com/apache/pinot/issues/9981) and we skip using any star-tree indexes if query time null handling is enabled (https://docs.pinot.apache.org/developers/advanced/null-value-support#advanced-null-handling-support) - https://github.com/apache/pinot/blob/19b79f406c36e8b075e9c1698a8752af5b4e6d23/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java#L357-L359
- However, we should still be using an existing star-tree index for a segment if there aren't actually any null values in that segment for the metrics being aggregated and the dimensions being filtered on.
- This patch introduces this additional conditional logic so that the star-tree index can be used in these situations. It's still important to introduce null value support in the star-tree index though, so that it can be used even when there are null values in the metric / dimension columns (along with being able to support predicates like `IS NULL` / `IS NOT NULL`).