### PR TITLE
Revert #14206 as the automatic library version bump breaks integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <h3.version>4.1.1</h3.version>
     <jmh.version>1.37</jmh.version>
     <audienceannotations.version>0.15.0</audienceannotations.version>
-    <clp-ffi.version>0.4.6</clp-ffi.version>
+    <clp-ffi.version>0.4.5</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
     <aws.sdk.version>2.28.12</aws.sdk.version>
     <azure.sdk.version>1.2.28</azure.sdk.version>


### PR DESCRIPTION
The automatic bumping of library version caused integration test to break for unknown reason under jdk21. Will investigate and fix the bug and release a new version before bumping the version in Pinot again.