### PR TITLE
Adjust JsonExtractScalarTest to show failure of reading LONGs

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
@@ -140,6 +140,8 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     records.add(createRecord(13, 13, "days",
         "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"days\": 111}"));
     records.add(createRecord(14, 14, "top level array", "[{\"i1\":1,\"i2\":2}, {\"i1\":3,\"i2\":4}]"));
+    records.add(createRecord(15, 15, "john doe",
+            "{\"name\": {\"first\": \"john\", \"last\": \"doe\"}, \"id\": 101, \"largeLongValue\": \"1790416068515225918\", \"data\": [\"a\", \"b\", \"c\", \"d\"]}"));
 
     tableConfig.getIndexingConfig().setJsonIndexColumns(List.of("jsonColumn"));
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
@@ -90,6 +90,13 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
   }
 
   @Test(dataProvider = "allJsonColumns")
+  public void testExtractJsonLongValue(String column) {
+    // test fails, actual number returned is 1790416068515225856
+    Object[][] expecteds1 = {{1790416068515225918L}};
+    checkResult("SELECT jsonextractscalar(" + column + ", '$.largeLongValue', 'LONG') FROM testTable where intColumn = 15 LIMIT 1", expecteds1);
+  }
+
+  @Test(dataProvider = "allJsonColumns")
   public void testNestedExtractJsonField(String column) {
     Object[][] expecteds1 = {{"duck"}, {"mouse"}, {"duck"}};
     checkResult("SELECT jsonextractscalar(jsonextractscalar(" + column


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Test adds a record with a large long JSON field and verifies its extraction as LONG\.

```mermaid
flowchart TD
  N0["BaseJsonQueryTest#46;setUp adds record with largeLongValue #40;F1#41;"]:::stAdded
  N1["JsonExtractScalarTest#46;testExtractJsonLongValue checks extraction #40;F2#41;"]:::stAdded
  N0 -->|"record with intColumn#61;15 used in query WHERE clause"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest\.java — [before](https://github.com/apache/pinot/blob/4bafac8439e006750308ad8031c373791c594b1c/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java) · [after](https://github.com/apache/pinot/blob/04301a2fc45673bf641f5ffd02d9a2cec5d18908/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java)
- F2: pinot\-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest\.java — [before](https://github.com/apache/pinot/blob/4bafac8439e006750308ad8031c373791c594b1c/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java) · [after](https://github.com/apache/pinot/blob/04301a2fc45673bf641f5ffd02d9a2cec5d18908/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjRiYWZhYzg0MzllMDA2NzUwMzA4YWQ4MDMxYzM3Mzc5MWM1OTRiMWMiLCJjb250ZXh0X2hhc2giOiIxZTZkZTk5YjA0ZDQwOGQ4MjE4Mjc2NjBiMWUzMjBlMjE1MTA4MjUzY2ExNGNmNDlkZDYxMWE2OTUzNGRjMjc3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODY4NjAwLCJoZWFkX3NoYSI6IjA0MzAxYTJmYzQ1NjczYmY2NDFmNWZmZDAyZDlhMmNlYzVkMTg5MDgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI0YmFmYWM4NDM5ZTAwNjc1MDMwOGFkODAzMWMzNzM3OTFjNTk0YjFjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 2d002351e6e8c4a4a1f42147581a25b35dcefd8741552f2132f3cebcb8ec46e7 -->
<!-- pinot-pr-flow:end -->

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
