### PR TITLE
add PulsarAvroMessageDecoder

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-avro-base</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-admin</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/PulsarAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/PulsarAvroMessageDecoder.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.avro;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of StreamMessageDecoder to read avro records from pulsar
+ */
+public class PulsarAvroMessageDecoder extends SimpleAvroMessageDecoder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PulsarAvroMessageDecoder.class);
+
+  private static final String PULSAR_ADMIN_URL = "admin.servers";
+
+  private List<String> _microsFieldNames = new ArrayList<>();
+
+  @Override
+  protected void initAvroSchema(Map<String, String> props, String topicName) {
+    Preconditions.checkState(props.containsKey(PULSAR_ADMIN_URL), "Pulsar admin url must be provided");
+    String adminUrl = props.get(PULSAR_ADMIN_URL);
+    String topic = TopicName.get(topicName).getPartitionedTopicName();
+    SchemaInfo schemaInfo;
+    try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build()) {
+      schemaInfo = admin.schemas().getSchemaInfo(topic);
+    } catch (Exception e) {
+      LOGGER.error("[{}] get schema info failed.", topic);
+      throw new RuntimeException("Get schema info failed", e);
+    }
+    if (schemaInfo.getType() != SchemaType.AVRO) {
+      LOGGER.error("[{}] schema type is {}, current decoder only support avro.", topic, schemaInfo.getType());
+      throw new RuntimeException("UnSupport schema type in PulsarAvroMessageDecoder");
+    }
+    _avroSchema = new org.apache.avro.Schema.Parser().parse(schemaInfo.getSchemaDefinition());
+
+    if (_avroSchema != null) {
+      for (Schema.Field field : _avroSchema.getFields()) {
+        Schema nonNullSchema = getNonNullSchema(field.schema());
+        if (nonNullSchema.getLogicalType() instanceof LogicalTypes.TimestampMicros
+            || nonNullSchema.getLogicalType() instanceof LogicalTypes.LocalTimestampMicros
+            || nonNullSchema.getLogicalType() instanceof LogicalTypes.TimeMicros) {
+          _microsFieldNames.add(field.name());
+        }
+      }
+    }
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+    _binaryDecoderToReuse = DecoderFactory.get().binaryDecoder(payload, offset, length, _binaryDecoderToReuse);
+    try {
+      _avroRecordToReuse = _datumReader.read(_avroRecordToReuse, _binaryDecoderToReuse);
+      for (String name : _microsFieldNames) {
+        // convert micros to millis
+        _avroRecordToReuse.put(name, ((long) _avroRecordToReuse.get(name)) / 1000);
+      }
+    } catch (IOException e) {
+      LOGGER.error("Caught exception while reading message using schema: {}", _avroSchema, e);
+      return null;
+    }
+    return _avroRecordExtractor.extract(_avroRecordToReuse, destination);
+  }
+
+  private Schema getNonNullSchema(Schema fieldSchema) {
+    if (fieldSchema.getType().equals(Schema.Type.UNION)) {
+      List<Schema> types = fieldSchema.getTypes();
+      for (int i = types.size() - 1; i >= 0; i--) {
+        Schema type = types.get(i);
+        if (!type.isNullable()) {
+          return type;
+        }
+      }
+    }
+    return fieldSchema;
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
@@ -47,17 +47,16 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
 
   private static final String SCHEMA = "schema";
 
-  private org.apache.avro.Schema _avroSchema;
-  private DatumReader<GenericData.Record> _datumReader;
-  private RecordExtractor<GenericData.Record> _avroRecordExtractor;
-  private BinaryDecoder _binaryDecoderToReuse;
-  private GenericData.Record _avroRecordToReuse;
+  protected org.apache.avro.Schema _avroSchema;
+  protected DatumReader<GenericData.Record> _datumReader;
+  protected RecordExtractor<GenericData.Record> _avroRecordExtractor;
+  protected BinaryDecoder _binaryDecoderToReuse;
+  protected GenericData.Record _avroRecordToReuse;
 
   @Override
   public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
       throws Exception {
-    Preconditions.checkState(props.containsKey(SCHEMA), "Avro schema must be provided");
-    _avroSchema = new org.apache.avro.Schema.Parser().parse(props.get(SCHEMA));
+    initAvroSchema(props, topicName);
     _datumReader = new GenericDatumReader<>(_avroSchema);
     String recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
     String recordExtractorConfigClass = props.get(RECORD_EXTRACTOR_CONFIG_CONFIG_KEY);
@@ -100,5 +99,10 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
       return null;
     }
     return _avroRecordExtractor.extract(_avroRecordToReuse, destination);
+  }
+
+  protected void initAvroSchema(Map<String, String> props, String topicName) {
+    Preconditions.checkState(props.containsKey(SCHEMA), "Avro schema must be provided");
+    _avroSchema = new org.apache.avro.Schema.Parser().parse(props.get(SCHEMA));
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

The PulsarAvroMessageDecoder fetches schema from Pulsar admin, prepares field conversions, then decodes messages by converting timestamp and decimal fields before extraction\.

```mermaid
flowchart TD
  N0["Fetch and validate Pulsar schema #40;F2#41;"]:::stAdded
  N1["Parse schema and prepare field conversions #40;F2#41;"]:::stAdded
  N2["Set up decoder and read Avro record #40;F2#41;"]:::stAdded
  N3["Convert TimestampMicros fields #40;F2#41;"]:::stAdded
  N4["Convert Decimal fields #40;F2#41;"]:::stAdded
  N5["Extract record to GenericRow #40;F2#41;"]:::stAdded
  N0 --> N1
  N2 --> N3
  N3 --> N4
  N4 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-plugins/pinot\-input\-format/pinot\-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/PulsarAvroMessageDecoder\.java — [after](https://github.com/apache/pinot/blob/6beab2f97e50e97c278424a3de5f07bd755098aa/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/PulsarAvroMessageDecoder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU3NzgzMGNiZTBhMTg1MjE5ZTNhMmMzYzVkMjJhYzRkMDM4ODc3YjEiLCJjb250ZXh0X2hhc2giOiJhZjRkNWY4ODcxMDIzZDAwYWMwOTYwMTM3YmFiNGY0NWRjMjlkM2MwMWM0MjY3ZWFjNjYyNzRmOWQ4NGIxMDdiIiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODkzMjc2LCJoZWFkX3NoYSI6IjZiZWFiMmY5N2U1MGU5N2MyNzg0MjRhM2RlNWYwN2JkNzU1MDk4YWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1Nzc4MzBjYmUwYTE4NTIxOWUzYTJjM2M1ZDIyYWM0ZDAzODg3N2IxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c46f56933750adb23f951cc6a6ba137f73ba68ae738b05fe422b73bd035c1c08 -->
<!-- pinot-pr-flow:end -->

With this PR, decoder can directly obtain the schema through the pulsar admin API, instead of setting the avro schema in the table config.
In addition, the following configurations need to be added in the table config
```
"stream.pulsar.decoder.prop.admin.servers": "http://localhost:8081",
"stream.pulsar.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.PulsarAvroMessageDecoder"
```
