### PR TITLE
[Test] Use EV check to ensure table deletion

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
@@ -192,6 +192,7 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
       throws Exception {
     dropRealtimeTable(getTableName());
     waitForTableDataManagerRemoved(TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
+    waitForEVToDisappear(TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
     stopServer();
     stopBroker();
     stopController();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -485,7 +485,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
     waitForNumOfSegmentsBecomeOnline(offlineTableName, 1);
     dropOfflineTable(SEGMENT_UPLOAD_TEST_TABLE);
-    waitForTableDataManagerRemoved(offlineTableName);
+    waitForEVToDisappear(offlineTableName);
   }
 
   private void waitForNumOfSegmentsBecomeOnline(String tableNameWithType, int numSegments)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeConsumptionRateLimiterClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeConsumptionRateLimiterClusterIntegrationTest.java
@@ -167,7 +167,7 @@ public class RealtimeConsumptionRateLimiterClusterIntegrationTest extends BaseRe
       }
     } finally {
       dropRealtimeTable(tableName);
-      waitForTableDataManagerRemoved(TableNameBuilder.REALTIME.tableNameWithType(tableName));
+      waitForEVToDisappear(TableNameBuilder.REALTIME.tableNameWithType(tableName));
     }
   }
 
@@ -227,9 +227,9 @@ public class RealtimeConsumptionRateLimiterClusterIntegrationTest extends BaseRe
       }
     } finally {
       dropRealtimeTable(tableName1);
-      waitForTableDataManagerRemoved(TableNameBuilder.REALTIME.tableNameWithType(tableName1));
       dropRealtimeTable(tableName2);
-      waitForTableDataManagerRemoved(TableNameBuilder.REALTIME.tableNameWithType(tableName2));
+      waitForEVToDisappear(TableNameBuilder.REALTIME.tableNameWithType(tableName1));
+      waitForEVToDisappear(TableNameBuilder.REALTIME.tableNameWithType(tableName2));
     }
   }
 


### PR DESCRIPTION
After #14334, table data manager is removed immediately without waiting for EV to disappear when server receives the delete table message.
Adjust the integration tests to not wait for data manager removed