### PR TITLE
Fix bug with server return final aggregation result when null handling is enabled

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -116,7 +116,8 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       }
       dataTableBuilder.startRow();
       for (int i = 0; i < numColumns; i++) {
-        Object result = _results.get(i);
+        Object result =
+            returnFinalResult ? _aggregationFunctions[i].extractFinalResult(_results.get(i)) : _results.get(i);
         if (result == null) {
           result = columnDataTypes[i].getNullPlaceholder();
           nullBitmaps[i].add(0);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -311,6 +311,21 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     assertEquals(response.get("resultTable").get("rows").get(0).get(0).asInt(), 1);
   }
 
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testAggregateServerReturnFinalResult(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String sqlQuery = "SET serverReturnFinalResult = true; SELECT AVG(salary) FROM mytable";
+    JsonNode response = postQuery(sqlQuery);
+    assertNoError(response);
+    assertEquals(5429377.34, response.get("resultTable").get("rows").get(0).get(0).asDouble(), 0.1);
+
+    sqlQuery = "SET serverReturnFinalResult = true; SELECT AVG(salary) FROM mytable WHERE city = 'does_not_exist'";
+    response = postQuery(sqlQuery);
+    assertNoError(response);
+    assertTrue(response.get("resultTable").get("rows").get(0).get(0).isNull());
+  }
+
   @Override
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
     brokerConf.setProperty(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING, "true");


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/9304 added the ability for a server to directly return the final aggregation result instead of serializing the intermediate result (useful when a single server is queried and the aggregation function like distinct count has a huge intermediate result).
- There's a bug in this code path when null handling is enabled - the aggregation function's `extractFinalResult` method is not called to convert the intermediate result to final result. This happens to work fine for some aggregation functions like `SUM` / `COUNT` / `MIN` / `MAX` where this method simply returns the intermediate result. However, for many other aggregation functions, this doesn't work since the intermediate result is not the same as the final result.
- Taking the `AVG` aggregation function as an example, a query like `SET enableNullHandling = true; SET serverReturnFinalResult = true; SELECT AVG(salary) FROM mytable` fails with:
```
java.lang.ClassCastException: class org.apache.pinot.segment.local.customobject.AvgPair cannot be cast to class java.lang.Double (org.apache.pinot.segment.local.customobject.AvgPair is in unnamed module of loader 'app'; java.lang.Double is in module java.base of loader 'bootstrap')
	at org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock.setFinalResult(AggregationResultsBlock.java:187) ~[classes/:?]
	at org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock.getDataTable(AggregationResultsBlock.java:127) ~[classes/:?]
	at org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataOnlyDataTable(InstanceResponseBlock.java:117) ~[classes/:?]
	at org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataTable(InstanceResponseBlock.java:110) ~[classes/:?]
	at org.apache.pinot.core.query.scheduler.QueryScheduler.serializeResponse(QueryScheduler.java:221) ~[classes/:?]
	at org.apache.pinot.core.query.scheduler.QueryScheduler.processQueryAndSerialize(QueryScheduler.java:156) ~[classes/:?]
```
- This patch fixes the above bug and adds a small integration test.