### PR TITLE
Add NULLIF scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -74,4 +74,14 @@ public class ObjectFunctions {
     // with or without else statement.
     return objs.length % 2 == 0 ? null : objs[objs.length - 1];
   }
+
+  @Nullable
+  @ScalarFunction(nullableParameters = true)
+  public static Object nullIf(Object obj1, Object obj2) {
+    if (obj1 == null) {
+      return null;
+    } else {
+      return obj1.equals(obj2) ? null : obj1;
+    }
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -77,7 +77,7 @@ public class ObjectFunctions {
 
   @Nullable
   @ScalarFunction(nullableParameters = true)
-  public static Object nullIf(Object obj1, Object obj2) {
+  public static Object nullIf(@Nullable Object obj1, @Nullable Object obj2) {
     if (obj1 == null) {
       return null;
     } else {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ObjectFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ObjectFunctionsTest.java
@@ -97,7 +97,7 @@ public class ObjectFunctionsTest {
     oneValue.putValue("value2", null);
 
     inputs.add(new Object[]{
-        "coalesce(null0,null1, null2, value1, value2)", Lists.newArrayList("null0", "null1", "null2", "value1",
+        "coalesce(null0, null1, null2, value1, value2)", Lists.newArrayList("null0", "null1", "null2", "value1",
         "value2"), oneValue, 1
     });
 
@@ -155,6 +155,27 @@ public class ObjectFunctionsTest {
         "value1", "value1", "value1", "value1", "value1", "value1", "value1", "value1", "value1",
         "value1"), caseWhenCaseMultipleExpression2, "fifteen"
     });
+
+    // NULLIF
+    GenericRow nullIf = new GenericRow();
+    nullIf.putValue("value1", 1);
+    nullIf.putValue("value2", 1);
+    inputs.add(new Object[]{"NULLIF(value1, value2)", Lists.newArrayList("value1", "value2"), nullIf, null});
+
+    GenericRow nullIf2 = new GenericRow();
+    nullIf2.putValue("value1", 1);
+    nullIf2.putValue("value2", 2);
+    inputs.add(new Object[]{"NULLIF(value1, value2)", Lists.newArrayList("value1", "value2"), nullIf2, 1});
+
+    GenericRow nullIf3 = new GenericRow();
+    nullIf3.putValue("value1", null);
+    nullIf3.putValue("value2", 2);
+    inputs.add(new Object[]{"NULLIF(value1, value2)", Lists.newArrayList("value1", "value2"), nullIf3, null});
+
+    GenericRow nullIf4 = new GenericRow();
+    nullIf4.putValue("value1", 1);
+    nullIf4.putValue("value2", null);
+    inputs.add(new Object[]{"NULLIF(value1, value2)", Lists.newArrayList("value1", "value2"), nullIf4, 1});
 
     return inputs.toArray(new Object[0][]);
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -161,6 +161,7 @@ public class PinotOperatorTable implements SqlOperatorTable {
       SqlStdOperatorTable.LIKE,
 //      SqlStdOperatorTable.CASE,
       SqlStdOperatorTable.OVER,
+      SqlStdOperatorTable.NULLIF,
 
       // FUNCTIONS
       // String functions


### PR DESCRIPTION
- Adds support for the `NULLIF` standard SQL function (exists in Postgres, MySQL, SQL Server, Calcite etc.)
- Note that `NULLIF` expressions are rewritten to the equivalent `CASE WHEN` expressions by Calcite by default (https://github.com/apache/calcite/blob/7ce986fbc635722f3390b81dcdfe24bbd82ddb3d/core/src/main/java/org/apache/calcite/sql/fun/SqlNullifFunction.java#L56-L72). So, for the multi-stage engine, simply adding the `SqlStdOperatorTable.NULLIF` entry to Pinot's operator table would be enough to get this functionality. However, we're also adding the scalar function implementation here so that the same function can be used in the single-stage engine as well.

Edit: this is actually fixing a regression for the multi-stage query engine. Prior to https://github.com/apache/pinot/pull/13573/, the `NULLIF` function worked fine (only on the multi-stage engine, and not on the single-stage engine). Before that refactor, Pinot's operator table extended Calcite's `SqlStdOperatorTable` which has the `SqlNullifFunction` defined. Since it automatically rewrites calls to equivalent calls to `CASE WHEN`, this worked fine even though Pinot didn't have an actual implementation for `NULLIF`. However, the above linked PR updated Pinot's operator table to no longer extend Calcite's `SqlStdOperatorTable`, and instead manually register all the operators that Pinot actually has support for. Since Pinot didn't have an actual implementation for `NULLIF`, it was probably missed. This PR fixes the regression and also adds support for the function in the single-stage engine.