### PR TITLE
Add error log sampling to CLPLogMessageDecoder

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
   public static final String ERROR_SAMPLING_PERIOD_CONFIG_KEY = "errorSamplingPeriod";
   private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogMessageDecoder.class);
-  private static final int DEFAULT_ERROR_SAMPLING_PERIOD = 1;
+  private static final int DEFAULT_ERROR_SAMPLING_PERIOD = 10000;
 
   private RecordExtractor<Map<String, Object>> _recordExtractor;
   // Period at which errors should be sampled for printing:

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
@@ -38,18 +38,27 @@ import org.slf4j.LoggerFactory;
  * details. The implementation is based on {@link org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder}.
  */
 public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
+  public static final String ERROR_SAMPLING_PERIOD_CONFIG_KEY = "errorSamplingPeriod";
   private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogMessageDecoder.class);
+  private static final int DEFAULT_ERROR_SAMPLING_PERIOD = 1;
 
   private RecordExtractor<Map<String, Object>> _recordExtractor;
+  // Period at which errors should be sampled for printing:
+  // * 0            - Don't print errors
+  // * n > 0        - Print one error every n errors
+  private int _errorSamplingPeriod = DEFAULT_ERROR_SAMPLING_PERIOD;
+  private int _numErrorsUntilNextPrint = 0;
 
   @Override
   public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
       throws Exception {
     String recordExtractorClass = null;
     String recordExtractorConfigClass = null;
+    String errorSamplingPeriodString = null;
     if (null != props) {
       recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
       recordExtractorConfigClass = props.get(RECORD_EXTRACTOR_CONFIG_CONFIG_KEY);
+      errorSamplingPeriodString = props.get(ERROR_SAMPLING_PERIOD_CONFIG_KEY);
     }
     if (null == recordExtractorClass) {
       recordExtractorClass = CLPLogRecordExtractor.class.getName();
@@ -59,6 +68,19 @@ public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
     RecordExtractorConfig config = PluginManager.get().createInstance(recordExtractorConfigClass);
     config.init(props);
     _recordExtractor.init(fieldsToRead, config);
+
+    // Parse error sampling period
+    if (null != errorSamplingPeriodString) {
+      try {
+        _errorSamplingPeriod = Integer.parseInt(errorSamplingPeriodString);
+      } catch (NumberFormatException e) {
+        LOGGER.error("Could not parse errorSamplingPeriod");
+      }
+      if (_errorSamplingPeriod < 0) {
+        LOGGER.error("errorSamplingPeriod cannot be less than 0");
+        _errorSamplingPeriod = DEFAULT_ERROR_SAMPLING_PERIOD;
+      }
+    }
   }
 
   @Override
@@ -69,7 +91,13 @@ public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
       _recordExtractor.extract(from, destination);
       return destination;
     } catch (Exception e) {
-      LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
+      if (0 != _errorSamplingPeriod) {
+        _numErrorsUntilNextPrint--;
+        if (0 == _numErrorsUntilNextPrint) {
+          LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
+          _numErrorsUntilNextPrint = _errorSamplingPeriod;
+        }
+      }
       return null;
     }
   }


### PR DESCRIPTION
In certain rare cases, error logs in `CLPLogMessageDecoder` can become excessively verbose. This PR introduces the ability to sample error logs in the decoding process through a configurable setting.