### PR TITLE
Fix Bug in Handling Empty Filters in Time Series + Minor Fixes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -83,6 +83,10 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
   @Override
   protected TimeSeriesResultsBlock getNextBlock() {
     ValueBlock transformBlock = _projectOperator.nextBlock();
+    if (transformBlock == null) {
+      TimeSeriesBuilderBlock builderBlock = new TimeSeriesBuilderBlock(_timeBuckets, new HashMap<>());
+      return new TimeSeriesResultsBlock(builderBlock);
+    }
     BlockValSet blockValSet = transformBlock.getBlockValueSet(_timeColumn);
     long[] timeValues = blockValSet.getLongValuesSV();
     if (_timeOffset != null && _timeOffset != 0L) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -35,7 +35,7 @@ public class QueryContextUtils {
    * Returns {@code true} if the given query is a selection query, {@code false} otherwise.
    */
   public static boolean isSelectionQuery(QueryContext query) {
-    return !query.isDistinct() && query.getAggregationFunctions() == null;
+    return !query.isDistinct() && query.getAggregationFunctions() == null && !isTimeSeriesQuery(query);
   }
 
   /**
@@ -51,7 +51,7 @@ public class QueryContextUtils {
    * Returns {@code true} if the given query is an aggregation query, {@code false} otherwise.
    */
   public static boolean isAggregationQuery(QueryContext query) {
-    return query.getAggregationFunctions() != null;
+    return query.getAggregationFunctions() != null && !isTimeSeriesQuery(query);
   }
 
   /**

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
@@ -36,7 +36,6 @@ import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
  *   the time filter based on the computed time buckets in {@link TimeSeriesLogicalPlanner}.
  */
 public class LeafTimeSeriesPlanNode extends BaseTimeSeriesPlanNode {
-  private static final String EXPLAIN_NAME = "LEAF_TIME_SERIES_PLAN_NODE";
   private final String _tableName;
   private final String _timeColumn;
   private final TimeUnit _timeUnit;
@@ -72,7 +71,9 @@ public class LeafTimeSeriesPlanNode extends BaseTimeSeriesPlanNode {
 
   @Override
   public String getExplainName() {
-    return EXPLAIN_NAME;
+    return String.format("LEAF_TIME_SERIES_PLAN_NODE(%s, table=%s, timeExpr=%s, valueExpr=%s, aggInfo=%s, "
+        + "groupBy=%s, filter=%s, offsetSeconds=%s)", _id, _tableName, _timeColumn, _valueExpression,
+        _aggInfo.getAggFunction(), _groupByExpressions, _filterExpression, _offsetSeconds);
   }
 
   @Override


### PR DESCRIPTION
We were getting NPE for empty filters since transform operator can return a null value block. This handles that case, and additionally 

* Improve the explain name for Leaf Time Series Plan node.
* Improves some QueryContextUtils methods which are used in places like segment pruner service.