### PR TITLE
Declare annotation processors as compiler plugin config

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -245,7 +245,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
+      <artifactId>auto-service-annotations</artifactId>
     </dependency>
 
     <!-- Test -->

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
+      <artifactId>auto-service-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.uber</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1183,7 +1183,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
-        <artifactId>auto-service</artifactId>
+        <artifactId>auto-service-annotations</artifactId>
         <version>${google.auto-service.version}</version>
         <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
       </dependency>
@@ -2278,6 +2278,21 @@
             <target>${jdk.version}</target>
             <fork>true</fork>
             <encoding>${project.build.sourceEncoding}</encoding>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-metadata-generator</artifactId>
+              </path>
+              <path>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+              </path>
+              <path>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${google.auto-service.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This PR declares Java annotation processors as recommended since Maven 3.5 (see https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths).

This change is pretty simple, we just need to declare the dependencies in a specific section in the plugin config.

Although the older way to use this annotation processors in Maven still works, Maven shows a warning when that mode is used.

## Context

Java annotation processors are a way to generate code at compile time in Java. This can be used by tools like Google Auto project (https://github.com/google/auto/tree/main) or Immutables.

In Pinot we use Google AutoServices to generate Java Service Provider Interfaces (see https://www.baeldung.com/java-spi). For example this is used on IndexType. We have other open PRs at this time that use annotation processors to generate Calcite Rule config  (see https://github.com/apache/pinot/pull/13943).

Originally these annotation processors were just drop into the compilation classpath, but in the latest years the javac has a explicit way to define these processors. Since version 3.5, Maven supports this new javac argument, but in order to use it the dependencies must be declared explicitly.