### PR TITLE
Improve MSQ explain and stageStats when dealing with empty tables

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -297,11 +297,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       List<MultiStageQueryStats.StageStats.Closed> queryStats, DispatchableSubPlan dispatchableSubPlan) {
     try {
       List<DispatchablePlanFragment> stagePlans = dispatchableSubPlan.getQueryStageList();
-      List<PlanNode> planNodes = new ArrayList<>(stagePlans.size());
-      for (DispatchablePlanFragment stagePlan : stagePlans) {
-        planNodes.add(stagePlan.getPlanFragment().getFragmentRoot());
-      }
-      MultiStageStatsTreeBuilder treeBuilder = new MultiStageStatsTreeBuilder(planNodes, queryStats);
+
+      MultiStageStatsTreeBuilder treeBuilder = new MultiStageStatsTreeBuilder(stagePlans, queryStats);
       brokerResponse.setStageStats(treeBuilder.jsonStatsByStage(0));
       for (MultiStageQueryStats.StageStats.Closed stageStats : queryStats) {
         if (stageStats != null) { // for example pipeline breaker may not have stats

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.catalog;
 
-import com.google.common.base.Preconditions;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.rel.type.RelDataType;
@@ -44,8 +43,12 @@ public class PinotTable extends AbstractTable implements ScannableTable {
 
   @Override
   public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
-    Preconditions.checkState(relDataTypeFactory instanceof TypeFactory);
-    TypeFactory typeFactory = (TypeFactory) relDataTypeFactory;
+    TypeFactory typeFactory;
+    if (relDataTypeFactory instanceof TypeFactory) {
+      typeFactory = (TypeFactory) relDataTypeFactory;
+    } else { // this can happen when using Frameworks.withPrepare, which wraps our factory in a JavaTypeFactoryImpl
+      typeFactory = TypeFactory.INSTANCE;
+    }
     return typeFactory.createRelDataTypeFromSchema(_schema);
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/MultiStageExplainAskingServersUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/MultiStageExplainAskingServersUtils.java
@@ -52,7 +52,7 @@ public class MultiStageExplainAskingServersUtils {
       TransformationTracker<PlanNode, RelNode> tracker, AskingServerStageExplainer serversExplainer) {
     // extract a key node operator
     Map<DispatchablePlanFragment, PlanNode> leafNodes = queryStages.stream()
-        .filter(fragment -> !fragment.getWorkerIdToSegmentsMap().isEmpty()) // ignore root and intermediate stages
+        .filter(fragment -> fragment.getTableName() != null) // ignore root and intermediate stages
         .collect(Collectors.toMap(Function.identity(), fragment -> fragment.getPlanFragment().getFragmentRoot()));
 
     // creates a map where each leaf node is converted into another RelNode that may contain physical information

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -222,6 +222,10 @@ public class QueryDispatcher {
 
     List<StageInfo> stageInfos = serializePlanFragments(stagePlans, serverInstances, deadline);
 
+    if (serverInstances.isEmpty()) {
+      throw new RuntimeException("No server instances to dispatch query to");
+    }
+
     Map<String, String> requestMetadata = prepareRequestMetadata(requestId, queryOptions, deadline);
     ByteString protoRequestMetadata = QueryPlanSerDeUtils.toProtoProperties(requestMetadata);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -37,16 +37,13 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryServerEnclosure;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.planner.PlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
-import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.runtime.MultiStageStatsTreeBuilder;
 import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
@@ -279,10 +276,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
   private Map<String, JsonNode> tableToStats(String sql, QueryDispatcher.QueryResult queryResult) {
 
-    List<PlanNode> planNodes = planQuery(sql).getQueryPlan().getQueryStageList().stream()
-        .map(DispatchablePlanFragment::getPlanFragment)
-        .map(PlanFragment::getFragmentRoot)
-        .collect(Collectors.toList());
+    List<DispatchablePlanFragment> planNodes = planQuery(sql).getQueryPlan().getQueryStageList();
 
     MultiStageStatsTreeBuilder multiStageStatsTreeBuilder =
         new MultiStageStatsTreeBuilder(planNodes, queryResult.getQueryStats());


### PR DESCRIPTION
As discovered in #14350, some errors were reported in the query stats when multi-stage queries include empty tables (specifically tables without segments). The query doesn't fail, but the usability wasn't great.

While fixing the issue, I've also seen that explain plan in segment mode wasn't working as expected as well. It didn't fail, but it was returning the same as the logical plan.

With this PR:
- Stages whose stats are not found will be shown as:
  ```
  {
    "type": "MAILBOX_RECEIVE",
    "children": [
      {
        "type": "EMPTY_MAILBOX_SEND",
        "stage": 3,
        "description": "No stats available for this stage. It may have been pruned.",
        "table": "userAttributes2"
      }
    ]
  }
  ```
- Explain asking servers will return a line saying `PlanWithNoSegments(table=[userAttributes2])`, where `userAttributes2` is the name of the empty table.

Closes #14350