### PR TITLE
Add missing precondition check for V5 writer version in BaseChunkForwardIndexWriter

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkForwardIndexWriter.java
@@ -88,7 +88,7 @@ public abstract class BaseChunkForwardIndexWriter implements Closeable {
   protected BaseChunkForwardIndexWriter(File file, ChunkCompressionType compressionType, int totalDocs,
       int numDocsPerChunk, long chunkSize, int sizeOfEntry, int version, boolean fixed)
       throws IOException {
-    Preconditions.checkArgument(version == 2 || version == 3 || (fixed && version == 4),
+    Preconditions.checkArgument(version == 2 || version == 3 || (fixed && (version == 4 || version == 5)),
         "Illegal version: %s for %s bytes values", version, fixed ? "fixed" : "variable");
     Preconditions.checkArgument(chunkSize <= Integer.MAX_VALUE, "Chunk size limited to 2GB");
     _chunkSize = (int) chunkSize;


### PR DESCRIPTION
This PR adds a missing precondition check for the V5 writer version introduced in [PR #14105](https://github.com/apache/pinot/pull/14105). Specifically, it ensures proper handling of the V5 writer version in BaseChunkForwardIndexWriter.