### PR TITLE
Add minor optimization for FIRST_VALUE / LAST_VALUE with IGNORE NULLS and unbounded ROWS window frame

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/ValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/ValueWindowFunction.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.operator.window.value;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -47,11 +46,5 @@ public abstract class ValueWindowFunction extends WindowFunction {
       List<RelFieldCollation> collations, WindowFrame windowFrame) {
     super(aggCall, inputSchema, collations, windowFrame);
     _ignoreNulls = aggCall.isIgnoreNulls();
-  }
-
-  protected List<Object> fillAllWithValue(List<Object[]> rows, Object value) {
-    int numRows = rows.size();
-    assert numRows > 0;
-    return Collections.nCopies(numRows, value);
   }
 }


### PR DESCRIPTION
- See related discussion here - https://github.com/apache/pinot/pull/14264#discussion_r1818218038
- Minor refactor to use the same logic for `ROWS` / `RANGE` with the `IGNORE NULLS` option when the window frame is `UNBOUNDED PRECEDING TO UNBOUNDED FOLLOWING`.
- A similar optimization was already applied to the `RESPECT NULLS` (default) case earlier in https://github.com/apache/pinot/pull/14273.