### PR TITLE
Strip Matrix parameter from BasePath check

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -41,8 +41,7 @@ import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.glassfish.grizzly.http.server.Request;
-
-import static org.apache.pinot.common.auth.AuthProviderUtils.stripMatrixParams;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 
 
 /**
@@ -76,8 +75,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     UriInfo uriInfo = requestContext.getUriInfo();
 
     // exclude public/unprotected paths
-    if (isBaseFile(stripMatrixParams(uriInfo.getPath())) ||
-        UNPROTECTED_PATHS.contains(stripMatrixParams(uriInfo.getPath()))) {
+    if (isBaseFile(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))
+        || UNPROTECTED_PATHS.contains(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))) {
       return;
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -42,6 +42,9 @@ import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.glassfish.grizzly.http.server.Request;
 
+import static org.apache.pinot.common.auth.AuthProviderUtils.stripMatrixParams;
+
+
 /**
  * A container filter class responsible for automatic authentication of REST endpoints. Any rest endpoints not annotated
  * with {@link org.apache.pinot.core.auth.ManualAuthorization} annotation, will go through authentication.
@@ -73,7 +76,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     UriInfo uriInfo = requestContext.getUriInfo();
 
     // exclude public/unprotected paths
-    if (isBaseFile(uriInfo.getPath()) || UNPROTECTED_PATHS.contains(uriInfo.getPath())) {
+    if (isBaseFile(stripMatrixParams(uriInfo.getPath())) ||
+        UNPROTECTED_PATHS.contains(stripMatrixParams(uriInfo.getPath()))) {
       return;
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -37,11 +37,11 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.glassfish.grizzly.http.server.Request;
-import org.apache.pinot.common.auth.AuthProviderUtils;
 
 
 /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -226,4 +226,17 @@ public final class AuthProviderUtils {
 
     return new NullAuthProvider();
   }
+
+  /**
+   * Strips everything after the first matrix/semicolon character in a path.
+   * @param path the path to strip
+   * @return the stripped path
+   */
+  public static String stripMatrixParams(String path) {
+    int matrixIndex = path.indexOf(';');
+    if (matrixIndex != -1) {
+      return path.substring(0, matrixIndex);
+    }
+    return path;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -239,4 +239,5 @@ public final class AuthProviderUtils {
     }
     return path;
   }
+
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -239,5 +239,4 @@ public final class AuthProviderUtils {
     }
     return path;
   }
-
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -41,8 +41,7 @@ import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.glassfish.grizzly.http.server.Request;
-
-import static org.apache.pinot.common.auth.AuthProviderUtils.stripMatrixParams;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 
 
 /**
@@ -79,8 +78,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     UriInfo uriInfo = requestContext.getUriInfo();
 
     // exclude public/unprotected paths
-    if (isBaseFile(stripMatrixParams(uriInfo.getPath())) ||
-        UNPROTECTED_PATHS.contains(stripMatrixParams(uriInfo.getPath()))) {
+    if (isBaseFile(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))
+        || UNPROTECTED_PATHS.contains(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))) {
       return;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -37,11 +37,11 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.glassfish.grizzly.http.server.Request;
-import org.apache.pinot.common.auth.AuthProviderUtils;
 
 
 /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -42,6 +42,8 @@ import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.glassfish.grizzly.http.server.Request;
 
+import static org.apache.pinot.common.auth.AuthProviderUtils.stripMatrixParams;
+
 
 /**
  * A container filter class responsible for automatic authentication of REST endpoints. Any rest endpoints annotated
@@ -77,7 +79,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     UriInfo uriInfo = requestContext.getUriInfo();
 
     // exclude public/unprotected paths
-    if (isBaseFile(uriInfo.getPath()) || UNPROTECTED_PATHS.contains(uriInfo.getPath())) {
+    if (isBaseFile(stripMatrixParams(uriInfo.getPath())) ||
+        UNPROTECTED_PATHS.contains(stripMatrixParams(uriInfo.getPath()))) {
       return;
     }
 
@@ -150,6 +153,6 @@ public class AuthenticationFilter implements ContainerRequestFilter {
   }
 
   private static boolean isBaseFile(String path) {
-    return !path.contains("/") && !path.contains(";") && path.contains(".");
+    return !path.contains("/") && path.contains(".");
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -150,6 +150,6 @@ public class AuthenticationFilter implements ContainerRequestFilter {
   }
 
   private static boolean isBaseFile(String path) {
-    return !path.contains("/") && path.contains(".");
+    return !path.contains("/") && !path.contains(";") && path.contains(".");
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -131,7 +131,7 @@ public class AuthenticationFilterTest {
         {"/path/to/resource;param1=value1;param2=value2", "/path/to/resource"}, // with matrix params
         {"/path/to/resource", "/path/to/resource"},                             // no matrix params
         {"", ""},                                                               // empty path
-        {";param1=value1/path/to/resource", ""},                                // matrix at start
+        {";param1=value1/path/to/resource", ""},                                // matrix at beginning
         {"/path;param1=value1;param2=value2/to/resource", "/path"}              // multiple semicolons
     };
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -26,8 +26,10 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.auth.AuthProviderUtils.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -121,6 +123,24 @@ public class AuthenticationFilterTest {
     assertEquals(AccessType.UPDATE, _authFilter.extractAccessType(method));
     method = AuthenticationFilterTest.class.getMethod("methodWithDelete");
     assertEquals(AccessType.DELETE, _authFilter.extractAccessType(method));
+  }
+
+  // DataProvider supplying test cases
+  @DataProvider(name = "pathProvider")
+  public Object[][] pathProvider() {
+    return new Object[][] {
+        {"/path/to/resource;param1=value1;param2=value2", "/path/to/resource"}, // with matrix params
+        {"/path/to/resource", "/path/to/resource"},                             // no matrix params
+        {"", ""},                                                               // empty path
+        {";param1=value1/path/to/resource", ""},                                // matrix at start
+        {"/path;param1=value1;param2=value2/to/resource", "/path"}              // multiple semicolons
+    };
+  }
+
+  // Test method using the DataProvider
+  @Test(dataProvider = "pathProvider")
+  public void testStripMatrixParams(String input, String expected) {
+    assertEquals(stripMatrixParams(input), expected);
   }
 
   @Authenticate(AccessType.UPDATE)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -26,12 +26,11 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.auth.AuthProviderUtils.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.*;
 
 
 public class AuthenticationFilterTest {
@@ -137,10 +136,9 @@ public class AuthenticationFilterTest {
     };
   }
 
-  // Test method using the DataProvider
   @Test(dataProvider = "pathProvider")
   public void testStripMatrixParams(String input, String expected) {
-    assertEquals(stripMatrixParams(input), expected);
+    assertEquals(AuthProviderUtils.stripMatrixParams(input), expected);
   }
 
   @Authenticate(AccessType.UPDATE)


### PR DESCRIPTION
## Summary
Modify Parser to strip matrix parameter when checking for basePath

## Testing
unit test added
