### PR TITLE
Upgrade http5 Client to 5.4 and using Http 2 Protocol 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
@@ -117,8 +117,7 @@ public class MultiHttpRequest {
         HttpClients.custom().setConnectionManager(_connectionManager).setDefaultRequestConfig(defaultRequestConfig);
 
     CompletionService<MultiHttpRequestResponse> completionService = new ExecutorCompletionService<>(_executor);
-    CloseableHttpClient client = httpClientBuilder
-        .setConnectionReuseStrategy((request, response, context) -> false).build();
+    CloseableHttpClient client = httpClientBuilder.build();
     for (Pair<String, String> pair : urlsAndRequestBodies) {
       completionService.submit(() -> {
         String url = pair.getLeft();

--- a/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
@@ -116,7 +116,8 @@ public class MultiHttpRequest {
         HttpClients.custom().setConnectionManager(_connectionManager).setDefaultRequestConfig(defaultRequestConfig);
 
     CompletionService<MultiHttpRequestResponse> completionService = new ExecutorCompletionService<>(_executor);
-    CloseableHttpClient client = httpClientBuilder.build();
+    CloseableHttpClient client = httpClientBuilder
+        .setConnectionReuseStrategy((request, response, context) -> false).build();
     for (Pair<String, String> pair : urlsAndRequestBodies) {
       completionService.submit(() -> {
         String url = pair.getLeft();

--- a/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.util.Timeout;
@@ -127,6 +128,7 @@ public class MultiHttpRequest {
         if (httpMethod instanceof HttpPost) {
           ((HttpPost) httpMethod).setEntity(new StringEntity(body));
         }
+        httpMethod.setVersion(HttpVersion.HTTP_2_0);
         if (requestHeaders != null) {
           requestHeaders.forEach(((HttpUriRequestBase) httpMethod)::setHeader);
         }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.entity.mime.ContentBody;
@@ -48,7 +49,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
@@ -59,6 +59,7 @@ import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
 import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.common.utils.http.HttpClientConfig;
+import org.apache.pinot.common.utils.http.HttpUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -404,9 +405,9 @@ public class FileUploadDownloadClient implements AutoCloseable {
         .addPart(contentBody.getFilename(), contentBody).build();
 
     // Build the request
-    ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_2_0).setUri(uri).setEntity(entity);
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, method);
+    requestBuilder.setEntity(entity);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
@@ -417,9 +418,9 @@ public class FileUploadDownloadClient implements AutoCloseable {
         .addPart(contentBody.getFilename(), contentBody).build();
 
     // Build the request
-    ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_2_0).setUri(uri).setEntity(entity);
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, method);
+    requestBuilder.setEntity(entity);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
@@ -455,36 +456,35 @@ public class FileUploadDownloadClient implements AutoCloseable {
     HttpEntity entity = multipartEntityBuilder.build();
 
     // Build the POST request.
-    ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(HttpPost.METHOD_NAME).setVersion(HttpVersion.HTTP_2_0).setUri(uri)
-            .setEntity(entity);
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setEntity(entity);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
   private static ClassicHttpRequest getSendSegmentUriRequest(URI uri, String downloadUri,
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
-        .setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.URI.toString())
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.URI.toString())
         .setHeader(CustomHeaders.DOWNLOAD_URI, downloadUri)
         .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
   private static ClassicHttpRequest getSendSegmentJsonRequest(URI uri, String jsonString,
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
-        .setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.JSON.toString())
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.JSON.toString())
         .setEntity(new StringEntity(jsonString, ContentType.APPLICATION_JSON));
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
   private static ClassicHttpRequest getStartReplaceSegmentsRequest(URI uri, String jsonRequestBody,
       @Nullable AuthProvider authProvider) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
-        .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE)
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE)
         .setEntity(new StringEntity(jsonRequestBody, ContentType.APPLICATION_JSON));
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     return requestBuilder.build();
@@ -492,8 +492,8 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   private static ClassicHttpRequest getEndReplaceSegmentsRequest(URI uri, String jsonRequestBody,
       @Nullable AuthProvider authProvider) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
-        .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
     if (jsonRequestBody != null) {
       requestBuilder.setEntity(new StringEntity(jsonRequestBody, ContentType.APPLICATION_JSON));
     }
@@ -502,15 +502,15 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   private static ClassicHttpRequest getRevertReplaceSegmentRequest(URI uri) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
-        .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
+    requestBuilder.setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
     return requestBuilder.build();
   }
 
   private static ClassicHttpRequest getSegmentCompletionProtocolRequest(URI uri, @Nullable List<Header> headers,
       @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
-    HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpGet.METHOD_NAME);
+    HttpUtils.applyHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
 
@@ -888,7 +888,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
       String uri =
           controllerRequestURLBuilder.forSegmentListAPI(rawTableName, tableTypeToFilter, excludeReplacedSegments,
               startTimestamp, endTimestamp, excludeOverlapping);
-      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
+      ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(new URI(uri), HttpGet.METHOD_NAME);
       AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
 
       RetryPolicies.exponentialBackoffRetryPolicy(5, 10_000L, 2.0).attempt(() -> {
@@ -950,7 +950,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
    */
   public String uploadToSegmentStore(String uri)
       throws URISyntaxException, IOException, HttpErrorStatusException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(new URI(uri), HttpPost.METHOD_NAME);
     // sendRequest checks the response status code
     SimpleHttpResponse response = HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(requestBuilder.build(), HttpClient.DEFAULT_SOCKET_TIMEOUT_MS));

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -405,7 +405,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
     // Build the request
     ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_1_1).setUri(uri).setEntity(entity);
+        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_2_0).setUri(uri).setEntity(entity);
     HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
@@ -418,7 +418,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
     // Build the request
     ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_1_1).setUri(uri).setEntity(entity);
+        ClassicRequestBuilder.create(method).setVersion(HttpVersion.HTTP_2_0).setUri(uri).setEntity(entity);
     HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
@@ -456,7 +456,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
     // Build the POST request.
     ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(HttpPost.METHOD_NAME).setVersion(HttpVersion.HTTP_1_1).setUri(uri)
+        ClassicRequestBuilder.create(HttpPost.METHOD_NAME).setVersion(HttpVersion.HTTP_2_0).setUri(uri)
             .setEntity(entity);
     HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
@@ -464,7 +464,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   private static ClassicHttpRequest getSendSegmentUriRequest(URI uri, String downloadUri,
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
         .setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.URI.toString())
         .setHeader(CustomHeaders.DOWNLOAD_URI, downloadUri)
         .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
@@ -474,7 +474,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   private static ClassicHttpRequest getSendSegmentJsonRequest(URI uri, String jsonString,
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
         .setHeader(CustomHeaders.UPLOAD_TYPE, FileUploadType.JSON.toString())
         .setEntity(new StringEntity(jsonString, ContentType.APPLICATION_JSON));
     HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
@@ -483,7 +483,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   private static ClassicHttpRequest getStartReplaceSegmentsRequest(URI uri, String jsonRequestBody,
       @Nullable AuthProvider authProvider) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
         .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE)
         .setEntity(new StringEntity(jsonRequestBody, ContentType.APPLICATION_JSON));
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
@@ -492,7 +492,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   private static ClassicHttpRequest getEndReplaceSegmentsRequest(URI uri, String jsonRequestBody,
       @Nullable AuthProvider authProvider) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
         .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
     if (jsonRequestBody != null) {
       requestBuilder.setEntity(new StringEntity(jsonRequestBody, ContentType.APPLICATION_JSON));
@@ -502,14 +502,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   private static ClassicHttpRequest getRevertReplaceSegmentRequest(URI uri) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0)
         .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
     return requestBuilder.build();
   }
 
   private static ClassicHttpRequest getSegmentCompletionProtocolRequest(URI uri, @Nullable List<Header> headers,
       @Nullable List<NameValuePair> parameters) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
     HttpClient.addHeadersAndParameters(requestBuilder, headers, parameters);
     return requestBuilder.build();
   }
@@ -888,7 +888,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
       String uri =
           controllerRequestURLBuilder.forSegmentListAPI(rawTableName, tableTypeToFilter, excludeReplacedSegments,
               startTimestamp, endTimestamp, excludeOverlapping);
-      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
       AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
 
       RetryPolicies.exponentialBackoffRetryPolicy(5, 10_000L, 2.0).attempt(() -> {
@@ -950,7 +950,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
    */
   public String uploadToSegmentStore(String uri)
       throws URISyntaxException, IOException, HttpErrorStatusException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_2_0);
     // sendRequest checks the response status code
     SimpleHttpResponse response = HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(requestBuilder.build(), HttpClient.DEFAULT_SOCKET_TIMEOUT_MS));

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -85,7 +85,6 @@ public class HttpClient implements AutoCloseable {
   public static final int DEFAULT_SOCKET_TIMEOUT_MS = 600 * 1000; // 10 minutes
   public static final int GET_REQUEST_SOCKET_TIMEOUT_MS = 5 * 1000; // 5 seconds
   public static final int DELETE_REQUEST_SOCKET_TIMEOUT_MS = 10 * 1000; // 10 seconds
-  public static final String AUTH_HTTP_HEADER = "Authorization";
   public static final String JSON_CONTENT_TYPE = "application/json";
 
   private final CloseableHttpClient _httpClient;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -55,7 +55,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -35,6 +35,8 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -53,8 +55,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.hc.core5.http.HttpVersion;
-import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -135,7 +136,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendGetRequest(URI uri, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpGet.METHOD_NAME);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     if (MapUtils.isNotEmpty(headers)) {
       for (Map.Entry<String, String> header : headers.entrySet()) {
@@ -163,7 +164,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendDeleteRequest(URI uri, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpDelete.METHOD_NAME);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     if (MapUtils.isNotEmpty(headers)) {
       for (Map.Entry<String, String> header : headers.entrySet()) {
@@ -187,7 +188,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendPostRequest(URI uri, @Nullable HttpEntity payload,
       @Nullable Map<String, String> headers, @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPost.METHOD_NAME);
     if (payload != null) {
       requestBuilder.setEntity(payload);
     }
@@ -213,7 +214,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendPutRequest(URI uri, @Nullable HttpEntity payload, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.put(uri).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpPut.METHOD_NAME);
     if (payload != null) {
       requestBuilder.setEntity(payload);
     }
@@ -478,20 +479,6 @@ public class HttpClient implements AutoCloseable {
     }
   }
 
-  public static void addHeadersAndParameters(ClassicRequestBuilder requestBuilder, @Nullable List<Header> headers,
-      @Nullable List<NameValuePair> parameters) {
-    if (headers != null) {
-      for (Header header : headers) {
-        requestBuilder.addHeader(header);
-      }
-    }
-    if (parameters != null) {
-      for (NameValuePair parameter : parameters) {
-        requestBuilder.addParameter(parameter);
-      }
-    }
-  }
-
   private static CloseableHttpClient buildCloseableHttpClient(HttpClientConfig httpClientConfig,
       SSLConnectionSocketFactory csf) {
     PoolingHttpClientConnectionManager connManager =
@@ -543,7 +530,7 @@ public class HttpClient implements AutoCloseable {
 
   private static ClassicHttpRequest getDownloadFileRequest(URI uri, AuthProvider authProvider,
       List<Header> httpHeaders) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, Method.GET.name());
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     String userInfo = uri.getUserInfo();
     if (userInfo != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -530,7 +530,7 @@ public class HttpClient implements AutoCloseable {
 
   private static ClassicHttpRequest getDownloadFileRequest(URI uri, AuthProvider authProvider,
       List<Header> httpHeaders) {
-    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, Method.GET.name());
+    ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, HttpGet.METHOD_NAME);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     String userInfo = uri.getUserInfo();
     if (userInfo != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -512,7 +512,7 @@ public class HttpClient implements AutoCloseable {
     if (httpClientConfig.isDisableDefaultUserAgent()) {
       httpClientBuilder.disableDefaultUserAgent();
     }
-    return httpClientBuilder.build();
+    return httpClientBuilder.setConnectionReuseStrategy((request, response, context) -> false).build();
   }
 
   private static String getErrorMessage(ClassicHttpRequest request, CloseableHttpResponse response) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -135,7 +135,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendGetRequest(URI uri, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     if (MapUtils.isNotEmpty(headers)) {
       for (Map.Entry<String, String> header : headers.entrySet()) {
@@ -163,7 +163,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendDeleteRequest(URI uri, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_2_0);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     if (MapUtils.isNotEmpty(headers)) {
       for (Map.Entry<String, String> header : headers.entrySet()) {
@@ -187,7 +187,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendPostRequest(URI uri, @Nullable HttpEntity payload,
       @Nullable Map<String, String> headers, @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_2_0);
     if (payload != null) {
       requestBuilder.setEntity(payload);
     }
@@ -213,7 +213,7 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendPutRequest(URI uri, @Nullable HttpEntity payload, @Nullable Map<String, String> headers,
       @Nullable AuthProvider authProvider)
       throws IOException {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.put(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.put(uri).setVersion(HttpVersion.HTTP_2_0);
     if (payload != null) {
       requestBuilder.setEntity(payload);
     }
@@ -293,8 +293,8 @@ public class HttpClient implements AutoCloseable {
       if (response.containsHeader(CommonConstants.Controller.HOST_HTTP_HEADER)) {
         String controllerHost = response.getFirstHeader(CommonConstants.Controller.HOST_HTTP_HEADER).getValue();
         String controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
-        LOGGER.info("Sending request: {} to controller: {}, version: {}", request.getRequestUri(), controllerHost,
-            controllerVersion);
+        LOGGER.info("Sending request: {}, http method: {}, to controller: {}, version: {}",
+            request.getRequestUri(), request.getMethod(), controllerHost, controllerVersion);
       }
       int statusCode = response.getCode();
       if (statusCode >= 300) {
@@ -511,7 +511,7 @@ public class HttpClient implements AutoCloseable {
     if (httpClientConfig.isDisableDefaultUserAgent()) {
       httpClientBuilder.disableDefaultUserAgent();
     }
-    return httpClientBuilder.setConnectionReuseStrategy((request, response, context) -> false).build();
+    return httpClientBuilder.build();
   }
 
   private static String getErrorMessage(ClassicHttpRequest request, CloseableHttpResponse response) {
@@ -543,7 +543,7 @@ public class HttpClient implements AutoCloseable {
 
   private static ClassicHttpRequest getDownloadFileRequest(URI uri, AuthProvider authProvider,
       List<Header> httpHeaders) {
-    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
     AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
     String userInfo = uri.getUserInfo();
     if (userInfo != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpUtils.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.http;
+
+import java.net.URI;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+
+
+/**
+ * Utility class for creating and managing HTTP related requests utility functions.
+ * - This class provides various utility methods to facilitate HTTP request creation and manipulation.
+ */
+public class HttpUtils {
+  private HttpUtils() {
+  }
+
+  /**
+   * Creates a {@link ClassicRequestBuilder} with the given URI and method.
+   *
+   * @param uri the URI for the request
+   * @param method the HTTP method for the request (e.g., GET, POST)
+   * @return a {@link ClassicRequestBuilder} instance
+   */
+  public static ClassicRequestBuilder createRequestBuilder(URI uri, String method) {
+    return ClassicRequestBuilder.create(method).setUri(uri).setVersion(HttpVersion.HTTP_2_0);
+  }
+
+  /**
+   * Apply the provided headers and parameters to the given {@link ClassicRequestBuilder}.
+   *
+   * @param requestBuilder the {@link ClassicRequestBuilder} to which headers and parameters will be added
+   * @param headers a list of headers to be added to the request, or null if no headers are to be added
+   * @param parameters a list of parameters to be added to the request, or null if no parameters are to be added
+   */
+  public static void applyHeadersAndParameters(ClassicRequestBuilder requestBuilder, @Nullable List<Header> headers,
+      @Nullable List<NameValuePair> parameters) {
+    if (headers != null) {
+      for (Header header : headers) {
+        requestBuilder.addHeader(header);
+      }
+    }
+    if (parameters != null) {
+      for (NameValuePair parameter : parameters) {
+        requestBuilder.addParameter(parameter);
+      }
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -51,12 +51,13 @@ import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LoggerUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.common.utils.http.HttpUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.controller.api.access.AccessType;
@@ -215,7 +216,7 @@ public class PinotControllerLogger {
     try {
       URI uri = UriBuilder.fromUri(getInstanceBaseUri(instanceName)).path("/loggers/download")
           .queryParam("filePath", filePath).build();
-      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
+      ClassicRequestBuilder requestBuilder = HttpUtils.createRequestBuilder(uri, Method.GET.name());
       if (MapUtils.isNotEmpty(headers)) {
         for (Map.Entry<String, String> header : headers.entrySet()) {
           requestBuilder.addHeader(header.getKey(), header.getValue());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -215,7 +215,7 @@ public class PinotControllerLogger {
     try {
       URI uri = UriBuilder.fromUri(getInstanceBaseUri(instanceName)).path("/loggers/download")
           .queryParam("filePath", filePath).build();
-      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+      ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_2_0);
       if (MapUtils.isNotEmpty(headers)) {
         for (Map.Entry<String, String> header : headers.entrySet()) {
           requestBuilder.addHeader(header.getKey(), header.getValue());

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <!-- HTTP Components Libraries -->
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
-    <httpclient5.version>5.3.1</httpclient5.version>
+    <httpclient5.version>5.4</httpclient5.version>
     <httpcore5.version>5.3.1</httpcore5.version>
 
     <!-- Google Libraries -->


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Requests now use HttpUtils to set HTTP/2 and apply headers before sending\.

```mermaid
flowchart TD
  N0["HttpUtils#46;createRequestBuilder #40;F4#41;"]:::stAdded
  N1["HttpUtils#46;applyHeadersAndParameters #40;F4#41;"]:::stAdded
  N2["HttpClient#46;sendGetRequest #40;F3#41;"]:::stModified
  N3["MultiHttpRequest#46;build #40;F1#41;"]:::stModified
  N4["FileUploadDownloadClient#46;getUploadFileRequest #40;F2#41;"]:::stModified
  N5["PinotControllerLogger#46;downloadLogFileFromInstance #40;F6#41;"]:::stModified
  N0 -->|"passes builder"| N1
  N1 -->|"used to build request"| N4
  N0 -->|"passes builder"| N2
  N0 -->|"passes builder"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest\.java — [before](https://github.com/apache/pinot/blob/d41192e9a7e342c38ce2d8bbf5d60c3e5679b304/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java) · [after](https://github.com/apache/pinot/blob/1e7cd92ce68a6371cbd6fce4aea3212ed98d01bb/pinot-common/src/main/java/org/apache/pinot/common/http/MultiHttpRequest.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient\.java — [before](https://github.com/apache/pinot/blob/d41192e9a7e342c38ce2d8bbf5d60c3e5679b304/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java) · [after](https://github.com/apache/pinot/blob/1e7cd92ce68a6371cbd6fce4aea3212ed98d01bb/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java)
- F3: pinot\-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient\.java — [before](https://github.com/apache/pinot/blob/d41192e9a7e342c38ce2d8bbf5d60c3e5679b304/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java) · [after](https://github.com/apache/pinot/blob/1e7cd92ce68a6371cbd6fce4aea3212ed98d01bb/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java)
- F4: pinot\-common/src/main/java/org/apache/pinot/common/utils/http/HttpUtils\.java — [after](https://github.com/apache/pinot/blob/1e7cd92ce68a6371cbd6fce4aea3212ed98d01bb/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpUtils.java)
- F6: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger\.java — [before](https://github.com/apache/pinot/blob/d41192e9a7e342c38ce2d8bbf5d60c3e5679b304/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java) · [after](https://github.com/apache/pinot/blob/1e7cd92ce68a6371cbd6fce4aea3212ed98d01bb/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQ0MTE5MmU5YTdlMzQyYzM4Y2UyZDhiYmY1ZDYwYzNlNTY3OWIzMDQiLCJjb250ZXh0X2hhc2giOiJiMjJmOTBlYTlmMDc1ZTA2NzdiNDE5NzQ3OGYwMjUyYWVmODU3ZGMxNWU3OTE4MDVhNjRiZjBhZTljMzA2MGE4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDMyMTY1LCJoZWFkX3NoYSI6IjFlN2NkOTJjZTY4YTYzNzFjYmQ2ZmNlNGFlYTMyMTJlZDk4ZDAxYmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkNDExOTJlOWE3ZTM0MmMzOGNlMmQ4YmJmNWQ2MGMzZTU2NzliMzA0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1f89828e7c0580dd61017a8ee43d0af8cf813ea19b3be8e5ac5e29ee97a63244 -->
<!-- pinot-pr-flow:end -->

As per the [issue](https://github.com/apache/pinot/issues/14063), In this PR we are upgrading the [httpclient5](https://github.com/apache/httpcomponents-client) from 5.3.1 to 5.4.

**Details**
- We observed test failures in the Dependabot [PR](https://github.com/apache/pinot/pull/14045) because of the default connection reuse strategy. In httpclient5 version 5.4-alpha2, team fixed the [issue](https://issues.apache.org/jira/browse/HTTPCLIENT-2316), and because of this, we started seeing the failures with the error log
```
Connection error . Details: org.apache.hc.core5.http.NoHttpResponseException: localhost:22000 failed to respond
10:03:41.417 ERROR [CompletionServiceHelper] [grizzly-http-server-16] Connection error . Details: org.apache.hc.core5.http.NoHttpResponseException: localhost:22000 failed to respond
```
~~To fix this issue, In this PR we are setting the ConnectionReuseStrategy to `false` to resolve all the errors.~~

On further investigation, I am unable to determine whether the failures are purely due to the above-mentioned issue or to changes in caching with connections. **I need help from someone to pin down the exact reason.**

While investigating, I noticed that using the HTTP 2 protocol instead of HTTP 1.1 resulted in no issues in our entire test suite. Can we accept this as a solution?