### PR TITLE
Upgrade Jersey from 2.42 to 2.45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <jackson.version>2.17.2</jackson.version>
     <zookeeper.version>3.9.2</zookeeper.version>
     <async-http-client.version>3.0.0</async-http-client.version>
-    <jersey.version>2.42</jersey.version>
+    <jersey.version>2.45</jersey.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.14</swagger.version>
     <swagger-ui.version>5.17.14</swagger-ui.version>


### PR DESCRIPTION
We are still on Jersey 2, so upgrade Jersey to the latest Jersey 2 version