### PR TITLE
Check for `peerSegmentDownloadScheme` when reaching out to peer servers

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1539,9 +1539,15 @@ public class PinotLLCRealtimeSegmentManager {
         try {
           LOGGER.info("Fixing LLC segment {} whose deep store copy is unavailable", segmentName);
           // Find servers which have online replica
+
+          String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
+          if (peerSegmentDownloadScheme == null) {
+            peerSegmentDownloadScheme = CommonConstants.HTTP_PROTOCOL;
+          }
+
           List<URI> peerSegmentURIs =
               PeerServerSegmentFinder.getPeerServerURIs(_helixManager, realtimeTableName, segmentName,
-                  CommonConstants.HTTP_PROTOCOL);
+                  peerSegmentDownloadScheme);
           if (peerSegmentURIs.isEmpty()) {
             throw new IllegalStateException(
                 String.format("Failed to upload segment %s to deep store because no online replica is found",


### PR DESCRIPTION
Solves https://github.com/apache/pinot/issues/14377

Tested on internal Pinot cluster with successful resolution for realtime segments that failed to be uploaded to S3 due to the controller not able to reach the peer server to request the upload.