### PR TITLE
Compute all groups for group by queries with only filtered aggregations

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -234,6 +234,10 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT_KEY_UNPARTITIONED));
   }
 
+  public static boolean isFilteredAggregationsComputeAllGroups(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS));
+  }
+
   @Nullable
   public static String getOrderByAlgorithm(Map<String, String> queryOptions) {
     return queryOptions.get(QueryOptionKey.ORDER_BY_ALGORITHM);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -234,12 +234,8 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT_KEY_UNPARTITIONED));
   }
 
-  public static Optional<Boolean> isFilteredAggregationsComputeAllGroups(Map<String, String> queryOptions) {
-    String value = queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS);
-    if (value == null) {
-      return Optional.empty();
-    }
-    return Optional.of(Boolean.parseBoolean(value));
+  public static boolean isFilteredAggregationsSkipEmptyGroups(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS));
   }
 
   @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -234,8 +234,12 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT_KEY_UNPARTITIONED));
   }
 
-  public static boolean isFilteredAggregationsComputeAllGroups(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS));
+  public static Optional<Boolean> isFilteredAggregationsComputeAllGroups(Map<String, String> queryOptions) {
+    String value = queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS);
+    if (value == null) {
+      return Optional.empty();
+    }
+    return Optional.of(Boolean.parseBoolean(value));
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -385,8 +385,8 @@ public class AggregationFunctionUtils {
       }
     }
 
-    if (!nonFilteredFunctions.isEmpty() || QueryOptionsUtils.isFilteredAggregationsComputeAllGroups(
-        queryContext.getQueryOptions())) {
+    if (!nonFilteredFunctions.isEmpty() || (QueryOptionsUtils.isFilteredAggregationsComputeAllGroups(
+        queryContext.getQueryOptions()).orElse(false))) {
       // If there are no non-filtered aggregation functions, but the query option to compute all groups is set, we
       // add a new AggregationInfo with an empty AggregationFunction array and the main query filter so that the
       // GroupByExecutor will compute all the groups (from the result of applying the main query filter) but no

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.operator.BaseProjectOperator;
@@ -384,7 +385,12 @@ public class AggregationFunctionUtils {
       }
     }
 
-    if (!nonFilteredFunctions.isEmpty()) {
+    if (!nonFilteredFunctions.isEmpty() || QueryOptionsUtils.isFilteredAggregationsComputeAllGroups(
+        queryContext.getQueryOptions())) {
+      // If there are no non-filtered aggregation functions, but the query option to compute all groups is set, we
+      // add a new AggregationInfo with an empty AggregationFunction array and the main query filter so that the
+      // GroupByExecutor will compute all the groups (from the result of applying the main query filter) but no
+      // unnecessary additional aggregation will be done since the AggregationFunction array is empty.
       AggregationFunction[] aggregationFunctions = nonFilteredFunctions.toArray(new AggregationFunction[0]);
       aggregationInfos.add(
           buildAggregationInfo(segmentContext, queryContext, aggregationFunctions, mainFilter, mainFilterOperator,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -394,9 +395,9 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
 
   @Test
   public void testGroupByMultipleColumns() {
-    String filterQuery =
-        "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 25000) testSum FROM MyTable GROUP BY BOOLEAN_COL, STRING_COL "
-            + "ORDER BY BOOLEAN_COL, STRING_COL";
+    String filterQuery = "SET " + CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS
+        + "=true; SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 25000) testSum FROM MyTable GROUP BY BOOLEAN_COL, "
+        + "STRING_COL ORDER BY BOOLEAN_COL, STRING_COL";
     String nonFilterQuery =
         "SELECT SUM(INT_COL) testSum FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL, STRING_COL "
             + "ORDER BY BOOLEAN_COL, STRING_COL";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1040,8 +1040,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     // Use a hint to ensure that the aggregation will not be pushed to the leaf stage, so that we can test the
     // MultistageGroupByExecutor
-    String sqlQuery = "SET " + CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS
-        + "=false; SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */"
+    String sqlQuery = "SET " + CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS
+        + "=true; SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */"
         + "AirlineID, COUNT(*) FILTER (WHERE Origin = 'garbage') FROM mytable WHERE AirlineID > 20000 GROUP BY "
         + "AirlineID";
 
@@ -1049,7 +1049,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertNoError(result);
 
     // Result set will be empty since the aggregation filter does not match any rows, and we've set the query option to
-    // not compute all groups
+    // skip empty groups
     assertEquals(result.get("numRowsResultSet").asInt(), 0);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -58,7 +58,7 @@ public class MultistageGroupByExecutor {
   private final AggType _aggType;
   private final DataSchema _resultSchema;
   private final int _numGroupsLimit;
-  private final boolean _filteredAggregationsComputeAllGroups;
+  private final boolean _filteredAggregationsSkipEmptyGroups;
 
   // Group By Result holders for each mode
   private final GroupByResultHolder[] _aggregateResultHolders;
@@ -82,8 +82,7 @@ public class MultistageGroupByExecutor {
 
     // By default, we compute all groups for SQL compliant results. However, we allow overriding this behavior via
     // query option for improved performance.
-    _filteredAggregationsComputeAllGroups =
-        QueryOptionsUtils.isFilteredAggregationsComputeAllGroups(opChainMetadata).orElse(true);
+    _filteredAggregationsSkipEmptyGroups = QueryOptionsUtils.isFilteredAggregationsSkipEmptyGroups(opChainMetadata);
 
     int numFunctions = aggFunctions.length;
     if (!aggType.isInputIntermediateFormat()) {
@@ -247,9 +246,10 @@ public class MultistageGroupByExecutor {
           aggFunction.aggregateGroupBySV(numMatchedRows, filteredIntKeys, groupByResultHolder, blockValSetMap);
         }
       }
-      if (intKeys == null && _filteredAggregationsComputeAllGroups) {
+      if (intKeys == null && !_filteredAggregationsSkipEmptyGroups) {
         // _groupIdGenerator should still have all the groups even if there are only filtered aggregates for SQL
-        // compliant results.
+        // compliant results. However, if the query option to skip empty groups is set, we avoid this step for
+        // improved performance.
         generateGroupByKeys(block);
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -241,6 +241,11 @@ public class MultistageGroupByExecutor {
           aggFunction.aggregateGroupBySV(numMatchedRows, filteredIntKeys, groupByResultHolder, blockValSetMap);
         }
       }
+      if (intKeys == null) {
+        // _groupIdGenerator should still have all the groups even if there are only filtered aggregates for SQL
+        // compliant results.
+        generateGroupByKeys(block);
+      }
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -227,10 +227,6 @@ public class ServerPlanRequestUtils {
     Map<String, String> queryOptions = new HashMap<>(executionContext.getOpChainMetadata());
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
-    // All groups should be computed by default for group by queries with only filtered aggregations in the
-    // multi-stage query engine since that is the standard SQL behavior.
-    queryOptions.putIfAbsent(CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS,
-        "true");
     pinotQuery.setQueryOptions(queryOptions);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -229,7 +229,8 @@ public class ServerPlanRequestUtils {
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
     // All groups should be computed by default for group by queries with only filtered aggregations in the
     // multi-stage query engine since that is the standard SQL behavior.
-    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS, "true");
+    queryOptions.putIfAbsent(CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS,
+        "true");
     pinotQuery.setQueryOptions(queryOptions);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -227,6 +227,9 @@ public class ServerPlanRequestUtils {
     Map<String, String> queryOptions = new HashMap<>(executionContext.getOpChainMetadata());
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
+    // All groups should be computed by default for group by queries with only filtered aggregations in the
+    // multi-stage query engine since that is the standard SQL behavior.
+    queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS, "true");
     pinotQuery.setQueryOptions(queryOptions);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -459,14 +459,14 @@ public class CommonConstants {
         // fashion with limited compute.
         public static final String IS_SECONDARY_WORKLOAD = "isSecondaryWorkload";
 
-        // For group by queries with only filtered aggregations (and no non-filtered aggregations), the v1 query engine
-        // does not compute all groups by default - instead, it will only compute the groups from the filtered result
-        // set (i.e., union of the main query filter and all the individual aggregation filters). This is good for
-        // performance, since indexes can be used, but the result won't match standard SQL behavior (where all groups
-        // are expected to be returned). If this option is set to true, the v1 query engine will compute all groups for
-        // group by queries with only filtered aggregations. This could require a full scan if the main query does not
-        // have a filter and performance could be much worse, but the result will be SQL compliant.
-        public static final String FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS = "filteredAggregationsComputeAllGroups";
+        // For group by queries with only filtered aggregations (and no non-filtered aggregations), the default behavior
+        // is to compute all groups over the rows matching the main query filter. This ensures SQL compliant results,
+        // since empty groups are also expected to be returned in such queries. However, this could be quite inefficient
+        // if the main query does not have a filter (since a scan would be required to compute all groups). In case
+        // users are okay with skipping empty groups - i.e., only the groups matching at least one aggregation filter
+        // will be returned - this query option can be set. This is useful for performance, since indexes can be used
+        // for the aggregation filters and a full scan can be avoided.
+        public static final String FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS = "filteredAggregationsSkipEmptyGroups";
       }
 
       public static class QueryOptionValue {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -458,6 +458,15 @@ public class CommonConstants {
         // executed in an  Unbounded FCFS fashion. However, secondary workloads are executed in a constrainted FCFS
         // fashion with limited compute.
         public static final String IS_SECONDARY_WORKLOAD = "isSecondaryWorkload";
+
+        // For group by queries with only filtered aggregations (and no non-filtered aggregations), the v1 query engine
+        // does not compute all groups by default - instead, it will only compute the groups from the filtered result
+        // set (i.e., union of the main query filter and all the individual aggregation filters). This is good for
+        // performance, since indexes can be used, but the result won't match standard SQL behavior (where all groups
+        // are expected to be returned). If this option is set to true, the v1 query engine will compute all groups for
+        // group by queries with only filtered aggregations. This could require a full scan if the main query does not
+        // have a filter and performance could be much worse, but the result will be SQL compliant.
+        public static final String FILTERED_AGGREGATIONS_COMPUTE_ALL_GROUPS = "filteredAggregationsComputeAllGroups";
       }
 
       public static class QueryOptionValue {


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/12647 and https://github.com/apache/pinot/issues/13982.
- Both the above issues have a good description of the problem but the TLDR is that for group by queries with only filtered aggregations, we currently only compute the groups based on the rows that match the query's main filter and the rows that match at least one of the aggregation filters.
- This is good for performance, since in cases where the group by query doesn't have a main filter and there are only filtered aggregations (i.e., no non-filtered aggregations), indexes can be used and a full scan is avoided. However, this leads to results that are not SQL compliant, since all groups (computed over the results of the main query filter) are expected to be returned even for queries with only filtered aggregations.
- For the single-stage query engine, this actually appears to be a regression from https://github.com/apache/pinot/pull/10356, prior to which all groups should have been returned by default.
- For the multi-stage query engine's group by executor, this appears to always have been an issue.
- ~This patch takes a different approach for both the query engines - in the single-stage engine, the default behavior remains the same, but the standard SQL behavior of returning all groups can be enabled using a new query option. In the multi-stage engine, however, all groups will be computed by default. The reasoning is that Pinot has historically chosen performance over standard SQL behavior for the v1 engine in such cases where the behavioral difference might not be too significant. For the multi-stage query engine, however, we have been moving towards standard SQL behavior regardless of potential performance impact.~
- This patch fixes both the query engines to follow standard SQL behavior. However, a query option is also provided to override this behavior for performance reasons - i.e., if users are okay with skipping computation of empty groups (groups not matching any aggregation filter), then this query option can be set. This can provide a large performance boost if the main query filter has high selectivity.
- For the v1 engine's executor, the fix is to simply put an additional `AggregationInfo` with an empty `AggregationFunction` array and the main query filter. This ensures that the `GroupByExecutor` will compute all the groups (from the result of applying the main query filter) but no additional unnecessary aggregation will be done.
- For the v2 engine's executor, the fix is similar. Before this patch, all the group keys are only computed if there is at least one non-filtered aggregation. For group by queries with only filtered aggregations, groups were computed over the rows matching the aggregation filters. Now, all the groups will be computed even for group by queries with only filtered aggregations.