### PR TITLE
Update intellij codestyle

### DIFF
--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -206,7 +206,7 @@
     <option name="THROWS_LIST_WRAP" value="1"/>
     <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
     <option name="THROWS_KEYWORD_WRAP" value="2"/>
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5"/>
     <option name="BINARY_OPERATION_WRAP" value="1"/>
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
     <option name="TERNARY_OPERATION_WRAP" value="1"/>

--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -189,7 +189,6 @@
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
     <option name="RIGHT_MARGIN" value="120"/>
-    <option name="KEEP_LINE_BREAKS" value="false"/>
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>


### PR DESCRIPTION
This PR updates the intellij codestyle in two ways that are still compatible with checkstyle:

## Chop long method chain calls

We have been (ab)using of `//@formatter:off` to be able to write things like:

```
      //@formatter:off
      QueryEnvironment queryEnvironment = new QueryEnvironment(QueryEnvironment.configBuilder()
          .database(database)
          .tableCache(_tableCache)
          .workerManager(_workerManager)
          .defaultInferPartitionHint(inferPartitionHint)
          .build());
      //@formatter:on
```

Otherwise Intellij formatter will reformat that to:
```
      QueryEnvironment queryEnvironment = new QueryEnvironment(
          QueryEnvironment.configBuilder().database(database).tableCache(_tableCache).workerManager(_workerManager)
              .defaultInferPartitionHint(inferPartitionHint).build());
```

Which for several of us is more difficult to read, specially when reviewing PRs that modify something in the chain.

This PR changes the config in intellij to automatically use the first option. In intellij nomenclature the current mode is _wrap if long_ and the new one is _chop if long_. 

The side effect of this PR is that intellij may reformat some lines to the chop format. If we don't want that we can also configure Intellij to simply do not modify these chained methods, which would give each developer the choice to use one or the other format.

## Keep line breaks when reformatting

This configures intellij to keep custom line breaks when it is reformatting. This is mainly useful to give developers more flexibility to adapt the code. This also means that intellij reformat may end up allowing to write things that checkstyle will reject, but usually checkstyle is permissive enough and in general it looks like a good idea.