### PR TITLE
For consuming segment, avoid using setter in IndexLoadingConfig

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -759,4 +759,11 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected long getLongCellValue(JsonNode jsonNode, int colIndex, int rowIndex) {
     return getCellValue(jsonNode, colIndex, rowIndex, JsonNode::asLong).longValue();
   }
+
+  protected JsonNode getColumnIndexSize(String column)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(
+            sendGetRequest(_controllerRequestURLBuilder.forTableAggregateMetadata(getTableName(), List.of(column))))
+        .get("columnIndexSizeMap").get(column);
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -49,6 +49,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.plugin.stream.kafka.KafkaMessageBatch;
 import org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory;
 import org.apache.pinot.plugin.stream.kafka20.KafkaPartitionLevelConsumer;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -73,6 +74,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -319,6 +321,37 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
   public void testReload()
       throws Exception {
     testReload(false);
+  }
+
+  @Test
+  public void testSortedColumn()
+      throws Exception {
+    // There should be no inverted index or range index sealed because the sorted column is not configured with them
+    JsonNode columnIndexSize = getColumnIndexSize(getSortedColumn());
+    assertFalse(columnIndexSize.has(StandardIndexes.INVERTED_ID));
+    assertFalse(columnIndexSize.has(StandardIndexes.RANGE_ID));
+
+    // For point lookup query, there should be no scan from the committed/consuming segments, but full scan from the
+    // uploaded segments:
+    // - Committed segments have sorted index
+    // - Consuming segments have inverted index
+    // - Uploaded segments have neither of them
+    String query = "SELECT COUNT(*) FROM myTable WHERE Carrier = 'DL'";
+    JsonNode response = postQuery(query);
+    long numEntriesScannedInFilter = response.get("numEntriesScannedInFilter").asLong();
+    long numDocsInUploadedSegments = super.getCountStarResult();
+    assertEquals(numEntriesScannedInFilter, numDocsInUploadedSegments);
+
+    // For range query, there should be no scan from the committed segments, but full scan from the uploaded/consuming
+    // segments:
+    // - Committed segments have sorted index
+    // - Consuming/Uploaded segments do not have sorted index
+    query = "SELECT COUNT(*) FROM myTable WHERE Carrier > 'DL'";
+    response = postQuery(query);
+    numEntriesScannedInFilter = response.get("numEntriesScannedInFilter").asLong();
+    // NOTE: If this test is running after force commit test, there will be no records in consuming segments
+    assertTrue(numEntriesScannedInFilter >= numDocsInUploadedSegments);
+    assertTrue(numEntriesScannedInFilter < 2 * numDocsInUploadedSegments);
   }
 
   @Test(dataProvider = "useBothQueryEngines")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1324,10 +1324,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     String column = "DestCityName";
     JsonNode columnIndexSize = getColumnIndexSize(column);
-    assertTrue(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    double dictionarySize = columnIndexSize.get("dictionary").asDouble();
-    double forwardIndexSize = columnIndexSize.get("forward_index").asDouble();
+    assertTrue(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    double dictionarySize = columnIndexSize.get(StandardIndexes.DICTIONARY_ID).asDouble();
+    double forwardIndexSize = columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble();
 
     // Convert 'DestCityName' to raw index
     TableConfig tableConfig = getOfflineTableConfig();
@@ -1339,9 +1339,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     long numTotalDocs = getCountStarResult();
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
     columnIndexSize = getColumnIndexSize(column);
-    assertFalse(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    double v2rawIndexSize = columnIndexSize.get("forward_index").asDouble();
+    assertFalse(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    double v2rawIndexSize = columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble();
     assertTrue(v2rawIndexSize > forwardIndexSize);
 
     // NOTE: Currently Pinot doesn't support directly changing raw index version, so we need to first reset it back to
@@ -1361,9 +1361,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
     columnIndexSize = getColumnIndexSize(column);
-    assertFalse(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    double v4RawIndexSize = columnIndexSize.get("forward_index").asDouble();
+    assertFalse(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    double v4RawIndexSize = columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble();
     assertTrue(v4RawIndexSize < v2rawIndexSize && v4RawIndexSize > forwardIndexSize);
 
     // Convert 'DestCityName' to SNAPPY compression
@@ -1377,9 +1377,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
     columnIndexSize = getColumnIndexSize(column);
-    assertFalse(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    double v4SnappyRawIndexSize = columnIndexSize.get("forward_index").asDouble();
+    assertFalse(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    double v4SnappyRawIndexSize = columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble();
     assertTrue(v4SnappyRawIndexSize > v2rawIndexSize);
 
     // Removing FieldConfig should be no-op because compression is not explicitly set
@@ -1387,9 +1387,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
     columnIndexSize = getColumnIndexSize(column);
-    assertFalse(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    assertEquals(columnIndexSize.get("forward_index").asDouble(), v4SnappyRawIndexSize);
+    assertFalse(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    assertEquals(columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble(), v4SnappyRawIndexSize);
 
     // Adding 'LZ4' compression explicitly should trigger the conversion
     forwardIndexConfig = new ForwardIndexConfig.Builder().withCompressionCodec(CompressionCodec.LZ4).build();
@@ -1400,18 +1400,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
     columnIndexSize = getColumnIndexSize(column);
-    assertFalse(columnIndexSize.has("dictionary"));
-    assertTrue(columnIndexSize.has("forward_index"));
-    assertEquals(columnIndexSize.get("forward_index").asDouble(), v2rawIndexSize);
+    assertFalse(columnIndexSize.has(StandardIndexes.DICTIONARY_ID));
+    assertTrue(columnIndexSize.has(StandardIndexes.FORWARD_ID));
+    assertEquals(columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble(), v2rawIndexSize);
 
     resetForwardIndex(dictionarySize, forwardIndexSize);
-  }
-
-  private JsonNode getColumnIndexSize(String column)
-      throws Exception {
-    return JsonUtils.stringToJsonNode(
-            sendGetRequest(_controllerRequestURLBuilder.forTableAggregateMetadata(getTableName(), List.of(column))))
-        .get("columnIndexSizeMap").get(column);
   }
 
   private void resetForwardIndex(double expectedDictionarySize, double expectedForwardIndexSize)
@@ -1420,8 +1413,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, getCountStarResult());
     JsonNode columnIndexSize = getColumnIndexSize("DestCityName");
-    assertEquals(columnIndexSize.get("dictionary").asDouble(), expectedDictionarySize);
-    assertEquals(columnIndexSize.get("forward_index").asDouble(), expectedForwardIndexSize);
+    assertEquals(columnIndexSize.get(StandardIndexes.DICTIONARY_ID).asDouble(), expectedDictionarySize);
+    assertEquals(columnIndexSize.get(StandardIndexes.FORWARD_ID).asDouble(), expectedForwardIndexSize);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -63,9 +63,6 @@ public class RealtimeSegmentConverter {
     _segmentZKPropsConfig = segmentZKPropsConfig;
     _outputPath = outputPath;
     _columnIndicesForRealtimeTable = cdc;
-    if (cdc.getSortedColumn() != null) {
-      _columnIndicesForRealtimeTable.getInvertedIndexColumns().remove(cdc.getSortedColumn());
-    }
     _dataSchema = getUpdatedSchema(schema);
     _tableName = tableName;
     _tableConfig = tableConfig;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.segment.index.loader;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -459,13 +458,6 @@ public class IndexLoadingConfig {
   @VisibleForTesting
   public void setInvertedIndexColumns(Set<String> invertedIndexColumns) {
     _invertedIndexColumns = new HashSet<>(invertedIndexColumns);
-    _dirty = true;
-  }
-
-  @Deprecated
-  @VisibleForTesting
-  public void addInvertedIndexColumns(String... invertedIndexColumns) {
-    _invertedIndexColumns.addAll(Arrays.asList(invertedIndexColumns));
     _dirty = true;
   }
 


### PR DESCRIPTION
Sub-task of #14106 

Currently in `RealtimeSegmentDataManager` we rely on calling `IndexLoadingConfig.addInvertedIndexColumns()` to create inverted index for sorted column. It can cause inconsistent index loading config and table config.
This PR avoids that and moves the handling logic into `RealtimeSegmentConfig`.
Added `LLCRealtimeClusterIntegrationTest.testSortedColumn()` to ensure the expected behavior.