### PR TITLE
[timeseries] Minor Time Series Engine Improvements

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -105,6 +105,9 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
         case LONG:
           tagValues[i] = ArrayUtils.toObject(blockValSet.getLongValuesSV());
           break;
+        case INT:
+          tagValues[i] = ArrayUtils.toObject(blockValSet.getIntValuesSV());
+          break;
         default:
           throw new NotImplementedException("Can't handle types other than string and long");
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -253,7 +253,8 @@ public class QueryRunner {
     final Consumer<Throwable> handleErrors = (t) -> {
       Map<String, String> errorMetadata = new HashMap<>();
       errorMetadata.put(WorkerResponseMetadataKeys.ERROR_TYPE, t.getClass().getSimpleName());
-      errorMetadata.put(WorkerResponseMetadataKeys.ERROR_MESSAGE, t.getMessage());
+      errorMetadata.put(WorkerResponseMetadataKeys.ERROR_MESSAGE, t.getMessage() == null
+          ? "Unknown error: no message" : t.getMessage());
       responseObserver.onNext(Worker.TimeSeriesResponse.newBuilder().putAllMetadata(errorMetadata).build());
       responseObserver.onCompleted();
     };
@@ -280,6 +281,7 @@ public class QueryRunner {
         }
       });
     } catch (Throwable t) {
+      LOGGER.error("Error running time-series query", t);
       handleErrors.accept(t);
     }
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
@@ -54,7 +54,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
       assertEquals(queryContext.getTimeSeriesContext().getTimeColumn(), timeColumn);
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().getIdentifier(), "orderCount");
       assertEquals(queryContext.getFilter().toString(),
-          "(cityName = 'Chicago' AND orderTime >= '1000' AND orderTime <= '2000')");
+          "(cityName = 'Chicago' AND orderTime >= '1000' AND orderTime < '2000')");
     }
     // Case-2: With offset, complex group-by expression, complex value, and non-empty filter
     {
@@ -75,7 +75,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().toString(), "times(orderCount,'2')");
       assertNotNull(queryContext.getFilter());
       assertEquals(queryContext.getFilter().toString(),
-          "(cityName = 'Chicago' AND orderTime >= '990' AND orderTime <= '1990')");
+          "(cityName = 'Chicago' AND orderTime >= '990' AND orderTime < '1990')");
     }
   }
 }

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
@@ -119,7 +119,7 @@ public class LeafTimeSeriesPlanNode extends BaseTimeSeriesPlanNode {
     long endTime =
         _timeUnit.convert(Duration.ofSeconds(
             timeBuckets.getEndTime() + timeBuckets.getBucketSize().toSeconds() - _offsetSeconds));
-    String addnFilter = String.format("%s >= %d AND %s <= %d", _timeColumn, startTime, _timeColumn, endTime);
+    String addnFilter = String.format("%s >= %d AND %s < %d", _timeColumn, startTime, _timeColumn, endTime);
     if (filter.strip().isEmpty()) {
       return addnFilter;
     }

--- a/pinot-timeseries/pinot-timeseries-spi/src/test/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNodeTest.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/test/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNodeTest.java
@@ -46,7 +46,7 @@ public class LeafTimeSeriesPlanNodeTest {
           new LeafTimeSeriesPlanNode(ID, Collections.emptyList(), TABLE, TIME_COLUMN, TIME_UNIT, 0L, "", "value_col",
               new AggInfo("SUM", null), Collections.singletonList("cityName"));
       assertEquals(planNode.getEffectiveFilter(timeBuckets),
-          "orderTime >= " + expectedStartTimeInFilter + " AND orderTime <= " + expectedEndTimeInFilter);
+          "orderTime >= " + expectedStartTimeInFilter + " AND orderTime < " + expectedEndTimeInFilter);
     }
     // Case-2: Offset, but empty filter
     {
@@ -54,7 +54,7 @@ public class LeafTimeSeriesPlanNodeTest {
           new LeafTimeSeriesPlanNode(ID, Collections.emptyList(), TABLE, TIME_COLUMN, TIME_UNIT, 123L, "", "value_col",
               new AggInfo("SUM", null), Collections.singletonList("cityName"));
       assertEquals(planNode.getEffectiveFilter(timeBuckets),
-          "orderTime >= " + (expectedStartTimeInFilter - 123) + " AND orderTime <= " + (expectedEndTimeInFilter - 123));
+          "orderTime >= " + (expectedStartTimeInFilter - 123) + " AND orderTime < " + (expectedEndTimeInFilter - 123));
     }
     // Case-3: Offset and non-empty filter
     {
@@ -62,7 +62,7 @@ public class LeafTimeSeriesPlanNodeTest {
           new LeafTimeSeriesPlanNode(ID, Collections.emptyList(), TABLE, TIME_COLUMN, TIME_UNIT, 123L, nonEmptyFilter,
               "value_col", new AggInfo("SUM", null), Collections.singletonList("cityName"));
       assertEquals(planNode.getEffectiveFilter(timeBuckets),
-          String.format("(%s) AND (orderTime >= %s AND orderTime <= %s)", nonEmptyFilter,
+          String.format("(%s) AND (orderTime >= %s AND orderTime < %s)", nonEmptyFilter,
               (expectedStartTimeInFilter - 123), (expectedEndTimeInFilter - 123)));
     }
     // Case-4: Offset, and non-empty filter, and time-unit that is not seconds
@@ -71,7 +71,7 @@ public class LeafTimeSeriesPlanNodeTest {
           new LeafTimeSeriesPlanNode(ID, Collections.emptyList(), TABLE, TIME_COLUMN, TimeUnit.MILLISECONDS, 123L,
               nonEmptyFilter, "value_col", new AggInfo("SUM", null), Collections.singletonList("cityName"));
       assertEquals(planNode.getEffectiveFilter(timeBuckets),
-          String.format("(%s) AND (orderTime >= %s AND orderTime <= %s)", nonEmptyFilter,
+          String.format("(%s) AND (orderTime >= %s AND orderTime < %s)", nonEmptyFilter,
               (expectedStartTimeInFilter * 1000 - 123 * 1000), (expectedEndTimeInFilter * 1000 - 123 * 1000)));
     }
   }


### PR DESCRIPTION
Minor miscellaneous time-series engine improvements for bugs detected in our testing:

- Excludes right edge from the time-filter. This is because if the last time bucket has the value, say 1300, and if the window is 60 seconds, then including 1360 in the result will lead to index out of bounds.
- Handles null messages in exceptions
- Adds support for int columns
- Logs error in QueryRunner. This may need to be revisited in the future.