### PR TITLE
Update hadoop & protobuf deps to fix vuls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.14</swagger.version>
     <swagger-ui.version>5.17.14</swagger-ui.version>
-    <hadoop.version>3.4.0</hadoop.version>
+    <hadoop.version>3.4.1</hadoop.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.1</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>
@@ -230,7 +230,7 @@
     <httpcore5.version>5.3</httpcore5.version>
 
     <!-- Google Libraries -->
-    <protobuf.version>3.25.4</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <grpc.version>1.68.0</grpc.version>
     <google.cloud.libraries.version>26.49.0</google.cloud.libraries.version>
     <google.auto-service.version>1.1.1</google.auto-service.version>
@@ -1732,13 +1732,10 @@
       <!-- Dependencies in Hadoop libraries -->
       <dependency>
         <groupId>org.apache.kerby</groupId>
-        <artifactId>kerb-core</artifactId>
+        <artifactId>kerby-bom</artifactId>
         <version>${kerby.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kerby</groupId>
-        <artifactId>kerb-simplekdc</artifactId>
-        <version>${kerby.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>


### PR DESCRIPTION
Small PR updating deps to solve https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-8055227.

Update:
* hadoop from 3.4.0 to 3.4.1
* protobuf from 3.25.4 to 3.25.5