### PR TITLE
try to acquire segmentLock before taking segment snapshot

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -40,7 +40,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
-import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -919,9 +918,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         immutableSegment.persistValidDocIdsSnapshot();
         numImmutableSegments++;
         numPrimaryKeysInSnapshot += immutableSegment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
-      } catch (Exception e) {
-        _logger.warn("Caught exception while taking snapshot for segment: {}, skipping", segmentName, e);
-        Utils.rethrowException(e);
       } finally {
         segmentLock.unlock();
       }
@@ -938,9 +934,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         segment.persistValidDocIdsSnapshot();
         numImmutableSegments++;
         numPrimaryKeysInSnapshot += segment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
-      } catch (Exception e) {
-        _logger.warn("Caught exception while taking snapshot for segment: {} w/o snapshot, skipping", segmentName, e);
-        Utils.rethrowException(e);
       } finally {
         segmentLock.unlock();
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -57,6 +59,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -104,6 +107,9 @@ public class BasePartitionUpsertMetadataManagerTest {
       throws IOException {
     UpsertContext upsertContext = mock(UpsertContext.class);
     when(upsertContext.isSnapshotEnabled()).thenReturn(true);
+    TableDataManager tdm = mock(TableDataManager.class);
+    when(upsertContext.getTableDataManager()).thenReturn(tdm);
+    when(tdm.getSegmentLock(anyString())).thenReturn(new ReentrantLock());
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 
@@ -150,10 +156,90 @@ public class BasePartitionUpsertMetadataManagerTest {
   }
 
   @Test
+  public void testSkipTakeSnapshotUponRaceCondition()
+      throws IOException {
+    UpsertContext upsertContext = mock(UpsertContext.class);
+    when(upsertContext.isSnapshotEnabled()).thenReturn(true);
+    TableDataManager tdm = mock(TableDataManager.class);
+    when(upsertContext.getTableDataManager()).thenReturn(tdm);
+    Map<String, Lock> segmentLocks = new HashMap<>();
+    segmentLocks.put("seg01", new ReentrantLock());
+    segmentLocks.put("seg02", new ReentrantLock());
+    segmentLocks.put("seg03", new ReentrantLock());
+    segmentLocks.put("seg04", new ReentrantLock());
+    when(tdm.getSegmentLock(anyString())).thenAnswer(invocation -> {
+      String segmentName = invocation.getArgument(0);
+      return segmentLocks.get(segmentName);
+    });
+    DummyPartitionUpsertMetadataManager upsertMetadataManager =
+        new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
+
+    List<String> segmentsTakenSnapshot = new ArrayList<>();
+
+    File segDir01 = new File(TEMP_DIR, "seg01");
+    ImmutableSegmentImpl seg01 = createImmutableSegment("seg01", segDir01, segmentsTakenSnapshot);
+    seg01.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3), null);
+    upsertMetadataManager.addSegment(seg01);
+    // seg01 has a tmp snapshot file, but no snapshot file
+    FileUtils.touch(new File(segDir01, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME + "_tmp"));
+
+    File segDir02 = new File(TEMP_DIR, "seg02");
+    ImmutableSegmentImpl seg02 = createImmutableSegment("seg02", segDir02, segmentsTakenSnapshot);
+    seg02.enableUpsert(upsertMetadataManager, createValidDocIds(0, 1, 2, 3, 4, 5), null);
+    upsertMetadataManager.addSegment(seg02);
+    // seg02 has snapshot file, so its snapshot is taken first.
+    FileUtils.touch(new File(segDir02, V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
+
+    File segDir03 = new File(TEMP_DIR, "seg03");
+    ImmutableSegmentImpl seg03 = createImmutableSegment("seg03", segDir03, segmentsTakenSnapshot);
+    seg03.enableUpsert(upsertMetadataManager, createValidDocIds(3, 4, 7), null);
+    upsertMetadataManager.addSegment(seg03);
+
+    // The mutable segments will be skipped.
+    MutableSegmentImpl seg04 = mock(MutableSegmentImpl.class);
+    upsertMetadataManager.addRecord(seg04, mock(RecordInfo.class));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      // seg02 is the only segment with existing snapshot file, so skipping it should skip other segments w/o snapshots.
+      Lock seg02Lock = segmentLocks.get("seg02");
+      ReentrantLock holderLock = new ReentrantLock();
+      holderLock.lock();
+      executor.submit(() -> {
+        seg02Lock.lock();
+        // Block this thread a while to test if snapshots are skipped.
+        holderLock.lock();
+        seg02Lock.unlock();
+      });
+      upsertMetadataManager.doTakeSnapshot();
+      assertEquals(segmentsTakenSnapshot.size(), 0);
+      // Unblock the bg thread so that it releases the segmentLock.
+      holderLock.unlock();
+      // Acquire the segmentLock once, in case the bg thread is not running in time and causes flakiness.
+      seg02Lock.lock();
+      seg02Lock.unlock();
+      // Now the segmentLock can be acquired for sure, and snapshots should be taken.
+      upsertMetadataManager.doTakeSnapshot();
+      assertEquals(segmentsTakenSnapshot.size(), 3);
+      assertTrue(segDir01.exists());
+      assertEquals(seg01.loadValidDocIdsFromSnapshot().getCardinality(), 4);
+      assertTrue(segDir02.exists());
+      assertEquals(seg02.loadValidDocIdsFromSnapshot().getCardinality(), 6);
+      assertTrue(segDir03.exists());
+      assertEquals(seg03.loadValidDocIdsFromSnapshot().getCardinality(), 3);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
   public void testTakeSnapshotInOrderBasedOnUpdates()
       throws IOException {
     UpsertContext upsertContext = mock(UpsertContext.class);
     when(upsertContext.isSnapshotEnabled()).thenReturn(true);
+    TableDataManager tdm = mock(TableDataManager.class);
+    when(upsertContext.getTableDataManager()).thenReturn(tdm);
+    when(tdm.getSegmentLock(anyString())).thenReturn(new ReentrantLock());
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 
@@ -207,6 +293,9 @@ public class BasePartitionUpsertMetadataManagerTest {
       throws IOException {
     UpsertContext upsertContext = mock(UpsertContext.class);
     when(upsertContext.isSnapshotEnabled()).thenReturn(true);
+    TableDataManager tdm = mock(TableDataManager.class);
+    when(upsertContext.getTableDataManager()).thenReturn(tdm);
+    when(tdm.getSegmentLock(anyString())).thenReturn(new ReentrantLock());
     DummyPartitionUpsertMetadataManager upsertMetadataManager =
         new DummyPartitionUpsertMetadataManager("myTable", 0, upsertContext);
 


### PR DESCRIPTION
This PR tries to fix a race condition between consuming thread taking snapshot for upsert table, and the Helix task threading replacing a segment. 

When replacing a segment, `FileUtils.cleanupDirectory(indexDir)` was called but failed due to `DirectoryNotEmptyException` with stack trace like below
```
Caused by: java.nio.file.DirectoryNotEmptyException:  <path to a segment directory>
        at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:289)
        at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:104)
        at java.base/java.nio.file.Files.delete(Files.java:1152)
        at org.apache.commons.io.FileUtils.delete(FileUtils.java:1222)
        at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1242)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.moveSegment(BaseTableDataManager.java:864)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadSegmentFromDeepStore(BaseTableDataManager.java:801)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadSegment(BaseTableDataManager.java:746)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadAndLoadSegment(BaseTableDataManager.java:389)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.replaceSegmentIfCrcMismatch(BaseTableDataManager.java:380)
        at org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager.doAddOnlineSegment(RealtimeTableDataManager.java:424)
        at org.apache.pinot.core.data.manager.BaseTableDataManager.addOnlineSegment(BaseTableDataManager.java:313)
        at org.apache.pinot.server.starter.helix.HelixInstanceDataManager.addOnlineSegment(HelixInstanceDataManager.java:275)
        at org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory$SegmentOnlineOfflineStateModel.onBecomeOnlineFromConsuming(SegmentOnlineOfflineStateModelFactory.java:88)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```
Because due to race condition, the consuming thread put a new snapshot file into the folder between the two major cleanup steps in this deleteDirectory() method showed below.
```
FileUtils.java:
 public static void deleteDirectory(final File directory) throws IOException {
...
        if (!isSymlink(directory)) {
            cleanDirectory(directory); <--- clean up files or subfolders in the folder
        } 
        // the consuming thread might drop a new snapshot file into the folder, and failed the delete() method call.
        delete(directory); <--- remove the folder that's supposed to be empty now
    }
```