### PR TITLE
Set skipUnparseableLines to true by default in CSV reader

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -37,7 +37,7 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private Character _escapeCharacter; // Default is null
   private String _nullStringValue;
   private boolean _skipHeader;
-  private boolean _skipUnParseableLines = false;
+  private boolean _skipUnParseableLines = true;
   private boolean _ignoreEmptyLines = true;
   private boolean _ignoreSurroundingSpaces = true;
   private Character _quoteCharacter = '"';


### PR DESCRIPTION
Needed to ensure we don't fail in `.hasNext()` when CSV has corrupt records