### PR TITLE
[Bugfix] delete segment API always deletes consuming segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -223,7 +223,7 @@ public class PinotSegmentRestletResource {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     boolean shouldExcludeReplacedSegments = Boolean.parseBoolean(excludeReplacedSegments);
     return selectSegments(tableName, tableTypeStr, shouldExcludeReplacedSegments,
-        startTimestampStr, endTimestampStr, excludeOverlapping)
+        startTimestampStr, endTimestampStr, excludeOverlapping, false)
         .stream()
         .map(pair -> Collections.singletonMap(pair.getKey(), pair.getValue()))
         .collect(Collectors.toList());
@@ -787,7 +787,8 @@ public class PinotSegmentRestletResource {
 
     int numSegments = 0;
     for (Pair<TableType, List<String>> tableTypeSegments : selectSegments(
-        tableName, tableTypeStr, excludeReplacedSegments, startTimestampStr, endTimestampStr, excludeOverlapping)) {
+        tableName, tableTypeStr, excludeReplacedSegments, startTimestampStr, endTimestampStr,
+        excludeOverlapping, true)) {
       TableType tableType = tableTypeSegments.getLeft();
       List<String> segments = tableTypeSegments.getRight();
       numSegments += segments.size();
@@ -1014,7 +1015,7 @@ public class PinotSegmentRestletResource {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       List<String> segments =
           _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, true, startTimestamp, endTimestamp,
-              excludeOverlapping);
+              excludeOverlapping, false);
       resultList.add(Collections.singletonMap(tableType, segments));
     }
     return resultList;
@@ -1102,7 +1103,7 @@ public class PinotSegmentRestletResource {
 
   private List<Pair<TableType, List<String>>> selectSegments(
       String tableName, String tableTypeStr, boolean excludeReplacedSegments, String startTimestampStr,
-      String endTimestampStr, boolean excludeOverlapping) {
+      String endTimestampStr, boolean excludeOverlapping, boolean excludeConsuming) {
     long startTimestamp;
     long endTimestamp;
     try {
@@ -1124,7 +1125,7 @@ public class PinotSegmentRestletResource {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       List<String> segments =
           _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, excludeReplacedSegments, startTimestamp,
-              endTimestamp, excludeOverlapping);
+              endTimestamp, excludeOverlapping, excludeConsuming);
       resultList.add(Pair.of(tableType, segments));
     }
     return resultList;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -223,7 +223,7 @@ public class PinotSegmentRestletResource {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     boolean shouldExcludeReplacedSegments = Boolean.parseBoolean(excludeReplacedSegments);
     return selectSegments(tableName, tableTypeStr, shouldExcludeReplacedSegments,
-        startTimestampStr, endTimestampStr, excludeOverlapping, false)
+        startTimestampStr, endTimestampStr, excludeOverlapping)
         .stream()
         .map(pair -> Collections.singletonMap(pair.getKey(), pair.getValue()))
         .collect(Collectors.toList());
@@ -787,8 +787,7 @@ public class PinotSegmentRestletResource {
 
     int numSegments = 0;
     for (Pair<TableType, List<String>> tableTypeSegments : selectSegments(
-        tableName, tableTypeStr, excludeReplacedSegments, startTimestampStr, endTimestampStr,
-        excludeOverlapping, true)) {
+        tableName, tableTypeStr, excludeReplacedSegments, startTimestampStr, endTimestampStr, excludeOverlapping)) {
       TableType tableType = tableTypeSegments.getLeft();
       List<String> segments = tableTypeSegments.getRight();
       numSegments += segments.size();
@@ -1015,7 +1014,7 @@ public class PinotSegmentRestletResource {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       List<String> segments =
           _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, true, startTimestamp, endTimestamp,
-              excludeOverlapping, false);
+              excludeOverlapping);
       resultList.add(Collections.singletonMap(tableType, segments));
     }
     return resultList;
@@ -1103,7 +1102,7 @@ public class PinotSegmentRestletResource {
 
   private List<Pair<TableType, List<String>>> selectSegments(
       String tableName, String tableTypeStr, boolean excludeReplacedSegments, String startTimestampStr,
-      String endTimestampStr, boolean excludeOverlapping, boolean excludeConsuming) {
+      String endTimestampStr, boolean excludeOverlapping) {
     long startTimestamp;
     long endTimestamp;
     try {
@@ -1125,7 +1124,7 @@ public class PinotSegmentRestletResource {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       List<String> segments =
           _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, excludeReplacedSegments, startTimestamp,
-              endTimestamp, excludeOverlapping, excludeConsuming);
+              endTimestamp, excludeOverlapping);
       resultList.add(Pair.of(tableType, segments));
     }
     return resultList;


### PR DESCRIPTION
label:
`bugfix` 

At present, while using DELETE API `"/segments/{tableName}/choose"` we always end up deleting consuming segments. This is because of using common segments selection logic across GET and DELETE APIs. 

The root cause is the following line in the selection logic.
https://github.com/apache/pinot/blob/f251f00182a75dd79f2a7388546e92fb2a1658e6/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java#L951-L954

For consuming segment, we don't have startTime and endTime in ZK populated. For fixing, we have introduced a variable `excludeConsuming` in the selection logic to still use the same method for GET and DELETE APIs. For DELETE, we mark excludeConsuming as true.
