### PR TITLE
Fix pinot-perf annotation processor support

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
-      <artifactId>jmh-generator-annprocess</artifactId>
+      <artifactId>jmh-core</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>
@@ -102,6 +102,19 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -919,7 +919,7 @@
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-generator-annprocess</artifactId>
+        <artifactId>jmh-core</artifactId>
         <version>${jmh.version}</version>
       </dependency>
 


### PR DESCRIPTION
In PR https://github.com/apache/pinot/pull/14185 I changed the way annotation processors are declared in Pinot but I forgot to add the special JMH annotation processors required in pinot-perf. This PR fixes that issue.