### PR TITLE
Add table and column information to query errors

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -129,7 +129,11 @@ public class DataBlockCache {
         intValues = new int[_length];
         putValues(FieldSpec.DataType.INT, column, intValues);
       }
-      _dataFetcher.fetchIntValues(column, _docIds, _length, intValues);
+      try {
+        _dataFetcher.fetchIntValues(column, _docIds, _length, intValues);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withColumnName(column);
+      }
     }
     return intValues;
   }
@@ -147,7 +151,11 @@ public class DataBlockCache {
         longValues = new long[_length];
         putValues(FieldSpec.DataType.LONG, column, longValues);
       }
-      _dataFetcher.fetchLongValues(column, _docIds, _length, longValues);
+      try {
+        _dataFetcher.fetchLongValues(column, _docIds, _length, longValues);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withColumnName(column);
+      }
     }
     return longValues;
   }
@@ -165,7 +173,11 @@ public class DataBlockCache {
         floatValues = new float[_length];
         putValues(FieldSpec.DataType.FLOAT, column, floatValues);
       }
-      _dataFetcher.fetchFloatValues(column, _docIds, _length, floatValues);
+      try {
+        _dataFetcher.fetchFloatValues(column, _docIds, _length, floatValues);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withColumnName(column);
+      }
     }
     return floatValues;
   }
@@ -183,7 +195,11 @@ public class DataBlockCache {
         doubleValues = new double[_length];
         putValues(FieldSpec.DataType.DOUBLE, column, doubleValues);
       }
-      _dataFetcher.fetchDoubleValues(column, _docIds, _length, doubleValues);
+      try {
+        _dataFetcher.fetchDoubleValues(column, _docIds, _length, doubleValues);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withColumnName(column);
+      }
     }
     return doubleValues;
   }
@@ -201,7 +217,11 @@ public class DataBlockCache {
         bigDecimalValues = new BigDecimal[_length];
         putValues(FieldSpec.DataType.BIG_DECIMAL, column, bigDecimalValues);
       }
-      _dataFetcher.fetchBigDecimalValues(column, _docIds, _length, bigDecimalValues);
+      try {
+        _dataFetcher.fetchBigDecimalValues(column, _docIds, _length, bigDecimalValues);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withColumnName(column);
+      }
     }
     return bigDecimalValues;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/PinotRuntimeException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/PinotRuntimeException.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.common;
+
+/**
+ *  Simple runtime query exception containing useful contextual information, e.g. table or column name.
+ */
+public class PinotRuntimeException extends RuntimeException {
+
+  //table name or alias
+  private String _tableName;
+
+  // column or expression name
+  private String _columnName;
+
+  private PinotRuntimeException(Throwable e) {
+    super(e);
+  }
+
+  public static PinotRuntimeException create(Throwable e) {
+    if (e instanceof PinotRuntimeException) {
+      return (PinotRuntimeException) e;
+    } else {
+      return new PinotRuntimeException(e);
+    }
+  }
+
+  public PinotRuntimeException withColumnName(String columnName) {
+    _columnName = columnName;
+    return this;
+  }
+
+  public PinotRuntimeException withTableName(String tableName) {
+    _tableName = tableName;
+    return this;
+  }
+
+  @Override
+  public String getMessage() {
+    StringBuilder message = new StringBuilder("Error when processing");
+    if (_tableName != null) {
+      message.append(" ").append(_tableName);
+    }
+    if (_columnName != null) {
+      if (_tableName != null) {
+        message.append(".");
+      } else {
+        message.append(" ");
+      }
+      message.append(_columnName);
+    }
+    message.append(": ");
+    message.append(super.getMessage());
+
+    return message.toString();
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.common.PinotRuntimeException;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
@@ -122,12 +123,13 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
             // NOTE: We need to handle Error here, or the execution threads will die without adding the execution
             //       exception into the query response, and the main thread might wait infinitely (until timeout) or
             //       throw unexpected exceptions (such as NPE).
+            PinotRuntimeException pe = PinotRuntimeException.create(t).withTableName(_queryContext.getTableName());
             if (t instanceof Exception) {
-              LOGGER.error("Caught exception while processing query: {}", _queryContext, t);
+              LOGGER.error("Caught exception while processing query: {}", _queryContext, pe);
             } else {
-              LOGGER.error("Caught serious error while processing query: {}", _queryContext, t);
+              LOGGER.error("Caught serious error while processing query: {}", _queryContext, pe);
             }
-            onProcessSegmentsException(t);
+            onProcessSegmentsException(pe);
           } finally {
             onProcessSegmentsFinish();
             _phaser.arriveAndDeregister();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredRowBasedBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredRowBasedBlockValSet.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.PinotRuntimeException;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -43,17 +44,20 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
   private final DataType _dataType;
   private final DataType _storedType;
   private final List<Object[]> _rows;
+  private final String _colName;
   private final int _colId;
   private final int _numMatchedRows;
   private final RoaringBitmap _matchedBitmap;
   private final RoaringBitmap _matchedNullBitmap;
 
-  public FilteredRowBasedBlockValSet(ColumnDataType columnDataType, List<Object[]> rows, int colId, int numMatchedRows,
+  public FilteredRowBasedBlockValSet(ColumnDataType columnDataType, List<Object[]> rows, int colId, String columnName,
+      int numMatchedRows,
       RoaringBitmap matchedBitmap, boolean nullHandlingEnabled) {
     _dataType = columnDataType.toDataType();
     _storedType = _dataType.getStoredType();
     _rows = rows;
     _colId = colId;
+    _colName = columnName;
     _numMatchedRows = numMatchedRows;
     _matchedBitmap = matchedBitmap;
 
@@ -108,16 +112,20 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
       return values;
     }
     PeekableIntIterator iterator = _matchedBitmap.getIntIterator();
-    for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
-      int rowId = iterator.next();
-      if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
-        continue;
+    try {
+      for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
+        int rowId = iterator.next();
+        if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
+          continue;
+        }
+        if (_storedType.isNumeric()) {
+          values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).intValue();
+        } else {
+          values[matchedRowId] = Integer.parseInt((String) _rows.get(rowId)[_colId]);
+        }
       }
-      if (_storedType.isNumeric()) {
-        values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).intValue();
-      } else {
-        values[matchedRowId] = Integer.parseInt((String) _rows.get(rowId)[_colId]);
-      }
+    } catch (RuntimeException re) {
+      throw PinotRuntimeException.create(re).withColumnName(_colName);
     }
     return values;
   }
@@ -131,16 +139,20 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
       return values;
     }
     PeekableIntIterator iterator = _matchedBitmap.getIntIterator();
-    for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
-      int rowId = iterator.next();
-      if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
-        continue;
+    try {
+      for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
+        int rowId = iterator.next();
+        if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
+          continue;
+        }
+        if (_storedType.isNumeric()) {
+          values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).longValue();
+        } else {
+          values[matchedRowId] = Long.parseLong((String) _rows.get(rowId)[_colId]);
+        }
       }
-      if (_storedType.isNumeric()) {
-        values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).longValue();
-      } else {
-        values[matchedRowId] = Long.parseLong((String) _rows.get(rowId)[_colId]);
-      }
+    } catch (RuntimeException re) {
+      throw PinotRuntimeException.create(re).withColumnName(_colName);
     }
     return values;
   }
@@ -154,16 +166,20 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
       return values;
     }
     PeekableIntIterator iterator = _matchedBitmap.getIntIterator();
-    for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
-      int rowId = iterator.next();
-      if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
-        continue;
+    try {
+      for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
+        int rowId = iterator.next();
+        if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
+          continue;
+        }
+        if (_storedType.isNumeric()) {
+          values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).floatValue();
+        } else {
+          values[matchedRowId] = Float.parseFloat((String) _rows.get(rowId)[_colId]);
+        }
       }
-      if (_storedType.isNumeric()) {
-        values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).floatValue();
-      } else {
-        values[matchedRowId] = Float.parseFloat((String) _rows.get(rowId)[_colId]);
-      }
+    } catch (RuntimeException re) {
+      throw PinotRuntimeException.create(re).withColumnName(_colName);
     }
     return values;
   }
@@ -177,16 +193,20 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
       return values;
     }
     PeekableIntIterator iterator = _matchedBitmap.getIntIterator();
-    for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
-      int rowId = iterator.next();
-      if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
-        continue;
+    try {
+      for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
+        int rowId = iterator.next();
+        if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
+          continue;
+        }
+        if (_storedType.isNumeric()) {
+          values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).doubleValue();
+        } else {
+          values[matchedRowId] = Double.parseDouble((String) _rows.get(rowId)[_colId]);
+        }
       }
-      if (_storedType.isNumeric()) {
-        values[matchedRowId] = ((Number) _rows.get(rowId)[_colId]).doubleValue();
-      } else {
-        values[matchedRowId] = Double.parseDouble((String) _rows.get(rowId)[_colId]);
-      }
+    } catch (RuntimeException re) {
+      throw PinotRuntimeException.create(re).withColumnName(_colName);
     }
     return values;
   }
@@ -202,31 +222,35 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
       return values;
     }
     PeekableIntIterator iterator = _matchedBitmap.getIntIterator();
-    for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
-      int rowId = iterator.next();
-      if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
-        values[matchedRowId] = NullValuePlaceHolder.BIG_DECIMAL;
-        continue;
+    try {
+      for (int matchedRowId = 0; matchedRowId < _numMatchedRows; matchedRowId++) {
+        int rowId = iterator.next();
+        if (_matchedNullBitmap != null && _matchedNullBitmap.contains(matchedRowId)) {
+          values[matchedRowId] = NullValuePlaceHolder.BIG_DECIMAL;
+          continue;
+        }
+        switch (_storedType) {
+          case INT:
+          case LONG:
+            values[matchedRowId] = BigDecimal.valueOf(((Number) _rows.get(rowId)[_colId]).longValue());
+            break;
+          case FLOAT:
+          case DOUBLE:
+          case STRING:
+            values[matchedRowId] = new BigDecimal(_rows.get(rowId)[_colId].toString());
+            break;
+          case BIG_DECIMAL:
+            values[matchedRowId] = (BigDecimal) _rows.get(rowId)[_colId];
+            break;
+          case BYTES:
+            values[matchedRowId] = BigDecimalUtils.deserialize((ByteArray) _rows.get(rowId)[_colId]);
+            break;
+          default:
+            throw new IllegalStateException("Cannot read BigDecimal values from data type: " + _dataType);
+        }
       }
-      switch (_storedType) {
-        case INT:
-        case LONG:
-          values[matchedRowId] = BigDecimal.valueOf(((Number) _rows.get(rowId)[_colId]).longValue());
-          break;
-        case FLOAT:
-        case DOUBLE:
-        case STRING:
-          values[matchedRowId] = new BigDecimal(_rows.get(rowId)[_colId].toString());
-          break;
-        case BIG_DECIMAL:
-          values[matchedRowId] = (BigDecimal) _rows.get(rowId)[_colId];
-          break;
-        case BYTES:
-          values[matchedRowId] = BigDecimalUtils.deserialize((ByteArray) _rows.get(rowId)[_colId]);
-          break;
-        default:
-          throw new IllegalStateException("Cannot read BigDecimal values from data type: " + _dataType);
-      }
+    } catch (RuntimeException re) {
+      throw PinotRuntimeException.create(re).withColumnName(_colName);
     }
     return values;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
+import org.apache.pinot.core.common.PinotRuntimeException;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -127,6 +128,9 @@ public class ProjectionBlockValSet implements BlockValSet {
     try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
       recordReadValues(scope, DataType.FLOAT, true);
       return _dataBlockCache.getFloatValuesForSVColumn(_column);
+    } catch (RuntimeException re) {
+      //add column information, then later enrich it with table name
+      throw PinotRuntimeException.create(re).withColumnName(_column);
     }
   }
 
@@ -135,6 +139,9 @@ public class ProjectionBlockValSet implements BlockValSet {
     try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
       recordReadValues(scope, DataType.DOUBLE, true);
       return _dataBlockCache.getDoubleValuesForSVColumn(_column);
+    } catch (RuntimeException re) {
+      //add column information, then later enrich it with table name
+      throw PinotRuntimeException.create(re).withColumnName(_column);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/RowBasedBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/RowBasedBlockValSet.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.PinotRuntimeException;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
@@ -43,15 +44,17 @@ public class RowBasedBlockValSet implements BlockValSet {
   private final DataType _storedType;
   private final List<Object[]> _rows;
   private final int _colId;
+  private final String _colName;
   private final RoaringBitmap _nullBitmap;
   private final Object _nullPlaceHolder;
 
-  public RowBasedBlockValSet(ColumnDataType columnDataType, List<Object[]> rows, int colId,
+  public RowBasedBlockValSet(ColumnDataType columnDataType, List<Object[]> rows, int colId, String colName,
       boolean nullHandlingEnabled) {
     _dataType = columnDataType.toDataType();
     _storedType = _dataType.getStoredType();
     _rows = rows;
     _colId = colId;
+    _colName = colName;
     _nullPlaceHolder = columnDataType.getNullPlaceholder();
 
     if (nullHandlingEnabled) {
@@ -114,8 +117,12 @@ public class RowBasedBlockValSet implements BlockValSet {
           values[i] = ((Number) _rows.get(i)[_colId]).intValue();
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          values[i] = Integer.parseInt((String) _rows.get(i)[_colId]);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            values[i] = Integer.parseInt((String) _rows.get(i)[_colId]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read int values from data type: " + _dataType);
@@ -129,11 +136,15 @@ public class RowBasedBlockValSet implements BlockValSet {
           }
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          String value = (String) _rows.get(i)[_colId];
-          if (value != null) {
-            values[i] = Integer.parseInt(value);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            String value = (String) _rows.get(i)[_colId];
+            if (value != null) {
+              values[i] = Integer.parseInt(value);
+            }
           }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read int values from data type: " + _dataType);
@@ -155,8 +166,12 @@ public class RowBasedBlockValSet implements BlockValSet {
           values[i] = ((Number) _rows.get(i)[_colId]).longValue();
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          values[i] = Long.parseLong((String) _rows.get(i)[_colId]);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            values[i] = Long.parseLong((String) _rows.get(i)[_colId]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read long values from data type: " + _dataType);
@@ -170,11 +185,15 @@ public class RowBasedBlockValSet implements BlockValSet {
           }
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          String value = (String) _rows.get(i)[_colId];
-          if (value != null) {
-            values[i] = Long.parseLong(value);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            String value = (String) _rows.get(i)[_colId];
+            if (value != null) {
+              values[i] = Long.parseLong(value);
+            }
           }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read long values from data type: " + _dataType);
@@ -196,8 +215,12 @@ public class RowBasedBlockValSet implements BlockValSet {
           values[i] = ((Number) _rows.get(i)[_colId]).floatValue();
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          values[i] = Float.parseFloat((String) _rows.get(i)[_colId]);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            values[i] = Float.parseFloat((String) _rows.get(i)[_colId]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read float values from data type: " + _dataType);
@@ -211,11 +234,15 @@ public class RowBasedBlockValSet implements BlockValSet {
           }
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          String value = (String) _rows.get(i)[_colId];
-          if (value != null) {
-            values[i] = Float.parseFloat(value);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            String value = (String) _rows.get(i)[_colId];
+            if (value != null) {
+              values[i] = Float.parseFloat(value);
+            }
           }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read float values from data type: " + _dataType);
@@ -237,8 +264,12 @@ public class RowBasedBlockValSet implements BlockValSet {
           values[i] = ((Number) _rows.get(i)[_colId]).doubleValue();
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          values[i] = Double.parseDouble((String) _rows.get(i)[_colId]);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            values[i] = Double.parseDouble((String) _rows.get(i)[_colId]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read double values from data type: " + _dataType);
@@ -252,11 +283,15 @@ public class RowBasedBlockValSet implements BlockValSet {
           }
         }
       } else if (_storedType == DataType.STRING) {
-        for (int i = 0; i < numRows; i++) {
-          String value = (String) _rows.get(i)[_colId];
-          if (value != null) {
-            values[i] = Double.parseDouble(value);
+        try {
+          for (int i = 0; i < numRows; i++) {
+            String value = (String) _rows.get(i)[_colId];
+            if (value != null) {
+              values[i] = Double.parseDouble(value);
+            }
           }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Cannot read double values from data type: " + _dataType);
@@ -287,8 +322,12 @@ public class RowBasedBlockValSet implements BlockValSet {
         case FLOAT:
         case DOUBLE:
         case STRING:
-          for (int i = 0; i < numRows; i++) {
-            values[i] = new BigDecimal(_rows.get(i)[_colId].toString());
+          try {
+            for (int i = 0; i < numRows; i++) {
+              values[i] = new BigDecimal(_rows.get(i)[_colId].toString());
+            }
+          } catch (RuntimeException re) {
+            throw PinotRuntimeException.create(re).withColumnName(_colName);
           }
           break;
         case BIG_DECIMAL:
@@ -316,9 +355,13 @@ public class RowBasedBlockValSet implements BlockValSet {
         case FLOAT:
         case DOUBLE:
         case STRING:
-          for (int i = 0; i < numRows; i++) {
-            Object value = _rows.get(i)[_colId];
-            values[i] = value != null ? new BigDecimal(value.toString()) : NullValuePlaceHolder.BIG_DECIMAL;
+          try {
+            for (int i = 0; i < numRows; i++) {
+              Object value = _rows.get(i)[_colId];
+              values[i] = value != null ? new BigDecimal(value.toString()) : NullValuePlaceHolder.BIG_DECIMAL;
+            }
+          } catch (RuntimeException re) {
+            throw PinotRuntimeException.create(re).withColumnName(_colName);
           }
           break;
         case BIG_DECIMAL:
@@ -432,8 +475,12 @@ public class RowBasedBlockValSet implements BlockValSet {
       } else if (storedValue instanceof String[]) {
         String[] stringArray = (String[]) storedValue;
         values[i] = new int[stringArray.length];
-        for (int j = 0; j < stringArray.length; j++) {
-          values[i][j] = Integer.parseInt(stringArray[j]);
+        try {
+          for (int j = 0; j < stringArray.length; j++) {
+            values[i][j] = Integer.parseInt(stringArray[j]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Unsupported data type: " + storedValue.getClass().getName());
@@ -472,8 +519,12 @@ public class RowBasedBlockValSet implements BlockValSet {
       } else if (storedValue instanceof String[]) {
         String[] stringArray = (String[]) storedValue;
         values[i] = new long[stringArray.length];
-        for (int j = 0; j < stringArray.length; j++) {
-          values[i][j] = Long.parseLong(stringArray[j]);
+        try {
+          for (int j = 0; j < stringArray.length; j++) {
+            values[i][j] = Long.parseLong(stringArray[j]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Unsupported data type: " + storedValue.getClass().getName());
@@ -512,8 +563,12 @@ public class RowBasedBlockValSet implements BlockValSet {
       } else if (storedValue instanceof String[]) {
         String[] stringArray = (String[]) storedValue;
         values[i] = new float[stringArray.length];
-        for (int j = 0; j < stringArray.length; j++) {
-          values[i][j] = Float.parseFloat(stringArray[j]);
+        try {
+          for (int j = 0; j < stringArray.length; j++) {
+            values[i][j] = Float.parseFloat(stringArray[j]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Unsupported data type: " + storedValue.getClass().getName());
@@ -552,8 +607,12 @@ public class RowBasedBlockValSet implements BlockValSet {
       } else if (storedValue instanceof String[]) {
         String[] stringArray = (String[]) storedValue;
         values[i] = new double[stringArray.length];
-        for (int j = 0; j < stringArray.length; j++) {
-          values[i][j] = Double.parseDouble(stringArray[j]);
+        try {
+          for (int j = 0; j < stringArray.length; j++) {
+            values[i][j] = Double.parseDouble(stringArray[j]);
+          }
+        } catch (RuntimeException re) {
+          throw PinotRuntimeException.create(re).withColumnName(_colName);
         }
       } else {
         throw new IllegalStateException("Unsupported data type: " + storedValue.getClass().getName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TestAggregationFunction.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.math.BigDecimal;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TestAggregationFunction.java
@@ -1,0 +1,146 @@
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.DoubleAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.DoubleGroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+// aggregation created to test type conversions
+public class TestAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
+  private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
+
+  private ExpressionContext _type;
+
+  public TestAggregationFunction(ExpressionContext expression, ExpressionContext type, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
+    _type = type;
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.TEST_AGGREGATE;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    if (_nullHandlingEnabled) {
+      return new ObjectAggregationResultHolder();
+    }
+    return new DoubleAggregationResultHolder(DEFAULT_VALUE);
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    if (_nullHandlingEnabled) {
+      return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+    }
+    return new DoubleGroupByResultHolder(initialCapacity, maxCapacity, DEFAULT_VALUE);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    FieldSpec.DataType type = FieldSpec.DataType.valueOf(_type.getLiteral().getStringValue().toUpperCase());
+    switch (type) {
+      case INT:
+        int[] ints = blockValSet.getIntValuesSV();
+        break;
+      case LONG:
+        long[] longs = blockValSet.getLongValuesSV();
+        break;
+      case FLOAT:
+        float[] floats = blockValSet.getFloatValuesSV();
+        break;
+      case DOUBLE:
+        double[] doubles = blockValSet.getDoubleValuesSV();
+        break;
+      case BIG_DECIMAL:
+        BigDecimal[] decimals = blockValSet.getBigDecimalValuesSV();
+        break;
+      case BYTES:
+        byte[][] bytes = blockValSet.getBytesValuesSV();
+        break;
+      case STRING:
+        String[] strings = blockValSet.getStringValuesSV();
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected type " + type);
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    aggregate(-1, null, blockValSetMap);
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    FieldSpec.DataType type = FieldSpec.DataType.valueOf(_type.getLiteral().getStringValue().toUpperCase());
+    switch (type) {
+      case INT:
+        int[][] ints = blockValSet.getIntValuesMV();
+        break;
+      case LONG:
+        long[][] longs = blockValSet.getLongValuesMV();
+        break;
+      case FLOAT:
+        float[][] floats = blockValSet.getFloatValuesMV();
+        break;
+      case DOUBLE:
+        double[][] doubles = blockValSet.getDoubleValuesMV();
+        break;
+      case BYTES:
+        byte[][][] bytes = blockValSet.getBytesValuesMV();
+        break;
+      case STRING:
+        String[][] string = blockValSet.getStringValuesMV();
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected type " + type);
+    }
+  }
+
+  @Override
+  public Double extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return 0.0;
+  }
+
+  @Override
+  public Double extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return 0.0;
+  }
+
+  @Override
+  public Double merge(Double intermediateResult1, Double intermediateResult2) {
+    return 0.0;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.DOUBLE;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.DOUBLE;
+  }
+
+  @Override
+  public Double extractFinalResult(Double aDouble) {
+    return 0.0;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.core.common.PinotRuntimeException;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
@@ -168,8 +169,12 @@ public class BrokerReduceService extends BaseReduceService {
       if (gapfillType == null) {
         throw new BadQueryRequestException("Nested query is not supported without gapfill");
       }
-      BaseGapfillProcessor gapfillProcessor = GapfillProcessorFactory.getGapfillProcessor(queryContext, gapfillType);
-      gapfillProcessor.process(brokerResponseNative);
+      try {
+        BaseGapfillProcessor gapfillProcessor = GapfillProcessorFactory.getGapfillProcessor(queryContext, gapfillType);
+        gapfillProcessor.process(brokerResponseNative);
+      } catch (RuntimeException re) {
+        throw PinotRuntimeException.create(re).withTableName(tableName);
+      }
     }
 
     if (!serverQueryContext.isExplain()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -273,7 +273,7 @@ public class GapfillProcessor extends BaseGapfillProcessor {
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     for (int i = 1; i < dataSchema.getColumnNames().length; i++) {
       blockValSetMap.put(ExpressionContext.forIdentifier(dataSchema.getColumnName(i)),
-          new RowBasedBlockValSet(dataSchema.getColumnDataType(i), bucketedRows, i,
+          new RowBasedBlockValSet(dataSchema.getColumnDataType(i), bucketedRows, i, dataSchema.getColumnName(i),
               _queryContext.isNullHandlingEnabled()));
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.query;
 
 import java.util.Arrays;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
@@ -174,7 +174,7 @@ public class QueryParseErrorReportingTest extends AbstractAggregationFunctionTes
                            .setSchemaName(RAW_TABLE_NAME)
                            .setEnableColumnBasedNullHandling(true)
                            .addSingleValueDimension(EVENT_TIME_COLUMN, FieldSpec.DataType.LONG)
-                           .addDimensionField(IS_OCCUPIED_COLUMN, FieldSpec.DataType.LONG)
+                           .addDimensionField(IS_OCCUPIED_COLUMN, FieldSpec.DataType.STRING)
                            .addSingleValueDimension(LEVEL_ID_COLUMN, FieldSpec.DataType.STRING)
                            .addSingleValueDimension(LOT_ID_COLUMN, FieldSpec.DataType.STRING)
                            .setPrimaryKeyColumns(Arrays.asList(LOT_ID_COLUMN, EVENT_TIME_COLUMN))
@@ -193,10 +193,12 @@ public class QueryParseErrorReportingTest extends AbstractAggregationFunctionTes
                        row("2021-11-07 04:31:00.000", 1, 0, null)
                    )
                    .whenQuery(
-                       "select max(isOccupied) filter (where levelId in ('level_0')) from parkingData where lotId = "
-                           + "'lot_0'")
+                       // max with filter triggers `Cannot compute max for non-numeric type: STRING`
+                       "select lastWithTime(isOccupied, eventTime, 'INT') filter (where levelId in ('level_0')) from "
+                           + "parkingData where lotId = 'lot_0'")
                    .thenResultIsException(
-                       "Error when processing testTable.myField.*NumberFormatException: For input string:", 2);
+                       "Error when processing parkingData.lastwithtime\\(isOccupied,eventTime,'INT'\\)"
+                           + ".*NumberFormatException: For input string:", 2);
   }
 
   private static Object[] row(String timestamp, int level, int lot, String isOccupied) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/QueryParseErrorReportingTest.java
@@ -1,0 +1,228 @@
+package org.apache.pinot.core.query;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.core.common.PinotRuntimeException;
+import org.apache.pinot.core.query.aggregation.function.AbstractAggregationFunctionTest;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import org.apache.pinot.core.query.aggregation.function.TestAggregationFunction;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.ArgumentMatcher;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class QueryParseErrorReportingTest extends AbstractAggregationFunctionTest {
+
+  private static final String RAW_TABLE_NAME = "parkingData";
+
+  private static final String IS_OCCUPIED_COLUMN = "isOccupied";
+  private static final String LEVEL_ID_COLUMN = "levelId";
+  private static final String LOT_ID_COLUMN = "lotId";
+  private static final String EVENT_TIME_COLUMN = "eventTime";
+
+  private static final DateTimeFormatSpec FORMATTER =
+      new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+
+  @Test
+  public void testNoKeyAggregateConversionError() {
+    FluentQueryTest.withBaseDir(_baseDir)
+                   .withNullHandling(false)
+                   .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.STRING),
+                       SINGLE_FIELD_TABLE_CONFIG)
+                   .onFirstInstance(
+                       new Object[]{"A"}
+                   )
+                   .andOnSecondInstance(
+                       new Object[]{"1A"}
+                   )
+                   .whenQuery("select max(myField) from testTable")
+                   .thenResultIsException(
+                       "Error when processing testTable.myField.*NumberFormatException: For input string:", 2);
+  }
+
+  @Test
+  public void testKeyedAggregateConversionError() {
+    FluentQueryTest.withBaseDir(_baseDir)
+                   .withNullHandling(false)
+                   .givenTable(
+                       new Schema.SchemaBuilder()
+                           .setSchemaName("testTable")
+                           .setEnableColumnBasedNullHandling(true)
+                           .addDimensionField("key", FieldSpec.DataType.STRING)
+                           .addDimensionField("value", FieldSpec.DataType.STRING)
+                           .build(), SINGLE_FIELD_TABLE_CONFIG)
+                   .onFirstInstance(
+                       new Object[]{"k1", "v10"}
+                   )
+                   .andOnSecondInstance(
+                       new Object[]{"k2", "20v"}
+                   )
+                   .whenQuery("select key, max(value) from testTable group by key")
+                   .thenResultIsException(
+                       "Error when processing testTable.value.*NumberFormatException: For input string:", 2);
+  }
+
+  @Test(dataProvider = "dataTypes")
+  public void testGapFillConversionError(FieldSpec.DataType functionType, boolean nullHandlingEnabled) {
+    String query = "SELECT "
+        + " time_col, TEST_AGG( occupied, '" + functionType + "' ) as occupied_slots_count "
+        + "FROM ( "
+        + "  SELECT GapFill(time_col, '1:MILLISECONDS:EPOCH', '1636257600000',  '1636286400000', '1:HOURS',"
+        + "                 FILL( occupied, 'FILL_PREVIOUS_VALUE'), "
+        + "                 TIMESERIESON(levelId, lotId) ) AS time_col,"
+        + "         occupied , lotId, levelId"
+        + "  FROM ("
+        + "    SELECT DATETRUNC('hour', eventTime, 'milliseconds') AS time_col, "
+        + "           lastWithTime(isOccupied, eventTime, 'STRING') as occupied, "
+        + "           lotId, levelId "
+        + "    FROM parkingData "
+        + "    GROUP BY time_col, levelId, lotId"
+        + "    LIMIT 200 "
+        + "  ) "
+        + "  LIMIT 200 "
+        + ") "
+        + " GROUP BY time_col ";
+
+    try (MockedStatic<AggregationFunctionFactory> mock = Mockito.mockStatic(AggregationFunctionFactory.class,
+        Mockito.CALLS_REAL_METHODS)) {
+
+      mock.when(() -> {
+        AggregationFunctionFactory.getAggregationFunction(Mockito.argThat(new ArgumentMatcher<FunctionContext>() {
+          @Override
+          public boolean matches(FunctionContext argument) {
+            return "testagg".equals(argument.getFunctionName());
+          }
+        }), Mockito.anyBoolean());
+      }).thenAnswer(invocation -> {
+            List<ExpressionContext> arguments = ((FunctionContext) invocation.getArgument(0)).getArguments();
+            return new TestAggregationFunction(arguments.get(0), arguments.get(1), false);
+          }
+      );
+
+      PinotRuntimeException pe = Assert.expectThrows(PinotRuntimeException.class, () -> {
+        FluentQueryTest.withBaseDir(_baseDir)
+                       .withNullHandling(true)
+                       .givenTable(
+                           new Schema.SchemaBuilder()
+                               .setSchemaName(RAW_TABLE_NAME)
+                               .setEnableColumnBasedNullHandling(nullHandlingEnabled)
+                               .addSingleValueDimension(EVENT_TIME_COLUMN, FieldSpec.DataType.LONG)
+                               .addDimensionField(IS_OCCUPIED_COLUMN, FieldSpec.DataType.STRING,
+                                   f -> {
+                                     f.setDefaultNullValue(null);
+                                     f.setNullable(nullHandlingEnabled);
+                                   })
+                               .addSingleValueDimension(LEVEL_ID_COLUMN, FieldSpec.DataType.STRING)
+                               .addSingleValueDimension(LOT_ID_COLUMN, FieldSpec.DataType.STRING)
+                               .setPrimaryKeyColumns(Arrays.asList(LOT_ID_COLUMN, EVENT_TIME_COLUMN))
+                               .build(),
+                           new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build())
+                       .onFirstInstance(
+                           row("2021-11-07 04:11:00.000", 0, 0, "v1"),
+                           row("2021-11-07 04:21:00.000", 0, 0, "true"),
+                           row("2021-11-07 04:31:00.000", 1, 0, "1.2QQ"),
+                           row("2021-11-07 04:31:00.000", 1, 0, null)
+                       ).andOnSecondInstance(
+                           row("2021-11-07 04:11:00.000", 0, 0, "v1"),
+                           row("2021-11-07 04:21:00.000", 0, 0, "true"),
+                           row("2021-11-07 04:31:00.000", 1, 0, "1.2QQ"),
+                           row("2021-11-07 04:31:00.000", 1, 0, null)
+                       )
+                       .whenQuery(query); // exception is thrown during local merge
+      });
+
+      Assert.assertTrue(pe.getMessage().matches(
+          ".*Error when processing parkingData.occupied.*NumberFormatException: .*"), pe.getMessage());
+    }
+  }
+
+  @Test
+  public void testFilteredAggregateConversionError() {
+    FluentQueryTest.withBaseDir(_baseDir)
+                   .withNullHandling(false)
+                   .givenTable(
+                       new Schema.SchemaBuilder()
+                           .setSchemaName(RAW_TABLE_NAME)
+                           .setEnableColumnBasedNullHandling(true)
+                           .addSingleValueDimension(EVENT_TIME_COLUMN, FieldSpec.DataType.LONG)
+                           .addDimensionField(IS_OCCUPIED_COLUMN, FieldSpec.DataType.LONG)
+                           .addSingleValueDimension(LEVEL_ID_COLUMN, FieldSpec.DataType.STRING)
+                           .addSingleValueDimension(LOT_ID_COLUMN, FieldSpec.DataType.STRING)
+                           .setPrimaryKeyColumns(Arrays.asList(LOT_ID_COLUMN, EVENT_TIME_COLUMN))
+                           .build(),
+                       new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build())
+                   .onFirstInstance(
+                       row("2021-11-07 04:11:00.000", 0, 0, "v1"),
+                       row("2021-11-07 04:21:00.000", 0, 0, "true"),
+                       row("2021-11-07 04:31:00.000", 1, 0, "1.2QQ"),
+                       row("2021-11-07 04:31:00.000", 1, 0, null)
+                   )
+                   .andOnSecondInstance(
+                       row("2021-11-07 04:11:00.000", 0, 0, "v1"),
+                       row("2021-11-07 04:21:00.000", 0, 0, "true"),
+                       row("2021-11-07 04:31:00.000", 1, 0, "1.2QQ"),
+                       row("2021-11-07 04:31:00.000", 1, 0, null)
+                   )
+                   .whenQuery(
+                       "select max(isOccupied) filter (where levelId in ('level_0')) from parkingData where lotId = "
+                           + "'lot_0'")
+                   .thenResultIsException(
+                       "Error when processing testTable.myField.*NumberFormatException: For input string:", 2);
+  }
+
+  private static Object[] row(String timestamp, int level, int lot, String isOccupied) {
+    return new Object[]{
+        FORMATTER.fromFormatToMillis(timestamp),
+        isOccupied,
+        "level_" + level,
+        "lot_" + lot,
+    };
+  }
+
+  @DataProvider(name = "dataTypes")
+  public Object[][] dataTypes() {
+    FieldSpec.DataType[] types = {
+        FieldSpec.DataType.FLOAT,
+        FieldSpec.DataType.DOUBLE,
+        FieldSpec.DataType.INT,
+        FieldSpec.DataType.LONG,
+        FieldSpec.DataType.BIG_DECIMAL
+    };
+
+    Object[][] result = new Object[types.length * 2][2];
+
+    for (int i = 0; i < types.length; i++) {
+      result[i * 2] = new Object[]{types[i], false};
+      result[i * 2 + 1] = new Object[]{types[i], true};
+    }
+
+    return result;
+
+//    FieldSpec.DataType[][] result = new FieldSpec.DataType[types.length * types.length][2];
+//
+//    for (int i = 0; i < types.length; i++) {
+//      for (int j = 0; j < types.length; j++) {
+//        {
+//          if (types[j] == FieldSpec.DataType.BIG_DECIMAL) {
+//            continue;
+//          }
+//          result[i * types.length + j] = new FieldSpec.DataType[]{types[i], types[j]};
+//        }
+//      }
+//    }
+//
+//    return result;
+//  }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AbstractAggregationFunctionTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractAggregationFunctionTest {
   }
 
   @BeforeClass
-  void createBaseDir() {
+  protected void createBaseDir() {
     try {
       _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
     } catch (IOException ex) {
@@ -142,7 +142,7 @@ public abstract class AbstractAggregationFunctionTest {
   }
 
   @AfterClass
-  void destroyBaseDir()
+  protected void destroyBaseDir()
       throws IOException {
     if (_baseDir != null) {
       FileUtils.deleteDirectory(_baseDir);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -285,7 +285,7 @@ public class AggregateOperator extends MultiStageOperator {
         if (identifier != null) {
           int colId = fromIdentifierToColId(identifier);
           blockValSetMap.put(expression,
-              new RowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, true));
+              new RowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, identifier, true));
         }
       }
     } else {
@@ -317,8 +317,8 @@ public class AggregateOperator extends MultiStageOperator {
         if (identifier != null) {
           int colId = fromIdentifierToColId(identifier);
           blockValSetMap.put(expression,
-              new FilteredRowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, numMatchedRows,
-                  matchedBitmap, true));
+              new FilteredRowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, identifier,
+                  numMatchedRows, matchedBitmap, true));
         }
       }
     } else {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -345,10 +345,12 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       if (except == null) {
         throw e;
       } else {
-        Pattern pattern = Pattern.compile(except);
-        Assert.assertTrue(pattern.matcher(e.getMessage()).matches(),
-            String.format("Caught exception '%s', but it did not match the expected pattern '%s'.", e.getMessage(),
-                except));
+        Pattern pattern = Pattern.compile(except, Pattern.DOTALL);
+        if (!pattern.matcher(e.getMessage()).matches()) {
+          throw new AssertionError(
+              "Caught exception, but it did not match the expected pattern '" + except + "',\n exception: "
+                  + e.getMessage(), e);
+        }
       }
     }
 

--- a/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
@@ -117,6 +117,18 @@
     },
     "queries": [
       {
+        "sql": "SELECT array_agg(string_col2, 'INT') FILTER (WHERE string_col2 IN ('a', 'b')), count(*) FROM {tbl2}",
+        "expectedException": ".*Error when processing general_aggregate_with_filter_where_after_join_tbl2_OFFLINE.arrayagg.*string_col2.*"
+      },
+      {
+        "sql": "SELECT max(cast(string_col2 as BIGINT)) FILTER (WHERE string_col2 IN ('a', 'b')), count(*) FROM {tbl2}",
+        "expectedException": ".*Error when processing general_aggregate_with_filter_where_after_join_tbl2_OFFLINE.max\\(cast\\(string_col2,'LONG'\\)\\).*"
+      },
+      {
+        "sql": "SELECT int_col2, max(string_col2) FILTER (WHERE string_col2 IN ('a', 'b')), count(*) FROM {tbl2} group by int_col2",
+        "expectedException": ".*Error when processing general_aggregate_with_filter_where_after_join_tbl2_OFFLINE.string_col2.*"
+      },
+      {
         "sql": "SELECT min(double_col) FILTER (WHERE string_col IN ('a', 'b')), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2"
       },
       {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -218,7 +218,11 @@ public enum AggregationFunctionType {
       SqlTypeName.OTHER),
   PERCENTILERAWKLLMV("percentileRawKLLMV", ReturnTypes.VARCHAR,
       OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER), i -> i == 2),
-      SqlTypeName.OTHER);
+      SqlTypeName.OTHER),
+
+  // test functions
+  TEST_AGGREGATE("testAgg", ReturnTypes.DOUBLE,
+      OperandTypes.family(List.of(SqlTypeFamily.ANY, SqlTypeFamily.STRING)), SqlTypeName.OTHER);
 
   private static final Set<String> NAMES =
       Arrays.stream(values()).flatMap(func -> Stream.of(func.name(), func.getName(), func.getName().toLowerCase()))


### PR DESCRIPTION
At the moment exceptions thrown during query execution are often missing basic table and column information, making it hard to diagnose issues. 

For example, if  dat is a string column containing dates then issuing following query :
```sql
select key , max(dat) as last_seen_date 
from table
group by key
limit 10
```
might return 
`NumberFormatException: For input string: "2021-10-01T09:01:00-0800"`.

This PR adds table/alias and column/expression information to conversion errors, e.g. 

Error when processing table.dat: NumberFormatException: For input string: "2021-10-01T09:01:00-0800".

