### PR TITLE
Add bucketing time zone paramter to dateTimeConvert() function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -115,12 +115,9 @@ public enum TransformFunctionType {
   // Date time functions
   TIME_CONVERT("timeConvert", ReturnTypes.BIGINT,
       OperandTypes.family(List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER))),
-  DATE_TIME_CONVERT("dateTimeConvert", TransformFunctionType::dateTimeConverterReturnTypeInference,
-      OperandTypes.or(
-          OperandTypes.family(
-              List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
-                  SqlTypeFamily.CHARACTER), i -> i == 4)
-      )),
+  DATE_TIME_CONVERT("dateTimeConvert", TransformFunctionType::dateTimeConverterReturnTypeInference, OperandTypes.family(
+      List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
+          SqlTypeFamily.CHARACTER), i -> i == 4)),
   DATE_TIME_CONVERT_WINDOW_HOP("dateTimeConvertWindowHop",
       ReturnTypes.cascade(TransformFunctionType::dateTimeConverterReturnTypeInference, SqlTypeTransforms.TO_ARRAY),
       OperandTypes.family(

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -118,10 +118,8 @@ public enum TransformFunctionType {
   DATE_TIME_CONVERT("dateTimeConvert", TransformFunctionType::dateTimeConverterReturnTypeInference,
       OperandTypes.or(
           OperandTypes.family(
-              List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
-          OperandTypes.family(
               List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
-                  SqlTypeFamily.CHARACTER))
+                  SqlTypeFamily.CHARACTER), i -> i == 4)
       )),
   DATE_TIME_CONVERT_WINDOW_HOP("dateTimeConvertWindowHop",
       ReturnTypes.cascade(TransformFunctionType::dateTimeConverterReturnTypeInference, SqlTypeTransforms.TO_ARRAY),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -115,8 +115,14 @@ public enum TransformFunctionType {
   // Date time functions
   TIME_CONVERT("timeConvert", ReturnTypes.BIGINT,
       OperandTypes.family(List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER))),
-  DATE_TIME_CONVERT("dateTimeConvert", TransformFunctionType::dateTimeConverterReturnTypeInference, OperandTypes.family(
-      List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER))),
+  DATE_TIME_CONVERT("dateTimeConvert", TransformFunctionType::dateTimeConverterReturnTypeInference,
+      OperandTypes.or(
+          OperandTypes.family(
+              List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
+          OperandTypes.family(
+              List.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
+                  SqlTypeFamily.CHARACTER))
+      )),
   DATE_TIME_CONVERT_WINDOW_HOP("dateTimeConvertWindowHop",
       ReturnTypes.cascade(TransformFunctionType::dateTimeConverterReturnTypeInference, SqlTypeTransforms.TO_ARRAY),
       OperandTypes.family(

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -108,9 +111,10 @@ public class DateTimeConvert {
       try {
         // we're not using TimeZone.getTimeZone() because it's globally synchronized
         // and returns default TZ when str makes no sense
-        _bucketingChronology = ISOChronology.getInstance(DateTimeZone.forID(bucketingTimeZone));
-      } catch (IllegalArgumentException iae) {
-        throw new IllegalArgumentException("Error parsing bucketing time zone: " + iae.getMessage(), iae);
+        _bucketingChronology =
+            ISOChronology.getInstance(DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(bucketingTimeZone))));
+      } catch (DateTimeException dte) {
+        throw new IllegalArgumentException("Error parsing bucketing time zone: " + dte.getMessage(), dte);
       }
 
       _dateTime = new MutableDateTime(0L, DateTimeZone.UTC);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
@@ -108,7 +108,7 @@ public class DateTimeConvert {
         timeZone = DateTimeZone.UTC;
       }
     }
-
+    // use reusable objects for parsing and formatting dates, instead of allocating them on each function call
     _dateTime = new MutableDateTime(0L, timeZone);
     _buffer = new StringBuilder();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
@@ -26,10 +26,8 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
-import org.joda.time.Chronology;
 import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
-import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormatter;
 
 
@@ -40,7 +38,7 @@ public class DateTimeConvert {
   private DateTimeFormatSpec _inputFormatSpec;
   private DateTimeFormatSpec _outputFormatSpec;
   private DateTimeGranularitySpec _granularitySpec;
-  private Chronology _bucketingChronology;
+  private DateTimeZone _bucketingTimeZone;
   private MutableDateTime _dateTime;
   private StringBuilder _buffer;
 
@@ -48,46 +46,13 @@ public class DateTimeConvert {
   public Object dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
       String outputGranularityStr) {
     if (_inputFormatSpec == null) {
-      _inputFormatSpec = new DateTimeFormatSpec(inputFormatStr);
-      _outputFormatSpec = new DateTimeFormatSpec(outputFormatStr);
-      _granularitySpec = new DateTimeGranularitySpec(outputGranularityStr);
-      _dateTime = new MutableDateTime(0L, DateTimeZone.UTC);
-      _buffer = new StringBuilder();
+      init(inputFormatStr, outputFormatStr, outputGranularityStr, null, false);
     }
 
     long timeValueMs = _inputFormatSpec.fromFormatToMillis(timeValueStr);
     if (_outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
-      DateTimeFormatter outputFormatter = _outputFormatSpec.getDateTimeFormatter();
-      _dateTime.setMillis(timeValueMs);
-      _dateTime.setZone(outputFormatter.getZone());
-      int size = _granularitySpec.getSize();
-
-      switch (_granularitySpec.getTimeUnit()) {
-        case MILLISECONDS:
-          _dateTime.setMillisOfSecond((_dateTime.getMillisOfSecond() / size) * size);
-          break;
-        case SECONDS:
-          _dateTime.setSecondOfMinute((_dateTime.getSecondOfMinute() / size) * size);
-          _dateTime.secondOfMinute().roundFloor();
-          break;
-        case MINUTES:
-          _dateTime.setMinuteOfHour((_dateTime.getMinuteOfHour() / size) * size);
-          _dateTime.minuteOfHour().roundFloor();
-          break;
-        case HOURS:
-          _dateTime.setHourOfDay((_dateTime.getHourOfDay() / size) * size);
-          _dateTime.hourOfDay().roundFloor();
-          break;
-        case DAYS:
-          _dateTime.setDayOfMonth(((_dateTime.getDayOfMonth() - 1) / size) * size + 1);
-          _dateTime.dayOfMonth().roundFloor();
-          break;
-        default:
-          break;
-      }
-      _buffer.setLength(0);
-      outputFormatter.printTo(_buffer, _dateTime);
-      return _buffer.toString();
+      truncateDateTime(timeValueMs);
+      return getFormattedDate();
     } else {
       long granularityMs = _granularitySpec.granularityToMillis();
       long roundedTimeValueMs = timeValueMs / granularityMs * granularityMs;
@@ -104,27 +69,59 @@ public class DateTimeConvert {
   public Object dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
       String outputGranularityStr, String bucketingTimeZone) {
     if (_inputFormatSpec == null) {
-      _inputFormatSpec = new DateTimeFormatSpec(inputFormatStr);
-      _outputFormatSpec = new DateTimeFormatSpec(outputFormatStr);
-      _granularitySpec = new DateTimeGranularitySpec(outputGranularityStr);
-
-      try {
-        // we're not using TimeZone.getTimeZone() because it's globally synchronized
-        // and returns default TZ when str makes no sense
-        _bucketingChronology =
-            ISOChronology.getInstance(DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(bucketingTimeZone))));
-      } catch (DateTimeException dte) {
-        throw new IllegalArgumentException("Error parsing bucketing time zone: " + dte.getMessage(), dte);
-      }
-
-      _dateTime = new MutableDateTime(0L, DateTimeZone.UTC);
-      _buffer = new StringBuilder();
+      init(inputFormatStr, outputFormatStr, outputGranularityStr, bucketingTimeZone, true);
     }
 
     long timeValueMs = _inputFormatSpec.fromFormatToMillis(timeValueStr);
+    truncateDateTime(timeValueMs);
 
+    if (_outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
+      return getFormattedDate();
+    } else {
+      timeValueMs = _dateTime.getMillis();
+      return _outputFormatSpec.getColumnUnit().convert(timeValueMs, TimeUnit.MILLISECONDS)
+          / _outputFormatSpec.getColumnSize();
+    }
+  }
+
+  private void init(String inputFormatStr, String outputFormatStr, String outputGranularityStr,
+      String bucketingTimeZone, boolean bucketTzRequired) {
+    _inputFormatSpec = new DateTimeFormatSpec(inputFormatStr);
+    _outputFormatSpec = new DateTimeFormatSpec(outputFormatStr);
+    _granularitySpec = new DateTimeGranularitySpec(outputGranularityStr);
+
+    DateTimeZone timeZone;
+
+    if (bucketTzRequired) {
+      try {
+        // we're not using TimeZone.getTimeZone() because it's globally synchronized
+        // and returns default TZ when str makes no sense
+        _bucketingTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(bucketingTimeZone)));
+        timeZone = _bucketingTimeZone;
+      } catch (DateTimeException dte) {
+        throw new IllegalArgumentException("Error parsing bucketing time zone: " + dte.getMessage(), dte);
+      }
+    } else {
+      if (_outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
+        timeZone = _outputFormatSpec.getDateTimeFormatter().getZone();
+      } else {
+        timeZone = DateTimeZone.UTC;
+      }
+    }
+
+    _dateTime = new MutableDateTime(0L, timeZone);
+    _buffer = new StringBuilder();
+  }
+
+  private String getFormattedDate() {
+    _buffer.setLength(0);
+    DateTimeFormatter outputFormatter = _outputFormatSpec.getDateTimeFormatter();
+    outputFormatter.printTo(_buffer, _dateTime);
+    return _buffer.toString();
+  }
+
+  private void truncateDateTime(long timeValueMs) {
     _dateTime.setMillis(timeValueMs);
-    _dateTime.setChronology(_bucketingChronology);
     int size = _granularitySpec.getSize();
 
     switch (_granularitySpec.getTimeUnit()) {
@@ -149,17 +146,6 @@ public class DateTimeConvert {
         break;
       default:
         break;
-    }
-
-    if (_outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
-      _buffer.setLength(0);
-      DateTimeFormatter outputFormatter = _outputFormatSpec.getDateTimeFormatter();
-      outputFormatter.printTo(_buffer, _dateTime);
-      return _buffer.toString();
-    } else {
-      timeValueMs = _dateTime.getMillis();
-      return _outputFormatSpec.getColumnUnit().convert(timeValueMs, TimeUnit.MILLISECONDS)
-          / _outputFormatSpec.getColumnSize();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -113,10 +113,12 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
     super.init(arguments, columnContextMap);
-    String bucketTimeZone = null;
+    String bucketTimeZone;
     if (arguments.size() == 5) {
       bucketTimeZone = ((LiteralTransformFunction) arguments.get(4)).getStringLiteral();
-    } else if (arguments.size() != 4) {
+    } else if (arguments.size() == 4) {
+      bucketTimeZone = null;
+    } else {
       throw new IllegalArgumentException(
           "Exactly 4 or 5 arguments are required for DATE_TIME_CONVERT transform function");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -53,6 +53,21 @@ import org.roaringbitmap.RoaringBitmap;
  *       <li>
  *         Granularity to bucket data into. E.g. 1:HOURS; 15:MINUTES
  *       </li>
+ *       <li>
+ *         Bucketing time zone, e.g. 'PST' (optional).
+ *         If not set then output time zone is used when bucketing (e.g. 'UTC' for epoch millis).<br/>
+ *         Note: when time zone is not set, bucketing is done relative to epoch, not relative to nearest
+ *         bigger time unit. For example, when truncating epoch millis of `2024-09-20T00:13:27.834Z` to 5 hours we get:
+ *         <ul>
+ *            <li>with no time zone -> 2024-09-19T20:00:00.000Z</li>
+ *            <li>with explicit UTC time zone -> 2024-09-20T00:00:00.000Z</li>
+ *         </ul>
+ *         Similarly, when truncating epoch millis of the date to 5 days we get:
+ *         <ul>
+ *            <li>with no time zone -> 2024-02-19T00:00:00.000Z</li>
+ *            <li>with explicit UTC time zone -> 2024-09-16T00:00:00.000Z</li>
+ *         </ul>
+ *       </li>
  *     </ul>
  *   </li>
  *   <li>
@@ -65,6 +80,11 @@ import org.roaringbitmap.RoaringBitmap;
  *       <li>
  *         If Date column is expressed in hoursSinceEpoch, and output is expected in weeksSinceEpoch bucketed to
  *         weeks: dateTimeConvert(Date, '1:HOURS:EPOCH', '1:WEEKS:EPOCH', '1:WEEKS')
+ *       </li>
+ *       <li>
+ *         If Date column is expressed in millis, and output is expected in millis but bucketed to days in
+ *         PST time zone:
+ *         dateTimeConvert(Date, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:DAY', 'PST')
  *       </li>
  *     </ul>
  *   </li>
@@ -93,10 +113,14 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
     super.init(arguments, columnContextMap);
-    // Check that there are exactly 4 arguments
-    if (arguments.size() != 4) {
-      throw new IllegalArgumentException("Exactly 4 arguments are required for DATE_TIME_CONVERT transform function");
+    String bucketTimeZone = null;
+    if (arguments.size() == 5) {
+      bucketTimeZone = ((LiteralTransformFunction) arguments.get(4)).getStringLiteral();
+    } else if (arguments.size() != 4) {
+      throw new IllegalArgumentException(
+          "Exactly 4 or 5 arguments are required for DATE_TIME_CONVERT transform function");
     }
+
     TransformFunction firstArgument = arguments.get(0);
     if (firstArgument instanceof LiteralTransformFunction || !firstArgument.getResultMetadata().isSingleValue()) {
       throw new IllegalArgumentException(
@@ -108,7 +132,9 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     _dateTimeTransformer = DateTimeTransformerFactory.getDateTimeTransformer(
         ((LiteralTransformFunction) arguments.get(1)).getStringLiteral(),
         ((LiteralTransformFunction) arguments.get(2)).getStringLiteral(),
-        ((LiteralTransformFunction) arguments.get(3)).getStringLiteral());
+        ((LiteralTransformFunction) arguments.get(3)).getStringLiteral(),
+        bucketTimeZone);
+
     if (_dateTimeTransformer instanceof EpochToEpochTransformer
         || _dateTimeTransformer instanceof SDFToEpochTransformer) {
       _resultMetadata = LONG_SV_NO_DICTIONARY_METADATA;
@@ -130,12 +156,11 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     int length = valueBlock.getNumDocs();
     initLongValuesSV(length);
     if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
-      EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
-      dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _longValuesSV, length);
+      EpochToEpochTransformer transformer = (EpochToEpochTransformer) _dateTimeTransformer;
+      transformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _longValuesSV, length);
     } else {
-      SDFToEpochTransformer dateTimeTransformer = (SDFToEpochTransformer) _dateTimeTransformer;
-      dateTimeTransformer.transform(_mainTransformFunction.transformToStringValuesSV(valueBlock), _longValuesSV,
-          length);
+      SDFToEpochTransformer transformer = (SDFToEpochTransformer) _dateTimeTransformer;
+      transformer.transform(_mainTransformFunction.transformToStringValuesSV(valueBlock), _longValuesSV, length);
     }
     return _longValuesSV;
   }
@@ -148,13 +173,11 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     int length = valueBlock.getNumDocs();
     initStringValuesSV(length);
     if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
-      EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
-      dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _stringValuesSV,
-          length);
+      EpochToSDFTransformer transformer = (EpochToSDFTransformer) _dateTimeTransformer;
+      transformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _stringValuesSV, length);
     } else {
-      SDFToSDFTransformer dateTimeTransformer = (SDFToSDFTransformer) _dateTimeTransformer;
-      dateTimeTransformer.transform(_mainTransformFunction.transformToStringValuesSV(valueBlock), _stringValuesSV,
-          length);
+      SDFToSDFTransformer transformer = (SDFToSDFTransformer) _dateTimeTransformer;
+      transformer.transform(_mainTransformFunction.transformToStringValuesSV(valueBlock), _stringValuesSV, length);
     }
     return _stringValuesSV;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
@@ -49,6 +49,7 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
   private final SDFDateTimeTruncate _sdfDateTimeTruncate;
   private final MillisDateTimeTruncate _millisDateTimeTruncate;
   private final Chronology _bucketingChronology;
+  // use reusable objects for parsing and formatting dates, instead of allocating them on each function call
   private final MutableDateTime _dateTime;
   private final StringBuilder _printBuffer;
 
@@ -61,9 +62,9 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
   }
 
   public BaseDateTimeTransformer(
-      @Nonnull DateTimeFormatSpec inputFormat,
-      @Nonnull DateTimeFormatSpec outputFormat,
-      @Nonnull DateTimeGranularitySpec outputGranularity,
+      DateTimeFormatSpec inputFormat,
+      DateTimeFormatSpec outputFormat,
+      DateTimeGranularitySpec outputGranularity,
       @Nullable DateTimeZone bucketingTimeZone) {
 
     _inputTimeSize = inputFormat.getColumnSize();
@@ -191,6 +192,8 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
         }
         break;
       default:
+        // truncating to MICROSECONDS or NANOSECONDS doesn't do anything because timestamps are stored
+        // in milliseconds at most
         _sdfDateTimeTruncate = _outputDateTimeFormatter::print;
         _millisDateTimeTruncate = (dateTime) -> dateTime.getMillis();
         break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
@@ -81,7 +81,7 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
     final int size = _outputGranularity.getSize();
 
     // setup date time truncating based on output granularity
-    //when size == 1, skip the needless set() calls
+    // when size == 1, skip the needless set() calls
     switch (_outputGranularity.getTimeUnit()) {
       case MILLISECONDS:
         if (size != 1) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/BaseDateTimeTransformer.java
@@ -20,11 +20,15 @@ package org.apache.pinot.core.operator.transform.transformer.datetime;
 
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.transform.transformer.DataTransformer;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeFormatUnitSpec.DateTimeTransformUnit;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
-import org.joda.time.DateTime;
+import org.joda.time.Chronology;
+import org.joda.time.DateTimeZone;
+import org.joda.time.MutableDateTime;
+import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormatter;
 
 
@@ -42,14 +46,26 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
   private final DateTimeFormatter _outputDateTimeFormatter;
   private final DateTimeGranularitySpec _outputGranularity;
   private final long _outputGranularityMillis;
-  private final SDFDateTimeTruncate _dateTimeTruncate;
+  private final SDFDateTimeTruncate _sdfDateTimeTruncate;
+  private final MillisDateTimeTruncate _millisDateTimeTruncate;
+  private final Chronology _bucketingChronology;
+  private final MutableDateTime _dateTime;
+  private final StringBuilder _printBuffer;
 
   private interface SDFDateTimeTruncate {
-    String truncate(DateTime dateTime);
+    String truncate(MutableDateTime dateTime);
   }
 
-  public BaseDateTimeTransformer(@Nonnull DateTimeFormatSpec inputFormat, @Nonnull DateTimeFormatSpec outputFormat,
-      @Nonnull DateTimeGranularitySpec outputGranularity) {
+  private interface MillisDateTimeTruncate {
+    long truncate(MutableDateTime dateTime);
+  }
+
+  public BaseDateTimeTransformer(
+      @Nonnull DateTimeFormatSpec inputFormat,
+      @Nonnull DateTimeFormatSpec outputFormat,
+      @Nonnull DateTimeGranularitySpec outputGranularity,
+      @Nullable DateTimeZone bucketingTimeZone) {
+
     _inputTimeSize = inputFormat.getColumnSize();
     _inputTimeUnit = inputFormat.getColumnUnit();
     _inputDateTimeFormatter = inputFormat.getDateTimeFormatter();
@@ -58,39 +74,143 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
     _outputDateTimeFormatter = outputFormat.getDateTimeFormatter();
     _outputGranularity = outputGranularity;
     _outputGranularityMillis = outputGranularity.granularityToMillis();
+    _bucketingChronology = bucketingTimeZone != null ? ISOChronology.getInstance(bucketingTimeZone) : null;
+    _dateTime = new MutableDateTime(0L, DateTimeZone.UTC);
+    _printBuffer = new StringBuilder();
+
+    final int size = _outputGranularity.getSize();
 
     // setup date time truncating based on output granularity
-    final int sz = _outputGranularity.getSize();
+    //when size == 1, skip the needless set() calls
     switch (_outputGranularity.getTimeUnit()) {
       case MILLISECONDS:
-        _dateTimeTruncate = (dateTime) -> _outputDateTimeFormatter
-            .print(dateTime.withMillisOfSecond((dateTime.getMillisOfSecond() / sz) * sz));
+        if (size != 1) {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.setMillisOfSecond((dateTime.getMillisOfSecond() / size) * size);
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.setMillisOfSecond((dateTime.getMillisOfSecond() / size) * size);
+            return dateTime.getMillis();
+          };
+        } else {
+          _sdfDateTimeTruncate = (dateTime) -> print(dateTime);
+          _millisDateTimeTruncate = (dateTime) -> dateTime.getMillis();
+        }
         break;
       case SECONDS:
-        _dateTimeTruncate = (dateTime) -> _outputDateTimeFormatter.print(
-            dateTime.withSecondOfMinute((dateTime.getSecondOfMinute() / sz) * sz).secondOfMinute().roundFloorCopy());
+        if (size != 1) {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.setSecondOfMinute((dateTime.getSecondOfMinute() / size) * size);
+            dateTime.secondOfMinute().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.setSecondOfMinute((dateTime.getSecondOfMinute() / size) * size);
+            dateTime.secondOfMinute().roundFloor();
+            return dateTime.getMillis();
+          };
+        } else {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.secondOfMinute().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.secondOfMinute().roundFloor();
+            return dateTime.getMillis();
+          };
+        }
         break;
       case MINUTES:
-        _dateTimeTruncate = (dateTime) -> _outputDateTimeFormatter
-            .print(dateTime.withMinuteOfHour((dateTime.getMinuteOfHour() / sz) * sz).minuteOfHour().roundFloorCopy());
+        if (size != 1) {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.setMinuteOfHour((dateTime.getMinuteOfHour() / size) * size);
+            dateTime.minuteOfHour().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.setMinuteOfHour((dateTime.getMinuteOfHour() / size) * size);
+            dateTime.minuteOfHour().roundFloor();
+            return dateTime.getMillis();
+          };
+        } else {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.minuteOfHour().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.minuteOfHour().roundFloor();
+            return dateTime.getMillis();
+          };
+        }
         break;
       case HOURS:
-        _dateTimeTruncate = (dateTime) -> _outputDateTimeFormatter
-            .print(dateTime.withHourOfDay((dateTime.getHourOfDay() / sz) * sz).hourOfDay().roundFloorCopy());
+        if (size != 1) {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.setHourOfDay((dateTime.getHourOfDay() / size) * size);
+            dateTime.hourOfDay().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.setHourOfDay((dateTime.getHourOfDay() / size) * size);
+            dateTime.hourOfDay().roundFloor();
+            return dateTime.getMillis();
+          };
+        } else {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.hourOfDay().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.hourOfDay().roundFloor();
+            return dateTime.getMillis();
+          };
+        }
         break;
       case DAYS:
-        _dateTimeTruncate = (dateTime) -> _outputDateTimeFormatter
-            .print(dateTime.withDayOfMonth(((dateTime.getDayOfMonth() - 1) / sz) * sz + 1).dayOfMonth()
-                .roundFloorCopy());
+        if (size != 1) {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / size) * size + 1);
+            dateTime.dayOfMonth().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / size) * size + 1);
+            dateTime.dayOfMonth().roundFloor();
+            return dateTime.getMillis();
+          };
+        } else {
+          _sdfDateTimeTruncate = (dateTime) -> {
+            dateTime.dayOfMonth().roundFloor();
+            return print(dateTime);
+          };
+          _millisDateTimeTruncate = (dateTime) -> {
+            dateTime.dayOfMonth().roundFloor();
+            return dateTime.getMillis();
+          };
+        }
         break;
       default:
-        _dateTimeTruncate = _outputDateTimeFormatter::print;
+        _sdfDateTimeTruncate = _outputDateTimeFormatter::print;
+        _millisDateTimeTruncate = (dateTime) -> dateTime.getMillis();
         break;
     }
   }
 
+  private String print(MutableDateTime dateTime) {
+    _printBuffer.setLength(0);
+    _outputDateTimeFormatter.printTo(_printBuffer, dateTime);
+    return _printBuffer.toString();
+  }
+
   protected long transformEpochToMillis(long epochTime) {
     return _inputTimeUnit.toMillis(epochTime * _inputTimeSize);
+  }
+
+  protected MutableDateTime toDateWithTZ(long millis) {
+    _dateTime.setMillis(millis);
+    _dateTime.setChronology(_bucketingChronology);
+    return _dateTime;
   }
 
   protected long transformSDFToMillis(@Nonnull String sdfTime) {
@@ -103,10 +223,24 @@ public abstract class BaseDateTimeTransformer<I, O> implements DataTransformer<I
 
   protected String transformMillisToSDF(long millisSinceEpoch) {
     // convert to date time (with timezone), then truncate/bucket to the desired output granularity
-    return _dateTimeTruncate.truncate(new DateTime(millisSinceEpoch, _outputDateTimeFormatter.getZone()));
+    _dateTime.setZone(_outputDateTimeFormatter.getZone());
+    _dateTime.setMillis(millisSinceEpoch);
+    return _sdfDateTimeTruncate.truncate(_dateTime);
+  }
+
+  protected String truncateDateToSDF(MutableDateTime dateTime) {
+    return _sdfDateTimeTruncate.truncate(dateTime);
+  }
+
+  protected long truncateToMillis(MutableDateTime dateTime) {
+    return _millisDateTimeTruncate.truncate(dateTime);
   }
 
   protected long transformToOutputGranularity(long millisSinceEpoch) {
     return (millisSinceEpoch / _outputGranularityMillis) * _outputGranularityMillis;
+  }
+
+  protected boolean useCustomBucketingTimeZone() {
+    return _bucketingChronology != null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
@@ -34,7 +35,7 @@ public class DateTimeTransformerFactory {
   }
 
   public static BaseDateTimeTransformer getDateTimeTransformer(String inputFormatStr, String outputFormatStr,
-      String outputGranularityStr, String bucketTimeZoneStr) {
+      String outputGranularityStr, @Nullable String bucketTimeZoneStr) {
 
     DateTimeFormatSpec inputFormat = new DateTimeFormatSpec(inputFormatStr);
     DateTimeFormatSpec outputFormat = new DateTimeFormatSpec(outputFormatStr);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.TimeZone;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
@@ -45,9 +48,9 @@ public class DateTimeTransformerFactory {
       try {
         // we're not using TimeZone.getTimeZone() because it's globally synchronized and returns default TZ when str
         // makes no sense
-        bucketingTz = DateTimeZone.forID(bucketTimeZoneStr);
-      } catch (IllegalArgumentException iae) {
-        throw new IllegalArgumentException("Error parsing bucketing time zone: " + iae.getMessage(), iae);
+        bucketingTz = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(bucketTimeZoneStr)));
+      } catch (DateTimeException dte) {
+        throw new IllegalArgumentException("Error parsing bucketing time zone: " + dte.getMessage(), dte);
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToEpochTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToEpochTransformer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.transformer.datetime;
 import javax.annotation.Nonnull;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -29,14 +30,20 @@ import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 public class EpochToEpochTransformer extends BaseDateTimeTransformer<long[], long[]> {
 
   public EpochToEpochTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity) {
-    super(inputFormat, outputFormat, outputGranularity);
+      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTz) {
+    super(inputFormat, outputFormat, outputGranularity, bucketingTz);
   }
 
   @Override
   public void transform(@Nonnull long[] input, @Nonnull long[] output, int length) {
-    for (int i = 0; i < length; i++) {
-      output[i] = transformMillisToEpoch(transformToOutputGranularity(transformEpochToMillis(input[i])));
+    if (useCustomBucketingTimeZone()) {
+      for (int i = 0; i < length; i++) {
+        output[i] = transformMillisToEpoch(truncateToMillis(toDateWithTZ(transformEpochToMillis(input[i]))));
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        output[i] = transformMillisToEpoch(transformToOutputGranularity(transformEpochToMillis(input[i])));
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToEpochTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToEpochTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTimeZone;
@@ -30,7 +31,7 @@ import org.joda.time.DateTimeZone;
 public class EpochToEpochTransformer extends BaseDateTimeTransformer<long[], long[]> {
 
   public EpochToEpochTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTz) {
+      DateTimeGranularitySpec outputGranularity, @Nullable DateTimeZone bucketingTz) {
     super(inputFormat, outputFormat, outputGranularity, bucketingTz);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToSDFTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToSDFTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTimeZone;
@@ -30,7 +31,7 @@ import org.joda.time.DateTimeZone;
 public class EpochToSDFTransformer extends BaseDateTimeTransformer<long[], String[]> {
 
   public EpochToSDFTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+      DateTimeGranularitySpec outputGranularity, @Nullable DateTimeZone bucketingTimeZone) {
     super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToSDFTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/EpochToSDFTransformer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.transformer.datetime;
 import javax.annotation.Nonnull;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -29,15 +30,21 @@ import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 public class EpochToSDFTransformer extends BaseDateTimeTransformer<long[], String[]> {
 
   public EpochToSDFTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity) {
-    super(inputFormat, outputFormat, outputGranularity);
+      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+    super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 
   @Override
   public void transform(@Nonnull long[] input, @Nonnull String[] output, int length) {
-    for (int i = 0; i < length; i++) {
-      // NOTE: No need to bucket time because it's implicit in the output simple date format
-      output[i] = transformMillisToSDF(transformEpochToMillis(input[i]));
+    // NOTE: No need to bucket time because it's implicit in the output simple date format
+    if (useCustomBucketingTimeZone()) {
+      for (int i = 0; i < length; i++) {
+        output[i] = truncateDateToSDF(toDateWithTZ(transformEpochToMillis(input[i])));
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        output[i] = transformMillisToSDF(transformEpochToMillis(input[i]));
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToEpochTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToEpochTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTimeZone;
@@ -30,7 +31,7 @@ import org.joda.time.DateTimeZone;
 public class SDFToEpochTransformer extends BaseDateTimeTransformer<String[], long[]> {
 
   public SDFToEpochTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+      DateTimeGranularitySpec outputGranularity, @Nullable DateTimeZone bucketingTimeZone) {
     super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToEpochTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToEpochTransformer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.transformer.datetime;
 import javax.annotation.Nonnull;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -29,14 +30,20 @@ import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 public class SDFToEpochTransformer extends BaseDateTimeTransformer<String[], long[]> {
 
   public SDFToEpochTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity) {
-    super(inputFormat, outputFormat, outputGranularity);
+      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+    super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 
   @Override
   public void transform(@Nonnull String[] input, @Nonnull long[] output, int length) {
-    for (int i = 0; i < length; i++) {
-      output[i] = transformMillisToEpoch(transformToOutputGranularity(transformSDFToMillis(input[i])));
+    if (useCustomBucketingTimeZone()) {
+      for (int i = 0; i < length; i++) {
+        output[i] = truncateToMillis(toDateWithTZ(transformSDFToMillis(input[i])));
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        output[i] = transformMillisToEpoch(transformToOutputGranularity(transformSDFToMillis(input[i])));
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToSDFTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToSDFTransformer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.transformer.datetime;
 import javax.annotation.Nonnull;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -30,15 +31,21 @@ import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 public class SDFToSDFTransformer extends BaseDateTimeTransformer<String[], String[]> {
 
   public SDFToSDFTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity) {
-    super(inputFormat, outputFormat, outputGranularity);
+      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+    super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 
   @Override
   public void transform(@Nonnull String[] input, @Nonnull String[] output, int length) {
-    for (int i = 0; i < length; i++) {
-      // NOTE: No need to bucket time because it's implicit in the output simple date format
-      output[i] = transformMillisToSDF(transformSDFToMillis(input[i]));
+    // NOTE: No need to bucket time because it's implicit in the output simple date format
+    if (useCustomBucketingTimeZone()) {
+      for (int i = 0; i < length; i++) {
+        output[i] = truncateDateToSDF(toDateWithTZ(transformSDFToMillis(input[i])));
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        output[i] = transformMillisToSDF(transformSDFToMillis(input[i]));
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToSDFTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/SDFToSDFTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.transformer.datetime;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTimeZone;
@@ -31,7 +32,7 @@ import org.joda.time.DateTimeZone;
 public class SDFToSDFTransformer extends BaseDateTimeTransformer<String[], String[]> {
 
   public SDFToSDFTransformer(DateTimeFormatSpec inputFormat, DateTimeFormatSpec outputFormat,
-      DateTimeGranularitySpec outputGranularity, DateTimeZone bucketingTimeZone) {
+      DateTimeGranularitySpec outputGranularity, @Nullable DateTimeZone bucketingTimeZone) {
     super(inputFormat, outputFormat, outputGranularity, bucketingTimeZone);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
@@ -249,6 +249,12 @@ public class TimePredicateFilterOptimizer implements FilterOptimizer {
   private void optimizeDateTimeConvert(Function filterFunction, FilterKind filterKind) {
     List<Expression> filterOperands = filterFunction.getOperands();
     List<Expression> dateTimeConvertOperands = filterOperands.get(0).getFunctionCall().getOperands();
+
+    // dateTimeConvert with bucketing time zone is not optimized yet
+    if (dateTimeConvertOperands.size() == 5) {
+      return;
+    }
+
     Preconditions.checkArgument(dateTimeConvertOperands.size() == 4,
         "Exactly 4 arguments are required for DATE_TIME_CONVERT transform function");
     Preconditions.checkArgument(

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -54,6 +54,27 @@ public class DateTimeFunctionsTest {
     assertEquals(evaluator.evaluate(row), expectedResult);
   }
 
+  private void testDateFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
+      Object expectedResult) {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    assertEquals(evaluator.getArguments(), expectedArguments);
+    Object actual = evaluator.evaluate(row);
+    try {
+      assertEquals(actual, expectedResult);
+    } catch (AssertionError ae) {
+      String actualDate = "";
+      if (actual instanceof Long) {
+        actualDate = " (" + new DateTime(actual, DateTimeZone.UTC) + ")";
+      }
+      String expectedDate = "";
+      if (expectedResult instanceof Long) {
+        expectedDate = " (" + new DateTime(expectedResult, DateTimeZone.UTC) + ")";
+      }
+
+      throw new AssertionError("Expected: " + expectedResult + (expectedDate) + " but was " + actual + actualDate, ae);
+    }
+  }
+
   @Test(dataProvider = "dateTimeFunctionsDataProvider")
   public void testDateTimeFunctions(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
@@ -489,6 +510,7 @@ public class DateTimeFunctionsTest {
     // Test conversion from millis to hours
     testDateTimeConvert(1505902560000L/* 20170920T03:16:00 */, "1:MILLISECONDS:EPOCH", "1:HOURS:EPOCH", "1:HOURS",
         418306L/* 20170920T03:00:00 */);
+
     // Test conversion from 5 minutes to hours
     testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:HOURS:EPOCH", "1:HOURS",
         418306L/* 20170920T03:00:00 */);
@@ -497,68 +519,130 @@ public class DateTimeFunctionsTest {
         1505901600000L/* 20170920T03:00:00 */);
 
     testDateTimeConvert(null, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS", null);
+    // test custom bucketing time zone
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS", "UTC",
+        1505901600000L/* 20170920T03:00:00 */);
+
+    // test with custom bucketing time zone
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "4:HOURS",
+        1505894400000L/* 20170920T03:00:00 */);
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "4:HOURS", "UTC",
+        1505894400000L/* 20170920T03:00:00 */);
+    testDateTimeConvert(5019635L/* 20170919T23:55:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "4:HOURS", "CET",
+        1505887200000L/* 20170920T03:00:00 */);
+
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "2:DAYS",
+        1505779200000L/* 20170920T03:00:00 */);
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "2:DAYS", "UTC",
+        1505779200000L/* 20170920T03:00:00 */);
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "2:DAYS", "CET",
+        1505772000000L/* 20170920T03:00:00 */);
 
     // EPOCH to SDF
     // Test conversion from millis since epoch to simple date format (UTC)
     testDateTimeConvert(1505985360000L/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "20170921");
+    testDateTimeConvert(1505985360000L/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "CET", "20170920");
+
     // Test conversion from millis since epoch to simple date format (Pacific timezone)
     testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Los_Angeles)", "1:DAYS", "20170920");
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Los_Angeles)", "1:DAYS", "CET", "20170920");
+
     // Test conversion from millis since epoch to simple date format (IST)
     testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", "1:DAYS", "20170921");
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", "1:DAYS", "CET", "20170921");
+
     // Test conversion from millis since epoch to simple date format (Pacific timezone)
     testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/Los_Angeles)", "1:HOURS", "2017092020");
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/Los_Angeles)", "1:HOURS", "CET", "2017092020");
+
     // Test conversion from millis since epoch to simple date format (East Coast timezone)
     testDateTimeConvert(1505970000000L/* 20170920T22:00:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)", "1:HOURS", "2017092101");
+    testDateTimeConvert(1505970000000L/* 20170920T22:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)", "1:HOURS", "CET", "2017092101");
+
     // Test conversion from millis since epoch to simple date format (America/Denver timezone with 15 second
     // granularity)
     testDateTimeConvert(1523560632000L/* 20180412T19:17:12 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS",
         "2018-04-12 13:17:00.000");
+
     // Test conversion from millis since epoch to simple date format (America/Denver timezone with 3 minute granularity)
     testDateTimeConvert(1523561708000L/* 20180412T19:35:08 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "3:MINUTES",
         "2018-04-12 13:33:00.000");
+
     // Test conversion from millis since epoch to simple date format (America/Denver timezone with 12 hour granularity)
     testDateTimeConvert(1523430205000L/* 20180411T07:03:25 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "12:HOURS",
         "2018-04-11 00:00:00.000");
+    testDateTimeConvert(1523430205000L/* 20180411T07:03:25 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "12:HOURS", "CET",
+        "2018-04-10 16:00:00.000");
+
     // Test conversion from millis since epoch to simple date format (America/Denver timezone with 5 day granularity)
     testDateTimeConvert(1519926205000L/* 20180301T09:43:25 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS",
         "2018-03-01 00:00:00.000");
+    testDateTimeConvert(1519926205000L/* 20180301T09:43:25 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS", "CET",
+        "2018-02-28 16:00:00.000");
+
     testDateTimeConvert(1522230205000L/* 20180328T09:43:25 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS",
         "2018-03-26 00:00:00.000");
+    testDateTimeConvert(1522230205000L/* 20180328T09:43:25 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS", "CET",
+        "2018-03-25 16:00:00.000");
+
     // Test conversion from millis since epoch to simple date format (America/Los_Angeles timezone with 1 day
     // granularity)
     testDateTimeConvert(1524013200000L/* 20180418T01:00:00 */, "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
         "2018-04-17 00:00:00.000");
+    testDateTimeConvert(1524013200000L/* 20180418T01:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS", "CET",
+        "2018-04-17 15:00:00.000");
 
     // SDF to EPOCH
     // Test conversion from simple date format to millis since epoch
     testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS:EPOCH", "1:DAYS",
         1505952000000L/* 20170921T00:00:00 */);
+    testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS:EPOCH", "1:DAYS", "CET",
+        1505944800000L/* 20170921T00:00:00 */);
+
     // Test conversion from simple date format (East Coast timezone) to millis since epoch
     testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/New_York)", "1:MILLISECONDS:EPOCH",
         "1:DAYS", 1505952000000L/* 20170921T00:00:00 */);
+    testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/New_York)", "1:MILLISECONDS:EPOCH",
+        "1:DAYS", "CET", 1505944800000L/* 20170920T22:00:00 */);
+
     // Test conversion from simple date format (East Coast timezone) to millis since epoch
     testDateTimeConvert("2017092000", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)",
         "1:MILLISECONDS:EPOCH", "1:HOURS", 1505880000000L/* 20170920T00:00:00 Eastern */);
+    testDateTimeConvert("2017092000", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)",
+        "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", 1505880000000L/* 20170920T00:00:00 Eastern */);
+
     // Test conversion from simple date format with special characters to millis since epoch
     testDateTimeConvert("2017092000 America/Los_Angeles", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH ZZZ",
         "1:MILLISECONDS:EPOCH", "1:HOURS", 1505890800000L/* 20170920T00:00:00 UTC */);
+
     // Test conversion from simple date format with special characters to millis since epoch
     testDateTimeConvert("8/7/2017 12 PM", "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h a", "1:MILLISECONDS:EPOCH", "1:HOURS",
         1502107200000L/* 20170807T12:00:00 UTC */);
+
     // Test conversion from simple date format with special characters to millis since epoch, with bucketing
     testDateTimeConvert("8/7/2017 12:00:01 PM", "1:SECONDS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a",
         "1:MILLISECONDS:EPOCH", "1:HOURS", 1502107200000L/* 20170807T12:00:00 UTC */);
+
     // Test conversion from simple date format with special characters to millis since epoch, without bucketing
     testDateTimeConvert("8/7/2017 12:00:01 PM", "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", "1:MILLISECONDS:EPOCH",
         "1:MILLISECONDS", 1502107201000L/* 20170807T12:00:01 UTC */);
@@ -567,27 +651,42 @@ public class DateTimeFunctionsTest {
     // Test conversion from simple date format to another simple date format
     testDateTimeConvert("8/7/2017 12:45:50 AM", "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS", "20170807");
+
     // Test conversion from simple date format with timezone to another simple date format
     testDateTimeConvert("20170921 Asia/Kolkata", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS", "20170920");
+
     // Test conversion from simple date format with timezone to another simple date format with timezone
     testDateTimeConvert("20170921 Asia/Kolkata", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Chicago)", "1:MILLISECONDS", "20170920");
+
     // Test conversion from simple date format to another simple date format (America/Denver timezone with 15 second
     // granularity)
     testDateTimeConvert("20180412T19:17:12", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS",
         "2018-04-12 13:17:00.000");
+    testDateTimeConvert("20180412T19:17:12", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS", "CET",
+        "2018-04-12 13:17:00.000");
+
     // Test conversion from simple date format to another simple date format (America/Denver timezone with 5 day
     // granularity)
     testDateTimeConvert("20180328T09:43:25", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
-        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss" + ".SSS tz(America/Denver)", "5:DAYS",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS",
         "2018-03-26 00:00:00.000");
+    testDateTimeConvert("20180328T09:43:25", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS", "CET",
+        "2018-03-25 16:00:00.000");
+
     // Test conversion from simple date format to another simple date format (America/Los_Angeles timezone with 1 day
     // granularity)
     testDateTimeConvert("20180418T01:00:00", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
         "2018-04-17 00:00:00.000");
+    testDateTimeConvert("20180418T01:00:00", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS", "CET",
+        "2018-04-17 15:00:00.000");
+
     // Test time value with scientific number
     testDateTimeConvert(1.50598536E12/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
         "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "20170921");
@@ -640,8 +739,17 @@ public class DateTimeFunctionsTest {
     GenericRow row = new GenericRow();
     row.putValue("timeCol", timeValue);
     List<String> arguments = Collections.singletonList("timeCol");
-    testFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
+    testDateFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
         outputGranularityStr), arguments, row, expectedResult == null ? null : expectedResult);
+  }
+
+  private void testDateTimeConvert(Object timeValue, String inputFormatStr, String outputFormatStr,
+      String outputGranularityStr, String bucketingTz, Object expectedResult) {
+    GenericRow row = new GenericRow();
+    row.putValue("timeCol", timeValue);
+    List<String> arguments = Collections.singletonList("timeCol");
+    testDateFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
+        outputGranularityStr, bucketingTz), arguments, row, expectedResult == null ? null : expectedResult);
   }
 
   private void testMultipleInvocations(String functionExpression, List<GenericRow> rows, List<Object> expectedResults) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
@@ -18,13 +18,33 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatPatternSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTimeZone;
+import org.joda.time.MutableDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.roaringbitmap.RoaringBitmap;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -33,6 +53,1163 @@ import static org.testng.Assert.assertTrue;
 
 
 public class DateTimeConversionTransformFunctionTest extends BaseTransformFunctionTest {
+
+  private final MutableDateTime _expBuffer = new MutableDateTime(DateTimeZone.UTC);
+  private final MutableDateTime _actualBuffer = new MutableDateTime(DateTimeZone.UTC);
+  private final DateTimeFormatter _formatter = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ss.SSSZ");
+  private final TestSVLongTransformFunction _firstArg = new TestSVLongTransformFunction();
+
+  @BeforeTest
+  public void setUp()
+  throws Exception {
+    super.setUp();
+    _expBuffer.hourOfDay().roundFloor();
+  }
+
+  // tests with static data
+  // convert with no bucketing time zone
+  @Test
+  public void testConvertEpochToEpochWith1HourBucketNoTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 02:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/10/20 05:00:00.000+0000",
+        "2024/10/20 06:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS", null);
+
+    assertLongInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith3HoursBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 06:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "3:HOURS", null);
+
+    assertLongInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/21 00:00:00.000+0000",
+        "2024/10/22 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/24 00:00:00.000+0000",
+        "2024/10/25 00:00:00.000+0000",
+        "2024/10/26 00:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:DAYS", null);
+    assertLongInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith3DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/26 00:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "3:DAYS", null);
+
+    assertLongInLongOut(input, expected, function);
+  }
+
+  //convert with cet bucket time zone
+  @Test
+  public void testConvertEpochToEpochWith3HoursBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/19 22:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "3:HOURS", "CET");
+
+    assertLongInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/19 22:00:00.000+0000",
+        "2024/10/20 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/22 22:00:00.000+0000",
+        "2024/10/23 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000",
+        "2024/10/25 22:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:DAYS", "CET");
+    assertLongInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith3DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/18 22:00:00.000+0000",
+        "2024/10/18 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "3:DAYS", "CET");
+
+    assertLongInLongOut(input, expected, function);
+  }
+
+  //convert to string with cet bucket time zone
+  @Test
+  public void testConvertEpochToStringWith3HoursBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000",
+        "2024/11/25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-20 00:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-11-25 06:00:00.000+0100",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "3:HOURS", "CET");
+
+    assertLongInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToStringWith1DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000",
+        "2024/11/25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-20 00:00:00.000+0200",
+        "2024-10-21 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-23 00:00:00.000+0200",
+        "2024-10-24 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-10-26 00:00:00.000+0200",
+        "2024-11-25 00:00:00.000+0100"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "1:DAYS", "CET");
+    assertLongInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToStringWith3DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000",
+        "2024/11/20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-19 00:00:00.000+0200",
+        "2024-10-19 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-11-19 00:00:00.000+0100",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "3:DAYS", "CET");
+
+    assertLongInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertEpochToStringWith3DaysBucketWithEetTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000",
+        "2024/11/20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-19 01:00:00.000+0300",
+        "2024-10-19 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-25 01:00:00.000+0300",
+        "2024-10-25 01:00:00.000+0300",
+        "2024-11-19 01:00:00.000+0200",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(EET)",
+            "3:DAYS", "CET");
+
+    assertLongInStrOut(input, expected, function);
+  }
+
+  // convert from utc string to cet string without bucket time zone
+  @Test
+  public void testConvertStringToStringWith1HourBucketNoTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 02:00:00.000+0200",
+        "2024/10/20 03:00:00.000+0200",
+        "2024/10/20 04:00:00.000+0200",
+        "2024/10/20 05:00:00.000+0200",
+        "2024/10/20 06:00:00.000+0200",
+        "2024/10/20 07:00:00.000+0200",
+        "2024/10/20 08:00:00.000+0200"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ tz(CET)", "1:HOURS", null);
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith3HoursBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/20 01:20:15.002+0000",
+        "2024/10/20 02:40:15.003+0000",
+        "2024/10/20 03:35:45.004+0000",
+        "2024/10/20 04:05:45.005+0000",
+        "2024/10/20 05:12:01.006+0000",
+        "2024/10/20 06:15:01.007+0000",
+        "2024/11/20 06:15:01.007+0000",
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0200",
+        "2024/10/20 03:00:00.000+0200",
+        "2024/10/20 03:00:00.000+0200",
+        "2024/10/20 03:00:00.000+0200",
+        "2024/10/20 06:00:00.000+0200",
+        "2024/10/20 06:00:00.000+0200",
+        "2024/10/20 06:00:00.000+0200",
+        "2024/11/20 06:00:00.000+0100",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ tz(CET)", "3:HOURS", null);
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith1DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0200",
+        "2024/10/21 00:00:00.000+0200",
+        "2024/10/22 00:00:00.000+0200",
+        "2024/10/23 00:00:00.000+0200",
+        "2024/10/24 00:00:00.000+0200",
+        "2024/10/25 00:00:00.000+0200",
+        "2024/10/26 00:00:00.000+0200"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ tz(CET)", "1:DAYS", null);
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith3DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024/10/20 00:12:15.001+0000",
+        "2024/10/21 01:20:15.002+0000",
+        "2024/10/22 02:40:15.003+0000",
+        "2024/10/23 03:35:45.004+0000",
+        "2024/10/24 04:05:45.005+0000",
+        "2024/10/25 05:12:01.006+0000",
+        "2024/10/26 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/19 00:00:00.000+0000",
+        "2024/10/19 00:00:00.000+0000",
+        "2024/10/22 00:00:00.000+0000",
+        "2024/10/22 00:00:00.000+0000",
+        "2024/10/22 00:00:00.000+0000",
+        "2024/10/25 00:00:00.000+0000",
+        "2024/10/25 00:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy/MM/dd HH:mm:ss.SSSZ tz(UTC)", "3:DAYS", null);
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  // convert from utc string to string with bucket time zone
+  @Test
+  public void testConvertStringToStringWith3HoursBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-20 01:20:15.002+0000",
+        "2024-10-20 02:40:15.003+0000",
+        "2024-10-20 03:35:45.004+0000",
+        "2024-10-20 04:05:45.005+0000",
+        "2024-10-20 05:12:01.006+0000",
+        "2024-10-20 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-20 00:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 03:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-10-20 06:00:00.000+0200",
+        "2024-11-25 06:00:00.000+0100",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "3:HOURS", "CET");
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith1DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-20 00:00:00.000+0200",
+        "2024-10-21 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-23 00:00:00.000+0200",
+        "2024-10-24 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-10-26 00:00:00.000+0200",
+        "2024-11-25 00:00:00.000+0100"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "1:DAYS", "CET");
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith3DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-19 00:00:00.000+0200",
+        "2024-10-19 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-22 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-10-25 00:00:00.000+0200",
+        "2024-11-19 00:00:00.000+0100",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)",
+            "3:DAYS", "CET");
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToStringWith3DaysBucketWithEetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024-10-19 01:00:00.000+0300",
+        "2024-10-19 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-22 01:00:00.000+0300",
+        "2024-10-25 01:00:00.000+0300",
+        "2024-10-25 01:00:00.000+0300",
+        "2024-11-19 01:00:00.000+0200",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(EET)",
+            "3:DAYS", "CET");
+
+    assertStrInStrOut(input, expected, function);
+  }
+
+  // convert from utc string to millis without bucket time zone
+  @Test
+  public void testConvertStringToEpochWith3HoursBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-20 01:20:15.002+0000",
+        "2024-10-20 02:40:15.003+0000",
+        "2024-10-20 03:35:45.004+0000",
+        "2024-10-20 04:05:45.005+0000",
+        "2024-10-20 05:12:01.006+0000",
+        "2024-10-20 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 03:00:00.000+0000",
+        "2024/10/20 06:00:00.000+0000",
+        "2024/11/25 06:00:00.000+0000",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "3:HOURS", null);
+
+    assertStrInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToEpochWith1DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/21 00:00:00.000+0000",
+        "2024/10/22 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/24 00:00:00.000+0000",
+        "2024/10/25 00:00:00.000+0000",
+        "2024/10/26 00:00:00.000+0000",
+        "2024/11/25 00:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "1:DAYS", null);
+    assertStrInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToEpochWith3DaysBucketWithoutTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/20 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/23 00:00:00.000+0000",
+        "2024/10/26 00:00:00.000+0000",
+        "2024/11/19 00:00:00.000+0000",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "3:DAYS", null);
+
+    assertStrInLongOut(input, expected, function);
+  }
+
+  // convert from utc string to millis with bucket time zone
+  @Test
+  public void testConvertStringToEpochWith3HoursBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-20 01:20:15.002+0000",
+        "2024-10-20 02:40:15.003+0000",
+        "2024-10-20 03:35:45.004+0000",
+        "2024-10-20 04:05:45.005+0000",
+        "2024-10-20 05:12:01.006+0000",
+        "2024-10-20 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/19 22:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 01:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/10/20 04:00:00.000+0000",
+        "2024/11/25 05:00:00.000+0000",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "3:HOURS", "CET");
+
+    assertStrInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToEpochWith1DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-25 06:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/19 22:00:00.000+0000",
+        "2024/10/20 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/22 22:00:00.000+0000",
+        "2024/10/23 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000",
+        "2024/10/25 22:00:00.000+0000",
+        "2024/11/24 23:00:00.000+0000"
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "1:DAYS", "CET");
+    assertStrInLongOut(input, expected, function);
+  }
+
+  @Test
+  public void testConvertStringToEpochWith3DaysBucketWithCetTimeZone() {
+    String[] input = new String[]{
+        "2024-10-20 00:12:15.001+0000",
+        "2024-10-21 01:20:15.002+0000",
+        "2024-10-22 02:40:15.003+0000",
+        "2024-10-23 03:35:45.004+0000",
+        "2024-10-24 04:05:45.005+0000",
+        "2024-10-25 05:12:01.006+0000",
+        "2024-10-26 06:15:01.007+0000",
+        "2024-11-20 07:15:01.007+0000"
+    };
+    String[] expected = new String[]{
+        "2024/10/18 22:00:00.000+0000",
+        "2024/10/18 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/21 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000",
+        "2024/10/24 22:00:00.000+0000",
+        "2024/11/18 23:00:00.000+0000",
+    };
+
+    DateTimeConversionTransformFunction function =
+        prepareFunction("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ",
+            "1:MILLISECONDS:EPOCH",
+            "3:DAYS", "CET");
+
+    assertStrInLongOut(input, expected, function);
+  }
+
+  private @NotNull DateTimeConversionTransformFunction prepareFunction(String inputFormat,
+      String outputFormat, String bucketGranularity, String bucketingTimeZone) {
+
+    DateTimeConversionTransformFunction function = new DateTimeConversionTransformFunction();
+    ArrayList<TransformFunction> args = new ArrayList<>();
+    args.add(_firstArg);
+    args.add(strLiteral(inputFormat));
+    args.add(strLiteral(outputFormat));
+    args.add(strLiteral(bucketGranularity));
+
+    if (bucketingTimeZone != null) {
+      args.add(literal(DataType.STRING, bucketingTimeZone));
+    }
+
+    function.init(args, Collections.emptyMap());
+    return function;
+  }
+
+  private void assertLongInLongOut(String[] input, String[] expected, DateTimeConversionTransformFunction function) {
+    SingleValueTestBlock block = new SingleValueTestBlock();
+
+    for (int i = 0; i < input.length; i++) {
+      long inputMs = parse(input[i]);
+      parse(expected[i]);
+
+      _firstArg.setLongValue(inputMs);
+      long[] result = function.transformToLongValuesSV(block);
+
+      assertEquals(toDate(result), _expBuffer);
+    }
+  }
+
+  private long parse(String inp) {
+    int pos = _formatter.parseInto(_expBuffer, inp, 0);
+    if (pos < 0) {
+      throw new IllegalArgumentException("parsing of " + inp + " failed!");
+    }
+    return _expBuffer.getMillis();
+  }
+
+  private void assertLongInStrOut(String[] input, String[] expected, DateTimeConversionTransformFunction function) {
+    SingleValueTestBlock block = new SingleValueTestBlock();
+
+    for (int i = 0; i < input.length; i++) {
+      long inputMs = parse(input[i]);
+
+      _firstArg.setLongValue(inputMs);
+      String[] result = function.transformToStringValuesSV(block);
+
+      assertEquals(result[0], expected[i]);
+    }
+  }
+
+  private void assertStrInStrOut(String[] input, String[] expected, DateTimeConversionTransformFunction function) {
+    SingleValueTestBlock block = new SingleValueTestBlock();
+
+    for (int i = 0; i < input.length; i++) {
+      _firstArg.setStringValue(input[i]);
+      String[] result = function.transformToStringValuesSV(block);
+
+      assertEquals(result[0], expected[i], "position:" + i);
+    }
+  }
+
+  private void assertStrInLongOut(String[] input, String[] expected, DateTimeConversionTransformFunction function) {
+    SingleValueTestBlock block = new SingleValueTestBlock();
+
+    for (int i = 0; i < input.length; i++) {
+      _firstArg.setStringValue(input[i]);
+      parse(expected[i]);
+
+      long[] result = function.transformToLongValuesSV(block);
+
+      assertEquals(toDate(result), _expBuffer, "position:" + i);
+    }
+  }
+
+  private MutableDateTime toDate(long[] milliDates) {
+    assertEquals(milliDates.length, 1);
+    _actualBuffer.setMillis(milliDates[0]);
+    _actualBuffer.setZone(DateTimeZone.UTC);
+    return _actualBuffer;
+  }
+
+  private class TestSVLongTransformFunction implements TransformFunction {
+
+    private long _longValue;
+    private String _stringValue;
+    private long[] _longbuffer = new long[1];
+    private String[] _stringbuffer = new String[1];
+
+    public TestSVLongTransformFunction() {
+    }
+
+    public TestSVLongTransformFunction(long value) {
+      _longValue = value;
+    }
+
+    public void setLongValue(long value) {
+      _longValue = value;
+    }
+
+    public void setStringValue(String value) {
+      _stringValue = value;
+    }
+
+    @Override
+    public String getName() {
+      return "test";
+    }
+
+    @Override
+    public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+      //
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return new TransformResultMetadata(DataType.LONG, true, false);
+    }
+
+    @Nullable
+    @Override
+    public Dictionary getDictionary() {
+      return null;
+    }
+
+    @Override
+    public int[] transformToDictIdsSV(ValueBlock valueBlock) {
+      return new int[0];
+    }
+
+    @Override
+    public int[][] transformToDictIdsMV(ValueBlock valueBlock) {
+      return new int[0][];
+    }
+
+    @Override
+    public int[] transformToIntValuesSV(ValueBlock valueBlock) {
+      return new int[]{(int) _longValue};
+    }
+
+    @Override
+    public long[] transformToLongValuesSV(ValueBlock valueBlock) {
+      return new long[]{_longValue};
+    }
+
+    @Override
+    public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
+      return new float[]{_longValue};
+    }
+
+    @Override
+    public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
+      return new double[]{_longValue};
+    }
+
+    @Override
+    public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
+      return new BigDecimal[0];
+    }
+
+    @Override
+    public String[] transformToStringValuesSV(ValueBlock valueBlock) {
+      _stringbuffer[0] = _stringValue;
+      return _stringbuffer;
+    }
+
+    @Override
+    public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
+      return new byte[0][];
+    }
+
+    @Override
+    public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
+      return new int[0][];
+    }
+
+    @Override
+    public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
+      return new long[0][];
+    }
+
+    @Override
+    public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
+      return new float[0][];
+    }
+
+    @Override
+    public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
+      return new double[0][];
+    }
+
+    @Override
+    public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
+      return new String[0][];
+    }
+
+    @Override
+    public byte[][][] transformToBytesValuesMV(ValueBlock valueBlock) {
+      return new byte[0][][];
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap(ValueBlock block) {
+      return null;
+    }
+  }
+
+  private class SingleValueTestBlock implements ValueBlock {
+
+    @Override
+    public int getNumDocs() {
+      return 1;
+    }
+
+    @Nullable
+    @Override
+    public int[] getDocIds() {
+      return new int[]{0};
+    }
+
+    @Override
+    public BlockValSet getBlockValueSet(ExpressionContext expression) {
+      return null;
+    }
+
+    @Override
+    public BlockValSet getBlockValueSet(String column) {
+      return null;
+    }
+
+    @Override
+    public BlockValSet getBlockValueSet(String[] paths) {
+      return null;
+    }
+  }
+
+  private static LiteralTransformFunction strLiteral(String value) {
+    return new LiteralTransformFunction(new LiteralContext(DataType.STRING, value));
+  }
+
+  private static LiteralTransformFunction literal(DataType type, Object value) {
+    return new LiteralTransformFunction(new LiteralContext(type, value));
+  }
+
+  // tests with random data
+
+  interface Transformer {
+    void transform(MutableDateTime dateTime);
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1DayBucketingWithNoTimeZone() {
+    testConvertEpochToEpochWithBucketingTimeZone("1:DAYS", null, (dateTime) -> dateTime.dayOfMonth().roundFloor());
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1HoursBucketingWithNoTimeZone() {
+    testConvertEpochToEpochWithBucketingTimeZone("1:HOURS", null, (dateTime) -> {
+          dateTime.hourOfDay().roundFloor();
+        }
+    );
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1DayBucketingInUTC() {
+    testConvertEpochToEpochWithBucketingTimeZone("1:DAYS", "UTC", (dateTime) -> dateTime.dayOfMonth().roundFloor());
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith4HoursBucketingInUTC() {
+    testConvertEpochToEpochWithBucketingTimeZone("4:HOURS", "UTC", (dateTime) -> {
+      dateTime.setHourOfDay((dateTime.getHourOfDay() / 4) * 4);
+      dateTime.hourOfDay().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith7DaysBucketingInUTC() {
+    testConvertEpochToEpochWithBucketingTimeZone("7:DAYS", "UTC", (dateTime) -> {
+      dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / 7) * 7 + 1);
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith1DayBucketingInCET() {
+    testConvertEpochToEpochWithBucketingTimeZone("1:DAYS", "CET", (dateTime) -> dateTime.dayOfMonth().roundFloor());
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith3HoursBucketingInCET() {
+    testConvertEpochToEpochWithBucketingTimeZone("3:HOURS", "CET", (dateTime) -> {
+      dateTime.setHourOfDay((dateTime.getHourOfDay() / 3) * 3);
+      dateTime.hourOfDay().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToEpochWith5DaysBucketingInCET() {
+    testConvertEpochToEpochWithBucketingTimeZone("5:DAYS", "CET", (dateTime) -> {
+      dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / 5) * 5 + 1);
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  private void testConvertEpochToEpochWithBucketingTimeZone(String granularity, String timeZone,
+      Transformer transformer) {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        "dateTimeConvert(" + TIME_COLUMN + ",'1:MILLISECONDS:EPOCH','1:MILLISECONDS:EPOCH','" + granularity + "'"
+            + (timeZone != null ? ", '" + timeZone + "'" : "") + ")"
+    );
+    TransformFunction function = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertEquals(function.getName(), DateTimeConversionTransformFunction.FUNCTION_NAME);
+    TransformResultMetadata meta = function.getResultMetadata();
+    assertTrue(meta.isSingleValue());
+    assertEquals(meta.getDataType(), DataType.LONG);
+
+    MutableDateTime dateTime = new MutableDateTime();
+    dateTime.setZone(timeZone != null ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone)) : DateTimeZone.UTC);
+
+    long[] expected = new long[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      dateTime.setMillis(_timeValues[i]);
+      transformer.transform(dateTime);
+      expected[i] = dateTime.getMillis();
+    }
+
+    testTransformFunction(function, expected);
+  }
+
+  @Test
+  public void testConvertEpochToStringWith3HoursBucketingInCETAndOutputInCET() {
+    testConvertEpochToStringWithBucketingTimeZone("3:HOURS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(CET)", (dateTime) -> {
+      dateTime.setHourOfDay((dateTime.getHourOfDay() / 3) * 3);
+      dateTime.hourOfDay().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToStringWith1DaysBucketingInCETAndOutputInCET() {
+    testConvertEpochToStringWithBucketingTimeZone("1:DAYS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(CET)", (dateTime) -> {
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToStringWith5DaysBucketingInCETAndOutputInCET() {
+    testConvertEpochToStringWithBucketingTimeZone("5:DAYS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(CET)", (dateTime) -> {
+      dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / 5) * 5 + 1);
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToStringWith3HoursBucketingInCETAndOutputInUTC() {
+    testConvertEpochToStringWithBucketingTimeZone("3:HOURS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(UTC)", (dateTime) -> {
+      dateTime.setHourOfDay((dateTime.getHourOfDay() / 3) * 3);
+      dateTime.hourOfDay().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToStringWith1DaysBucketingInCETAndOutputInUTC() {
+    testConvertEpochToStringWithBucketingTimeZone("1:DAYS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(UTC)", (dateTime) -> {
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  @Test
+  public void testConvertEpochToStringWith5DaysBucketingInCETAndOutputInUTC() {
+    testConvertEpochToStringWithBucketingTimeZone("5:DAYS", "CET", "yyyy-MM-dd HH:mm:ss.mmm tz(UTC)", (dateTime) -> {
+      dateTime.setDayOfMonth(((dateTime.getDayOfMonth() - 1) / 5) * 5 + 1);
+      dateTime.dayOfMonth().roundFloor();
+    });
+  }
+
+  private void testConvertEpochToStringWithBucketingTimeZone(String granularity, String timeZone,
+      String outputFormat, Transformer transformer) {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        "dateTimeConvert(" + TIME_COLUMN
+            + ",'1:MILLISECONDS:EPOCH','1:DAYS:SIMPLE_DATE_FORMAT:" + outputFormat + "','" + granularity
+            + "'"
+            + (timeZone != null ? ", '" + timeZone + "'" : "") + ")"
+    );
+    TransformFunction function = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertEquals(function.getName(), DateTimeConversionTransformFunction.FUNCTION_NAME);
+    TransformResultMetadata meta = function.getResultMetadata();
+    assertTrue(meta.isSingleValue());
+    assertEquals(meta.getDataType(), DataType.STRING);
+
+    MutableDateTime dateTime = new MutableDateTime();
+    dateTime.setZone(timeZone != null ? DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone)) : DateTimeZone.UTC);
+    DateTimeFormatter formatter = new DateTimeFormatPatternSpec(DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
+        outputFormat).getDateTimeFormatter();
+    StringBuilder buffer = new StringBuilder();
+
+    String[] expected = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      dateTime.setMillis(_timeValues[i]);
+      transformer.transform(dateTime);
+      buffer.setLength(0);
+      formatter.printTo(buffer, dateTime);
+      expected[i] = buffer.toString();
+    }
+
+    testTransformFunction(function, expected);
+  }
 
   @Test
   public void testDateTimeConversionTransformFunction() {
@@ -69,8 +1246,42 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
         String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','MINUTES:1')", TIME_COLUMN)
     }, new Object[]{
         String.format("dateTimeConvert(%s,%s,'1:MINUTES:EPOCH','1:MINUTES')", TIME_COLUMN, INT_SV_COLUMN)
+    }, new Object[]{
+        String.format("dateTimeConvert(%s,'1:MINUTES:EPOCH','1:MINUTES:EPOCH','1:MINUTES','aa')", TIME_COLUMN)
+    }, new Object[]{
+        String.format("dateTimeConvert(%s,'1:MINUTES:EPOCH','1:MINUTES:EPOCH','1:MINUTES','')", TIME_COLUMN)
+    }, new Object[]{
+        String.format("dateTimeConvert(%s,'1:MINUTES:EPOCH','1:MINUTES:EPOCH','1:MINUTES',null)", TIME_COLUMN)
     }
     };
+  }
+
+  @Test
+  public void testConvertNullColumnWithBucketingInUTC() {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MILLISECONDS:EPOCH','1:HOURS', 'UTC')",
+            TIMESTAMP_COLUMN_NULL));
+    TransformFunction function = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertEquals(function.getName(), DateTimeConversionTransformFunction.FUNCTION_NAME);
+    TransformResultMetadata meta = function.getResultMetadata();
+    assertTrue(meta.isSingleValue());
+    assertEquals(meta.getDataType(), DataType.LONG);
+
+    MutableDateTime dateTime = new MutableDateTime();
+    dateTime.setZone(DateTimeZone.UTC);
+
+    long[] expected = new long[NUM_ROWS];
+    RoaringBitmap expectedNulls = new RoaringBitmap();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (isNullRow(i)) {
+        expectedNulls.add(i);
+      } else {
+        dateTime.setMillis(_timeValues[i]);
+        dateTime.hourOfDay().roundFloor();
+        expected[i] = dateTime.getMillis();
+      }
+    }
+    testTransformFunctionWithNull(function, expected, expectedNulls);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeConverterTest.java
@@ -46,6 +46,400 @@ public class DateTimeConverterTest {
     Assert.assertEquals(output, expected);
   }
 
+  @Test(dataProvider = "testDateTimeConversion")
+  public void testDateTimeConversionWithBucketingTimeZone(String inputFormat, String outputFormat,
+      String outputGranularity, Object input, Object expected) {
+    BaseDateTimeTransformer converter =
+        DateTimeTransformerFactory.getDateTimeTransformer(inputFormat, outputFormat, outputGranularity);
+    int length;
+    Object output;
+    if (expected instanceof long[]) {
+      length = ((long[]) expected).length;
+      output = new long[length];
+    } else {
+      length = ((String[]) expected).length;
+      output = new String[length];
+    }
+    converter.transform(input, output, length);
+    Assert.assertEquals(output, expected);
+  }
+
+  @Test(dataProvider = "testConversionWithBucketTimeZone")
+  public void testConversionWithBucketTimeZone(String inputFormat, String outputFormat,
+      String outputGranularity, String bucketTimeZone, Object input, Object expected) {
+    BaseDateTimeTransformer converter =
+        DateTimeTransformerFactory.getDateTimeTransformer(inputFormat, outputFormat, outputGranularity, bucketTimeZone);
+    int length;
+    Object output;
+    if (expected instanceof long[]) {
+      length = ((long[]) expected).length;
+      output = new long[length];
+    } else {
+      length = ((String[]) expected).length;
+      output = new String[length];
+    }
+    converter.transform(input, output, length);
+    // cast to array, otherwise assert produces garbage error messages
+    if (expected instanceof long[]) {
+      Assert.assertEquals((long[]) output, (long[]) expected);
+    } else {
+      Assert.assertEquals((String[]) output, (String[]) expected);
+    }
+  }
+
+  @DataProvider(name = "testConversionWithBucketTimeZone")
+  public Object[][] testConversionWithBucketTimeZone() {
+    List<Object[]> entries = new ArrayList<>();
+
+    /*************** Epoch to Epoch ***************/
+    {
+      // Test bucketing to 15 minutes
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898300000L /* 20170920T02:05:00 */, 1505898960000L
+          /* 20170920T02:16:00 */
+      };
+      long[] expected = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898000000L /* 20170920T02:00:00 */, 1505898900000L
+          /* 20170920T02:15:00 */
+      };
+      entries.add(new Object[]{"1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "15:MINUTES", "CET", input, expected});
+    }
+    {
+      // Test input which should create no change
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898300000L /* 20170920T02:05:00 */, 1505898960000L
+          /* 20170920T02:16:00 */
+      };
+      long[] expected = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898300000L /* 20170920T02:05:00 */, 1505898960000L
+          /* 20170920T02:16:00 */
+      };
+      entries.add(
+          new Object[]{"1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS", "CET", input, expected});
+    }
+    {
+      // Test conversion from millis to hours
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898300000L /* 20170920T02:05:00 */, 1505902560000L
+          /* 20170920T03:16:00 */
+      };
+      long[] expected =
+          {418305L /* 20170920T02:00:00 */, 418305L /* 20170920T02:00:00 */, 418306L /* 20170920T03:00:00 */};
+      entries.add(new Object[]{"1:MILLISECONDS:EPOCH", "1:HOURS:EPOCH", "1:HOURS", "CET", input, expected});
+    }
+    {
+      // Test conversion from 5 minutes to hours
+      long[] input =
+          {5019660L /* 20170920T02:00:00 */, 5019661L /* 20170920T02:05:00 */, 5019675L /* 20170920T03:15:00 */};
+      long[] expected =
+          {418305L /* 20170920T02:00:00 */, 418305L /* 20170920T02:00:00 */, 418306L /* 20170920T03:00:00 */};
+      entries.add(new Object[]{"5:MINUTES:EPOCH", "1:HOURS:EPOCH", "1:HOURS", "CET", input, expected});
+    }
+    {
+      // Test conversion from 5 minutes to millis and bucketing to hours
+      long[] input =
+          {5019660L /* 20170920T02:00:00 */, 5019661L /* 20170920T02:05:00 */, 5019675L /* 20170920T03:15:00 */};
+      long[] expected = {
+          1505898000000L /* 20170920T02:00:00 */, 1505898000000L /* 20170920T02:00:00 */, 1505901600000L
+          /* 20170920T03:00:00 */
+      };
+      entries.add(new Object[]{"5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", input, expected});
+    }
+    {
+      // Test conversion to non-java time unit WEEKS
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505199600000L /* 20170912T00:00:00 */, 1504257300000L
+          /* 20170901T00:20:00 */
+      };
+      long[] expected = {2489L, 2488L, 2487L};
+      entries.add(new Object[]{"1:MILLISECONDS:EPOCH", "1:WEEKS:EPOCH", "1:MILLISECONDS", "CET", input, expected});
+    }
+
+    /*************** Epoch to SDF ***************/
+    {
+      // Test conversion from millis since epoch to simple date format (UTC)
+      long[] input = {
+          1505890800000L /* 20170920T00:00:00 */, 1505962800000L /* 20170920T20:00:00 */, 1505985360000L
+          /* 20170921T02:16:00 */
+      };
+      String[] expected = {"20170919", "20170920", "20170920"};
+      entries
+          .add(
+              new Object[]{
+                  "1:MILLISECONDS:EPOCH", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "CET", input,
+                  expected
+              });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (Pacific timezone)
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505952000000L /* 20170920T17:00:00 */, 1505962800000L
+          /* 20170920T20:00:00 */
+      };
+      String[] expected = {"20170919", "20170920", "20170920"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Los_Angeles)", "1:DAYS", "CET",
+          input,
+          expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (IST)
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505941200000L /* 20170920T14:00:00 */, 1505962800000L
+          /* 20170921T03:00:00 */
+      };
+      String[] expected = {"20170920", "20170920", "20170921"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", "1:DAYS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (Pacific timezone)
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505952000000L /* 20170920T17:00:00 */, 1505962800000L
+          /* 20170920T20:00:00 */
+      };
+      String[] expected = {"2017092002", "2017092017", "2017092020"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/Los_Angeles)", "1:HOURS", "CET",
+          input,
+          expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (East Coast timezone)
+      long[] input = {
+          1505898000000L /* 20170920T02:00:00 */, 1505941200000L /* 20170920T14:00:00 */, 1505970000000L
+          /* 20170920T22:00:00 */
+      };
+      String[] expected = {"2017092005", "2017092017", "2017092101"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)", "1:HOURS", "CET",
+          input,
+          expected
+      });
+    }
+
+    // additional granularity tests
+    {
+      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 15 second
+      // granularity)
+      long[] input = {
+          1523560598000L /* 20180412T19:16:38 */, 1523560589000L /* 20180412T19:16:29 */, 1523560632000L
+          /* 20180412T19:17:12 */
+      };
+      String[] expected = {"2018-04-12 13:16:30.000", "2018-04-12 13:16:15.000", "2018-04-12 13:17:00.000"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)",
+          "15:SECONDS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 3 minute
+      // granularity)
+      long[] input = {
+          1523560598000L /* 20180412T19:16:38 */, 1523560708000L /* 20180412T19:18:28 */, 1523561708000L
+          /* 20180412T19:35:08 */
+      };
+      String[] expected = {"2018-04-12 13:15:00.000", "2018-04-12 13:18:00.000", "2018-04-12 13:33:00.000"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)",
+          "3:MINUTES", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 12 hour
+      // granularity)
+      long[] input = {
+          1523560598000L /* 20180412T19:16:38 */, 1523460502000L /* 20180411T15:28:22 */, 1523430205000L
+          /* 20180411T07:03:25 */
+      };
+      String[] expected = {"2018-04-12 04:00:00.000", "2018-04-11 04:00:00.000", "2018-04-10 16:00:00.000"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)",
+          "12:HOURS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 5 day
+      // granularity
+      long[] input = {
+          1523560598000L /* 20180412T19:16:38 */, 1524160502000L /* 20180419T17:55:02 */, 1522230205000L
+          /* 20180328T09:43:25 */
+      };
+      String[] expected = {"2018-04-10 16:00:00.000", "2018-04-15 16:00:00.000", "2018-03-25 16:00:00.000"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)",
+          "5:DAYS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from millis since epoch to simple date format (America/Los_Angeles timezone with 1 day
+      // granularity)
+      long[] input = {1524045600000L /* 20180418T10:00:00 */, 1524013200000L /* 20180418T01:00:00 */};
+      String[] expected = {"2018-04-17 15:00:00.000", "2018-04-17 15:00:00.000"};
+      entries.add(new Object[]{
+          "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)",
+          "1:DAYS", "CET", input, expected
+      });
+    }
+
+    /*************** SDF to Epoch ***************/
+    {
+      // Test conversion from simple date format to millis since epoch
+      String[] input =
+          {"20170920" /* 20170920T00:00:00 */, "20170601" /* 20170601T00:00:00 */, "20170921" /* 20170921T00:00:00 */};
+      long[] expected = {
+          1505858400000L /* 20170920T00:00:00 */, 1496268000000L /* 20170601T00:00:00 */, 1505944800000L
+          /* 20170921T00:00:00 */
+      };
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS:EPOCH", "1:DAYS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from simple date format (East Coast timezone) to millis since epoch
+      // Converted to
+      String[] input =
+          {"20170920" /* 20170920T00:00:00 */, "20170601" /* 20170601T00:00:00 */, "20170921" /* 20170921T00:00:00 */};
+      long[] expected = {
+          1505858400000L /* 20170920T00:00:00 */, 1496268000000L /* 20170601T00:00:00 */, 1505944800000L
+          /* 20170921T00:00:00 */
+      };
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/New_York)", "1:MILLISECONDS:EPOCH", "1:DAYS", "CET", input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format (East Coast timezone) to millis since epoch
+      // Converted to
+      String[] input = {
+          "2017092013" /* 20170920T00:00:00 */, "2017092001" /* 20170601T00:00:00 */, "2017092000"
+          /* 20170921T00:00:00 */
+      };
+      long[] expected = {
+          1505926800000L /* 20170920T13:00:00 Eastern */, 1505883600000L /* 20170920T01:00:00 Eastern */, 1505880000000L
+          /* 20170920T00:00:00 Eastern */
+      };
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)", "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format with special characters to millis since epoch
+      String[] input = {"2017092013 America/New_York", "2017092004 Asia/Kolkata", "2017092000 America/Los_Angeles"};
+      long[] expected = {
+          1505926800000L /* 20170920T10:00:00 UTC */, 1505858400000L /* 20170919T22:00:00 UTC */, 1505890800000L
+          /* 20170920T00:00:00 UTC */
+      };
+      entries.add(
+          new Object[]{
+              "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH ZZZ", "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", input,
+              expected
+          });
+    }
+    {
+      // Test conversion from simple date format with special characters to millis since epoch
+      String[] input = {"8/7/2017 1 AM", "12/27/2016 11 PM", "8/7/2017 12 AM", "8/7/2017 12 PM"};
+      long[] expected = {1502067600000L, 1482879600000L, 1502064000000L, 1502107200000L};
+      entries.add(
+          new Object[]{
+              "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h a", "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", input,
+              expected
+          });
+    }
+    {
+      // Test conversion from simple date format with special characters to millis since epoch, with bucketing
+      String[] input =
+          {"8/7/2017 1:00:00 AM", "12/27/2016 11:20:00 PM", "8/7/2017 12:45:50 AM", "8/7/2017 12:00:01 PM"};
+      long[] expected = {1502067600000L, 1482879600000L, 1502064000000L, 1502107200000L};
+      entries.add(new Object[]{
+          "1:SECONDS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", "1:MILLISECONDS:EPOCH", "1:HOURS", "CET", input, expected
+      });
+    }
+    {
+      // Test conversion from simple date format with special characters to millis since epoch, without bucketing
+      String[] input =
+          {"8/7/2017 1:00:00 AM", "12/27/2016 11:20:00 PM", "8/7/2017 12:45:50 AM", "8/7/2017 12:00:01 PM"};
+      long[] expected = {1502067600000L, 1482880800000L, 1502066750000L, 1502107201000L};
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS", "CET", input,
+          expected
+      });
+    }
+
+    /*************** SDF to SDF ***************/
+    {
+      // Test conversion from simple date format to another simple date format
+      String[] input = {"8/7/2017 1:00:00 AM", "12/27/2016 11:20:00 PM", "8/7/2017 12:45:50 AM"};
+      String[] expected = {"20170807", "20161227", "20170807"};
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS",
+          "CET", input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format with timezone to another simple date format
+      String[] input = {"20170920 America/Chicago", "20170919 America/Los_Angeles", "20170921 Asia/Kolkata"};
+      String[] expected = {"20170920", "20170919", "20170920"};
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS", "CET",
+          input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format with timezone to another simple date format with timezone
+      String[] input = {"20170920 America/New_York", "20170919 America/Los_Angeles", "20170921 Asia/Kolkata"};
+      String[] expected = {"20170919", "20170919", "20170920"};
+      entries.add(new Object[]{
+          "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Chicago)",
+          "1:MILLISECONDS", "CET", input, expected
+      });
+    }
+
+    // additional granularity tests
+    {
+      // Test conversion from simple date format to another simple date format (America/Denver timezone with 15
+      // second granularity)
+      String[] input = {"20180412T19:16:38", "20180412T19:16:29", "20180412T19:17:12"};
+      String[] expected = {"2018-04-12 13:16:30.000", "2018-04-12 13:16:15.000", "2018-04-12 13:17:00.000"};
+      entries.add(new Object[]{
+          "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd'T'HH:mm:ss",
+          "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS", "CET", input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format to another simple date format (America/Denver timezone with 5 day
+      // granularity)
+      String[] input = {"20180412T19:16:38", "20180419T17:55:02", "20180328T09:43:25"};
+      String[] expected = {"2018-04-10 16:00:00.000", "2018-04-15 16:00:00.000", "2018-03-25 16:00:00.000"};
+      entries.add(new Object[]{
+          "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd'T'HH:mm:ss",
+          "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS", "CET", input,
+          expected
+      });
+    }
+    {
+      // Test conversion from simple date format to another simple date format (America/Los_Angeles timezone with 1
+      // day granularity)
+      String[] input = {"20180418T10:00:00", "20180418T01:00:00"};
+      String[] expected = {"2018-04-17 15:00:00.000", "2018-04-17 15:00:00.000"};
+      entries.add(new Object[]{
+          "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd'T'HH:mm:ss",
+          "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS", "CET",
+          input, expected
+      });
+    }
+
+    return entries.toArray(new Object[entries.size()][]);
+  }
+
   @DataProvider(name = "testDateTimeConversion")
   public Object[][] testDateTimeConversion() {
     List<Object[]> entries = new ArrayList<>();
@@ -175,7 +569,7 @@ public class DateTimeConverterTest {
     // additional granularity tests
     {
       // Test conversion from millis since epoch to simple date format (America/Denver timezone with 15 second
-      // granualrity)
+      // granularity)
       long[] input = {
           1523560598000L /* 20180412T19:16:38 */, 1523560589000L /* 20180412T19:16:29 */, 1523560632000L
           /* 20180412T19:17:12 */
@@ -188,7 +582,7 @@ public class DateTimeConverterTest {
     }
     {
       // Test conversion from millis since epoch to simple date format (America/Denver timezone with 3 minute
-      // granualrity)
+      // granularity)
       long[] input = {
           1523560598000L /* 20180412T19:16:38 */, 1523560708000L /* 20180412T19:18:28 */, 1523561708000L
           /* 20180412T19:35:08 */
@@ -201,7 +595,7 @@ public class DateTimeConverterTest {
     }
     {
       // Test conversion from millis since epoch to simple date format (America/Denver timezone with 12 hour
-      // granualrity)
+      // granularity)
       long[] input = {
           1523560598000L /* 20180412T19:16:38 */, 1523460502000L /* 20180411T15:28:22 */, 1523430205000L
           /* 20180411T07:03:25 */
@@ -213,7 +607,7 @@ public class DateTimeConverterTest {
       });
     }
     {
-      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 5 day granualrity)
+      // Test conversion from millis since epoch to simple date format (America/Denver timezone with 5 day granularity)
       long[] input = {
           1523560598000L /* 20180412T19:16:38 */, 1524160502000L /* 20180419T17:55:02 */, 1522230205000L
           /* 20180328T09:43:25 */
@@ -226,7 +620,7 @@ public class DateTimeConverterTest {
     }
     {
       // Test conversion from millis since epoch to simple date format (America/Los_Angeles timezone with 1 day
-      // granualrity)
+      // granularity)
       long[] input = {1524045600000L /* 20180418T10:00:00 */, 1524013200000L /* 20180418T01:00:00 */};
       String[] expected = {"2018-04-18 00:00:00.000", "2018-04-17 00:00:00.000"};
       entries.add(new Object[]{
@@ -344,7 +738,7 @@ public class DateTimeConverterTest {
     // additional granularity tests
     {
       // Test conversion from simple date format to another simple date format (America/Denver timezone with 15
-      // second granualrity)
+      // second granularity)
       String[] input = {"20180412T19:16:38", "20180412T19:16:29", "20180412T19:17:12"};
       String[] expected = {"2018-04-12 13:16:30.000", "2018-04-12 13:16:15.000", "2018-04-12 13:17:00.000"};
       entries.add(new Object[]{
@@ -354,7 +748,7 @@ public class DateTimeConverterTest {
     }
     {
       // Test conversion from simple date format to another simple date format (America/Denver timezone with 5 day
-      // granualrity)
+      // granularity)
       String[] input = {"20180412T19:16:38", "20180419T17:55:02", "20180328T09:43:25"};
       String[] expected = {"2018-04-11 00:00:00.000", "2018-04-16 00:00:00.000", "2018-03-26 00:00:00.000"};
       entries.add(new Object[]{
@@ -364,7 +758,7 @@ public class DateTimeConverterTest {
     }
     {
       // Test conversion from simple date format to another simple date format (America/Los_Angeles timezone with 1
-      // day granualrity)
+      // day granularity)
       String[] input = {"20180418T10:00:00", "20180418T01:00:00"};
       String[] expected = {"2018-04-18 00:00:00.000", "2018-04-17 00:00:00.000"};
       entries.add(new Object[]{

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
@@ -132,7 +132,7 @@ public class BenchmarkColumnValueSegmentPruner {
   @Setup
   public void setUp()
       throws Exception {
-    _supplier = Distribution.createLongSupplier(42, _scenario);
+    _supplier = Distribution.createSupplier(42, _scenario);
     FileUtils.deleteQuietly(INDEX_DIR);
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOrderByQueries.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOrderByQueries.java
@@ -130,7 +130,7 @@ public class BenchmarkOrderByQueries extends BaseQueriesTest {
   @Setup
   public void setUp()
       throws Exception {
-    _supplier = Distribution.createLongSupplier(42, _scenario);
+    _supplier = Distribution.createSupplier(42, _scenario);
     FileUtils.deleteQuietly(INDEX_DIR);
 
     buildSegment(FIRST_SEGMENT_NAME);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRangeIndex.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRangeIndex.java
@@ -21,7 +21,6 @@ package org.apache.pinot.perf;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.DoubleSupplier;
 import java.util.function.LongSupplier;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
@@ -88,7 +87,7 @@ public class BenchmarkRangeIndex {
       FileUtils.forceMkdir(_indexDir);
       switch (_dataType) {
         case INT: {
-          LongSupplier supplier = Distribution.createLongSupplier(_seed, _scenario);
+          LongSupplier supplier = Distribution.createSupplier(_seed, _scenario);
           int[] values = new int[_numDocs];
           for (int i = 0; i < values.length; i++) {
             values[i] = (int) supplier.getAsLong();
@@ -97,7 +96,7 @@ public class BenchmarkRangeIndex {
           break;
         }
         case LONG: {
-          LongSupplier supplier = Distribution.createLongSupplier(_seed, _scenario);
+          LongSupplier supplier = Distribution.createSupplier(_seed, _scenario);
           long[] values = new long[_numDocs];
           for (int i = 0; i < values.length; i++) {
             values[i] = supplier.getAsLong();
@@ -106,7 +105,7 @@ public class BenchmarkRangeIndex {
           break;
         }
         case FLOAT: {
-          DoubleSupplier supplier = Distribution.createDoubleSupplier(_seed, _scenario);
+          Distribution.DataSupplier supplier = Distribution.createSupplier(_seed, _scenario);
           float[] values = new float[_numDocs];
           for (int i = 0; i < values.length; i++) {
             values[i] = (float) supplier.getAsDouble();
@@ -115,7 +114,7 @@ public class BenchmarkRangeIndex {
           break;
         }
         case DOUBLE: {
-          DoubleSupplier supplier = Distribution.createDoubleSupplier(_seed, _scenario);
+          Distribution.DataSupplier supplier = Distribution.createSupplier(_seed, _scenario);
           double[] values = new double[_numDocs];
           for (int i = 0; i < values.length; i++) {
             values[i] = supplier.getAsDouble();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexReader.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexReader.java
@@ -106,7 +106,7 @@ public class BenchmarkRawForwardIndexReader {
     public void setup()
         throws IOException {
       FileUtils.forceMkdir(TARGET_DIR);
-      LongSupplier supplier = Distribution.createLongSupplier(42, _distribution);
+      LongSupplier supplier = Distribution.createSupplier(42, _distribution);
       SplittableRandom random = new SplittableRandom(42);
       _bytes = new byte[_records][];
       StringBuilder sb = new StringBuilder();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexWriter.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexWriter.java
@@ -98,7 +98,7 @@ public class BenchmarkRawForwardIndexWriter {
       throws IOException {
     FileUtils.forceMkdir(TARGET_DIR);
     SplittableRandom random = new SplittableRandom(42);
-    LongSupplier supplier = Distribution.createLongSupplier(42, _distribution);
+    LongSupplier supplier = Distribution.createSupplier(42, _distribution);
     _bytes = new byte[_records][];
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < _records; i++) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
@@ -88,7 +88,7 @@ public class BenchmarkScanDocIdIterators {
     FileUtils.forceMkdir(INDEX_DIR);
     File indexFile = new File(INDEX_DIR, "index-file");
     RoaringBitmapWriter<MutableRoaringBitmap> writer = RoaringBitmapWriter.bufferWriter().get();
-    LongSupplier supplier = Distribution.createLongSupplier(_seed, _distribution);
+    LongSupplier supplier = Distribution.createSupplier(_seed, _distribution);
     int[] values = new int[_numDocs];
     int max = Integer.MIN_VALUE;
     for (int i = 0; i < values.length; i++) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/GeneratedDataRecordReader.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/GeneratedDataRecordReader.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+
+
+public class GeneratedDataRecordReader implements RecordReader {
+
+  private final LazyDataGenerator _dataGenerator;
+  private final int _numRows;
+
+  private int _nextRowId = 0;
+
+  public GeneratedDataRecordReader(LazyDataGenerator dataGenerator) {
+    _dataGenerator = dataGenerator;
+    _numRows = dataGenerator.size();
+  }
+
+  @Override
+  public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
+  }
+
+  @Override
+  public boolean hasNext() {
+    return _nextRowId < _numRows;
+  }
+
+  @Override
+  public GenericRow next(GenericRow reuse) {
+    _dataGenerator.next(reuse, _nextRowId++);
+    return reuse;
+  }
+
+  @Override
+  public void rewind() {
+    _nextRowId = 0;
+    _dataGenerator.rewind();
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/LazyDataGenerator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/LazyDataGenerator.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+public interface LazyDataGenerator {
+  int size();
+
+  GenericRow next(GenericRow row, int index);
+
+  void rewind();
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/LazyDataList.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/LazyDataList.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+public class LazyDataList implements List<GenericRow> {
+
+  private final GenericRow _row;
+  private final int _size;
+  private final RowGenerator _rowGenerator;
+
+  public interface RowGenerator {
+    void generateRow(GenericRow row, int index);
+  }
+
+  public LazyDataList(int size, RowGenerator rowGenerator) {
+    _row = new GenericRow();
+    _size = size;
+    _rowGenerator = rowGenerator;
+  }
+
+  @Override
+  public int size() {
+    return _size;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _size == 0;
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return false;
+  }
+
+  @Override
+  public Iterator<GenericRow> iterator() {
+    return null;
+  }
+
+  @Override
+  public Object[] toArray() {
+    return new Object[0];
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return null;
+  }
+
+  @Override
+  public boolean add(GenericRow genericRow) {
+    return false;
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return false;
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends GenericRow> c) {
+    return false;
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<? extends GenericRow> c) {
+    return false;
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public void clear() {
+    // do nothing
+  }
+
+  @Override
+  public GenericRow get(int index) {
+    generateRow(index);
+    return _row;
+  }
+
+  private void generateRow(int index) {
+    _rowGenerator.generateRow(_row, index);
+  }
+
+  @Override
+  public GenericRow set(int index, GenericRow element) {
+    return null;
+  }
+
+  @Override
+  public void add(int index, GenericRow element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public GenericRow remove(int index) {
+    return null;
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    return 0;
+  }
+
+  @Override
+  public int lastIndexOf(Object o) {
+    return 0;
+  }
+
+  @Override
+  public ListIterator<GenericRow> listIterator() {
+    return null;
+  }
+
+  @Override
+  public ListIterator<GenericRow> listIterator(int index) {
+    return null;
+  }
+
+  @Override
+  public List<GenericRow> subList(int fromIndex, int toIndex) {
+    return List.of();
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/SyntheticBlockValSets.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/SyntheticBlockValSets.java
@@ -151,7 +151,7 @@ public class SyntheticBlockValSets {
     }
 
     public static Long create() {
-      return create(Distribution.createLongSupplier(42, "EXP(0.5)"));
+      return create(Distribution.createSupplier(42, "EXP(0.5)"));
     }
 
     public static Long create(LongSupplier supplier) {
@@ -210,7 +210,7 @@ public class SyntheticBlockValSets {
     }
 
     public static Double create() {
-      return create(Distribution.createDoubleSupplier(42, "EXP(0.5)"));
+      return create(Distribution.createSupplier(42, "EXP(0.5)"));
     }
 
     public static Double create(DoubleSupplier supplier) {

--- a/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
+++ b/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
@@ -150,6 +150,15 @@
         ]
       },
       {
+        "sql": "SELECT 1 FROM {tbl} where dateTimeConvert(timestampCol, '1:MILLISECONDS:EPOCH', '1:MINUTES:EPOCH', '30:MINUTES', 'UTC') > 1000000",
+        "outputs": [
+          [1],
+          [1],
+          [1],
+          [1]
+        ]
+      },
+      {
         "sql": "SELECT ROUND(longCol, 2) FROM {tbl}",
         "outputs": [
           [14],


### PR DESCRIPTION
This PR adds an optional parameter to dateTimeConvert() function - bucketing time zone.
It allows specifying specific time zone to bucketing, regardless of output time zone - which could be epoch millis or a formatted string.

Examples:

```sql
select dateTimeConvert( 86400001, 
                        '1:MILLISECONDS:EPOCH', 
                        '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ',
                        '1:MILLISECONDS' ) 
from dual
```

returns 
1970-01-02 00:00:00.001+0000

```sql
select dateTimeConvert( 86400001,
                        '1:MILLISECONDS:EPOCH', 
                        '1:MILLISECONDS:EPOCH', 
                        '1:DAYS', 
                        'CET') from dual
```

returns 
82800000

```sql
select dateTimeConvert( 86400001, 
                        '1:MILLISECONDS:EPOCH', 
                        '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ', 
                        '1:DAYS', 
                        'CET') 
from dual 
```

returns `1970-01-01 23:00:00.000+0000` because `1970-01-02 00:00:00.001+0000` is rounded to `1970-01-02 00:00:00.001+0200` in CET time zone and then converted to UTC.

```sql
select dateTimeConvert( 86400001, 
                        '1:MILLISECONDS:EPOCH', 
                        '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)', 
                        '1:DAYS', 
                        'CET') 
from dual
```

returns 
1970-01-01 15:00:00.000


Note: when bucketing time zone is set, bucketing is performed relative to bigger time unit (e.g. 1 day when bucketing to 1 hour ) and not epoch start.

Fixes #8581 

I ran the following queries with  BenchmarkQueries class, 15 mil rows: 
A. using new timezone parameter
```sql
SELECT * 
FROM MyTable 
WHERE  dateTimeConvert(TSTMP_COL, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:DAYS', 'CET') = 120000000
```
B. workaround 
```sql
SELECT * 
FROM MyTable 
WHERE FromDateTime(dateTimeConvert(TSTMP_COL, '1:MILLISECONDS:EPOCH', '1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSSZ tz(CET)', '1:DAYS'), 'yyyy-MM-dd HH:mm:ss.SSSZ') = 120000000
```
that shows new implementation is about 30 times faster than workaround:
`Benchmark               (_numRows) (_query)  (_scenario)  Mode  Cnt    Score     Error  Units
BenchmarkQueries.query    15000000  A        EXP(0.001)  avgt    5  479.288 ± 162.748  ms/op
BenchmarkQueries.query    15000000  A        EXP(0.5)    avgt    5  492.584 ±  94.075  ms/op
BenchmarkQueries.query    15000000  A        EXP(0.999)  avgt    5  496.491 ± 156.267  ms/op
`
vs
`
Benchmark               (_numRows) (_query)  (_scenario)  Mode  Cnt      Score     Error  Units
BenchmarkQueries.query    15000000  B        EXP(0.001)  avgt    5  15010.526 ±  10.270  ms/op
BenchmarkQueries.query    15000000  B        EXP(0.5)    avgt    5  14991.342 ± 112.595  ms/op
BenchmarkQueries.query    15000000  B        EXP(0.999)  avgt    5  14519.129 ± 490.620  ms/op
`

Also - changed TimePredicateFilterOptimizer to ignore calls (similarly to those with SDF output)  to dateTimeConvert with 5 arguments, instead of failing queries due to unexpected number of function arguments. 


