### PR TITLE
Handle null values encountered in CLPDecodeTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
@@ -120,7 +120,10 @@ public class CLPDecodeTransformFunction extends BaseTransformFunction {
         BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
     for (int i = 0; i < length; i++) {
       try {
-        _stringValuesSV[i] = clpMessageDecoder.decodeMessage(logtypes[i], dictionaryVars[i], encodedVars[i]);
+        // The current CLP decoder implementation expects at least the logtype to be non-null
+        // as it does not support null value messages
+        _stringValuesSV[i] = (null == logtypes[i]) ? null
+            : clpMessageDecoder.decodeMessage(logtypes[i], dictionaryVars[i], encodedVars[i]);
       } catch (Exception ex) {
         _logger.error("Failed to decode CLP-encoded field.", ex);
         _stringValuesSV[i] = _defaultValue;


### PR DESCRIPTION
The CLP message decoder in CLPDecodeTransformFunction does not correctly handle null values. While null is a valid value in Pinot, it is unsupported by CLP. This PR introduces null value handling before invoking the message decoder to ensure the expected user behavior is properly implemented.