### PR TITLE
Fix ROUND scalar function in the multi-stage query engine

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -186,7 +186,6 @@ public class PinotOperatorTable implements SqlOperatorTable {
       SqlStdOperatorTable.DEGREES,
       SqlStdOperatorTable.EXP,
       SqlStdOperatorTable.RADIANS,
-      SqlStdOperatorTable.ROUND,
       SqlStdOperatorTable.SIGN,
       SqlStdOperatorTable.SIN,
       SqlStdOperatorTable.TAN,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -88,6 +88,7 @@ public class QueryEnvironmentTestBase {
         .addSingleValueDimension("col2", FieldSpec.DataType.STRING, "")
         .addSingleValueDimension("col5", FieldSpec.DataType.BOOLEAN, false)
         .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
+        .addDateTime("ts_timestamp", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:HOURS")
         .addMetric("col3", FieldSpec.DataType.INT, 0)
         .addMetric("col4", FieldSpec.DataType.BIG_DECIMAL, 0)
         .addMetric("col6", FieldSpec.DataType.INT, 0)
@@ -231,6 +232,7 @@ public class QueryEnvironmentTestBase {
             "SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ a.col2, a.col3 FROM a JOIN b "
                 + "ON a.col1 = b.col1  WHERE a.col3 >= 0 GROUP BY a.col2, a.col3"
         },
+        new Object[]{"SELECT ROUND(ts_timestamp, 10000) FROM a"}
     };
   }
 

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -42,7 +42,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT * FROM a JOIN b ON a.col1 = b.col2",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[=($0, $8)], joinType=[inner])",
+          "\nLogicalJoin(condition=[=($0, $9)], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[1]])",
@@ -55,7 +55,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT * FROM a JOIN b ON a.col1 = b.col2 WHERE a.col3 >= 0",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[=($0, $8)], joinType=[inner])",
+          "\nLogicalJoin(condition=[=($0, $9)], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalFilter(condition=[>=($2, 0)])",
           "\n      LogicalTableScan(table=[[default, a]])",
@@ -69,7 +69,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT * FROM a JOIN b ON a.col1 = b.col2 WHERE a.col3 >= 0 AND a.col3 > b.col3",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[AND(=($0, $8), >($2, $9))], joinType=[inner])",
+          "\nLogicalJoin(condition=[AND(=($0, $9), >($2, $10))], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalFilter(condition=[>=($2, 0)])",
           "\n      LogicalTableScan(table=[[default, a]])",
@@ -83,7 +83,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[AND(=($0, $7), =($1, $8))], joinType=[inner])",
+          "\nLogicalJoin(condition=[AND(=($0, $8), =($1, $9))], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
@@ -429,9 +429,9 @@
         "sql": "EXPLAIN PLAN FOR WITH tmp1 AS ( SELECT * FROM a WHERE col2 NOT IN ('foo', 'bar') ) SELECT * FROM a WHERE col2 IN (SELECT col1 FROM tmp1) AND col2 IN (SELECT col1 FROM b WHERE col3 > 100) AND col3 IN (SELECT col3 from b WHERE col3 < 100)",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[=($2, $7)], joinType=[semi])",
-          "\n  LogicalJoin(condition=[=($1, $7)], joinType=[semi])",
-          "\n    LogicalJoin(condition=[=($1, $7)], joinType=[semi])",
+          "\nLogicalJoin(condition=[=($2, $8)], joinType=[semi])",
+          "\n  LogicalJoin(condition=[=($1, $8)], joinType=[semi])",
+          "\n    LogicalJoin(condition=[=($1, $8)], joinType=[semi])",
           "\n      LogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n        LogicalProject(col1=[$0])",
@@ -503,8 +503,8 @@
         "sql": "EXPLAIN PLAN FOR WITH tmp1 AS ( SELECT * FROM a WHERE col2 NOT IN ('foo', 'bar') ), tmp2 AS ( SELECT * FROM b WHERE col1 IN (SELECT col1 FROM tmp1) AND col3 < 100 ) SELECT * FROM tmp2 WHERE col3 IN (SELECT col3 from tmp1)",
         "output": [
           "Execution Plan",
-          "\nLogicalJoin(condition=[=($2, $7)], joinType=[semi])",
-          "\n  LogicalJoin(condition=[=($0, $7)], joinType=[semi])",
+          "\nLogicalJoin(condition=[=($2, $8)], joinType=[semi])",
+          "\n  LogicalJoin(condition=[=($0, $8)], joinType=[semi])",
           "\n    LogicalFilter(condition=[<($2, 100)])",
           "\n      LogicalTableScan(table=[[default, b]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",


### PR DESCRIPTION
- `ROUND` is a standard SQL function that takes two forms:
  - `ROUND(number)` -> rounds a number to its nearest integer
  - `ROUND(number, decimals)` -> rounds a number to the specified number of decimal places.
- Pinot's equivalent function is called `ROUND_DECIMAL` because there already existed a non-standard date time function with the same name previously ([ref1](https://github.com/apache/pinot/blob/281478e81951ce804ba890042002080dfbd201de/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java#L121-L133), [ref2](https://github.com/apache/pinot/blob/281478e81951ce804ba890042002080dfbd201de/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java#L527-L530)).
- In the v1 engine, this all works fine (even though ideally we shouldn't have completely different semantics for a standard SQL function).
- In the v2 engine, however, we register the standard `ROUND` operator from Calcite in the operator table (see [here](https://github.com/apache/pinot/blob/281478e81951ce804ba890042002080dfbd201de/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java#L189)) which obviously corresponds to the standard SQL function definition (i.e., Pinot's `ROUND_DECIMAL`).
- This breaks Pinot's `ROUND` function in v2, because the operand types don't match - `Cannot apply 'ROUND' to arguments of type 'ROUND(<TIMESTAMP(0)>, <INTEGER>)'. Supported form(s): 'ROUND(<NUMERIC>)' `
- This patch fixes the issue by simply removing the standard operator from the operator table (and relying on the scalar function registry instead to register Pinot's operators with Calcite).
- As a long term fix, however, we should ideally deprecate the existing functions and in a future major release change the definition of `ROUND` to match the standard SQL definition and rename the existing date time `ROUND` to something like `ROUND_TIMESTAMP`.