### PR TITLE
Rename multi-stage engine's explain asking servers to explain include segment plan

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -131,7 +131,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       QueryEnvironment queryEnvironment = new QueryEnvironment(database, _tableCache, _workerManager);
       switch (sqlNodeAndOptions.getSqlNode().getKind()) {
         case EXPLAIN:
-          boolean askServers = QueryOptionsUtils.isExplainAskingServers(queryOptions)
+          boolean askServers = QueryOptionsUtils.isExplainIncludeSegmentPlan(queryOptions)
               .orElse(_explainAskingServerDefault);
           @Nullable
           AskingServerStageExplainer.OnServerExplainer fragmentToPlanNode = askServers

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -190,8 +190,8 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.USE_MULTISTAGE_ENGINE));
   }
 
-  public static Optional<Boolean> isExplainAskingServers(Map<String, String> queryOptions) {
-    String value = queryOptions.get(QueryOptionKey.EXPLAIN_ASKING_SERVERS);
+  public static Optional<Boolean> isExplainIncludeSegmentPlan(Map<String, String> queryOptions) {
+    String value = queryOptions.get(QueryOptionKey.EXPLAIN_INCLUDE_SEGMENT_PLAN);
     if (value == null) {
       return Optional.empty();
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineExplainIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineExplainIntegrationTest.java
@@ -228,7 +228,7 @@ public class MultiStageEngineExplainIntegrationTest extends BaseClusterIntegrati
 
   private void explainLogical(@Language("sql") String query, String expected) {
     try {
-      JsonNode jsonNode = postQuery("set explainAskingServers=false; explain plan for " + query);
+      JsonNode jsonNode = postQuery("set explainIncludeSegmentPlan=false; explain plan for " + query);
       JsonNode plan = jsonNode.get("resultTable").get("rows").get(0).get(1);
 
       Assert.assertEquals(plan.asText(), expected);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -950,7 +950,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asInt(), 58538);
 
     explainQuery =
-        "SET " + CommonConstants.Broker.Request.QueryOptionKey.EXPLAIN_ASKING_SERVERS + "=true; EXPLAIN PLAN FOR "
+        "SET " + CommonConstants.Broker.Request.QueryOptionKey.EXPLAIN_INCLUDE_SEGMENT_PLAN + "=true; EXPLAIN PLAN FOR "
             + sqlQuery;
     jsonNode = postQuery(explainQuery);
     assertNoError(jsonNode);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -63,7 +63,7 @@ import org.apache.pinot.query.context.PlannerContext;
 import org.apache.pinot.query.planner.PlannerUtils;
 import org.apache.pinot.query.planner.SubPlan;
 import org.apache.pinot.query.planner.explain.AskingServerStageExplainer;
-import org.apache.pinot.query.planner.explain.MultiStageExplainAskingServersUtils;
+import org.apache.pinot.query.planner.explain.MultiStageExplainIncludeSegmentPlanUtils;
 import org.apache.pinot.query.planner.explain.PhysicalExplainPlanVisitor;
 import org.apache.pinot.query.planner.logical.PinotLogicalQueryPlanner;
 import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
@@ -196,7 +196,7 @@ public class QueryEnvironment {
           AskingServerStageExplainer serversExplainer = new AskingServerStageExplainer(
               onServerExplainer, explainPlanVerbose, RelBuilder.create(_config));
 
-          RelNode explainedNode = MultiStageExplainAskingServersUtils.modifyRel(relRoot.rel,
+          RelNode explainedNode = MultiStageExplainIncludeSegmentPlanUtils.modifyRel(relRoot.rel,
               dispatchableSubPlan.getQueryStageList(), nodeTracker, serversExplainer);
 
           String explainStr = PlannerUtils.explainPlan(explainedNode, format, level);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/MultiStageExplainIncludeSegmentPlanUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/MultiStageExplainIncludeSegmentPlanUtils.java
@@ -29,9 +29,9 @@ import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 
 
-public class MultiStageExplainAskingServersUtils {
+public class MultiStageExplainIncludeSegmentPlanUtils {
 
-  private MultiStageExplainAskingServersUtils() {
+  private MultiStageExplainIncludeSegmentPlanUtils() {
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -401,7 +401,7 @@ public class CommonConstants {
          *
          * Use false in order to mimic behavior of Pinot 1.2.0 and previous.
          */
-        public static final String EXPLAIN_ASKING_SERVERS = "explainAskingServers";
+        public static final String EXPLAIN_INCLUDE_SEGMENT_PLAN = "explainIncludeSegmentPlan";
 
         // Can be applied to aggregation and group-by queries to ask servers to directly return final results instead of
         // intermediate results for aggregations.


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/13733
- The broker config was renamed from `pinot.query.explain.ask.servers` to `pinot.query.multistage.explain.include.segment.plan` during the course of review. This patch updates the corresponding query option to match the name for a consistent user experience (and also updates a couple of internal usages of the term).