### PR TITLE
Support COALESCE as a variadic scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -52,6 +52,7 @@ public class ObjectFunctions {
     return !isDistinctFrom(obj1, obj2);
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, isVarArg = true)
   public static Object coalesce(Object... objects) {
     for (Object o : objects) {
@@ -62,6 +63,7 @@ public class ObjectFunctions {
     return null;
   }
 
+  @Nullable
   @ScalarFunction(names = {"case", "caseWhen"}, nullableParameters = true, isVarArg = true)
   public static Object caseWhen(Object... objs) {
     for (int i = 0; i < objs.length - 1; i += 2) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -52,39 +52,8 @@ public class ObjectFunctions {
     return !isDistinctFrom(obj1, obj2);
   }
 
-  @Nullable
-  public static Object coalesce(@Nullable Object obj) {
-    return coalesceVar(obj);
-  }
-
-  @Nullable
-  @ScalarFunction(nullableParameters = true)
-  public static Object coalesce(@Nullable Object obj1, @Nullable Object obj2) {
-    return coalesceVar(obj1, obj2);
-  }
-
-  @Nullable
-  @ScalarFunction(nullableParameters = true)
-  public static Object coalesce(@Nullable Object obj1, @Nullable Object obj2, @Nullable Object obj3) {
-    return coalesceVar(obj1, obj2, obj3);
-  }
-
-  @Nullable
-  @ScalarFunction(nullableParameters = true)
-  public static Object coalesce(@Nullable Object obj1, @Nullable Object obj2, @Nullable Object obj3,
-      @Nullable Object obj4) {
-    return coalesceVar(obj1, obj2, obj3, obj4);
-  }
-
-  @Nullable
-  @ScalarFunction(nullableParameters = true)
-  public static Object coalesce(@Nullable Object obj1, @Nullable Object obj2, @Nullable Object obj3,
-      @Nullable Object obj4, @Nullable Object obj5) {
-    return coalesceVar(obj1, obj2, obj3, obj4, obj5);
-  }
-
-  @Nullable
-  private static Object coalesceVar(Object... objects) {
+  @ScalarFunction(nullableParameters = true, isVarArg = true)
+  public static Object coalesce(Object... objects) {
     for (Object o : objects) {
       if (o != null) {
         return o;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
@@ -119,5 +119,14 @@ public class PostAggregationFunctionTest {
         false, 1, false, 2, false, 3, false, 4, false, 5, false, 6, false, 7, false, 8, false, 9, false, 10, false,
         11, false, 12, false, 13, false, 14, false, 15, false, 16, false, 17, false, 18, false, 19, 20
     }), 20);
+
+    // Coalesce with a large number of arguments
+    function = new PostAggregationFunction("coalesce", new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT,
+        ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.INT
+    });
+    assertEquals(function.getResultType(), ColumnDataType.OBJECT);
+    assertNull(function.invoke(new Object[]{null, null, null, null, null, null, null, null, null, null}));
+    assertEquals(function.invoke(new Object[]{null, null, null, null, null, null, null, null, null, 10}), 10);
   }
 }


### PR DESCRIPTION
- Similar to https://github.com/apache/pinot/pull/14125, but for `COALESCE`.
- For the single-stage engine, this fix is only relevant for post-aggregation (since other parts of the query can always use the transform function implementation of `COALESCE` that already supports an arbitrary number of arguments) - so something like `COALESCE(SUM(col1), SUM(col2), SUM(col3), SUM(col4), SUM(col5), SUM(col6)` wouldn't work before this fix.
- For the multi-stage engine, however, this fix is more important since any function call in the intermediate stages can only use the scalar function equivalent.