### PR TITLE
Fixed integer division in floating-point context

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVForwardIndexWriter.java
@@ -76,7 +76,7 @@ public class FixedBitMVForwardIndexWriter implements Closeable {
 
   public FixedBitMVForwardIndexWriter(File file, int numDocs, int totalNumValues, int numBitsPerValue)
       throws IOException {
-    float averageValuesPerDoc = totalNumValues / numDocs;
+    double averageValuesPerDoc = Math.max(totalNumValues / (double) numDocs, 1f);
     _docsPerChunk = (int) (Math.ceil(PREFERRED_NUM_VALUES_PER_CHUNK / averageValuesPerDoc));
     _numChunks = (numDocs + _docsPerChunk - 1) / _docsPerChunk;
     _chunkOffsetHeaderSize = _numChunks * SIZE_OF_INT * NUM_COLS_IN_HEADER;


### PR DESCRIPTION
```
2024/10/19 07:44:26.782 ERROR [RealtimeSegmentDataManager_owner5__12__65__20241018T0744Z] [owner5__12__65__20241018T0744Z] Could not build segment
java.lang.ArithmeticException: / by zero
        at org.apache.pinot.segment.local.io.writer.impl.FixedBitMVForwardIndexWriter.<init>(FixedBitMVForwardIndexWriter.java:81) 
        at org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueUnsortedForwardIndexCreator.<init>(MultiValueUnsortedForwardIndexCreator.java:41)
        at org.apache.pinot.segment.local.segment.index.forward.ForwardIndexCreatorFactory.createIndexCreator(ForwardIndexCreatorFactory.java:68)
        at org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType.createIndexCreator(ForwardIndexType.java:188)
...
```

`bugfix`

