### PR TITLE
do not add column name separator on download

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -350,7 +350,7 @@ const QueryPage = () => {
   };
 
   const downloadData = (exportType) => {
-    const data = Utils.tableFormat(resultData);
+    const data = Utils.tableFormat(resultData, false);
     const fileName = 'Pinot Data Explorer';
 
     exportFromJSON({ data, fileName, exportType });

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -75,7 +75,7 @@ const pinotTableDetailsFromArray = (tableDetails: Array<string | number | boolea
   };
 }
 
-const tableFormat = (data: TableData): Array<{ [key: string]: any }> => {
+const tableFormat = (data: TableData, withColumnNameSeparator: boolean = true): Array<{ [key: string]: any }> => {
   const rows = data.records;
   const header = data.columns;
 
@@ -83,7 +83,14 @@ const tableFormat = (data: TableData): Array<{ [key: string]: any }> => {
   rows.forEach((singleRow) => {
     const obj: { [key: string]: any } = {};
     singleRow.forEach((val: any, index: number) => {
-      obj[header[index]+app_state.columnNameSeparator+index] = val;
+      // The column name separator is added to avoid conflicts where 2 columns
+      // have the same name. But for cases where we download the raw data, we
+      // do not want the separate there.
+      if (withColumnNameSeparator) {
+        obj[header[index] + app_state.columnNameSeparator + index] = val;
+      } else {
+        obj[header[index]] = val;
+      }
     });
     results.push(obj);
   });


### PR DESCRIPTION
This is a `ui` `bugfix` that closes #14302

columnNameSeparator was added in #8131 to allow displaying columns with the same name. But we don't need to carry that over when downloading the data.

I ran pinot locally and ensured downloaded data was identical except for `#$%\d` no longer being in the column name