### PR TITLE
Upgraded clp-ffi.version from 0.4.5 to 0.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <h3.version>4.1.1</h3.version>
     <jmh.version>1.37</jmh.version>
     <audienceannotations.version>0.15.0</audienceannotations.version>
-    <clp-ffi.version>0.4.5</clp-ffi.version>
+    <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
     <aws.sdk.version>2.28.12</aws.sdk.version>
     <azure.sdk.version>1.2.28</azure.sdk.version>


### PR DESCRIPTION
Previously, the `clp-ffi` library version was automatically updated from `0.4.5` to `0.4.6` via a Dependabot-generated PR. However, this introduced a data race issue due to improper initialization of a thread-local variable. In PR #14230, the version bump was reverted to address the problem. The bug in 0.4.6 has since been [resolved](https://github.com/y-scope/clp-ffi-java/pull/56) in the latest release (0.4.7). This PR upgrades the `clp-ffi` to the latest version to be used by dependent PR such as #14241.