### PR TITLE
Modify segment metadata call

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -119,7 +119,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
  *       <li>"/segments/{tableName}/servers": get a map from server to segments hosted by the server</li>
  *       <li>"/segments/{tableName}/crc": get a map from segment to CRC of the segment (OFFLINE table only)</li>
  *       <li>"/segments/{tableName}/{segmentName}/metadata: get the metadata for a segment</li>
- *       <li>"/segments/{tableName}/metadata: get the metadata for all segments from the server</li>
+ *       <li>"/v2/segments/{tableName}/metadata: get the metadata for all/included segments from the server</li>
  *       <li>"/segments/{tableName}/zkmetadata: get the zk metadata for all segments of a table</li>
  *       <li>"/segments/{tableName}/{segmentName}/tiers": get storage tier for the segment in the table</li>
  *       <li>"/segments/{tableName}/tiers": get storage tier for all segments in the table</li>
@@ -178,6 +178,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
  *       <li>"POST /tables/{tableName}/segments/{segmentName}/reload"</li>
  *       <li>"GET /tables/{tableName}/segments/reload"</li>
  *       <li>"POST /tables/{tableName}/segments/reload"</li>
+ *       <li>"/segments/{tableName}/metadata</li>
  *     </ul>
  *   </li>
  * </ul>
@@ -917,6 +918,7 @@ public class PinotSegmentRestletResource {
     }
   }
 
+  @Deprecated
   @GET
   @Path("segments/{tableName}/metadata")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
@@ -927,8 +929,38 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
+      List<String> columns, @Context HttpHeaders headers) {
+    tableName = DatabaseUtils.translateTableName(tableName, headers);
+    LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
+    TableType tableType = Constants.validateTableType(tableTypeStr);
+
+    String tableNameWithType =
+        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
+    String segmentsMetadata;
+    try {
+      JsonNode segmentsMetadataJson = getSegmentsMetadataFromServer(tableNameWithType, columns);
+      segmentsMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
+    } catch (InvalidConfigException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Status.BAD_REQUEST);
+    } catch (IOException ioe) {
+      throw new ControllerApplicationException(LOGGER, "Error parsing Pinot server response: " + ioe.getMessage(),
+          Status.INTERNAL_SERVER_ERROR, ioe);
+    }
+    return segmentsMetadata;
+  }
+
+  @GET
+  @Path("v2/segments/{tableName}/metadata")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get the server metadata for all table segments",
+      notes = "Get the server metadata for all table segments")
+  public String getServerMetadata(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
+      @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
       List<String> columns, @ApiParam(value = "Segments name", allowMultiple = true) @QueryParam("segmentsToInclude")
-      @DefaultValue("") Set<String> segmentsToInclude, @Context HttpHeaders headers) {
+  Set<String> segmentsToInclude, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
@@ -1157,6 +1189,22 @@ public class PinotSegmentRestletResource {
    * This is a helper method to get the metadata for all segments for a given table name.
    * @param tableNameWithType name of the table along with its type
    * @param columns name of the columns
+   * @return Map<String, String>  metadata of the table segments -> map of segment name to its metadata
+   */
+  private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, List<String> columns)
+      throws InvalidConfigException, IOException {
+    TableMetadataReader tableMetadataReader =
+        new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
+    return tableMetadataReader
+        .getSegmentsMetadata(tableNameWithType, columns,
+            _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+  }
+
+  /**
+   * This is a helper method to get the metadata for all segments for a given table name.
+   * @param tableNameWithType name of the table along with its type
+   * @param columns name of the columns
+   * @param segmentsToInclude name of the segments to include in metadata
    * @return Map<String, String>  metadata of the table segments -> map of segment name to its metadata
    */
   private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, List<String> columns,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -919,6 +919,7 @@ public class PinotSegmentRestletResource {
 
   @GET
   @Path("segments/{tableName}/metadata")
+  @Encoded
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get the server metadata for all table segments",
@@ -926,10 +927,10 @@ public class PinotSegmentRestletResource {
   public String getServerMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
-      @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
-      Set<String> segments,
-      @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
-      List<String> columns, @Context HttpHeaders headers) {
+      @ApiParam(value = "Segments name", allowMultiple = true) @QueryParam("segments")
+      @Nullable Set<String> segments,
+      @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
+      @Nullable List<String> columns, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
@@ -1158,16 +1159,16 @@ public class PinotSegmentRestletResource {
    * This is a helper method to get the metadata for all segments for a given table name.
    * @param tableNameWithType name of the table along with its type
    * @param columns name of the columns
-   * @param segmentsToInclude name of the segments to include in metadata
+   * @param segments name of the segments to include in metadata
    * @return Map<String, String>  metadata of the table segments -> map of segment name to its metadata
    */
   private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, List<String> columns,
-      Set<String> segmentsToInclude)
+      Set<String> segments)
       throws InvalidConfigException, IOException {
     TableMetadataReader tableMetadataReader =
         new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
     return tableMetadataReader
-        .getSegmentsMetadata(tableNameWithType, columns, segmentsToInclude,
+        .getSegmentsMetadata(tableNameWithType, columns, segments,
             _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -919,7 +919,6 @@ public class PinotSegmentRestletResource {
 
   @GET
   @Path("segments/{tableName}/metadata")
-  @Encoded
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get the server metadata for all table segments",
@@ -927,9 +926,9 @@ public class PinotSegmentRestletResource {
   public String getServerMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
-      @ApiParam(value = "Segments name", allowMultiple = true) @QueryParam("segments")
+      @Encoded @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
       @Nullable Set<String> segments,
-      @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
+      @Encoded @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
       @Nullable List<String> columns, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
@@ -1162,8 +1161,8 @@ public class PinotSegmentRestletResource {
    * @param segments name of the segments to include in metadata
    * @return Map<String, String>  metadata of the table segments -> map of segment name to its metadata
    */
-  private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, List<String> columns,
-      Set<String> segments)
+  private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, @Nullable List<String> columns,
+      @Nullable Set<String> segments)
       throws InvalidConfigException, IOException {
     TableMetadataReader tableMetadataReader =
         new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -927,7 +927,7 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @Encoded @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
-      @Nullable Set<String> segments,
+      @Nullable List<String> segments,
       @Encoded @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
       @Nullable List<String> columns, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
@@ -1162,7 +1162,7 @@ public class PinotSegmentRestletResource {
    * @return Map<String, String>  metadata of the table segments -> map of segment name to its metadata
    */
   private JsonNode getSegmentsMetadataFromServer(String tableNameWithType, @Nullable List<String> columns,
-      @Nullable Set<String> segments)
+      @Nullable List<String> segments)
       throws InvalidConfigException, IOException {
     TableMetadataReader tableMetadataReader =
         new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -926,12 +926,13 @@ public class PinotSegmentRestletResource {
   public String getServerMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
-      @Encoded @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
-      @Nullable List<String> segments,
+      @Encoded @ApiParam(value = "Segments to include (all if not specified)", allowMultiple = true)
+      @QueryParam("segments") @Nullable List<String> segments,
       @Encoded @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns")
       @Nullable List<String> columns, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
-    LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
+    String segmentCount = (segments == null) ? "all" : String.valueOf(segments.size());
+    LOGGER.info("Received a request to fetch metadata for {} segments for table {}", segmentCount, tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
 
     String tableNameWithType =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -520,7 +520,7 @@ public class ServerSegmentMetadataReader {
     }
     List<String> params = new ArrayList<>(values.size());
     for (String value : values) {
-      params.add(String.format("segmentsToInclude=%s", value));
+      params.add(String.format("segments=%s", value));
     }
     paramsStr = String.join("&", params);
     return paramsStr;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -447,7 +447,7 @@ public class ServerSegmentMetadataReader {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     String paramsStr = generateColumnsParam(columns)
             + generateSegmentsParam(segmentsToInclude);
-    return String.format("%s/tables/%s/metadata?%s", endpoint, tableNameWithType, paramsStr);
+    return String.format("%s/tables/%s/segments/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 
   private String generateCheckReloadSegmentsServerURL(String tableNameWithType, String endpoint) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -442,6 +442,14 @@ public class ServerSegmentMetadataReader {
     return String.format("%s/tables/%s/segments/%s/metadata?%s", endpoint, tableNameWithType, segmentName, paramsStr);
   }
 
+  public String generateTableMetadataServerURL(String tableNameWithType, List<String> columns,
+                                               Set<String> segmentsToInclude, String endpoint) {
+    tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
+    String paramsStr = generateColumnsParam(columns)
+            + generateSegmentsParam(new ArrayList<>(segmentsToInclude));
+    return String.format("%s/tables/%s/metadata?%s", endpoint, tableNameWithType, paramsStr);
+  }
+
   private String generateCheckReloadSegmentsServerURL(String tableNameWithType, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     return String.format("%s/tables/%s/segments/needReload", endpoint, tableNameWithType);
@@ -504,6 +512,19 @@ public class ServerSegmentMetadataReader {
   private String generateStaleSegmentsServerURL(String tableNameWithType, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     return String.format("%s/tables/%s/segments/isStale", endpoint, tableNameWithType);
+  }
+
+  private String generateSegmentsParam(List<String> values) {
+    String paramsStr = "";
+    if (values == null || values.isEmpty()) {
+      return paramsStr;
+    }
+    List<String> params = new ArrayList<>(values.size());
+    for (String value : values) {
+      params.add(String.format("segmentsToInclude=%s", value));
+    }
+    paramsStr = String.join("&", params);
+    return paramsStr;
   }
 
   public class TableReloadResponse {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -446,7 +446,7 @@ public class ServerSegmentMetadataReader {
                                                Set<String> segmentsToInclude, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     String paramsStr = generateColumnsParam(columns)
-            + generateSegmentsParam(new ArrayList<>(segmentsToInclude));
+            + generateSegmentsParam(segmentsToInclude);
     return String.format("%s/tables/%s/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 
@@ -514,7 +514,7 @@ public class ServerSegmentMetadataReader {
     return String.format("%s/tables/%s/segments/isStale", endpoint, tableNameWithType);
   }
 
-  private String generateSegmentsParam(List<String> values) {
+  private String generateSegmentsParam(Set<String> values) {
     String paramsStr = "";
     if (values == null || values.isEmpty()) {
       return paramsStr;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -434,7 +434,7 @@ public class ServerSegmentMetadataReader {
     return String.format("%s/tables/%s/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 
-  private String generateSegmentMetadataServerURL(String tableNameWithType, String segmentName, List<String> columns,
+  public String generateSegmentMetadataServerURL(String tableNameWithType, String segmentName, List<String> columns,
       String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     segmentName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8);
@@ -443,10 +443,9 @@ public class ServerSegmentMetadataReader {
   }
 
   public String generateTableMetadataServerURL(String tableNameWithType, List<String> columns,
-                                               Set<String> segmentsToInclude, String endpoint) {
+      Set<String> segmentsToInclude, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
-    String paramsStr = generateColumnsParam(columns)
-            + generateSegmentsParam(segmentsToInclude);
+    String paramsStr = generateColumnsParam(columns) + generateSegmentsParam(segmentsToInclude);
     return String.format("%s/tables/%s/segments/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
@@ -65,6 +66,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ServerSegmentMetadataReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerSegmentMetadataReader.class);
+  private static final String COLUMNS_KEY = "columns";
+  private static final String SEGMENTS_KEY = "segments";
 
   private final Executor _executor;
   private final HttpClientConnectionManager _connectionManager;
@@ -430,22 +433,22 @@ public class ServerSegmentMetadataReader {
   private String generateAggregateSegmentMetadataServerURL(String tableNameWithType, List<String> columns,
       String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
-    String paramsStr = generateColumnsParam(columns);
+    String paramsStr = generateParam(COLUMNS_KEY, columns);
     return String.format("%s/tables/%s/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 
-  public String generateSegmentMetadataServerURL(String tableNameWithType, String segmentName, List<String> columns,
-      String endpoint) {
+  public String generateSegmentMetadataServerURL(String tableNameWithType, String segmentName,
+      @Nullable List<String> columns, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     segmentName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8);
-    String paramsStr = generateColumnsParam(columns);
+    String paramsStr = generateParam(COLUMNS_KEY, columns);
     return String.format("%s/tables/%s/segments/%s/metadata?%s", endpoint, tableNameWithType, segmentName, paramsStr);
   }
 
-  public String generateTableMetadataServerURL(String tableNameWithType, List<String> columns,
-      Set<String> segmentsToInclude, String endpoint) {
+  public String generateTableMetadataServerURL(String tableNameWithType, @Nullable List<String> columns,
+      @Nullable List<String> segmentsToInclude, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
-    String paramsStr = generateColumnsParam(columns) + generateSegmentsParam(segmentsToInclude);
+    String paramsStr = generateParam(COLUMNS_KEY, columns) + "&" + generateParam(SEGMENTS_KEY, segmentsToInclude);
     return String.format("%s/tables/%s/segments/metadata?%s", endpoint, tableNameWithType, paramsStr);
   }
 
@@ -495,32 +498,19 @@ public class ServerSegmentMetadataReader {
     return Pair.of(url, jsonTableSegments);
   }
 
-  private String generateColumnsParam(List<String> columns) {
-    String paramsStr = "";
-    if (columns == null || columns.isEmpty()) {
-      return paramsStr;
-    }
-    List<String> params = new ArrayList<>(columns.size());
-    for (String column : columns) {
-      params.add(String.format("columns=%s", column));
-    }
-    paramsStr = String.join("&", params);
-    return paramsStr;
-  }
-
   private String generateStaleSegmentsServerURL(String tableNameWithType, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     return String.format("%s/tables/%s/segments/isStale", endpoint, tableNameWithType);
   }
 
-  private String generateSegmentsParam(Set<String> values) {
+  private String generateParam(String key, List<String> values) {
     String paramsStr = "";
-    if (values == null || values.isEmpty()) {
+    if (CollectionUtils.isEmpty(values)) {
       return paramsStr;
     }
     List<String> params = new ArrayList<>(values.size());
     for (String value : values) {
-      params.add(String.format("segments=%s", value));
+      params.add(key + "=" + value);
     }
     paramsStr = String.join("&", params);
     return paramsStr;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -132,10 +132,10 @@ public class TableMetadataReader {
    * This api takes in list of segments for which we need the metadata.
    * This calls the server to get the metadata for all segments instead of making a call per segment.
    */
-  public JsonNode getSegmentsMetadata(String tableNameWithType, List<String> columns, Set<String> segmentsToInclude,
+  public JsonNode getSegmentsMetadata(String tableNameWithType, List<String> columns, Set<String> segments,
       int timeoutMs)
       throws InvalidConfigException, IOException {
-    return getSegmentsMetadataInternal(tableNameWithType, columns, segmentsToInclude, timeoutMs);
+    return getSegmentsMetadataInternal(tableNameWithType, columns, segments, timeoutMs);
   }
 
   /**
@@ -204,7 +204,7 @@ public class TableMetadataReader {
   }
 
   private JsonNode getSegmentsMetadataInternal(String tableNameWithType, List<String> columns,
-      Set<String> segmentsToInclude, int timeoutMs)
+      Set<String> segments, int timeoutMs)
       throws InvalidConfigException, IOException {
     Map<String, List<String>> serverToSegs =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -216,7 +216,7 @@ public class TableMetadataReader {
     // try table level endpoint first
     try {
       List<String> tableUrls = buildTableLevelUrls(serverToSegs, endpoints,
-          tableNameWithType, columns, segmentsToInclude, reader);
+          tableNameWithType, columns, segments, reader);
       return fetchAndAggregateMetadata(tableUrls, endpoints, /*perSegmentJson=*/false,
           tableNameWithType, timeoutMs);
     } catch (InvalidConfigException ignore) {
@@ -225,7 +225,7 @@ public class TableMetadataReader {
 
     // legacy per segment endpoint
     List<String> segmentUrls = buildSegmentLevelUrls(serverToSegs, endpoints,
-        tableNameWithType, columns, segmentsToInclude, reader);
+        tableNameWithType, columns, segments, reader);
     return fetchAndAggregateMetadata(segmentUrls, endpoints.inverse(), /*perSegmentJson=*/true,
         tableNameWithType, timeoutMs);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -163,9 +163,7 @@ public class TableMetadataReader {
       Iterator<Map.Entry<String, JsonNode>> fields = responseJson.fields();
       while (fields.hasNext()) {
         Map.Entry<String, JsonNode> field = fields.next();
-        String segmentName = field.getKey();
-        JsonNode segmentJson = field.getValue();
-        response.put(segmentName, segmentJson);
+        response.put(field.getKey(), field.getValue());
       }
     }
     return JsonUtils.objectToJsonNode(response);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -153,7 +153,8 @@ public class TableMetadataReader {
         cs.doMultiGetRequest(urls, tableNameWithType, perSegmentJson, timeoutMs);
     // all requests will fail if new server endpoint is not available
     if (resp._failedResponseCount > 0) {
-      throw new RuntimeException("All requests to server instances failed.");
+      throw new RuntimeException(String.format("Got %d failed responses from total %d server instances. "
+          + "Falling back to legacy segment metadata api", resp._failedResponseCount, urls.size()));
     }
 
     ObjectMapper mapper = new ObjectMapper();

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -873,6 +873,14 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         .get("columnIndexSizeMap").get(column);
   }
 
+  /**
+   * Get all segment names for a given tableName and tableType.
+   */
+  protected List<String> getSegmentNames(String tableName, @Nullable String tableType)
+      throws Exception {
+    return getControllerRequestClient().listSegments(tableName, tableType, true);
+  }
+
   protected List<ValidDocIdsMetadataInfo> getValidDocIdsMetadata(String tableNameWithType,
       ValidDocIdsType validDocIdsType)
       throws Exception {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -200,8 +200,8 @@ public class TablesResource {
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
       List<String> columns,
-      @ApiParam(value = "List of segments to fetch metadata for") @QueryParam("segmentsToInclude") @DefaultValue("")
-      List<String> segmentsToInclude, @Context HttpHeaders headers)
+      @ApiParam(value = "List of segments to fetch metadata for", allowMultiple = true) @QueryParam("segmentsToInclude")
+      @DefaultValue("") List<String> segmentsToInclude, @Context HttpHeaders headers)
       throws WebApplicationException {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
@@ -220,6 +220,14 @@ public class TablesResource {
       decodedColumns.add(URIUtils.decode(column));
     }
 
+    List<String> decodedSegments = new ArrayList<>();
+    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
+      for (String segment : segmentsToInclude) {
+        if (!segment.isEmpty()) {
+          decodedSegments.add(URIUtils.decode(segment));
+        }
+      }
+    }
     boolean allColumns = false;
     // For robustness, loop over all columns, if any of the columns is "*", return metadata for all columns.
     for (String column : decodedColumns) {
@@ -230,8 +238,8 @@ public class TablesResource {
     }
     Set<String> columnSet = allColumns ? null : new HashSet<>(decodedColumns);
     List<SegmentDataManager> segmentDataManagers;
-    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
-      segmentDataManagers = tableDataManager.acquireSegments(segmentsToInclude, new ArrayList<>());
+    if (!decodedSegments.isEmpty()) {
+      segmentDataManagers = tableDataManager.acquireSegments(decodedSegments, new ArrayList<>());
     } else {
       segmentDataManagers = tableDataManager.acquireAllSegments();
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -425,7 +425,7 @@ public class TablesResource {
   public String getSegmentsMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")
       @PathParam("tableName") String tableName,
-      @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
+      @ApiParam(value = "Segments name", allowMultiple = true) @QueryParam("segments")
       @DefaultValue("") List<String> segments,
       @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
       List<String> columns, @Context HttpHeaders headers) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -199,7 +199,9 @@ public class TablesResource {
   public String getSegmentMetadata(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
-      List<String> columns, @Context HttpHeaders headers)
+      List<String> columns,
+      @ApiParam(value = "List of segments to fetch metadata for") @QueryParam("segmentsToInclude") @DefaultValue("")
+      List<String> segmentsToInclude, @Context HttpHeaders headers)
       throws WebApplicationException {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
@@ -227,8 +229,12 @@ public class TablesResource {
       }
     }
     Set<String> columnSet = allColumns ? null : new HashSet<>(decodedColumns);
-
-    List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+    List<SegmentDataManager> segmentDataManagers;
+    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
+      segmentDataManagers = tableDataManager.acquireSegments(segmentsToInclude, new ArrayList<>());
+    } else {
+      segmentDataManagers = tableDataManager.acquireAllSegments();
+    }
     long totalSegmentSizeBytes = 0;
     long totalNumRows = 0;
     Map<String, Double> columnLengthMap = new HashMap<>();

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -61,6 +61,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.IdealState;
@@ -424,16 +425,16 @@ public class TablesResource {
   public String getSegmentsMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")
       @PathParam("tableName") String tableName,
-      @ApiParam(value = "Segment names to include", allowMultiple = true) @QueryParam("segmentsToInclude")
-      @DefaultValue("") List<String> segmentsToInclude,
+      @ApiParam(value = "Segments to include", allowMultiple = true) @QueryParam("segments")
+      @DefaultValue("") List<String> segments,
       @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
       List<String> columns, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
     // decode columns and segments
     List<String> decodedSegments = new ArrayList<>();
-    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
-      for (String segment : segmentsToInclude) {
+    if (CollectionUtils.isNotEmpty(segments)) {
+      for (String segment : segments) {
         if (!segment.isEmpty()) {
           decodedSegments.add(URIUtils.decode(segment));
         }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -200,9 +200,7 @@ public class TablesResource {
   public String getSegmentMetadata(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
-      List<String> columns,
-      @ApiParam(value = "List of segments to fetch metadata for", allowMultiple = true) @QueryParam("segmentsToInclude")
-      @DefaultValue("") List<String> segmentsToInclude, @Context HttpHeaders headers)
+      List<String> columns, @Context HttpHeaders headers)
       throws WebApplicationException {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
@@ -221,14 +219,6 @@ public class TablesResource {
       decodedColumns.add(URIUtils.decode(column));
     }
 
-    List<String> decodedSegments = new ArrayList<>();
-    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
-      for (String segment : segmentsToInclude) {
-        if (!segment.isEmpty()) {
-          decodedSegments.add(URIUtils.decode(segment));
-        }
-      }
-    }
     boolean allColumns = false;
     // For robustness, loop over all columns, if any of the columns is "*", return metadata for all columns.
     for (String column : decodedColumns) {
@@ -238,12 +228,8 @@ public class TablesResource {
       }
     }
     Set<String> columnSet = allColumns ? null : new HashSet<>(decodedColumns);
-    List<SegmentDataManager> segmentDataManagers;
-    if (!decodedSegments.isEmpty()) {
-      segmentDataManagers = tableDataManager.acquireSegments(decodedSegments, new ArrayList<>());
-    } else {
-      segmentDataManagers = tableDataManager.acquireAllSegments();
-    }
+
+    List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
     long totalSegmentSizeBytes = 0;
     long totalNumRows = 0;
     Map<String, Double> columnLengthMap = new HashMap<>();

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.server.api.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
@@ -422,6 +423,62 @@ public class TablesResource {
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);
     }
+  }
+
+  @GET
+  @Encoded
+  @Path("/tables/{tableName}/segments/metadata")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Provide segments metadata", notes = "Provide segments metadata for the segments on server")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 500, message = "Internal server error", response = ErrorInfo.class),
+      @ApiResponse(code = 404, message = "Table or segment not found", response = ErrorInfo.class)
+  })
+  public String getSegmentsMetadata(
+      @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")
+      @PathParam("tableName") String tableName,
+      @ApiParam(value = "Segment names to include", allowMultiple = true) @QueryParam("segmentsToInclude")
+      @DefaultValue("") List<String> segmentsToInclude,
+      @ApiParam(value = "Column name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
+      List<String> columns, @Context HttpHeaders headers) {
+    tableName = DatabaseUtils.translateTableName(tableName, headers);
+    TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
+    // decode columns and segments
+    List<String> decodedSegments = new ArrayList<>();
+    if (segmentsToInclude != null && !segmentsToInclude.isEmpty()) {
+      for (String segment : segmentsToInclude) {
+        if (!segment.isEmpty()) {
+          decodedSegments.add(URIUtils.decode(segment));
+        }
+      }
+    }
+    List<SegmentDataManager> segmentDataManagers;
+    if (!decodedSegments.isEmpty()) {
+      segmentDataManagers = tableDataManager.acquireSegments(decodedSegments, new ArrayList<>());
+    } else {
+      segmentDataManagers = tableDataManager.acquireAllSegments();
+    }
+    for (int i = 0; i < columns.size(); i++) {
+      columns.set(i, URIUtils.decode(columns.get(i)));
+    }
+    // get metadata for every segment in the list
+    Map<String, JsonNode> response = new HashMap<>();
+    for (SegmentDataManager segmentDataManager: segmentDataManagers) {
+      String segmentName = segmentDataManager.getSegmentName();
+      try {
+        String segmentMetadata = SegmentMetadataFetcher.getSegmentMetadata(segmentDataManager, columns);
+        JsonNode segmentMetadataJson = JsonUtils.stringToJsonNode(segmentMetadata);
+        response.put(segmentName, segmentMetadataJson);
+      } catch (Exception e) {
+        LOGGER.error("Failed to convert table {} segment {} to json", tableName, segmentName);
+        throw new WebApplicationException("Failed to convert segment metadata to json",
+            Response.Status.INTERNAL_SERVER_ERROR);
+      } finally {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
+    return ResourceUtils.convertToJsonString(response);
   }
 
   @GET

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -246,48 +246,43 @@ public class TablesResourceTest extends BaseResourceTest {
       throws Exception {
     IndexSegment defaultSegment = _realtimeIndexSegments.get(0);
     String segmentMetadataPath = "/tables/" + TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME)
-        + "/segments/metadata?segmentsToInclude=" + defaultSegment.getSegmentName();
+        + "/segments/metadata";
+    String segmentName = defaultSegment.getSegmentName();
 
-    JsonNode jsonResponse =
-        JsonUtils.stringToJsonNode(_webTarget.path(segmentMetadataPath).request().get(String.class));
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode((_webTarget.path(segmentMetadataPath)
+            .queryParam("segmentsToInclude", segmentName)).request().get(String.class));
+    JsonNode jsonNode = jsonResponse.get(segmentName);
     SegmentMetadata segmentMetadata = defaultSegment.getSegmentMetadata();
-    Assert.assertEquals(jsonResponse.get("segmentName").asText(), segmentMetadata.getName());
-    Assert.assertEquals(jsonResponse.get("crc").asText(), segmentMetadata.getCrc());
-    Assert.assertEquals(jsonResponse.get("creationTimeMillis").asLong(), segmentMetadata.getIndexCreationTime());
-    Assert.assertTrue(jsonResponse.has("startTimeReadable"));
-    Assert.assertTrue(jsonResponse.has("endTimeReadable"));
-    Assert.assertTrue(jsonResponse.has("creationTimeReadable"));
-    Assert.assertEquals(jsonResponse.get("columns").size(), 0);
-    Assert.assertEquals(jsonResponse.get("indexes").size(), 0);
+    Assert.assertEquals(jsonNode.get("segmentName").asText(), segmentMetadata.getName());
+    Assert.assertEquals(jsonNode.get("crc").asText(), segmentMetadata.getCrc());
+    Assert.assertEquals(jsonNode.get("creationTimeMillis").asLong(), segmentMetadata.getIndexCreationTime());
+    Assert.assertTrue(jsonNode.has("startTimeReadable"));
+    Assert.assertTrue(jsonNode.has("endTimeReadable"));
+    Assert.assertTrue(jsonNode.has("creationTimeReadable"));
+    Assert.assertEquals(jsonNode.get("columns").size(), 0);
+    Assert.assertEquals(jsonNode.get("indexes").size(), 0);
 
     jsonResponse = JsonUtils.stringToJsonNode(
-        _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2").request()
-            .get(String.class));
-    Assert.assertEquals(jsonResponse.get("columns").size(), 2);
-    Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
-    Assert.assertNotNull(jsonResponse.get("columns").get(0).get("indexSizeMap"));
-    Assert.assertNotNull(jsonResponse.get("columns").get(1).get("indexSizeMap"));
-    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("h3-index").asText(), "NO");
-    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("fst-index").asText(), "NO");
-    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("text-index").asText(), "NO");
-    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("h3-index").asText(), "NO");
-    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("fst-index").asText(), "NO");
-    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("text-index").asText(), "NO");
+        _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2")
+            .queryParam("segmentsToInclude", segmentName).request().get(String.class));
+    jsonNode = jsonResponse.get(segmentName);
+    Assert.assertEquals(jsonNode.get("columns").size(), 2);
+    Assert.assertEquals(jsonNode.get("indexes").size(), 2);
+    Assert.assertNotNull(jsonNode.get("columns").get(0).get("indexSizeMap"));
+    Assert.assertNotNull(jsonNode.get("columns").get(1).get("indexSizeMap"));
+    Assert.assertEquals(jsonNode.get("indexes").get("column1").get("h3-index").asText(), "NO");
+    Assert.assertEquals(jsonNode.get("indexes").get("column1").get("fst-index").asText(), "NO");
+    Assert.assertEquals(jsonNode.get("indexes").get("column1").get("text-index").asText(), "NO");
+    Assert.assertEquals(jsonNode.get("indexes").get("column2").get("h3-index").asText(), "NO");
+    Assert.assertEquals(jsonNode.get("indexes").get("column2").get("fst-index").asText(), "NO");
+    Assert.assertEquals(jsonNode.get("indexes").get("column2").get("text-index").asText(), "NO");
 
-    jsonResponse = JsonUtils.stringToJsonNode(
-        (_webTarget.path(segmentMetadataPath).queryParam("columns", "*").request().get(String.class)));
+    jsonResponse = JsonUtils.stringToJsonNode((_webTarget.path(segmentMetadataPath)
+        .queryParam("columns", "*").queryParam("segmentsToInclude", segmentName).request().get(String.class)));
     int physicalColumnCount = defaultSegment.getPhysicalColumnNames().size();
-    Assert.assertEquals(jsonResponse.get("columns").size(), physicalColumnCount);
-    Assert.assertEquals(jsonResponse.get("indexes").size(), physicalColumnCount);
-
-    Response response = _webTarget.path("/tables/UNKNOWN_TABLE/segments/" + defaultSegment.getSegmentName()).request()
-        .get(Response.class);
-    Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
-
-    response = _webTarget.path(
-            "/tables/" + TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME) + "/segments/UNKNOWN_SEGMENT")
-        .request().get(Response.class);
-    Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    jsonNode = jsonResponse.get(segmentName);
+    Assert.assertEquals(jsonNode.get("columns").size(), physicalColumnCount);
+    Assert.assertEquals(jsonNode.get("indexes").size(), physicalColumnCount);
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -445,7 +445,7 @@ public class ControllerRequestURLBuilder {
   }
 
   public String forSegmentsMetadataFromServer(String tableName, @Nullable List<String> columns) {
-    return StringUtil.join("/", _baseUrl, "segments", tableName, "metadata") + constructColumnsParameter(columns);
+    return StringUtil.join("/", _baseUrl, "segments", tableName, "metadataV2") + constructColumnsParameter(columns);
   }
 
   public String forSegmentMetadata(String tableName, String segmentName) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -445,7 +445,7 @@ public class ControllerRequestURLBuilder {
   }
 
   public String forSegmentsMetadataFromServer(String tableName, @Nullable List<String> columns) {
-    return StringUtil.join("/", _baseUrl, "segments", tableName, "metadataV2") + constructColumnsParameter(columns);
+    return StringUtil.join("/", _baseUrl, "segments", tableName, "metadata") + constructColumnsParameter(columns);
   }
 
   public String forSegmentMetadata(String tableName, String segmentName) {


### PR DESCRIPTION
Fixes #13990 
The fetch segment metadata call for a table makes one call per segment, instead we can have one call per server