### PR TITLE
bugfix: TextMatchFilterOptimizer grouping for inner compound query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TextMatchFilterOptimizer.java
@@ -132,7 +132,8 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
       if (allNot) {
         for (Expression expression : entry.getValue()) {
           Expression operand = expression.getFunctionCall().getOperands().get(0);
-          literals.add(operand.getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+          literals.add(
+              wrapWithParentheses(operand.getFunctionCall().getOperands().get(1).getLiteral().getStringValue()));
         }
       } else {
         for (Expression expression : entry.getValue()) {
@@ -147,12 +148,13 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
               continue;
             }
 
-            literals.add(FilterKind.NOT.name() + SPACE + operand.getFunctionCall().getOperands().get(1).getLiteral()
-                .getStringValue());
+            literals.add(FilterKind.NOT.name() + SPACE + wrapWithParentheses(
+                operand.getFunctionCall().getOperands().get(1).getLiteral().getStringValue()));
             continue;
           }
           assert expression.getFunctionCall().getOperator().equals(FilterKind.TEXT_MATCH.name());
-          literals.add(expression.getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+          literals.add(
+              wrapWithParentheses(expression.getFunctionCall().getOperands().get(1).getLiteral().getStringValue()));
         }
       }
 
@@ -170,7 +172,7 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
       }
       Expression mergedTextMatchExpression =
           RequestUtils.getFunctionExpression(FilterKind.TEXT_MATCH.name(), entry.getKey(),
-              RequestUtils.getLiteralExpression("(" + mergedTextMatchFilter + ")"));
+              RequestUtils.getLiteralExpression(mergedTextMatchFilter));
       if (allNot) {
         newChildren.add(RequestUtils.getFunctionExpression(FilterKind.NOT.name(), mergedTextMatchExpression));
       } else {
@@ -183,5 +185,9 @@ public class TextMatchFilterOptimizer implements FilterOptimizer {
     }
     assert operator.equals(FilterKind.OR.name()) || operator.equals(FilterKind.AND.name());
     return RequestUtils.getFunctionExpression(operator, newChildren);
+  }
+
+  private String wrapWithParentheses(String expression) {
+    return "(" + expression + ")";
   }
 }


### PR DESCRIPTION
I missed this edge case when adding TextMatchFilterOptimizer. 

For a query such as `text_match(col1, 'aaa') AND text_match(col1, 'bbb OR ccc')`, this would have previously been optimized to `text_match(col1, '(foo AND bar OR baz)'`, which would return unexpected results. 

Applying grouping for each filter (instead of at the merged filter level) produces an faithful translation to `text_match(col1, '(foo) AND (bar OR baz)'`. 