### PR TITLE
Fix long value parsing in jsonextractscalar

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
@@ -184,8 +184,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
       if (result instanceof Number) {
         _longValuesSV[i] = ((Number) result).longValue();
       } else {
-        // Handle scientific notation
-        _longValuesSV[i] = (long) Double.parseDouble(result.toString());
+        try {
+          _longValuesSV[i] = Long.parseLong(result.toString());
+        } catch (NumberFormatException nfe) {
+          // Handle scientific notation
+          _longValuesSV[i] = (long) Double.parseDouble(result.toString());
+        }
       }
     }
     return _longValuesSV;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
@@ -140,6 +140,12 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     records.add(createRecord(13, 13, "days",
         "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"days\": 111}"));
     records.add(createRecord(14, 14, "top level array", "[{\"i1\":1,\"i2\":2}, {\"i1\":3,\"i2\":4}]"));
+    records.add(createRecord(15, 15, "john doe",
+        "{\"name\": {\"first\": \"john\", \"last\": \"doe\"}, \"id\": 101, \"largeLongValue\": "
+            + "\"9223372036854775807\", \"data\": [\"a\", \"b\", \"c\", \"d\"]}"));
+    records.add(createRecord(16, 16, "john doe",
+        "{\"name\": {\"first\": \"john\", \"last\": \"doe\"}, \"id\": 101, \"largeLongValue\": "
+            + "\"-9223372036854775808\", \"data\": [\"a\", \"b\", \"c\", \"d\"]}"));
 
     tableConfig.getIndexingConfig().setJsonIndexColumns(List.of("jsonColumn"));
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
@@ -159,4 +159,16 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
     Object[][] expecteds3 = {{176.0}};
     checkResult("SELECT MAX(" + column + ".id - 5) FROM testTable", expecteds3);
   }
+
+  @Test(dataProvider = "allJsonColumns")
+  public void testExtractJsonLongValue(String column) {
+    // test fails, actual number returned is 1790416068515225856
+    Object[][] expecteds1 = {{Long.MAX_VALUE}};
+    checkResult("SELECT jsonextractscalar(" + column
+        + ", '$.largeLongValue', 'LONG') FROM testTable where intColumn = 15 LIMIT 1", expecteds1);
+
+    Object[][] expecteds2 = {{Long.MIN_VALUE}};
+    checkResult("SELECT jsonextractscalar(" + column
+        + ", '$.largeLongValue', 'LONG') FROM testTable where intColumn = 16 LIMIT 1", expecteds2);
+  }
 }


### PR DESCRIPTION
When extracting very large LONG numbers, `json_extract_scalar()` function is losing some precision, even though the numbers should be able to fit into a LONG size just fine.
For example, if there's a JSON column called properties that looks like
```
{
  "num_clicks": "5514400327644543899"
}
```
then sql such as 
```sql
select  json_extract_scalar(properties, '$.num_clicks', 'LONG', 0) from tab
```
returns 5514400327644544000.
That is because function parses as Double and then casts to long.
This PR first tries to parse as Long and then reverts to double to support scientific notation. 

Reported by @AlexanderKM