### PR TITLE
Make it explicit that receive plan node should have no inputs

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PinotLogicalQueryPlanner.java
@@ -112,7 +112,7 @@ public class PinotLogicalQueryPlanner {
         childPlanFragments.add(planFragmentMap.get(childPlanFragmentIdIterator.nextInt()));
       }
     }
-    MailboxReceiveNode rootReceiveNode = new MailboxReceiveNode(0, node.getDataSchema(), List.of(), node.getStageId(),
+    MailboxReceiveNode rootReceiveNode = new MailboxReceiveNode(0, node.getDataSchema(), node.getStageId(),
         PinotRelExchangeType.getDefaultExchangeType(), RelDistribution.Type.BROADCAST_DISTRIBUTED, null, null, false,
         false, subPlanRootSenderNode);
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanFragmenter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanFragmenter.java
@@ -168,7 +168,7 @@ public class PlanFragmenter implements PlanNodeVisitor<PlanNode, PlanFragmenter.
 
     // Return the MailboxReceiveNode as the leave node of the current PlanFragment.
     MailboxReceiveNode mailboxReceiveNode =
-        new MailboxReceiveNode(receiverPlanFragmentId, nextPlanFragmentRoot.getDataSchema(), List.of(),
+        new MailboxReceiveNode(receiverPlanFragmentId, nextPlanFragmentRoot.getDataSchema(),
             senderPlanFragmentId, exchangeType, distributionType, keys, node.getCollations(), node.isSortOnReceiver(),
             node.isSortOnSender(), mailboxSendNode);
     _mailboxReceiveToExchangeNodeMap.put(mailboxReceiveNode, node);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.plannode;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -40,11 +41,11 @@ public class MailboxReceiveNode extends BasePlanNode {
   private final transient MailboxSendNode _sender;
 
   // NOTE: null List is converted to empty List because there is no way to differentiate them in proto during ser/de.
-  public MailboxReceiveNode(int stageId, DataSchema dataSchema, List<PlanNode> inputs, int senderStageId,
+  public MailboxReceiveNode(int stageId, DataSchema dataSchema, int senderStageId,
       PinotRelExchangeType exchangeType, RelDistribution.Type distributionType, @Nullable List<Integer> keys,
       @Nullable List<RelFieldCollation> collations, boolean sort, boolean sortedOnSender,
       @Nullable MailboxSendNode sender) {
-    super(stageId, dataSchema, null, inputs);
+    super(stageId, dataSchema, null, List.of());
     _senderStageId = senderStageId;
     _exchangeType = exchangeType;
     _distributionType = distributionType;
@@ -104,8 +105,13 @@ public class MailboxReceiveNode extends BasePlanNode {
 
   @Override
   public PlanNode withInputs(List<PlanNode> inputs) {
-    return new MailboxReceiveNode(_stageId, _dataSchema, inputs, _senderStageId, _exchangeType, _distributionType,
-        _keys, _collations, _sort, _sortedOnSender, _sender);
+    Preconditions.checkArgument(inputs.isEmpty(), "Cannot set inputs for MailboxReceiveNode");
+    return this;
+  }
+
+  public MailboxReceiveNode withSender(MailboxSendNode sender) {
+    return new MailboxReceiveNode(_stageId, _dataSchema, _senderStageId, _exchangeType, _distributionType, _keys,
+        _collations, _sort, _sortedOnSender, sender);
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/PlanNodeVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/PlanNodeVisitor.java
@@ -58,9 +58,9 @@ public interface PlanNodeVisitor<T, C> {
 
   T visitWindow(WindowNode node, C context);
 
-  T visitSetOp(SetOpNode setOpNode, C context);
+  T visitSetOp(SetOpNode node, C context);
 
-  T visitExchange(ExchangeNode exchangeNode, C context);
+  T visitExchange(ExchangeNode node, C context);
 
   T visitExplained(ExplainedNode node, C context);
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.serde;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,8 +105,10 @@ public class PlanNodeDeserializer {
   }
 
   private static MailboxReceiveNode deserializeMailboxReceiveNode(Plan.PlanNode protoNode) {
+    List<PlanNode> planNodes = extractInputs(protoNode);
+    Preconditions.checkState(planNodes.isEmpty(), "MailboxReceiveNode should not have inputs but has: %s", planNodes);
     Plan.MailboxReceiveNode protoMailboxReceiveNode = protoNode.getMailboxReceiveNode();
-    return new MailboxReceiveNode(protoNode.getStageId(), extractDataSchema(protoNode), extractInputs(protoNode),
+    return new MailboxReceiveNode(protoNode.getStageId(), extractDataSchema(protoNode),
         protoMailboxReceiveNode.getSenderStageId(), convertExchangeType(protoMailboxReceiveNode.getExchangeType()),
         convertDistributionType(protoMailboxReceiveNode.getDistributionType()), protoMailboxReceiveNode.getKeysList(),
         convertCollations(protoMailboxReceiveNode.getCollationsList()), protoMailboxReceiveNode.getSort(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.mailbox;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.ThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -43,7 +44,13 @@ import org.slf4j.LoggerFactory;
  * the {@link SendingMailbox} whose ownership lies with the send operator. This is because the ReceivingMailbox can be
  * initialized even before the corresponding OpChain is registered on the receiver, whereas the SendingMailbox is
  * initialized when the send operator is running.
+ *
+ * There is a single ReceivingMailbox for each {@link org.apache.pinot.query.runtime.operator.MailboxReceiveOperator}.
+ * The offer methods will be called when new blocks are received from different sources. For example local workers will
+ * directly call {@link #offer(TransferableBlock, long)} while each remote worker opens a GPRC channel where messages
+ * are sent in raw format and {@link #offerRaw(ByteBuffer, long)} is called from them.
  */
+@ThreadSafe
 public class ReceivingMailbox {
   public static final int DEFAULT_MAX_PENDING_BLOCKS = 5;
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
@@ -290,7 +290,7 @@ public class PipelineBreakerExecutorTest {
   }
 
   private static MailboxReceiveNode getPBReceiveNode(int senderStageId) {
-    return new MailboxReceiveNode(0, DATA_SCHEMA, List.of(), senderStageId, PinotRelExchangeType.PIPELINE_BREAKER,
+    return new MailboxReceiveNode(0, DATA_SCHEMA, senderStageId, PinotRelExchangeType.PIPELINE_BREAKER,
         RelDistribution.Type.SINGLETON, null, null, false, false, null);
   }
 }


### PR DESCRIPTION
A simple PR that removes the inputs constructor in MailboxReceiveNode, which should always be called with no input.

Although receive nodes are associated with a MailboxSendNode, their association is not implemented in the inputs attribute but in the sender attribute. This is not something introduced by this PR, but this PR is making it easier to know about by removing the inputs argument (which was always an empty set).