### PR TITLE
Fixed a pesky error in PagedPinotOutputStream.getPages

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -745,7 +745,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   /**
    * Run equivalent Pinot and H2 query and compare the results.
    */
-  protected void testQuery(@Language("sql") String pinotQuery, String h2Query)
+  protected void testQuery(@Language("sql") String pinotQuery, @Language("sql") String h2Query)
       throws Exception {
     ClusterIntegrationTestUtils.testQuery(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(), h2Query,
         getH2Connection(), null, getExtraQueryProperties(), useMultiStageQueryEngine());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -176,6 +176,28 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     super.testGeneratedQueries(true, true);
   }
 
+  // This query was failing in https://github.com/apache/pinot/issues/14375
+  @Test
+  public void testIssue14375()
+      throws Exception {
+    String query = "SELECT \"DivArrDelay\", \"Cancelled\", \"DestAirportID\" "
+        + "FROM mytable "
+        + "WHERE \"OriginStateName\" BETWEEN 'Montana' AND 'South Dakota' "
+        + "AND \"OriginAirportID\" BETWEEN 13127 AND 12945 "
+        + "OR \"DistanceGroup\" = 4 "
+        + "ORDER BY \"Month\", \"LateAircraftDelay\", \"TailNum\" "
+        + "LIMIT 10000";
+    String h2Query = "SELECT `DivArrDelay`, `Cancelled`, `DestAirportID` "
+        + "FROM mytable "
+        + "WHERE `OriginStateName` BETWEEN 'Montana' AND 'South Dakota' "
+        + "AND `OriginAirportID` BETWEEN 13127 AND 12945 "
+        + "OR `DistanceGroup` = 4 "
+        + "ORDER BY `Month`, `LateAircraftDelay`, `TailNum` "
+        + "LIMIT 10000";
+
+    testQuery(query, h2Query);
+  }
+
   @Test
   public void testQueryOptions()
       throws Exception {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PagedPinotOutputStream.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PagedPinotOutputStream.java
@@ -88,7 +88,10 @@ public class PagedPinotOutputStream extends PinotOutputStream {
   public ByteBuffer[] getPages() {
     int numPages = _pages.size();
 
-    boolean lastPageIsEmpty = _written == (numPages - 1) * (long) _pageSize;
+    long lastPageStart = (numPages - 1) * (long) _pageSize;
+    assert lastPageStart >= 0 : "lastPageStart=" + lastPageStart;
+    assert lastPageStart <= _written : "lastPageStart=" + lastPageStart + ", _written=" + _written;
+    boolean lastPageIsEmpty = _written == lastPageStart;
     if (lastPageIsEmpty) {
       numPages--;
     }
@@ -105,10 +108,7 @@ public class PagedPinotOutputStream extends PinotOutputStream {
     }
 
     if (!lastPageIsEmpty) {
-      long startOffset = getCurrentOffset();
-      seek(_written);
-      result[numPages - 1].limit(_offsetInPage);
-      seek(startOffset);
+      result[numPages - 1].limit((int) (_written - lastPageStart));
     }
 
     return result;

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/memory/PagedPinotOutputStreamTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/memory/PagedPinotOutputStreamTest.java
@@ -311,4 +311,29 @@ public class PagedPinotOutputStreamTest {
     assertEquals(pages[1].position(), 0);
     assertEquals(pages[1].limit(), _pageSize);
   }
+
+  /**
+   * This tests that getPages works as expected when data has been written to the stream and all the pages are full.
+   *
+   * Originally there was an error that caused the last returned page to be empty.
+   *
+   * Detected in <a href="https://github.com/apache/pinot/issues/14375">#14375</a>
+   * @throws IOException
+   */
+  @Test
+  void testGetPagesFullPages()
+      throws IOException {
+    byte[] bytes = new byte[_pageSize];
+    _pagedPinotOutputStream.write(bytes);
+    _pagedPinotOutputStream.write(bytes);
+
+    ByteBuffer[] pages = _pagedPinotOutputStream.getPages();
+    assertEquals(pages.length, 2);
+
+    assertEquals(pages[0].position(), 0);
+    assertEquals(pages[0].limit(), _pageSize);
+
+    assertEquals(pages[1].position(), 0);
+    assertEquals(pages[1].limit(), _pageSize);
+  }
 }


### PR DESCRIPTION
In #14375 an error in the data block deserialization is reported. After some debugging, it looks like the issue is actually in one of the libraries introduced to write the serialization efficiently. Specifically, PagedPinotOutputStream has an error when the number of written bytes was exactly a multiple of the page size _and_ there was no seek.

This PR fixes the issue and therefore fixes #14375.
