### PR TITLE
Added validation for minionInstanceTag while updating / creating table-config

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -70,7 +70,8 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
   public void testInstanceListingAndCreation()
       throws Exception {
     String listInstancesUrl = _urlBuilder.forInstanceList();
-    int expectedNumInstances = 1 + DEFAULT_NUM_BROKER_INSTANCES + DEFAULT_NUM_SERVER_INSTANCES + DEFAULT_NUM_MINION_INSTANCES;
+    int expectedNumInstances =
+        1 + DEFAULT_NUM_BROKER_INSTANCES + DEFAULT_NUM_SERVER_INSTANCES + DEFAULT_NUM_MINION_INSTANCES;
     checkNumInstances(listInstancesUrl, expectedNumInstances);
 
     // Create untagged broker and server instances

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -70,7 +70,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
   public void testInstanceListingAndCreation()
       throws Exception {
     String listInstancesUrl = _urlBuilder.forInstanceList();
-    int expectedNumInstances = 1 + DEFAULT_NUM_BROKER_INSTANCES + DEFAULT_NUM_SERVER_INSTANCES;
+    int expectedNumInstances = 1 + DEFAULT_NUM_BROKER_INSTANCES + DEFAULT_NUM_SERVER_INSTANCES + DEFAULT_NUM_MINION_INSTANCES;
     checkNumInstances(listInstancesUrl, expectedNumInstances);
 
     // Create untagged broker and server instances

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -101,6 +101,7 @@ public class ControllerTest {
   public static final int DEFAULT_NUM_BROKER_INSTANCES = 3;
   // NOTE: To add HLC realtime table, number of Server instances must be multiple of replicas
   public static final int DEFAULT_NUM_SERVER_INSTANCES = 4;
+  public static final int DEFAULT_NUM_MINION_INSTANCES = 2;
 
   public static final long TIMEOUT_MS = 10_000L;
 
@@ -994,6 +995,7 @@ public class ControllerTest {
 
     addMoreFakeBrokerInstancesToAutoJoinHelixCluster(DEFAULT_NUM_BROKER_INSTANCES, true);
     addMoreFakeServerInstancesToAutoJoinHelixCluster(DEFAULT_NUM_SERVER_INSTANCES, true);
+    addFakeMinionInstancesToAutoJoinHelixCluster(DEFAULT_NUM_MINION_INSTANCES);
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core;
 
 import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,10 +59,12 @@ import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.resources.InstanceInfo;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TagOverrideConfig;
 import org.apache.pinot.spi.config.table.TenantConfig;
@@ -663,6 +666,58 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
   }
 
   @Test
+  public void testValidateTableTaskMinionInstanceTagConfig() {
+    TableConfig realtimeTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).build();
+
+    Map<String, String> segmentGenerationAndPushTaskConfig =
+        Map.of("invalidRecordsThresholdCount", "1", "schedule", "0 */30 * ? * *", "tableMaxNumTasks", "1",
+            "validDocIdsType", "SNAPSHOT");
+
+    Map<String, String> upsertCompactionTask =
+        Map.of("invalidRecordsThresholdCount", "1", "schedule", "0 */30 * ? * *", "tableMaxNumTasks", "1",
+            "validDocIdsType", "SNAPSHOT", "minionInstanceTag", "minionTenant");
+
+    Map<String, String> segmentGenerationAndPushTaskConfig2 =
+        Map.of("schedule", "0 */30 * ? * *", "tableMaxNumTasks", "1", "validDocIdsType", "SNAPSHOT",
+            "minionInstanceTag", "anotherMinionTenant");
+
+    // Minion instance tag set but no minion present
+    realtimeTableConfig.setTaskConfig(new TableTaskConfig(
+        ImmutableMap.of(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, upsertCompactionTask)));
+    assertThrows(InvalidTableConfigException.class,
+        () -> _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig));
+
+    // Valid minion instance tag with instances
+    addMinionInstance();
+    _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig);
+
+    //Untag minion instance
+    untagMinions();
+    realtimeTableConfig.setTaskConfig(new TableTaskConfig(
+        ImmutableMap.of(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, segmentGenerationAndPushTaskConfig)));
+    _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig);
+
+    realtimeTableConfig.setTaskConfig(new TableTaskConfig(
+        ImmutableMap.of(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, segmentGenerationAndPushTaskConfig2)));
+    assertThrows(InvalidTableConfigException.class,
+        () -> _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig));
+  }
+
+  private void untagMinions() {
+    for (InstanceConfig minionInstance : _helixResourceManager.getAllMinionInstanceConfigs()) {
+      _helixResourceManager.updateInstanceTags(minionInstance.getId(), Helix.UNTAGGED_MINION_INSTANCE, false);
+    }
+  }
+
+  private void addMinionInstance() {
+    untagMinions();
+    Instance minionTenant =
+        new Instance("2.3.4.5", 2345, InstanceType.MINION, Collections.singletonList("minionTenant"), null, 0, 0, 0, 0,
+            false);
+    _helixResourceManager.addInstance(minionTenant, false);
+  }
+
+  @Test
   public void testCreateColocatedTenant() {
     untagServers();
     Tenant serverTenant = new Tenant(TenantRole.SERVER, SERVER_TENANT_NAME, NUM_SERVER_INSTANCES, NUM_SERVER_INSTANCES,
@@ -708,8 +763,9 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
       throws Exception {
     // Create an instance with no tags
     String serverName = "Server_localhost_" + NUM_SERVER_INSTANCES;
-    Instance instance = new Instance("localhost", NUM_SERVER_INSTANCES, InstanceType.SERVER,
-        Collections.emptyList(), null, 0, 12345, 0, 0, false);
+    Instance instance =
+        new Instance("localhost", NUM_SERVER_INSTANCES, InstanceType.SERVER, Collections.emptyList(), null, 0, 12345, 0,
+            0, false);
     _helixResourceManager.addInstance(instance, false);
     addFakeServerInstanceToAutoJoinHelixClusterWithEmptyTag(serverName, false);
 
@@ -724,7 +780,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Takes care of the negative case
     assertFalse(untaggedServers.contains(SERVER_NAME_TAGGED), "Server with tags should not be considered untagged");
-
 
     stopAndDropFakeInstance(serverName);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -684,8 +684,16 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Minion instance tag set but no minion present
     realtimeTableConfig.setTaskConfig(new TableTaskConfig(
         ImmutableMap.of(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, upsertCompactionTask)));
-    assertThrows(InvalidTableConfigException.class,
-        () -> _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig));
+
+    assertThrows(InvalidTableConfigException.class, () -> {
+      try {
+        _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig);
+      } catch (InvalidTableConfigException e) {
+        assertEquals(e.getMessage(),
+            "Failed to find minion instances with tag: minionTenant for table: testTable_REALTIME");
+        throw e;
+      }
+    });
 
     // Valid minion instance tag with instances
     addMinionInstance();
@@ -699,8 +707,15 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     realtimeTableConfig.setTaskConfig(new TableTaskConfig(
         ImmutableMap.of(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, segmentGenerationAndPushTaskConfig2)));
-    assertThrows(InvalidTableConfigException.class,
-        () -> _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig));
+    assertThrows(InvalidTableConfigException.class, () -> {
+      try {
+        _helixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig);
+      } catch (InvalidTableConfigException e) {
+        assertEquals(e.getMessage(),
+            "Failed to find minion instances with tag: anotherMinionTenant for table: testTable_REALTIME");
+        throw e;
+      }
+    });
   }
 
   private void untagMinions() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -117,6 +117,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
     startController(properties);
     addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
     addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeMinionInstancesToAutoJoinHelixCluster(1);
     Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
         .addSingleValueDimension("myMap", FieldSpec.DataType.STRING)
         .addSingleValueDimension("myMapStr", FieldSpec.DataType.STRING)
@@ -183,6 +184,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
     startController(properties);
     addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
     addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeMinionInstancesToAutoJoinHelixCluster(1);
     Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
         .addSingleValueDimension("myMap", FieldSpec.DataType.STRING)
         .addSingleValueDimension("myMapStr", FieldSpec.DataType.STRING)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -107,6 +107,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     startController();
     startBroker();
     startServer();
+    startMinion();
     // Start Kafka
     startKafka();
 
@@ -183,7 +184,6 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Initialize the query generator
     setUpQueryGenerator(avroFiles);
 
-    startMinion();
     _helixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
     _taskManager = _controllerStarter.getTaskManager();
     _pinotHelixResourceManager = _controllerStarter.getHelixResourceManager();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -80,6 +80,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     startController();
     startBroker();
     startServer();
+    startMinion();
 
     List<String> allTables = List.of(PURGE_FIRST_RUN_TABLE, PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE,
         PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
@@ -110,7 +111,6 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
       uploadSegments(tableName, _segmentTarDir);
     }
 
-    startMinion();
     setRecordPurger();
     _helixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
     _taskManager = _controllerStarter.getTaskManager();


### PR DESCRIPTION
When creating a new Task with in TableTaskConfig, validate that a minion tenant with the same tag exists.
If a minion with same minionInstaceTag doesn't exist, we will fail the table creation.

closes #13941 

