### PR TITLE
Bump calcite SQL parser identifier max length from default 128 (SqlParser.DEFAULT_IDENTIFIER_MAX_LENGTH) to 1024.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -50,7 +50,6 @@ import org.apache.calcite.sql.fun.SqlBetweenOperator;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlLikeOperator;
 import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
-import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.common.request.DataSource;
@@ -83,6 +82,8 @@ public class CalciteSqlParser {
   public static final String NULLS_FIRST = "nullsfirst";
   public static final ImmutableSet<String> ORDER_BY_FUNCTIONS = ImmutableSet.of(ASC, DESC, NULLS_LAST, NULLS_FIRST);
   public static final List<QueryRewriter> QUERY_REWRITERS = new ArrayList<>(QueryRewriterFactory.getQueryRewriters());
+  // TODO: Add the ability to configure the parser's maximum identifier length via configuration if needed in the future
+  public static final int CALCITE_SQL_PARSER_IDENTIFIER_MAX_LENGTH = 1024;
   private static final Logger LOGGER = LoggerFactory.getLogger(CalciteSqlParser.class);
 
   // To Keep the backward compatibility with 'OPTION' Functionality in PQL, which is used to
@@ -418,7 +419,7 @@ public class CalciteSqlParser {
     sqlParser.setTabSize(1);
     sqlParser.setQuotedCasing(Casing.UNCHANGED);
     sqlParser.setUnquotedCasing(Casing.UNCHANGED);
-    sqlParser.setIdentifierMaxLength(SqlParser.DEFAULT_IDENTIFIER_MAX_LENGTH);
+    sqlParser.setIdentifierMaxLength(CALCITE_SQL_PARSER_IDENTIFIER_MAX_LENGTH);
     return sqlParser;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlParserTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlParserTest.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers;
+
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.sql.parsers.CalciteSqlParser.CALCITE_SQL_PARSER_IDENTIFIER_MAX_LENGTH;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.fail;
+
+public class CalciteSqlParserTest {
+  private static final String SINGLE_CHAR = "a";
+
+  @Test
+  public void testIdentifierLength() {
+    String tableName = extendIdentifierToMaxLength("exampleTable");
+    String columnName = extendIdentifierToMaxLength("exampleColumn");
+
+    try {
+      final String validQuery = "SELECT count(" + columnName + ") FROM " + tableName + " WHERE " + columnName
+          + " IS NOT NULL";
+      CalciteSqlParser.compileToPinotQuery(validQuery);
+    } catch (Exception ignore) {
+      // Should not reach this line
+      fail();
+    }
+
+    final String invalidTableNameQuery = "SELECT count(" + columnName + ") FROM " + tableName + SINGLE_CHAR + " WHERE "
+        + columnName + " IS NOT NULL";
+    final String invalidColumnNameQuery = "SELECT count(" + columnName + SINGLE_CHAR + ") FROM " + tableName + " WHERE "
+        + columnName + SINGLE_CHAR + " IS NOT NULL";
+    assertThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(invalidTableNameQuery));
+    assertThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(invalidColumnNameQuery));
+  }
+
+  private String extendIdentifierToMaxLength(String identifier) {
+    return identifier + SINGLE_CHAR.repeat(CALCITE_SQL_PARSER_IDENTIFIER_MAX_LENGTH - identifier.length());
+  }
+}


### PR DESCRIPTION
For Pinot queries that involve heavy text matching, such as searching logs with long stack traces or strings, the default SQL parser identifier max length of 128 is inadequate. This PR increases the limit from the default of 128 (SqlParser.DEFAULT_IDENTIFIER_MAX_LENGTH) to 1024. Currently, this maximum value cannot be modified through configuration, but if needed in the future, the public static variable that stores this value could be made configurable easily.