### PR TITLE
Support TIMESTAMP_NTZ, DATE and TIME datatype

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockEquals.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockEquals.java
@@ -235,6 +235,7 @@ public class DataBlockEquals {
               break;
             case LONG:
             case TIMESTAMP:
+            case TIMESTAMP_NTZ:
               for (int did = 0; did < numRows; did++) {
                 if (left.getLong(did, colId) != right.getLong(did, colId)) {
                   if (_failOnFalse) {
@@ -335,6 +336,7 @@ public class DataBlockEquals {
               break;
             case LONG_ARRAY:
             case TIMESTAMP_ARRAY:
+            case TIMESTAMP_NTZ_ARRAY:
               for (int did = 0; did < numRows; did++) {
                 if (!Arrays.equals(left.getLongArray(did, colId), right.getLongArray(did, colId))) {
                   if (_failOnFalse) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockEquals.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockEquals.java
@@ -236,6 +236,8 @@ public class DataBlockEquals {
             case LONG:
             case TIMESTAMP:
             case TIMESTAMP_NTZ:
+            case DATE:
+            case TIME:
               for (int did = 0; did < numRows; did++) {
                 if (left.getLong(did, colId) != right.getLong(did, colId)) {
                   if (_failOnFalse) {
@@ -337,6 +339,8 @@ public class DataBlockEquals {
             case LONG_ARRAY:
             case TIMESTAMP_ARRAY:
             case TIMESTAMP_NTZ_ARRAY:
+            case DATE_ARRAY:
+            case TIME_ARRAY:
               for (int did = 0; did < numRows; did++) {
                 if (!Arrays.equals(left.getLongArray(did, colId), right.getLongArray(did, colId))) {
                   if (_failOnFalse) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -20,7 +20,9 @@ package org.apache.pinot.common.function;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,6 +54,8 @@ public class FunctionUtils {
     put(Boolean.class, PinotDataType.BOOLEAN);
     put(Timestamp.class, PinotDataType.TIMESTAMP);
     put(LocalDateTime.class, PinotDataType.TIMESTAMP_NTZ);
+    put(LocalDate.class, PinotDataType.DATE);
+    put(LocalTime.class, PinotDataType.TIME);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
@@ -76,6 +80,8 @@ public class FunctionUtils {
     put(BigDecimal.class, PinotDataType.BIG_DECIMAL);
     put(Timestamp.class, PinotDataType.TIMESTAMP);
     put(LocalDateTime.class, PinotDataType.TIMESTAMP_NTZ);
+    put(LocalDate.class, PinotDataType.DATE);
+    put(LocalTime.class, PinotDataType.TIME);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
@@ -105,6 +111,8 @@ public class FunctionUtils {
     put(Boolean.class, DataType.BOOLEAN);
     put(Timestamp.class, DataType.TIMESTAMP);
     put(LocalDateTime.class, DataType.TIMESTAMP_NTZ);
+    put(LocalDate.class, DataType.DATE);
+    put(LocalTime.class, DataType.TIME);
     put(String.class, DataType.STRING);
     put(byte[].class, DataType.BYTES);
     put(int[].class, DataType.INT);
@@ -128,6 +136,8 @@ public class FunctionUtils {
     put(Boolean.class, ColumnDataType.BOOLEAN);
     put(Timestamp.class, ColumnDataType.TIMESTAMP);
     put(LocalDateTime.class, ColumnDataType.TIMESTAMP_NTZ);
+    put(LocalDate.class, ColumnDataType.DATE);
+    put(LocalTime.class, ColumnDataType.TIME);
     put(String.class, ColumnDataType.STRING);
     put(byte[].class, ColumnDataType.BYTES);
     put(int[].class, ColumnDataType.INT_ARRAY);
@@ -198,6 +208,10 @@ public class FunctionUtils {
         return typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
       case TIMESTAMP_NTZ:
         return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+      case DATE:
+        return typeFactory.createSqlType(SqlTypeName.DATE);
+      case TIME:
+        return typeFactory.createSqlType(SqlTypeName.TIME);
       case STRING:
       case JSON:
         return typeFactory.createSqlType(SqlTypeName.VARCHAR);
@@ -217,6 +231,10 @@ public class FunctionUtils {
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE), -1);
       case TIMESTAMP_NTZ_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), -1);
+      case DATE_ARRAY:
+        return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.DATE), -1);
+      case TIME_ARRAY:
+        return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.TIME), -1);
       case STRING_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARCHAR), -1);
       case BYTES_ARRAY:

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.function;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +51,7 @@ public class FunctionUtils {
     put(boolean.class, PinotDataType.BOOLEAN);
     put(Boolean.class, PinotDataType.BOOLEAN);
     put(Timestamp.class, PinotDataType.TIMESTAMP);
+    put(LocalDateTime.class, PinotDataType.TIMESTAMP_NTZ);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
@@ -73,6 +75,7 @@ public class FunctionUtils {
     put(Double.class, PinotDataType.DOUBLE);
     put(BigDecimal.class, PinotDataType.BIG_DECIMAL);
     put(Timestamp.class, PinotDataType.TIMESTAMP);
+    put(LocalDateTime.class, PinotDataType.TIMESTAMP_NTZ);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
@@ -101,6 +104,7 @@ public class FunctionUtils {
     put(boolean.class, DataType.BOOLEAN);
     put(Boolean.class, DataType.BOOLEAN);
     put(Timestamp.class, DataType.TIMESTAMP);
+    put(LocalDateTime.class, DataType.TIMESTAMP_NTZ);
     put(String.class, DataType.STRING);
     put(byte[].class, DataType.BYTES);
     put(int[].class, DataType.INT);
@@ -123,6 +127,7 @@ public class FunctionUtils {
     put(boolean.class, ColumnDataType.BOOLEAN);
     put(Boolean.class, ColumnDataType.BOOLEAN);
     put(Timestamp.class, ColumnDataType.TIMESTAMP);
+    put(LocalDateTime.class, ColumnDataType.TIMESTAMP_NTZ);
     put(String.class, ColumnDataType.STRING);
     put(byte[].class, ColumnDataType.BYTES);
     put(int[].class, ColumnDataType.INT_ARRAY);
@@ -190,6 +195,8 @@ public class FunctionUtils {
       case BOOLEAN:
         return typeFactory.createSqlType(SqlTypeName.BOOLEAN);
       case TIMESTAMP:
+        return typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+      case TIMESTAMP_NTZ:
         return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
       case STRING:
       case JSON:
@@ -207,6 +214,8 @@ public class FunctionUtils {
       case BOOLEAN_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.BOOLEAN), -1);
       case TIMESTAMP_ARRAY:
+        return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE), -1);
+      case TIMESTAMP_NTZ_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), -1);
       case STRING_ARRAY:
         return typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARCHAR), -1);

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -42,6 +42,8 @@ public abstract class BaseInPredicate extends BasePredicate {
   private int[] _booleanValues;
   private long[] _timestampValues;
   private long[] _localDateTimeValues;
+  private long[] _localDateValues;
+  private long[] _localTimeValues;
   private ByteArray[] _bytesValues;
 
   public BaseInPredicate(ExpressionContext lhs, List<String> values) {
@@ -155,6 +157,32 @@ public abstract class BaseInPredicate extends BasePredicate {
       _localDateTimeValues = localDateTimeValues;
     }
     return localDateTimeValues;
+  }
+
+  public long[] getLocalDateValues() {
+    long[] localDateValues = _localDateValues;
+    if (localDateValues == null) {
+      int numValues = _values.size();
+      localDateValues = new long[numValues];
+      for (int i = 0; i < numValues; i++) {
+        localDateValues[i] = TimestampUtils.toDaysSinceEpoch(_values.get(i));
+      }
+      _localDateValues = localDateValues;
+    }
+    return localDateValues;
+  }
+
+  public long[] getLocalTimeValues() {
+    long[] localTimeValues = _localTimeValues;
+    if (localTimeValues == null) {
+      int numValues = _values.size();
+      localTimeValues = new long[numValues];
+      for (int i = 0; i < numValues; i++) {
+        localTimeValues[i] = TimestampUtils.toMillsOfDay(_values.get(i));
+      }
+      _localTimeValues = localTimeValues;
+    }
+    return localTimeValues;
   }
 
   public ByteArray[] getBytesValues() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -152,7 +152,7 @@ public abstract class BaseInPredicate extends BasePredicate {
       int numValues = _values.size();
       localDateTimeValues = new long[numValues];
       for (int i = 0; i < numValues; i++) {
-        localDateTimeValues[i] = TimestampUtils.toMillsWithoutTimeZone(_values.get(i));
+        localDateTimeValues[i] = TimestampUtils.toMillisSinceEpochInUTC(_values.get(i));
       }
       _localDateTimeValues = localDateTimeValues;
     }
@@ -178,7 +178,7 @@ public abstract class BaseInPredicate extends BasePredicate {
       int numValues = _values.size();
       localTimeValues = new long[numValues];
       for (int i = 0; i < numValues; i++) {
-        localTimeValues[i] = TimestampUtils.toMillsOfDay(_values.get(i));
+        localTimeValues[i] = TimestampUtils.toMillisOfDay(_values.get(i));
       }
       _localTimeValues = localTimeValues;
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -41,6 +41,7 @@ public abstract class BaseInPredicate extends BasePredicate {
   private BigDecimal[] _bigDecimalValues;
   private int[] _booleanValues;
   private long[] _timestampValues;
+  private long[] _localDateTimeValues;
   private ByteArray[] _bytesValues;
 
   public BaseInPredicate(ExpressionContext lhs, List<String> values) {
@@ -141,6 +142,19 @@ public abstract class BaseInPredicate extends BasePredicate {
       _timestampValues = timestampValues;
     }
     return timestampValues;
+  }
+
+  public long[] getLocalDateTimeValues() {
+    long[] localDateTimeValues = _localDateTimeValues;
+    if (localDateTimeValues == null) {
+      int numValues = _values.size();
+      localDateTimeValues = new long[numValues];
+      for (int i = 0; i < numValues; i++) {
+        localDateTimeValues[i] = TimestampUtils.toMillsWithoutTimeZone(_values.get(i));
+      }
+      _localDateTimeValues = localDateTimeValues;
+    }
+    return localDateTimeValues;
   }
 
   public ByteArray[] getBytesValues() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.core.JsonParseException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collection;
@@ -112,6 +114,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BOOLEAN to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BOOLEAN to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -174,6 +186,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTE to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTE to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -223,6 +245,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from CHARACTER to TIMESTAMP_NTZ");
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from CHARACTER to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from CHARACTER to TIME");
     }
 
     @Override
@@ -278,6 +310,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from SHORT to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from SHORT to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -327,6 +369,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from INTEGER to TIMESTAMP_NTZ");
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return LocalDate.ofEpochDay(toLong(value));
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return LocalTime.ofNanoOfDay(toLong(value) * 1000000);
     }
 
     @Override
@@ -390,6 +442,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      return LocalDate.ofEpochDay((Long) value);
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return LocalTime.ofNanoOfDay((Long) value * 1000000);
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -446,6 +508,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from FLOAT to TIMESTAMP_NTZ");
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from FLOAT to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from FLOAT to TIME");
     }
 
     @Override
@@ -508,6 +580,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      return LocalDate.ofEpochDay(((Double) value).longValue());
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return LocalTime.ofNanoOfDay(((Double) value).longValue() * 1000000);
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -562,6 +644,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       return LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZoneId.of("UTC"));
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return LocalDate.ofEpochDay(((Number) value).longValue());
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return LocalTime.ofNanoOfDay(((Number) value).longValue() * 1000000);
     }
 
     @Override
@@ -633,6 +725,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -677,7 +779,7 @@ public enum PinotDataType {
 
     @Override
     public float toFloat(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to FLOAT");
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to FLOAT");
     }
 
     @Override
@@ -706,6 +808,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -718,6 +830,150 @@ public enum PinotDataType {
     @Override
     public LocalDateTime convert(Object value, PinotDataType sourceType) {
       return sourceType.toLocalDateTime(value);
+    }
+
+    @Override
+    public Long toInternal(Object value) {
+      return toLong(value);
+    }
+  },
+
+  DATE {
+    @Override
+    public int toInt(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to INTEGER");
+    }
+
+    @Override
+    public long toLong(Object value) {
+      return ((LocalDate) value).toEpochDay();
+    }
+
+    @Override
+    public float toFloat(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to FLOAT");
+    }
+
+    @Override
+    public double toDouble(Object value) {
+      return ((LocalDate) value).toEpochDay();
+    }
+
+    @Override
+    public BigDecimal toBigDecimal(Object value) {
+      return BigDecimal.valueOf(toLong(value));
+    }
+
+    @Override
+    public boolean toBoolean(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to BOOLEAN");
+    }
+
+    @Override
+    public Timestamp toTimestamp(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to TIMESTAMP_NTZ");
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return (LocalDate) value;
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to TIME");
+    }
+
+    @Override
+    public String toString(Object value) {
+      return value.toString();
+    }
+
+    @Override
+    public byte[] toBytes(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from DATE to BYTES");
+    }
+
+    @Override
+    public LocalDate convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalDate(value);
+    }
+
+    @Override
+    public Long toInternal(Object value) {
+      return toLong(value);
+    }
+  },
+
+  TIME {
+    @Override
+    public int toInt(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to INTEGER");
+    }
+
+    @Override
+    public long toLong(Object value) {
+      return ((LocalTime) value).toNanoOfDay() / 1000000;
+    }
+
+    @Override
+    public float toFloat(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to FLOAT");
+    }
+
+    @Override
+    public double toDouble(Object value) {
+      return ((LocalTime) value).toNanoOfDay() / 1000000;
+    }
+
+    @Override
+    public BigDecimal toBigDecimal(Object value) {
+      return BigDecimal.valueOf(toLong(value));
+    }
+
+    @Override
+    public boolean toBoolean(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to BOOLEAN");
+    }
+
+    @Override
+    public Timestamp toTimestamp(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to TIMESTAMP_NTZ");
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return (LocalTime) value;
+    }
+
+    @Override
+    public String toString(Object value) {
+      return value.toString();
+    }
+
+    @Override
+    public byte[] toBytes(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIME to BYTES");
+    }
+
+    @Override
+    public LocalTime convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalTime(value);
     }
 
     @Override
@@ -767,6 +1023,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       return TimestampUtils.toLocalDateTime(value.toString().trim());
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return TimestampUtils.toLocalDate(value.toString().trim());
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return TimestampUtils.toLocalTime(value.toString().trim());
     }
 
     @Override
@@ -824,6 +1090,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       return TimestampUtils.toLocalDateTime(value.toString().trim());
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return TimestampUtils.toLocalDate(value.toString().trim());
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return TimestampUtils.toLocalTime(value.toString().trim());
     }
 
     @Override
@@ -891,6 +1167,16 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDate toLocalDate(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTES to DATE");
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTES to TIME");
+    }
+
+    @Override
     public String toString(Object value) {
       return BytesUtils.toHexString((byte[]) value);
     }
@@ -945,6 +1231,16 @@ public enum PinotDataType {
     @Override
     public LocalDateTime toLocalDateTime(Object value) {
       return LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZoneId.of("UTC"));
+    }
+
+    @Override
+    public LocalDate toLocalDate(Object value) {
+      return LocalDate.ofEpochDay(((Number) value).longValue());
+    }
+
+    @Override
+    public LocalTime toLocalTime(Object value) {
+      return LocalTime.ofNanoOfDay(((Number) value).longValue() * 1000000);
     }
 
     @Override
@@ -1116,6 +1412,42 @@ public enum PinotDataType {
     }
   },
 
+  DATE_ARRAY {
+    @Override
+    public Object convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalDateArray(value);
+    }
+
+    @Override
+    public Long[] toInternal(Object value) {
+      LocalDate[] localDateArray = (LocalDate[]) value;
+      int length = localDateArray.length;
+      Long[] longArray = new Long[length];
+      for (int i = 0; i < length; i++) {
+        longArray[i] = localDateArray[i].toEpochDay();
+      }
+      return longArray;
+    }
+  },
+
+  TIME_ARRAY {
+    @Override
+    public Object convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalTimeArray(value);
+    }
+
+    @Override
+    public Long[] toInternal(Object value) {
+      LocalTime[] localTimeArray = (LocalTime[]) value;
+      int length = localTimeArray.length;
+      Long[] longArray = new Long[length];
+      for (int i = 0; i < length; i++) {
+        longArray[i] = localTimeArray[i].toNanoOfDay() / 1000000;
+      }
+      return longArray;
+    }
+  },
+
   STRING_ARRAY {
     @Override
     public String[] convert(Object value, PinotDataType sourceType) {
@@ -1169,6 +1501,14 @@ public enum PinotDataType {
 
   public LocalDateTime toLocalDateTime(Object value) {
     return getSingleValueType().toLocalDateTime(value);
+  }
+
+  public LocalDate toLocalDate(Object value) {
+    return getSingleValueType().toLocalDate(value);
+  }
+
+  public LocalTime toLocalTime(Object value) {
+    return getSingleValueType().toLocalTime(value);
   }
 
   public String toString(Object value) {
@@ -1491,6 +1831,42 @@ public enum PinotDataType {
     }
   }
 
+  public LocalDate[] toLocalDateArray(Object value) {
+    if (value instanceof LocalDate[]) {
+      return (LocalDate[]) value;
+    }
+    if (isSingleValue()) {
+      return new LocalDate[]{toLocalDate(value)};
+    } else {
+      Object[] valueArray = toObjectArray(value);
+      int length = valueArray.length;
+      LocalDate[] localDateArray = new LocalDate[length];
+      PinotDataType singleValueType = getSingleValueType();
+      for (int i = 0; i < length; i++) {
+        localDateArray[i] = singleValueType.toLocalDate(valueArray[i]);
+      }
+      return localDateArray;
+    }
+  }
+
+  public LocalTime[] toLocalTimeArray(Object value) {
+    if (value instanceof LocalTime[]) {
+      return (LocalTime[]) value;
+    }
+    if (isSingleValue()) {
+      return new LocalTime[]{toLocalTime(value)};
+    } else {
+      Object[] valueArray = toObjectArray(value);
+      int length = valueArray.length;
+      LocalTime[] localTimeArray = new LocalTime[length];
+      PinotDataType singleValueType = getSingleValueType();
+      for (int i = 0; i < length; i++) {
+        localTimeArray[i] = singleValueType.toLocalTime(valueArray[i]);
+      }
+      return localTimeArray;
+    }
+  }
+
   public Object convert(Object value, PinotDataType sourceType) {
     throw new UnsupportedOperationException("Cannot convert value from " + sourceType + " to " + this);
   }
@@ -1545,6 +1921,10 @@ public enum PinotDataType {
         return TIMESTAMP;
       case TIMESTAMP_NTZ_ARRAY:
         return TIMESTAMP_NTZ;
+      case DATE_ARRAY:
+        return DATE;
+      case TIME_ARRAY:
+        return TIME;
       default:
         throw new IllegalStateException("There is no single-value type for " + this);
     }
@@ -1580,6 +1960,12 @@ public enum PinotDataType {
     }
     if (cls == LocalDateTime.class) {
       return TIMESTAMP_NTZ;
+    }
+    if (cls == LocalDate.class) {
+      return DATE;
+    }
+    if (cls == LocalTime.class) {
+      return TIME;
     }
     if (cls == Byte.class) {
       return BYTE;
@@ -1675,6 +2061,10 @@ public enum PinotDataType {
         return fieldSpec.isSingleValueField() ? TIMESTAMP : TIMESTAMP_ARRAY;
       case TIMESTAMP_NTZ:
         return fieldSpec.isSingleValueField() ? TIMESTAMP_NTZ : TIMESTAMP_NTZ_ARRAY;
+      case DATE:
+        return fieldSpec.isSingleValueField() ? DATE : DATE_ARRAY;
+      case TIME:
+        return fieldSpec.isSingleValueField() ? TIME : TIME_ARRAY;
       case JSON:
         if (fieldSpec.isSingleValueField()) {
           return JSON;
@@ -1717,6 +2107,10 @@ public enum PinotDataType {
         return TIMESTAMP;
       case TIMESTAMP_NTZ:
         return TIMESTAMP_NTZ;
+      case DATE:
+        return DATE;
+      case TIME:
+        return TIME;
       case STRING:
         return STRING;
       case JSON:

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -21,6 +21,9 @@ package org.apache.pinot.common.utils;
 import com.fasterxml.jackson.core.JsonParseException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
@@ -104,6 +107,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BOOLEAN to TIMESTAMP_NTZ");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -157,7 +165,12 @@ public enum PinotDataType {
 
     @Override
     public Timestamp toTimestamp(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from BOOLEAN to TIMESTAMP");
+      throw new UnsupportedOperationException("Cannot convert value from BYTE to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTE to TIMESTAMP_NTZ");
     }
 
     @Override
@@ -208,6 +221,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from CHARACTER to TIMESTAMP_NTZ");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -255,6 +273,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from SHORT to TIMESTAMP_NTZ");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -299,6 +322,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from INTEGER to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from INTEGER to TIMESTAMP_NTZ");
     }
 
     @Override
@@ -357,6 +385,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) value), ZoneId.of("UTC"));
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -408,6 +441,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from FLOAT to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from FLOAT to TIMESTAMP_NTZ");
     }
 
     @Override
@@ -465,6 +503,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli(((Double) value).longValue()), ZoneId.of("UTC"));
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -514,6 +557,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       return new Timestamp(((Number) value).longValue());
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZoneId.of("UTC"));
     }
 
     @Override
@@ -580,6 +628,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to TIMESTAMP_NTZ");
+    }
+
+    @Override
     public String toString(Object value) {
       return value.toString();
     }
@@ -597,6 +650,79 @@ public enum PinotDataType {
     @Override
     public Long toInternal(Object value) {
       return ((Timestamp) value).getTime();
+    }
+  },
+
+  /**
+   * When converting from TIMESTAMP_NTZ to other types:
+   * - LONG/DOUBLE: millis since epoch value
+   * - String: SQL timestamp format (e.g. "2021-01-01 01:01:01.001")
+   *
+   * When converting to TIMESTAMP_NTZ from other types:
+   * - LONG/DOUBLE: read long value as millis since epoch
+   * - String:
+   *   - SQL timestamp format (e.g. "2021-01-01 01:01:01.001")
+   *   - Millis since epoch value (e.g. "1609491661001")
+   */
+  TIMESTAMP_NTZ {
+    @Override
+    public int toInt(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to INTEGER");
+    }
+
+    @Override
+    public long toLong(Object value) {
+      return ((LocalDateTime) value).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+    }
+
+    @Override
+    public float toFloat(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to FLOAT");
+    }
+
+    @Override
+    public double toDouble(Object value) {
+      return ((LocalDateTime) value).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+    }
+
+    @Override
+    public BigDecimal toBigDecimal(Object value) {
+      return BigDecimal.valueOf(toLong(value));
+    }
+
+    @Override
+    public boolean toBoolean(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to BOOLEAN");
+    }
+
+    @Override
+    public Timestamp toTimestamp(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to TIMESTAMP");
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return (LocalDateTime) value;
+    }
+
+    @Override
+    public String toString(Object value) {
+      return value.toString();
+    }
+
+    @Override
+    public byte[] toBytes(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP_NTZ to BYTES");
+    }
+
+    @Override
+    public LocalDateTime convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalDateTime(value);
+    }
+
+    @Override
+    public Long toInternal(Object value) {
+      return toLong(value);
     }
   },
 
@@ -636,6 +762,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       return TimestampUtils.toTimestamp(value.toString().trim());
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return TimestampUtils.toLocalDateTime(value.toString().trim());
     }
 
     @Override
@@ -688,6 +819,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       return TimestampUtils.toTimestamp(value.toString().trim());
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return TimestampUtils.toLocalDateTime(value.toString().trim());
     }
 
     @Override
@@ -750,6 +886,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from BYTES to TIMESTAMP_NTZ");
+    }
+
+    @Override
     public String toString(Object value) {
       return BytesUtils.toHexString((byte[]) value);
     }
@@ -799,6 +940,11 @@ public enum PinotDataType {
     @Override
     public Timestamp toTimestamp(Object value) {
       return new Timestamp(((Number) value).longValue());
+    }
+
+    @Override
+    public LocalDateTime toLocalDateTime(Object value) {
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZoneId.of("UTC"));
     }
 
     @Override
@@ -952,6 +1098,24 @@ public enum PinotDataType {
     }
   },
 
+  TIMESTAMP_NTZ_ARRAY {
+    @Override
+    public Object convert(Object value, PinotDataType sourceType) {
+      return sourceType.toLocalDateTimeArray(value);
+    }
+
+    @Override
+    public Long[] toInternal(Object value) {
+      LocalDateTime[] localDateTimeArray = (LocalDateTime[]) value;
+      int length = localDateTimeArray.length;
+      Long[] longArray = new Long[length];
+      for (int i = 0; i < length; i++) {
+        longArray[i] = localDateTimeArray[i].atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+      }
+      return longArray;
+    }
+  },
+
   STRING_ARRAY {
     @Override
     public String[] convert(Object value, PinotDataType sourceType) {
@@ -1001,6 +1165,10 @@ public enum PinotDataType {
 
   public Timestamp toTimestamp(Object value) {
     return getSingleValueType().toTimestamp(((Object[]) value)[0]);
+  }
+
+  public LocalDateTime toLocalDateTime(Object value) {
+    return getSingleValueType().toLocalDateTime(value);
   }
 
   public String toString(Object value) {
@@ -1305,6 +1473,24 @@ public enum PinotDataType {
     }
   }
 
+  public LocalDateTime[] toLocalDateTimeArray(Object value) {
+    if (value instanceof LocalDateTime[]) {
+      return (LocalDateTime[]) value;
+    }
+    if (isSingleValue()) {
+      return new LocalDateTime[]{toLocalDateTime(value)};
+    } else {
+      Object[] valueArray = toObjectArray(value);
+      int length = valueArray.length;
+      LocalDateTime[] localDateTimeArray = new LocalDateTime[length];
+      PinotDataType singleValueType = getSingleValueType();
+      for (int i = 0; i < length; i++) {
+        localDateTimeArray[i] = singleValueType.toLocalDateTime(valueArray[i]);
+      }
+      return localDateTimeArray;
+    }
+  }
+
   public Object convert(Object value, PinotDataType sourceType) {
     throw new UnsupportedOperationException("Cannot convert value from " + sourceType + " to " + this);
   }
@@ -1357,6 +1543,8 @@ public enum PinotDataType {
         return BOOLEAN;
       case TIMESTAMP_ARRAY:
         return TIMESTAMP;
+      case TIMESTAMP_NTZ_ARRAY:
+        return TIMESTAMP_NTZ;
       default:
         throw new IllegalStateException("There is no single-value type for " + this);
     }
@@ -1389,6 +1577,9 @@ public enum PinotDataType {
     }
     if (cls == Timestamp.class) {
       return TIMESTAMP;
+    }
+    if (cls == LocalDateTime.class) {
+      return TIMESTAMP_NTZ;
     }
     if (cls == Byte.class) {
       return BYTE;
@@ -1482,6 +1673,8 @@ public enum PinotDataType {
         return fieldSpec.isSingleValueField() ? BOOLEAN : BOOLEAN_ARRAY;
       case TIMESTAMP:
         return fieldSpec.isSingleValueField() ? TIMESTAMP : TIMESTAMP_ARRAY;
+      case TIMESTAMP_NTZ:
+        return fieldSpec.isSingleValueField() ? TIMESTAMP_NTZ : TIMESTAMP_NTZ_ARRAY;
       case JSON:
         if (fieldSpec.isSingleValueField()) {
           return JSON;
@@ -1522,6 +1715,8 @@ public enum PinotDataType {
         return BOOLEAN;
       case TIMESTAMP:
         return TIMESTAMP;
+      case TIMESTAMP_NTZ:
+        return TIMESTAMP_NTZ;
       case STRING:
         return STRING;
       case JSON:

--- a/pinot-common/src/main/proto/expressions.proto
+++ b/pinot-common/src/main/proto/expressions.proto
@@ -43,6 +43,8 @@ enum ColumnDataType {
   BYTES_ARRAY = 18;
   UNKNOWN = 19;
   MAP = 20;
+  TIMESTAMP_NTZ = 21;
+  TIMESTAMP_NTZ_ARRAY = 22;
 }
 
 message InputRef {

--- a/pinot-common/src/main/proto/expressions.proto
+++ b/pinot-common/src/main/proto/expressions.proto
@@ -45,6 +45,10 @@ enum ColumnDataType {
   MAP = 20;
   TIMESTAMP_NTZ = 21;
   TIMESTAMP_NTZ_ARRAY = 22;
+  DATE = 23;
+  TIME = 24;
+  DATE_ARRAY = 25;
+  TIME_ARRAY = 26;
 }
 
 message InputRef {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -21,6 +21,11 @@ package org.apache.pinot.common.utils;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
@@ -32,12 +37,14 @@ import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.*;
 public class DataSchemaTest {
   private static final String[] COLUMN_NAMES = {
       "int", "long", "float", "double", "string", "object", "int_array", "long_array", "float_array", "double_array",
-      "string_array", "boolean_array", "timestamp_array", "bytes_array"
+      "string_array", "boolean_array", "timestamp_array", "bytes_array", "timestamp", "timestamp_ntz", "date", "time",
+      "timestamp_ntz_array", "date_array", "time_array"
   };
   private static final int NUM_COLUMNS = COLUMN_NAMES.length;
   private static final DataSchema.ColumnDataType[] COLUMN_DATA_TYPES = {
       INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
-      BOOLEAN_ARRAY, TIMESTAMP_ARRAY, BYTES_ARRAY
+      BOOLEAN_ARRAY, TIMESTAMP_ARRAY, BYTES_ARRAY, TIMESTAMP, TIMESTAMP_NTZ, DATE, TIME, TIMESTAMP_NTZ_ARRAY,
+      DATE_ARRAY, TIME_ARRAY
   };
 
   @Test
@@ -73,7 +80,9 @@ public class DataSchemaTest {
     Assert.assertEquals(dataSchema.toString(),
         "[int(INT),long(LONG),float(FLOAT),double(DOUBLE),string(STRING),object(OBJECT),int_array(INT_ARRAY),"
             + "long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),string_array(STRING_ARRAY),"
-            + "boolean_array(BOOLEAN_ARRAY),timestamp_array(TIMESTAMP_ARRAY),bytes_array(BYTES_ARRAY)]");
+            + "boolean_array(BOOLEAN_ARRAY),timestamp_array(TIMESTAMP_ARRAY),bytes_array(BYTES_ARRAY),"
+            + "timestamp(TIMESTAMP),timestamp_ntz(TIMESTAMP_NTZ),date(DATE),time(TIME),"
+            + "timestamp_ntz_array(TIMESTAMP_NTZ_ARRAY),date_array(DATE_ARRAY),time_array(TIME_ARRAY)]");
   }
 
   @Test
@@ -154,7 +163,7 @@ public class DataSchemaTest {
     }
 
     for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{
-        STRING_ARRAY, BOOLEAN_ARRAY, TIMESTAMP_ARRAY, BYTES_ARRAY
+        STRING_ARRAY, BOOLEAN_ARRAY, TIMESTAMP_ARRAY, BYTES_ARRAY, TIMESTAMP_NTZ_ARRAY, DATE_ARRAY, TIME_ARRAY
     }) {
       Assert.assertFalse(columnDataType.isNumber());
       Assert.assertFalse(columnDataType.isWholeNumber());
@@ -181,6 +190,12 @@ public class DataSchemaTest {
     Assert.assertEquals(fromDataType(FieldSpec.DataType.BOOLEAN, false), BOOLEAN_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.TIMESTAMP, false), TIMESTAMP_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.BYTES, false), BYTES_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.TIMESTAMP_NTZ, true), TIMESTAMP_NTZ);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.TIMESTAMP_NTZ, false), TIMESTAMP_NTZ_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.DATE, true), DATE);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.DATE, false), DATE_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.TIME, true), TIME);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.TIME, false), TIME_ARRAY);
 
     BigDecimal bigDecimalValue = new BigDecimal("1.2345678901234567890123456789");
     Assert.assertEquals(BIG_DECIMAL.format(bigDecimalValue), bigDecimalValue.toPlainString());
@@ -188,5 +203,12 @@ public class DataSchemaTest {
     Assert.assertEquals(TIMESTAMP.format(timestampValue), timestampValue.toString());
     byte[] bytesValue = {12, 34, 56};
     Assert.assertEquals(BYTES.format(bytesValue), BytesUtils.toHexString(bytesValue));
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(1234567890123L), ZoneId.of("UTC"));
+    LocalDate localDate = localDateTime.toLocalDate();
+    LocalTime localTime = localDateTime.toLocalTime();
+    Assert.assertEquals(TIMESTAMP_NTZ.format(localDateTime), localDateTime.toString());
+    Assert.assertEquals(DATE.format(localDate), localDate.toString());
+    Assert.assertEquals(TIME.format(localTime), localTime.toString());
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -20,6 +20,11 @@ package org.apache.pinot.common.utils;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -206,6 +211,47 @@ public class PinotDataTypeTest {
     assertEquals(TIMESTAMP.convert(timestamp.toString(), STRING), timestamp);
     assertEquals(TIMESTAMP.convert(timestamp.getTime(), JSON), timestamp);
     assertEquals(TIMESTAMP.convert(timestamp.toString(), JSON), timestamp);
+  }
+
+  @Test
+  public void testTimestampNTZ() {
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("UTC"));
+    assertEquals(
+        TIMESTAMP_NTZ.convert(localDateTime.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(), LONG),
+        localDateTime);
+    assertEquals(
+        TIMESTAMP_NTZ.convert(localDateTime.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(), STRING),
+        localDateTime);
+    assertEquals(TIMESTAMP_NTZ.convert(localDateTime.toString(), STRING), localDateTime);
+    assertEquals(
+        TIMESTAMP_NTZ.convert(localDateTime.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(), JSON),
+        localDateTime);
+    assertEquals(TIMESTAMP_NTZ.convert(localDateTime.toString(), JSON), localDateTime);
+  }
+
+  @Test
+  public void testDate() {
+    LocalDate localDate = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("UTC")).toLocalDate();
+    assertEquals(DATE.convert(localDate.toEpochDay(), LONG), localDate);
+    assertEquals(DATE.convert(localDate.toEpochDay(), INTEGER), localDate);
+    assertEquals(DATE.convert(localDate.toEpochDay(), STRING), localDate);
+    assertEquals(DATE.convert(localDate.toString(), STRING), localDate);
+    assertEquals(DATE.convert(localDate.toEpochDay(), JSON), localDate);
+    assertEquals(DATE.convert(localDate.toString(), JSON), localDate);
+  }
+
+  @Test
+  public void testTime() {
+    LocalTime localTime = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("UTC")).toLocalTime();
+    assertEquals(TIME.convert(localTime.toNanoOfDay() / 1000000, LONG), localTime);
+    assertEquals(TIME.convert(localTime.toNanoOfDay() / 1000000, INTEGER), localTime);
+    assertEquals(TIME.convert(localTime.toNanoOfDay() / 1000000, STRING), localTime);
+    assertEquals(TIME.convert(localTime.toString(), STRING), localTime);
+    assertEquals(TIME.convert(localTime.toNanoOfDay() / 1000000, JSON), localTime);
+    assertEquals(TIME.convert(localTime.toString(), JSON), localTime);
   }
 
   @Test

--- a/pinot-connectors/pinot-spark-2-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/DataExtractor.scala
+++ b/pinot-connectors/pinot-spark-2-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/DataExtractor.scala
@@ -58,6 +58,8 @@ private[datasource] object DataExtractor {
       case FieldSpec.DataType.BYTES => ArrayType(ByteType)
       case FieldSpec.DataType.TIMESTAMP => LongType
       case FieldSpec.DataType.TIMESTAMP_NTZ => LongType
+      case FieldSpec.DataType.DATE => LongType
+      case FieldSpec.DataType.TIME => LongType
       case FieldSpec.DataType.BOOLEAN => BooleanType
       case _ =>
         throw PinotException(s"Unsupported pinot data type '$dataType")
@@ -119,6 +121,10 @@ private[datasource] object DataExtractor {
       dataTable.getLong(rowIndex, colIndex)
     case ColumnDataType.TIMESTAMP_NTZ =>
       dataTable.getLong(rowIndex, colIndex);
+    case ColumnDataType.DATE =>
+      dataTable.getLong(rowIndex, colIndex);
+    case ColumnDataType.TIME =>
+      dataTable.getLong(rowIndex, colIndex);
     case ColumnDataType.BOOLEAN =>
       dataTable.getInt(rowIndex, colIndex) == 1
 
@@ -140,6 +146,10 @@ private[datasource] object DataExtractor {
     case ColumnDataType.TIMESTAMP_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
     case ColumnDataType.TIMESTAMP_NTZ_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq);
+    case ColumnDataType.DATE_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq);
+    case ColumnDataType.TIME_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq);
     case ColumnDataType.BOOLEAN_ARRAY =>
       ArrayData.toArrayData(

--- a/pinot-connectors/pinot-spark-2-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/DataExtractor.scala
+++ b/pinot-connectors/pinot-spark-2-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/DataExtractor.scala
@@ -57,6 +57,7 @@ private[datasource] object DataExtractor {
       case FieldSpec.DataType.STRING => StringType
       case FieldSpec.DataType.BYTES => ArrayType(ByteType)
       case FieldSpec.DataType.TIMESTAMP => LongType
+      case FieldSpec.DataType.TIMESTAMP_NTZ => LongType
       case FieldSpec.DataType.BOOLEAN => BooleanType
       case _ =>
         throw PinotException(s"Unsupported pinot data type '$dataType")
@@ -116,6 +117,8 @@ private[datasource] object DataExtractor {
       dataTable.getDouble(rowIndex, colIndex)
     case ColumnDataType.TIMESTAMP =>
       dataTable.getLong(rowIndex, colIndex)
+    case ColumnDataType.TIMESTAMP_NTZ =>
+      dataTable.getLong(rowIndex, colIndex);
     case ColumnDataType.BOOLEAN =>
       dataTable.getInt(rowIndex, colIndex) == 1
 
@@ -136,6 +139,8 @@ private[datasource] object DataExtractor {
       ArrayData.toArrayData(dataTable.getBytes(rowIndex, colIndex).getBytes)
     case ColumnDataType.TIMESTAMP_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
+    case ColumnDataType.TIMESTAMP_NTZ_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq);
     case ColumnDataType.BOOLEAN_ARRAY =>
       ArrayData.toArrayData(
         dataTable.getIntArray(rowIndex, colIndex).map(i => i == 1).toSeq

--- a/pinot-connectors/pinot-spark-2-connector/src/test/scala/org/apache/pinot/connector/spark/datasource/DataExtractorTest.scala
+++ b/pinot-connectors/pinot-spark-2-connector/src/test/scala/org/apache/pinot/connector/spark/datasource/DataExtractorTest.scala
@@ -54,6 +54,12 @@ class DataExtractorTest extends BaseTest {
       "timestampCol",
       "booleanArrayCol",
       "booleanCol",
+      "timestampNTZArrayCol",
+      "timestampNTZCol",
+      "dateArrayCol",
+      "dateCol",
+      "timeArrayCol",
+      "timeCol",
     )
     val columnTypes = Array(
       ColumnDataType.STRING,
@@ -71,6 +77,12 @@ class DataExtractorTest extends BaseTest {
       ColumnDataType.TIMESTAMP,
       ColumnDataType.BOOLEAN_ARRAY,
       ColumnDataType.BOOLEAN,
+      ColumnDataType.TIMESTAMP_NTZ_ARRAY,
+      ColumnDataType.TIMESTAMP_NTZ,
+      ColumnDataType.DATE_ARRAY,
+      ColumnDataType.DATE,
+      ColumnDataType.TIME_ARRAY,
+      ColumnDataType.TIME,
     )
     val dataSchema = new DataSchema(columnNames, columnTypes)
 
@@ -91,6 +103,12 @@ class DataExtractorTest extends BaseTest {
     dataTableBuilder.setColumn(12, 123L)
     dataTableBuilder.setColumn(13, Array[Int](1,0,1,0))
     dataTableBuilder.setColumn(14, 1)
+    dataTableBuilder.setColumn(15, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(16, 123L)
+    dataTableBuilder.setColumn(17, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(18, 123L)
+    dataTableBuilder.setColumn(19, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(20, 123L)
 
     dataTableBuilder.finishRow()
     val dataTable = dataTableBuilder.build()
@@ -112,6 +130,12 @@ class DataExtractorTest extends BaseTest {
         StructField("timestampCol", LongType),
         StructField("booleanArrayCol", ArrayType(BooleanType)),
         StructField("booleanCol", BooleanType),
+        StructField("timestampNTZArrayCol", ArrayType(LongType)),
+        StructField("timestampNTZCol", LongType),
+        StructField("dateArrayCol", ArrayType(LongType)),
+        StructField("dateCol", LongType),
+        StructField("timeArrayCol", ArrayType(LongType)),
+        StructField("timeCol", LongType),
       )
     )
 
@@ -133,6 +157,12 @@ class DataExtractorTest extends BaseTest {
     result.getLong(12) shouldEqual 123L
     result.getArray(13) shouldEqual ArrayData.toArrayData(Seq(true, false, true, false))
     result.getBoolean(14) shouldEqual true
+    result.getArray(15) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(16) shouldEqual 123L
+    result.getArray(17) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(18) shouldEqual 123L
+    result.getArray(19) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(20) shouldEqual 123L
   }
 
   test("Method should throw field not found exception while converting pinot data table") {

--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractor.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractor.scala
@@ -58,6 +58,8 @@ private[pinot] object DataExtractor {
       case FieldSpec.DataType.BYTES => ArrayType(ByteType)
       case FieldSpec.DataType.TIMESTAMP => LongType
       case FieldSpec.DataType.TIMESTAMP_NTZ => LongType
+      case FieldSpec.DataType.DATE => LongType
+      case FieldSpec.DataType.TIME => LongType
       case FieldSpec.DataType.BOOLEAN => BooleanType
       case _ =>
         throw PinotException(s"Unsupported pinot data type '$dataType")
@@ -121,6 +123,10 @@ private[pinot] object DataExtractor {
       dataTable.getLong(rowIndex, colIndex)
     case ColumnDataType.TIMESTAMP_NTZ =>
       dataTable.getLong(rowIndex, colIndex)
+    case ColumnDataType.DATE =>
+      dataTable.getLong(rowIndex, colIndex)
+    case ColumnDataType.TIME =>
+      dataTable.getLong(rowIndex, colIndex)
     case ColumnDataType.BOOLEAN =>
       dataTable.getInt(rowIndex, colIndex) == 1
 
@@ -142,6 +148,10 @@ private[pinot] object DataExtractor {
     case ColumnDataType.TIMESTAMP_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
     case ColumnDataType.TIMESTAMP_NTZ_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
+    case ColumnDataType.DATE_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
+    case ColumnDataType.TIME_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
     case ColumnDataType.BOOLEAN_ARRAY =>
       ArrayData.toArrayData(

--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractor.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractor.scala
@@ -57,6 +57,7 @@ private[pinot] object DataExtractor {
       case FieldSpec.DataType.STRING => StringType
       case FieldSpec.DataType.BYTES => ArrayType(ByteType)
       case FieldSpec.DataType.TIMESTAMP => LongType
+      case FieldSpec.DataType.TIMESTAMP_NTZ => LongType
       case FieldSpec.DataType.BOOLEAN => BooleanType
       case _ =>
         throw PinotException(s"Unsupported pinot data type '$dataType")
@@ -118,6 +119,8 @@ private[pinot] object DataExtractor {
       dataTable.getDouble(rowIndex, colIndex)
     case ColumnDataType.TIMESTAMP =>
       dataTable.getLong(rowIndex, colIndex)
+    case ColumnDataType.TIMESTAMP_NTZ =>
+      dataTable.getLong(rowIndex, colIndex)
     case ColumnDataType.BOOLEAN =>
       dataTable.getInt(rowIndex, colIndex) == 1
 
@@ -137,6 +140,8 @@ private[pinot] object DataExtractor {
     case ColumnDataType.BYTES =>
       ArrayData.toArrayData(dataTable.getBytes(rowIndex, colIndex).getBytes)
     case ColumnDataType.TIMESTAMP_ARRAY =>
+      ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
+    case ColumnDataType.TIMESTAMP_NTZ_ARRAY =>
       ArrayData.toArrayData(dataTable.getLongArray(rowIndex, colIndex).toSeq)
     case ColumnDataType.BOOLEAN_ARRAY =>
       ArrayData.toArrayData(

--- a/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractorTest.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/DataExtractorTest.scala
@@ -54,6 +54,12 @@ class DataExtractorTest extends BaseTest {
       "timestampCol",
       "booleanArrayCol",
       "booleanCol",
+      "timestampNTZArrayCol",
+      "timestampNTZCol",
+      "dateArrayCol",
+      "dateCol",
+      "timeArrayCol",
+      "timeCol",
     )
     val columnTypes = Array(
       ColumnDataType.STRING,
@@ -71,6 +77,12 @@ class DataExtractorTest extends BaseTest {
       ColumnDataType.TIMESTAMP,
       ColumnDataType.BOOLEAN_ARRAY,
       ColumnDataType.BOOLEAN,
+      ColumnDataType.TIMESTAMP_NTZ_ARRAY,
+      ColumnDataType.TIMESTAMP_NTZ,
+      ColumnDataType.DATE_ARRAY,
+      ColumnDataType.DATE,
+      ColumnDataType.TIME_ARRAY,
+      ColumnDataType.TIME,
     )
     val dataSchema = new DataSchema(columnNames, columnTypes)
 
@@ -91,6 +103,12 @@ class DataExtractorTest extends BaseTest {
     dataTableBuilder.setColumn(12, 123L)
     dataTableBuilder.setColumn(13, Array[Int](1,0,1,0))
     dataTableBuilder.setColumn(14, 1)
+    dataTableBuilder.setColumn(15, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(16, 123L)
+    dataTableBuilder.setColumn(17, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(18, 123L)
+    dataTableBuilder.setColumn(19, Array[Long](123L,456L))
+    dataTableBuilder.setColumn(20, 123L)
 
     dataTableBuilder.finishRow()
     val dataTable = dataTableBuilder.build()
@@ -112,6 +130,12 @@ class DataExtractorTest extends BaseTest {
         StructField("timestampCol", LongType),
         StructField("booleanArrayCol", ArrayType(BooleanType)),
         StructField("booleanCol", BooleanType),
+        StructField("timestampNTZArrayCol", ArrayType(LongType)),
+        StructField("timestampNTZCol", LongType),
+        StructField("dateArrayCol", ArrayType(LongType)),
+        StructField("dateCol", LongType),
+        StructField("timeArrayCol", ArrayType(LongType)),
+        StructField("timeCol", LongType),
       )
     )
 
@@ -133,6 +157,12 @@ class DataExtractorTest extends BaseTest {
     result.getLong(12) shouldEqual 123L
     result.getArray(13) shouldEqual ArrayData.toArrayData(Seq(true, false, true, false))
     result.getBoolean(14) shouldEqual true
+    result.getArray(15) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(16) shouldEqual 123L
+    result.getArray(17) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(18) shouldEqual 123L
+    result.getArray(19) shouldEqual ArrayData.toArrayData(Seq(123L,456L))
+    result.getLong(20) shouldEqual 123L
   }
 
   test("Method should throw field not found exception while converting pinot data table") {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
@@ -80,6 +80,8 @@ public class NumberGenerator implements Generator {
       case LONG:
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case DATE:
+      case TIME:
         return (long) newValue;
       case FLOAT:
         return newValue + 0.5f;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
@@ -79,6 +79,7 @@ public class NumberGenerator implements Generator {
         return newValue;
       case LONG:
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
         return (long) newValue;
       case FLOAT:
         return newValue + 0.5f;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
@@ -51,7 +51,8 @@ public class TimeGenerator implements Generator {
   public Object next() {
     Object next = _numberGenerator.next();
     if (_dataType == FieldSpec.DataType.LONG || _dataType == FieldSpec.DataType.TIMESTAMP
-        || _dataType == FieldSpec.DataType.TIMESTAMP_NTZ) {
+        || _dataType == FieldSpec.DataType.TIMESTAMP_NTZ || _dataType == FieldSpec.DataType.DATE
+        || _dataType == FieldSpec.DataType.TIME) {
       return ((long) next) + _initialValue.longValue();
     }
     return ((int) next) + _initialValue.intValue();
@@ -61,7 +62,8 @@ public class TimeGenerator implements Generator {
   static Number convert(Date date, TimeUnit timeUnit, FieldSpec.DataType dataType) {
     long convertedTime = timeUnit.convert(date.getTime(), TimeUnit.MILLISECONDS);
     if (dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.TIMESTAMP
-        || dataType == FieldSpec.DataType.TIMESTAMP_NTZ) {
+        || dataType == FieldSpec.DataType.TIMESTAMP_NTZ || dataType == FieldSpec.DataType.DATE
+        || dataType == FieldSpec.DataType.TIME) {
       return convertedTime;
     }
     if (dataType == FieldSpec.DataType.INT) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
@@ -50,7 +50,8 @@ public class TimeGenerator implements Generator {
   @Override
   public Object next() {
     Object next = _numberGenerator.next();
-    if (_dataType == FieldSpec.DataType.LONG || _dataType == FieldSpec.DataType.TIMESTAMP) {
+    if (_dataType == FieldSpec.DataType.LONG || _dataType == FieldSpec.DataType.TIMESTAMP
+        || _dataType == FieldSpec.DataType.TIMESTAMP_NTZ) {
       return ((long) next) + _initialValue.longValue();
     }
     return ((int) next) + _initialValue.intValue();
@@ -59,7 +60,8 @@ public class TimeGenerator implements Generator {
   @VisibleForTesting
   static Number convert(Date date, TimeUnit timeUnit, FieldSpec.DataType dataType) {
     long convertedTime = timeUnit.convert(date.getTime(), TimeUnit.MILLISECONDS);
-    if (dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.TIMESTAMP) {
+    if (dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.TIMESTAMP
+        || dataType == FieldSpec.DataType.TIMESTAMP_NTZ) {
       return convertedTime;
     }
     if (dataType == FieldSpec.DataType.INT) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -132,6 +132,7 @@ public class InputManager {
     put(FieldSpec.DataType.INT, Integer.BYTES);
     put(FieldSpec.DataType.LONG, Long.BYTES);
     put(FieldSpec.DataType.TIMESTAMP, Long.BYTES);
+    put(FieldSpec.DataType.TIMESTAMP_NTZ, Long.BYTES);
     put(FieldSpec.DataType.FLOAT, Float.BYTES);
     put(FieldSpec.DataType.DOUBLE, Double.BYTES);
     put(FieldSpec.DataType.BYTES, Byte.BYTES);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -133,6 +133,8 @@ public class InputManager {
     put(FieldSpec.DataType.LONG, Long.BYTES);
     put(FieldSpec.DataType.TIMESTAMP, Long.BYTES);
     put(FieldSpec.DataType.TIMESTAMP_NTZ, Long.BYTES);
+    put(FieldSpec.DataType.DATE, Long.BYTES);
+    put(FieldSpec.DataType.TIME, Long.BYTES);
     put(FieldSpec.DataType.FLOAT, Float.BYTES);
     put(FieldSpec.DataType.DOUBLE, Double.BYTES);
     put(FieldSpec.DataType.BYTES, Byte.BYTES);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -79,6 +79,8 @@ public class EqualsPredicateEvaluatorFactory {
         return new IntRawValueBasedEqPredicateEvaluator(eqPredicate, BooleanUtils.toInt(value));
       case TIMESTAMP:
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisSinceEpoch(value));
+      case TIMESTAMP_NTZ:
+        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -80,11 +80,11 @@ public class EqualsPredicateEvaluatorFactory {
       case TIMESTAMP:
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case TIMESTAMP_NTZ:
-        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
+        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisSinceEpochInUTC(value));
       case DATE:
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toDaysSinceEpoch(value));
       case TIME:
-        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillsOfDay(value));
+        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisOfDay(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -81,6 +81,10 @@ public class EqualsPredicateEvaluatorFactory {
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case TIMESTAMP_NTZ:
         return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
+      case DATE:
+        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toDaysSinceEpoch(value));
+      case TIME:
+        return new LongRawValueBasedEqPredicateEvaluator(eqPredicate, TimestampUtils.toMillsOfDay(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -136,6 +136,22 @@ public class InPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
       }
+      case DATE: {
+        long[] localDateValues = inPredicate.getLocalDateValues();
+        LongSet matchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localDateValues.length));
+        for (long value : localDateValues) {
+          matchingValues.add(value);
+        }
+        return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
+      }
+      case TIME: {
+        long[] localTimeValues = inPredicate.getLocalTimeValues();
+        LongSet matchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localTimeValues.length));
+        for (long value : localTimeValues) {
+          matchingValues.add(value);
+        }
+        return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
+      }
       case STRING:
       case JSON: {
         List<String> stringValues = inPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -128,6 +128,14 @@ public class InPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
       }
+      case TIMESTAMP_NTZ: {
+        long[] localDateTimeValues = inPredicate.getLocalDateTimeValues();
+        LongSet matchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localDateTimeValues.length));
+        for (long value : localDateTimeValues) {
+          matchingValues.add(value);
+        }
+        return new LongRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
+      }
       case STRING:
       case JSON: {
         List<String> stringValues = inPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -76,11 +76,11 @@ public class NotEqualsPredicateEvaluatorFactory {
       case TIMESTAMP:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case TIMESTAMP_NTZ:
-        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
+        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpochInUTC(value));
       case DATE:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toDaysSinceEpoch(value));
       case TIME:
-        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillsOfDay(value));
+        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisOfDay(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -75,6 +75,8 @@ public class NotEqualsPredicateEvaluatorFactory {
         return new IntRawValueBasedNeqPredicateEvaluator(notEqPredicate, BooleanUtils.toInt(value));
       case TIMESTAMP:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpoch(value));
+      case TIMESTAMP_NTZ:
+        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -77,6 +77,10 @@ public class NotEqualsPredicateEvaluatorFactory {
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case TIMESTAMP_NTZ:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillsWithoutTimeZone(value));
+      case DATE:
+        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toDaysSinceEpoch(value));
+      case TIME:
+        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillsOfDay(value));
       case STRING:
       case JSON:
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -76,7 +76,8 @@ public class NotEqualsPredicateEvaluatorFactory {
       case TIMESTAMP:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpoch(value));
       case TIMESTAMP_NTZ:
-        return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toMillisSinceEpochInUTC(value));
+        return new LongRawValueBasedNeqPredicateEvaluator(
+            notEqPredicate, TimestampUtils.toMillisSinceEpochInUTC(value));
       case DATE:
         return new LongRawValueBasedNeqPredicateEvaluator(notEqPredicate, TimestampUtils.toDaysSinceEpoch(value));
       case TIME:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -128,6 +128,14 @@ public class NotInPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
       }
+      case TIMESTAMP_NTZ: {
+        long[] localDateTimeValues = notInPredicate.getLocalDateTimeValues();
+        LongSet nonMatchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localDateTimeValues.length));
+        for (long value : localDateTimeValues) {
+          nonMatchingValues.add(value);
+        }
+        return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
+      }
       case STRING:
       case JSON: {
         List<String> stringValues = notInPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -136,6 +136,22 @@ public class NotInPredicateEvaluatorFactory {
         }
         return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
       }
+      case DATE: {
+        long[] localDateValues = notInPredicate.getLocalDateValues();
+        LongSet nonMatchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localDateValues.length));
+        for (long value : localDateValues) {
+          nonMatchingValues.add(value);
+        }
+        return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
+      }
+      case TIME: {
+        long[] localTimeValues = notInPredicate.getLocalTimeValues();
+        LongSet nonMatchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(localTimeValues.length));
+        for (long value : localTimeValues) {
+          nonMatchingValues.add(value);
+        }
+        return new LongRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
+      }
       case STRING:
       case JSON: {
         List<String> stringValues = notInPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -53,6 +53,8 @@ public class PredicateUtils {
         return getStoredBooleanValue(value);
       case TIMESTAMP:
         return getStoredTimestampValue(value);
+      case TIMESTAMP_NTZ:
+        return getStoredLocalDateTimeValue(value);
       default:
         return value;
     }
@@ -70,6 +72,10 @@ public class PredicateUtils {
    */
   public static String getStoredTimestampValue(String timestampValue) {
     return Long.toString(TimestampUtils.toMillisSinceEpoch(timestampValue));
+  }
+
+  public static String getStoredLocalDateTimeValue(String localDateTimeValue) {
+    return Long.toString(TimestampUtils.toMillsWithoutTimeZone(localDateTimeValue));
   }
 
   /**
@@ -138,6 +144,15 @@ public class PredicateUtils {
       case TIMESTAMP:
         long[] timestampValues = inPredicate.getTimestampValues();
         for (long value : timestampValues) {
+          int dictId = dictionary.indexOf(value);
+          if (dictId >= 0) {
+            dictIdSet.add(dictId);
+          }
+        }
+        break;
+      case TIMESTAMP_NTZ:
+        long[] localDateTimeValues = inPredicate.getLocalDateTimeValues();
+        for (long value : localDateTimeValues) {
           int dictId = dictionary.indexOf(value);
           if (dictId >= 0) {
             dictIdSet.add(dictId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -79,7 +79,7 @@ public class PredicateUtils {
   }
 
   public static String getStoredLocalDateTimeValue(String localDateTimeValue) {
-    return Long.toString(TimestampUtils.toMillsWithoutTimeZone(localDateTimeValue));
+    return Long.toString(TimestampUtils.toMillisSinceEpochInUTC(localDateTimeValue));
   }
 
   public static String getStoredLocalDateValue(String localDateValue) {
@@ -87,7 +87,7 @@ public class PredicateUtils {
   }
 
   public static String getStoredLocalTimeValue(String localTimeValue) {
-    return Long.toString(TimestampUtils.toMillsOfDay(localTimeValue));
+    return Long.toString(TimestampUtils.toMillisOfDay(localTimeValue));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -55,6 +55,10 @@ public class PredicateUtils {
         return getStoredTimestampValue(value);
       case TIMESTAMP_NTZ:
         return getStoredLocalDateTimeValue(value);
+      case DATE:
+        return getStoredLocalDateValue(value);
+      case TIME:
+        return getStoredLocalTimeValue(value);
       default:
         return value;
     }
@@ -76,6 +80,14 @@ public class PredicateUtils {
 
   public static String getStoredLocalDateTimeValue(String localDateTimeValue) {
     return Long.toString(TimestampUtils.toMillsWithoutTimeZone(localDateTimeValue));
+  }
+
+  public static String getStoredLocalDateValue(String localDateValue) {
+    return Long.toString(TimestampUtils.toDaysSinceEpoch(localDateValue));
+  }
+
+  public static String getStoredLocalTimeValue(String localTimeValue) {
+    return Long.toString(TimestampUtils.toMillsOfDay(localTimeValue));
   }
 
   /**
@@ -153,6 +165,24 @@ public class PredicateUtils {
       case TIMESTAMP_NTZ:
         long[] localDateTimeValues = inPredicate.getLocalDateTimeValues();
         for (long value : localDateTimeValues) {
+          int dictId = dictionary.indexOf(value);
+          if (dictId >= 0) {
+            dictIdSet.add(dictId);
+          }
+        }
+        break;
+      case DATE:
+        long[] localDateValues = inPredicate.getLocalDateValues();
+        for (long value : localDateValues) {
+          int dictId = dictionary.indexOf(value);
+          if (dictId >= 0) {
+            dictIdSet.add(dictId);
+          }
+        }
+        break;
+      case TIME:
+        long[] localTimeValues = inPredicate.getLocalTimeValues();
+        for (long value : localTimeValues) {
           int dictId = dictionary.indexOf(value);
           if (dictId >= 0) {
             dictIdSet.add(dictId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -104,6 +104,11 @@ public class RangePredicateEvaluatorFactory {
             lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillisSinceEpoch(lowerBound),
             upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillisSinceEpoch(upperBound), lowerInclusive,
             upperInclusive);
+      case TIMESTAMP_NTZ:
+        return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
+            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillsWithoutTimeZone(lowerBound),
+            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillsWithoutTimeZone(upperBound), lowerInclusive,
+            upperInclusive);
       case STRING:
         return new StringRawValueBasedRangePredicateEvaluator(rangePredicate, lowerUnbounded ? null : lowerBound,
             upperUnbounded ? null : upperBound, lowerInclusive, upperInclusive);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -106,8 +106,8 @@ public class RangePredicateEvaluatorFactory {
             upperInclusive);
       case TIMESTAMP_NTZ:
         return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
-            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillsWithoutTimeZone(lowerBound),
-            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillsWithoutTimeZone(upperBound), lowerInclusive,
+            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillisSinceEpochInUTC(lowerBound),
+            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillisSinceEpochInUTC(upperBound), lowerInclusive,
             upperInclusive);
       case DATE:
         return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
@@ -116,8 +116,8 @@ public class RangePredicateEvaluatorFactory {
             upperInclusive);
       case TIME:
         return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
-            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillsOfDay(lowerBound),
-            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillsOfDay(upperBound), lowerInclusive,
+            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillisOfDay(lowerBound),
+            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillisOfDay(upperBound), lowerInclusive,
             upperInclusive);
       case STRING:
         return new StringRawValueBasedRangePredicateEvaluator(rangePredicate, lowerUnbounded ? null : lowerBound,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -109,6 +109,16 @@ public class RangePredicateEvaluatorFactory {
             lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillsWithoutTimeZone(lowerBound),
             upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillsWithoutTimeZone(upperBound), lowerInclusive,
             upperInclusive);
+      case DATE:
+        return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
+            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toDaysSinceEpoch(lowerBound),
+            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toDaysSinceEpoch(upperBound), lowerInclusive,
+            upperInclusive);
+      case TIME:
+        return new LongRawValueBasedRangePredicateEvaluator(rangePredicate,
+            lowerUnbounded ? Long.MIN_VALUE : TimestampUtils.toMillsOfDay(lowerBound),
+            upperUnbounded ? Long.MAX_VALUE : TimestampUtils.toMillsOfDay(upperBound), lowerInclusive,
+            upperInclusive);
       case STRING:
         return new StringRawValueBasedRangePredicateEvaluator(rangePredicate, lowerUnbounded ? null : lowerBound,
             upperUnbounded ? null : upperBound, lowerInclusive, upperInclusive);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -53,6 +53,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.TIMESTAMP, true, false);
   protected static final TransformResultMetadata TIMESTAMP_NTZ_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.TIMESTAMP_NTZ, true, false);
+  protected static final TransformResultMetadata DATE_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.DATE, true, false);
+  protected static final TransformResultMetadata TIME_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.TIME, true, false);
   protected static final TransformResultMetadata STRING_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.STRING, true, false);
   protected static final TransformResultMetadata JSON_SV_NO_DICTIONARY_METADATA =
@@ -77,6 +81,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.TIMESTAMP, false, false);
   protected static final TransformResultMetadata TIMESTAMP_NTZ_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.TIMESTAMP_NTZ, false, false);
+  protected static final TransformResultMetadata DATE_MV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.DATE, false, false);
+  protected static final TransformResultMetadata TIME_MV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.TIME, false, false);
   protected static final TransformResultMetadata STRING_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.STRING, false, false);
   protected static final TransformResultMetadata JSON_MV_NO_DICTIONARY_METADATA =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -51,6 +51,8 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.BOOLEAN, true, false);
   protected static final TransformResultMetadata TIMESTAMP_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.TIMESTAMP, true, false);
+  protected static final TransformResultMetadata TIMESTAMP_NTZ_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.TIMESTAMP_NTZ, true, false);
   protected static final TransformResultMetadata STRING_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.STRING, true, false);
   protected static final TransformResultMetadata JSON_SV_NO_DICTIONARY_METADATA =
@@ -73,6 +75,8 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.BOOLEAN, false, false);
   protected static final TransformResultMetadata TIMESTAMP_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.TIMESTAMP, false, false);
+  protected static final TransformResultMetadata TIMESTAMP_NTZ_MV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.TIMESTAMP_NTZ, false, false);
   protected static final TransformResultMetadata STRING_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.STRING, false, false);
   protected static final TransformResultMetadata JSON_MV_NO_DICTIONARY_METADATA =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -205,6 +205,13 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           throw new IllegalArgumentException("Invalid literal: " + literal + " for TIMESTAMP");
         }
         break;
+      case TIMESTAMP_NTZ:
+        try {
+          TimestampUtils.toLocalDateTime(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for TIMESTAMP_NTZ");
+        }
+        break;
       case STRING:
       case JSON:
         break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -212,6 +212,20 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           throw new IllegalArgumentException("Invalid literal: " + literal + " for TIMESTAMP_NTZ");
         }
         break;
+      case DATE:
+        try {
+          TimestampUtils.toLocalDate(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for DATE");
+        }
+        break;
+      case TIME:
+        try {
+          TimestampUtils.toLocalTime(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for TIME");
+        }
+        break;
       case STRING:
       case JSON:
         break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -88,6 +88,14 @@ public class CastTransformFunction extends BaseTransformFunction {
           _resultMetadata =
               sourceSV ? TIMESTAMP_NTZ_SV_NO_DICTIONARY_METADATA : TIMESTAMP_NTZ_MV_NO_DICTIONARY_METADATA;
           break;
+        case "DATE":
+          _resultMetadata =
+              sourceSV ? DATE_SV_NO_DICTIONARY_METADATA : DATE_MV_NO_DICTIONARY_METADATA;
+          break;
+        case "TIME":
+          _resultMetadata =
+              sourceSV ? TIME_SV_NO_DICTIONARY_METADATA : TIME_MV_NO_DICTIONARY_METADATA;
+          break;
         case "STRING":
         case "VARCHAR":
           _resultMetadata = sourceSV ? STRING_SV_NO_DICTIONARY_METADATA : STRING_MV_NO_DICTIONARY_METADATA;
@@ -181,6 +189,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         return transformToTimestampValuesSV(valueBlock);
       case TIMESTAMP_NTZ:
         return transformToLocalDateTimeValuesSV(valueBlock);
+      case DATE:
+        return transformToLocalDateValuesSV(valueBlock);
+      case TIME:
+        return transformToLocalTimeValuesSV(valueBlock);
       default:
         return super.transformToLongValuesSV(valueBlock);
     }
@@ -205,6 +217,30 @@ public class CastTransformFunction extends BaseTransformFunction {
       initLongValuesSV(length);
       String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
       ArrayCopyUtils.copyToLocalDateTime(stringValues, _longValuesSV, length);
+      return _longValuesSV;
+    } else {
+      return _transformFunction.transformToLongValuesSV(valueBlock);
+    }
+  }
+
+  private long[] transformToLocalDateValuesSV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesSV(length);
+      String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
+      ArrayCopyUtils.copyToLocalDate(stringValues, _longValuesSV, length);
+      return _longValuesSV;
+    } else {
+      return _transformFunction.transformToLongValuesSV(valueBlock);
+    }
+  }
+
+  private long[] transformToLocalTimeValuesSV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesSV(length);
+      String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
+      ArrayCopyUtils.copyToLocalTime(stringValues, _longValuesSV, length);
       return _longValuesSV;
     } else {
       return _transformFunction.transformToLongValuesSV(valueBlock);
@@ -261,6 +297,18 @@ public class CastTransformFunction extends BaseTransformFunction {
           longValues = _transformFunction.transformToLongValuesSV(valueBlock);
           ArrayCopyUtils.copyFromLocalDateTime(longValues, _stringValuesSV, length);
           return _stringValuesSV;
+        case DATE:
+          length = valueBlock.getNumDocs();
+          initStringValuesSV(length);
+          longValues = _transformFunction.transformToLongValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDate(longValues, _stringValuesSV, length);
+          return _stringValuesSV;
+        case TIME:
+          length = valueBlock.getNumDocs();
+          initStringValuesSV(length);
+          longValues = _transformFunction.transformToLongValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalTime(longValues, _stringValuesSV, length);
+          return _stringValuesSV;
         default:
           return _transformFunction.transformToStringValuesSV(valueBlock);
       }
@@ -299,6 +347,14 @@ public class CastTransformFunction extends BaseTransformFunction {
         case TIMESTAMP_NTZ:
           longValues = transformToLocalDateTimeValuesSV(valueBlock);
           ArrayCopyUtils.copyFromLocalDateTime(longValues, _stringValuesSV, length);
+          break;
+        case DATE:
+          longValues = transformToLocalDateValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDate(longValues, _stringValuesSV, length);
+          break;
+        case TIME:
+          longValues = transformToLocalTimeValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalTime(longValues, _stringValuesSV, length);
           break;
         case BYTES:
           byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
@@ -363,6 +419,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         return transformToTimestampValuesMV(valueBlock);
       case TIMESTAMP_NTZ:
         return transformToLocalDateTimeValuesMV(valueBlock);
+      case DATE:
+        return transformToLocalDateValuesMV(valueBlock);
+      case TIME:
+        return transformToLocalTimeValuesMV(valueBlock);
       default:
         return super.transformToLongValuesMV(valueBlock);
     }
@@ -387,6 +447,30 @@ public class CastTransformFunction extends BaseTransformFunction {
       initLongValuesMV(length);
       String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
       ArrayCopyUtils.copyToLocalDateTime(stringValuesMV, _longValuesMV, length);
+      return _longValuesMV;
+    } else {
+      return _transformFunction.transformToLongValuesMV(valueBlock);
+    }
+  }
+
+  private long[][] transformToLocalDateValuesMV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesMV(length);
+      String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
+      ArrayCopyUtils.copyToLocalDate(stringValuesMV, _longValuesMV, length);
+      return _longValuesMV;
+    } else {
+      return _transformFunction.transformToLongValuesMV(valueBlock);
+    }
+  }
+
+  private long[][] transformToLocalTimeValuesMV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesMV(length);
+      String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
+      ArrayCopyUtils.copyToLocalTime(stringValuesMV, _longValuesMV, length);
       return _longValuesMV;
     } else {
       return _transformFunction.transformToLongValuesMV(valueBlock);
@@ -434,6 +518,18 @@ public class CastTransformFunction extends BaseTransformFunction {
           longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
           ArrayCopyUtils.copyFromLocalDateTime(longValuesMV, _stringValuesMV, length);
           return _stringValuesMV;
+        case DATE:
+          length = valueBlock.getNumDocs();
+          initStringValuesMV(length);
+          longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDate(longValuesMV, _stringValuesMV, length);
+          return _stringValuesMV;
+        case TIME:
+          length = valueBlock.getNumDocs();
+          initStringValuesMV(length);
+          longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalTime(longValuesMV, _stringValuesMV, length);
+          return _stringValuesMV;
         default:
           return _transformFunction.transformToStringValuesMV(valueBlock);
       }
@@ -468,6 +564,14 @@ public class CastTransformFunction extends BaseTransformFunction {
         case TIMESTAMP_NTZ:
           longValuesMV = transformToLocalDateTimeValuesMV(valueBlock);
           ArrayCopyUtils.copyFromLocalDateTime(longValuesMV, _stringValuesMV, length);
+          break;
+        case DATE:
+          longValuesMV = transformToLocalDateValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDate(longValuesMV, _stringValuesMV, length);
+          break;
+        case TIME:
+          longValuesMV = transformToLocalTimeValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalTime(longValuesMV, _stringValuesMV, length);
           break;
         default:
           throw new IllegalStateException(String.format("Cannot cast from MV %s to STRING", resultDataType));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -84,6 +84,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "TIMESTAMP":
           _resultMetadata = sourceSV ? TIMESTAMP_SV_NO_DICTIONARY_METADATA : TIMESTAMP_MV_NO_DICTIONARY_METADATA;
           break;
+        case "TIMESTAMP_NTZ":
+          _resultMetadata =
+              sourceSV ? TIMESTAMP_NTZ_SV_NO_DICTIONARY_METADATA : TIMESTAMP_NTZ_MV_NO_DICTIONARY_METADATA;
+          break;
         case "STRING":
         case "VARCHAR":
           _resultMetadata = sourceSV ? STRING_SV_NO_DICTIONARY_METADATA : STRING_MV_NO_DICTIONARY_METADATA;
@@ -175,6 +179,8 @@ public class CastTransformFunction extends BaseTransformFunction {
         return _transformFunction.transformToLongValuesSV(valueBlock);
       case TIMESTAMP:
         return transformToTimestampValuesSV(valueBlock);
+      case TIMESTAMP_NTZ:
+        return transformToLocalDateTimeValuesSV(valueBlock);
       default:
         return super.transformToLongValuesSV(valueBlock);
     }
@@ -187,6 +193,18 @@ public class CastTransformFunction extends BaseTransformFunction {
       initLongValuesSV(length);
       String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
       ArrayCopyUtils.copyToTimestamp(stringValues, _longValuesSV, length);
+      return _longValuesSV;
+    } else {
+      return _transformFunction.transformToLongValuesSV(valueBlock);
+    }
+  }
+
+  private long[] transformToLocalDateTimeValuesSV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesSV(length);
+      String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
+      ArrayCopyUtils.copyToLocalDateTime(stringValues, _longValuesSV, length);
       return _longValuesSV;
     } else {
       return _transformFunction.transformToLongValuesSV(valueBlock);
@@ -237,6 +255,12 @@ public class CastTransformFunction extends BaseTransformFunction {
           long[] longValues = _transformFunction.transformToLongValuesSV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValues, _stringValuesSV, length);
           return _stringValuesSV;
+        case TIMESTAMP_NTZ:
+          length = valueBlock.getNumDocs();
+          initStringValuesSV(length);
+          longValues = _transformFunction.transformToLongValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDateTime(longValues, _stringValuesSV, length);
+          return _stringValuesSV;
         default:
           return _transformFunction.transformToStringValuesSV(valueBlock);
       }
@@ -271,6 +295,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         case TIMESTAMP:
           longValues = transformToTimestampValuesSV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValues, _stringValuesSV, length);
+          break;
+        case TIMESTAMP_NTZ:
+          longValues = transformToLocalDateTimeValuesSV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDateTime(longValues, _stringValuesSV, length);
           break;
         case BYTES:
           byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
@@ -333,6 +361,8 @@ public class CastTransformFunction extends BaseTransformFunction {
         return _transformFunction.transformToLongValuesMV(valueBlock);
       case TIMESTAMP:
         return transformToTimestampValuesMV(valueBlock);
+      case TIMESTAMP_NTZ:
+        return transformToLocalDateTimeValuesMV(valueBlock);
       default:
         return super.transformToLongValuesMV(valueBlock);
     }
@@ -345,6 +375,18 @@ public class CastTransformFunction extends BaseTransformFunction {
       initLongValuesMV(length);
       String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
       ArrayCopyUtils.copyToTimestamp(stringValuesMV, _longValuesMV, length);
+      return _longValuesMV;
+    } else {
+      return _transformFunction.transformToLongValuesMV(valueBlock);
+    }
+  }
+
+  private long[][] transformToLocalDateTimeValuesMV(ValueBlock valueBlock) {
+    if (_sourceDataType.getStoredType() == DataType.STRING) {
+      int length = valueBlock.getNumDocs();
+      initLongValuesMV(length);
+      String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
+      ArrayCopyUtils.copyToLocalDateTime(stringValuesMV, _longValuesMV, length);
       return _longValuesMV;
     } else {
       return _transformFunction.transformToLongValuesMV(valueBlock);
@@ -386,6 +428,12 @@ public class CastTransformFunction extends BaseTransformFunction {
           long[][] longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValuesMV, _stringValuesMV, length);
           return _stringValuesMV;
+        case TIMESTAMP_NTZ:
+          length = valueBlock.getNumDocs();
+          initStringValuesMV(length);
+          longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDateTime(longValuesMV, _stringValuesMV, length);
+          return _stringValuesMV;
         default:
           return _transformFunction.transformToStringValuesMV(valueBlock);
       }
@@ -416,6 +464,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         case TIMESTAMP:
           longValuesMV = transformToTimestampValuesMV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValuesMV, _stringValuesMV, length);
+          break;
+        case TIMESTAMP_NTZ:
+          longValuesMV = transformToLocalDateTimeValuesMV(valueBlock);
+          ArrayCopyUtils.copyFromLocalDateTime(longValuesMV, _stringValuesMV, length);
           break;
         default:
           throw new IllegalStateException(String.format("Cannot cast from MV %s to STRING", resultDataType));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -21,6 +21,9 @@ package org.apache.pinot.core.operator.transform.function;
 import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
@@ -132,6 +135,14 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
             }
             _scalarArguments[i] =
                 parameterTypes[i].convert(literalTransformFunction.getLongLiteral(), PinotDataType.TIMESTAMP);
+            break;
+          case TIMESTAMP_NTZ:
+            if (parameterTypes[i] == PinotDataType.STRING) {
+              _scalarArguments[i] = literalTransformFunction.getStringLiteral();
+              break;
+            }
+            _scalarArguments[i] =
+                parameterTypes[i].convert(literalTransformFunction.getLongLiteral(), PinotDataType.TIMESTAMP_NTZ);
             break;
           case STRING:
             _scalarArguments[i] =
@@ -416,6 +427,17 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
             timestampValues[j] = new Timestamp(longValues[j]);
           }
           _nonLiteralValues[i] = timestampValues;
+          break;
+        }
+        case TIMESTAMP_NTZ: {
+          long[] longValues = transformFunction.transformToLongValuesSV(valueBlock);
+          int numValues = longValues.length;
+          LocalDateTime[] localDateTimeValues = new LocalDateTime[numValues];
+          for (int j = 0; j < numValues; j++) {
+            localDateTimeValues[j] = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(longValues[j]), ZoneId.of("UTC"));
+          }
+          _nonLiteralValues[i] = localDateTimeValues;
           break;
         }
         case STRING:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -22,7 +22,9 @@ import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
@@ -143,6 +145,22 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
             }
             _scalarArguments[i] =
                 parameterTypes[i].convert(literalTransformFunction.getLongLiteral(), PinotDataType.TIMESTAMP_NTZ);
+            break;
+          case DATE:
+            if (parameterTypes[i] == PinotDataType.STRING) {
+              _scalarArguments[i] = literalTransformFunction.getStringLiteral();
+              break;
+            }
+            _scalarArguments[i] =
+                parameterTypes[i].convert(literalTransformFunction.getLongLiteral(), PinotDataType.DATE);
+            break;
+          case TIME:
+            if (parameterTypes[i] == PinotDataType.STRING) {
+              _scalarArguments[i] = literalTransformFunction.getStringLiteral();
+              break;
+            }
+            _scalarArguments[i] =
+                parameterTypes[i].convert(literalTransformFunction.getLongLiteral(), PinotDataType.TIME);
             break;
           case STRING:
             _scalarArguments[i] =
@@ -438,6 +456,26 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
                 Instant.ofEpochMilli(longValues[j]), ZoneId.of("UTC"));
           }
           _nonLiteralValues[i] = localDateTimeValues;
+          break;
+        }
+        case DATE: {
+          long[] longValues = transformFunction.transformToLongValuesSV(valueBlock);
+          int numValues = longValues.length;
+          LocalDate[] localDateValues = new LocalDate[numValues];
+          for (int j = 0; j < numValues; j++) {
+            localDateValues[j] = LocalDate.ofEpochDay(longValues[j]);
+          }
+          _nonLiteralValues[i] = localDateValues;
+          break;
+        }
+        case TIME: {
+          long[] longValues = transformFunction.transformToLongValuesSV(valueBlock);
+          int numValues = longValues.length;
+          LocalTime[] localTimeValues = new LocalTime[numValues];
+          for (int j = 0; j < numValues; j++) {
+            localTimeValues[j] = LocalTime.ofNanoOfDay(longValues[j] * 1000000);
+          }
+          _nonLiteralValues[i] = localTimeValues;
           break;
         }
         case STRING:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SelectTupleElementTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SelectTupleElementTransformFunction.java
@@ -33,7 +33,8 @@ public abstract class SelectTupleElementTransformFunction extends BaseTransformF
 
   private static final EnumSet<FieldSpec.DataType> SUPPORTED_DATATYPES = EnumSet.of(FieldSpec.DataType.INT,
       FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.BIG_DECIMAL,
-      FieldSpec.DataType.TIMESTAMP, FieldSpec.DataType.STRING, FieldSpec.DataType.UNKNOWN);
+      FieldSpec.DataType.TIMESTAMP, FieldSpec.DataType.TIMESTAMP_NTZ, FieldSpec.DataType.STRING,
+      FieldSpec.DataType.UNKNOWN);
 
   private static final EnumMap<FieldSpec.DataType, EnumSet<FieldSpec.DataType>> ACCEPTABLE_COMBINATIONS =
       createAcceptableCombinations();
@@ -111,6 +112,7 @@ public abstract class SelectTupleElementTransformFunction extends BaseTransformF
       combinations.put(numericType, numericTypes);
     }
     combinations.put(FieldSpec.DataType.TIMESTAMP, EnumSet.of(FieldSpec.DataType.TIMESTAMP));
+    combinations.put(FieldSpec.DataType.TIMESTAMP_NTZ, EnumSet.of(FieldSpec.DataType.TIMESTAMP_NTZ));
     combinations.put(FieldSpec.DataType.STRING, EnumSet.of(FieldSpec.DataType.STRING));
     return combinations;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SelectTupleElementTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SelectTupleElementTransformFunction.java
@@ -33,8 +33,8 @@ public abstract class SelectTupleElementTransformFunction extends BaseTransformF
 
   private static final EnumSet<FieldSpec.DataType> SUPPORTED_DATATYPES = EnumSet.of(FieldSpec.DataType.INT,
       FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.BIG_DECIMAL,
-      FieldSpec.DataType.TIMESTAMP, FieldSpec.DataType.TIMESTAMP_NTZ, FieldSpec.DataType.STRING,
-      FieldSpec.DataType.UNKNOWN);
+      FieldSpec.DataType.TIMESTAMP, FieldSpec.DataType.TIMESTAMP_NTZ, FieldSpec.DataType.DATE, FieldSpec.DataType.TIME,
+      FieldSpec.DataType.STRING, FieldSpec.DataType.UNKNOWN);
 
   private static final EnumMap<FieldSpec.DataType, EnumSet<FieldSpec.DataType>> ACCEPTABLE_COMBINATIONS =
       createAcceptableCombinations();
@@ -113,6 +113,8 @@ public abstract class SelectTupleElementTransformFunction extends BaseTransformF
     }
     combinations.put(FieldSpec.DataType.TIMESTAMP, EnumSet.of(FieldSpec.DataType.TIMESTAMP));
     combinations.put(FieldSpec.DataType.TIMESTAMP_NTZ, EnumSet.of(FieldSpec.DataType.TIMESTAMP_NTZ));
+    combinations.put(FieldSpec.DataType.DATE, EnumSet.of(FieldSpec.DataType.DATE));
+    combinations.put(FieldSpec.DataType.TIME, EnumSet.of(FieldSpec.DataType.TIME));
     combinations.put(FieldSpec.DataType.STRING, EnumSet.of(FieldSpec.DataType.STRING));
     return combinations;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -299,6 +299,7 @@ public class AggregationFunctionFactory {
                   return new ArrayAggDistinctIntFunction(firstArgument, dataType, nullHandlingEnabled);
                 case LONG:
                 case TIMESTAMP:
+                case TIMESTAMP_NTZ:
                   return new ArrayAggDistinctLongFunction(firstArgument, dataType, nullHandlingEnabled);
                 case FLOAT:
                   return new ArrayAggDistinctFloatFunction(firstArgument, nullHandlingEnabled);
@@ -316,6 +317,7 @@ public class AggregationFunctionFactory {
                 return new ArrayAggIntFunction(firstArgument, dataType, nullHandlingEnabled);
               case LONG:
               case TIMESTAMP:
+              case TIMESTAMP_NTZ:
                 return new ArrayAggLongFunction(firstArgument, dataType, nullHandlingEnabled);
               case FLOAT:
                 return new ArrayAggFloatFunction(firstArgument, nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -300,6 +300,8 @@ public class AggregationFunctionFactory {
                 case LONG:
                 case TIMESTAMP:
                 case TIMESTAMP_NTZ:
+                case DATE:
+                case TIME:
                   return new ArrayAggDistinctLongFunction(firstArgument, dataType, nullHandlingEnabled);
                 case FLOAT:
                   return new ArrayAggDistinctFloatFunction(firstArgument, nullHandlingEnabled);
@@ -318,6 +320,8 @@ public class AggregationFunctionFactory {
               case LONG:
               case TIMESTAMP:
               case TIMESTAMP_NTZ:
+              case DATE:
+              case TIME:
                 return new ArrayAggLongFunction(firstArgument, dataType, nullHandlingEnabled);
               case FLOAT:
                 return new ArrayAggFloatFunction(firstArgument, nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -25,7 +25,9 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -221,6 +223,10 @@ public class AggregationFunctionUtils {
         return new Timestamp(dataTable.getLong(rowId, colId));
       case TIMESTAMP_NTZ:
         return LocalDateTime.ofInstant(Instant.ofEpochMilli(dataTable.getLong(rowId, colId)), ZoneId.of("UTC"));
+      case DATE:
+        return LocalDate.ofEpochDay(dataTable.getLong(rowId, colId));
+      case TIME:
+        return LocalTime.ofNanoOfDay(dataTable.getLong(rowId, colId) * 1000000);
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);
@@ -260,6 +266,24 @@ public class AggregationFunctionUtils {
           localDateTimeValues[i] = LocalDateTime.ofInstant(Instant.ofEpochMilli(longValues[i]), ZoneId.of("UTC"));
         }
         return localDateTimeValues;
+      }
+      case DATE_ARRAY: {
+        long[] longValues = dataTable.getLongArray(rowId, colId);
+        int numValues = longValues.length;
+        LocalDate[] localDateValues = new LocalDate[numValues];
+        for (int i = 0; i < numValues; i++) {
+          localDateValues[i] = LocalDate.ofEpochDay(longValues[i]);
+        }
+        return localDateValues;
+      }
+      case TIME_ARRAY: {
+        long[] longValues = dataTable.getLongArray(rowId, colId);
+        int numValues = longValues.length;
+        LocalTime[] localTimeValues = new LocalTime[numValues];
+        for (int i = 0; i < numValues; i++) {
+          localTimeValues[i] = LocalTime.ofNanoOfDay(longValues[i] * 1000000);
+        }
+        return localTimeValues;
       }
       case STRING_ARRAY:
         return dataTable.getStringArray(rowId, colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -24,6 +24,9 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -216,6 +219,8 @@ public class AggregationFunctionUtils {
         return dataTable.getInt(rowId, colId) == 1;
       case TIMESTAMP:
         return new Timestamp(dataTable.getLong(rowId, colId));
+      case TIMESTAMP_NTZ:
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(dataTable.getLong(rowId, colId)), ZoneId.of("UTC"));
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);
@@ -246,6 +251,15 @@ public class AggregationFunctionUtils {
           timestampValues[i] = new Timestamp(longValues[i]);
         }
         return timestampValues;
+      }
+      case TIMESTAMP_NTZ_ARRAY: {
+        long[] longValues = dataTable.getLongArray(rowId, colId);
+        int numValues = longValues.length;
+        LocalDateTime[] localDateTimeValues = new LocalDateTime[numValues];
+        for (int i = 0; i < numValues; i++) {
+          localDateTimeValues[i] = LocalDateTime.ofInstant(Instant.ofEpochMilli(longValues[i]), ZoneId.of("UTC"));
+        }
+        return localDateTimeValues;
       }
       case STRING_ARRAY:
         return dataTable.getStringArray(rowId, colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
@@ -194,6 +194,11 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
                 new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP, blockValSet));
             projectionColTypes[i] = DataSchema.ColumnDataType.LONG;
             break;
+          case TIMESTAMP_NTZ:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP_NTZ, blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG;
+            break;
           case FLOAT:
             exprMinMaxWrapperProjectionColumnSets.add(
                 new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.FLOAT, blockValSet));
@@ -248,6 +253,12 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
           case TIMESTAMP:
             exprMinMaxWrapperProjectionColumnSets.add(
                 new ExprMinMaxProjectionValSetWrapper(false, DataSchema.ColumnDataType.TIMESTAMP_ARRAY, blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG_ARRAY;
+            break;
+          case TIMESTAMP_NTZ:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(false, DataSchema.ColumnDataType.TIMESTAMP_NTZ_ARRAY,
+                    blockValSet));
             projectionColTypes[i] = DataSchema.ColumnDataType.LONG_ARRAY;
             break;
           case FLOAT:
@@ -310,6 +321,11 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
         case TIMESTAMP:
           exprMinMaxWrapperMeasuringColumnSets.add(
               new ExprMinMaxMeasuringValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP, blockValSet));
+          measuringColTypes[i] = DataSchema.ColumnDataType.LONG;
+          break;
+        case TIMESTAMP_NTZ:
+          exprMinMaxWrapperMeasuringColumnSets.add(
+              new ExprMinMaxMeasuringValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP_NTZ, blockValSet));
           measuringColTypes[i] = DataSchema.ColumnDataType.LONG;
           break;
         case FLOAT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
@@ -199,6 +199,16 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
                 new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP_NTZ, blockValSet));
             projectionColTypes[i] = DataSchema.ColumnDataType.LONG;
             break;
+          case DATE:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.DATE, blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG;
+            break;
+          case TIME:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.TIME, blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG;
+            break;
           case FLOAT:
             exprMinMaxWrapperProjectionColumnSets.add(
                 new ExprMinMaxProjectionValSetWrapper(true, DataSchema.ColumnDataType.FLOAT, blockValSet));
@@ -258,6 +268,18 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
           case TIMESTAMP_NTZ:
             exprMinMaxWrapperProjectionColumnSets.add(
                 new ExprMinMaxProjectionValSetWrapper(false, DataSchema.ColumnDataType.TIMESTAMP_NTZ_ARRAY,
+                    blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG_ARRAY;
+            break;
+          case DATE:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(false, DataSchema.ColumnDataType.DATE_ARRAY,
+                    blockValSet));
+            projectionColTypes[i] = DataSchema.ColumnDataType.LONG_ARRAY;
+            break;
+          case TIME:
+            exprMinMaxWrapperProjectionColumnSets.add(
+                new ExprMinMaxProjectionValSetWrapper(false, DataSchema.ColumnDataType.TIME_ARRAY,
                     blockValSet));
             projectionColTypes[i] = DataSchema.ColumnDataType.LONG_ARRAY;
             break;
@@ -326,6 +348,16 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
         case TIMESTAMP_NTZ:
           exprMinMaxWrapperMeasuringColumnSets.add(
               new ExprMinMaxMeasuringValSetWrapper(true, DataSchema.ColumnDataType.TIMESTAMP_NTZ, blockValSet));
+          measuringColTypes[i] = DataSchema.ColumnDataType.LONG;
+          break;
+        case DATE:
+          exprMinMaxWrapperMeasuringColumnSets.add(
+              new ExprMinMaxMeasuringValSetWrapper(true, DataSchema.ColumnDataType.DATE, blockValSet));
+          measuringColTypes[i] = DataSchema.ColumnDataType.LONG;
+          break;
+        case TIME:
+          exprMinMaxWrapperMeasuringColumnSets.add(
+              new ExprMinMaxMeasuringValSetWrapper(true, DataSchema.ColumnDataType.TIME, blockValSet));
           measuringColTypes[i] = DataSchema.ColumnDataType.LONG;
           break;
         case FLOAT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxMeasuringValSetWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxMeasuringValSetWrapper.java
@@ -42,6 +42,8 @@ public class ExprMinMaxMeasuringValSetWrapper extends ExprMinMaxWrapperValSet {
       case LONG:
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case DATE:
+      case TIME:
         return _longValues[i];
       case FLOAT:
         return _floatValues[i];
@@ -63,6 +65,8 @@ public class ExprMinMaxMeasuringValSetWrapper extends ExprMinMaxWrapperValSet {
         case LONG:
         case TIMESTAMP:
         case TIMESTAMP_NTZ:
+        case DATE:
+        case TIME:
           return Long.compare((Long) o, _longValues[i]);
         case FLOAT:
           return Float.compare((Float) o, _floatValues[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxMeasuringValSetWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxMeasuringValSetWrapper.java
@@ -41,6 +41,7 @@ public class ExprMinMaxMeasuringValSetWrapper extends ExprMinMaxWrapperValSet {
         return _intValues[i];
       case LONG:
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
         return _longValues[i];
       case FLOAT:
         return _floatValues[i];
@@ -61,6 +62,7 @@ public class ExprMinMaxMeasuringValSetWrapper extends ExprMinMaxWrapperValSet {
           return Integer.compare((Integer) o, _intValues[i]);
         case LONG:
         case TIMESTAMP:
+        case TIMESTAMP_NTZ:
           return Long.compare((Long) o, _longValues[i]);
         case FLOAT:
           return Float.compare((Float) o, _floatValues[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxObject.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxObject.java
@@ -231,6 +231,8 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
           case LONG:
           case TIMESTAMP:
           case TIMESTAMP_NTZ:
+          case DATE:
+          case TIME:
             extremumKeys[i] = _immutableMeasuringKeys.getLong(0, i);
             break;
           case FLOAT:
@@ -267,6 +269,8 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
           return _immutableProjectionVals.getInt(rowId, colId);
         case TIMESTAMP:
         case TIMESTAMP_NTZ:
+        case DATE:
+        case TIME:
         case LONG:
           return _immutableProjectionVals.getLong(rowId, colId);
         case FLOAT:
@@ -286,6 +290,8 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
         case TIMESTAMP_ARRAY:
         case TIMESTAMP_NTZ_ARRAY:
         case LONG_ARRAY:
+        case DATE_ARRAY:
+        case TIME_ARRAY:
           return _immutableProjectionVals.getLongArray(rowId, colId);
         case FLOAT_ARRAY:
           return _immutableProjectionVals.getFloatArray(rowId, colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxObject.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxObject.java
@@ -230,6 +230,7 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
             break;
           case LONG:
           case TIMESTAMP:
+          case TIMESTAMP_NTZ:
             extremumKeys[i] = _immutableMeasuringKeys.getLong(0, i);
             break;
           case FLOAT:
@@ -265,6 +266,7 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
         case INT:
           return _immutableProjectionVals.getInt(rowId, colId);
         case TIMESTAMP:
+        case TIMESTAMP_NTZ:
         case LONG:
           return _immutableProjectionVals.getLong(rowId, colId);
         case FLOAT:
@@ -282,6 +284,7 @@ public class ExprMinMaxObject implements ParentAggregationFunctionResultObject {
         case INT_ARRAY:
           return _immutableProjectionVals.getIntArray(rowId, colId);
         case TIMESTAMP_ARRAY:
+        case TIMESTAMP_NTZ_ARRAY:
         case LONG_ARRAY:
           return _immutableProjectionVals.getLongArray(rowId, colId);
         case FLOAT_ARRAY:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxProjectionValSetWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxProjectionValSetWrapper.java
@@ -41,6 +41,7 @@ public class ExprMinMaxProjectionValSetWrapper extends ExprMinMaxWrapperValSet {
         return _intValues[i];
       case LONG:
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
         return _longValues[i];
       case FLOAT:
         return _floatValues[i];
@@ -55,6 +56,7 @@ public class ExprMinMaxProjectionValSetWrapper extends ExprMinMaxWrapperValSet {
         return _intValuesMV[i].length == 0 ? null : _intValuesMV[i];
       case LONG_ARRAY:
       case TIMESTAMP_ARRAY:
+      case TIMESTAMP_NTZ_ARRAY:
         return _longValuesMV[i].length == 0 ? null : _longValuesMV[i];
       case FLOAT_ARRAY:
         return _floatValuesMV[i].length == 0 ? null : _floatValuesMV[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxProjectionValSetWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxProjectionValSetWrapper.java
@@ -42,6 +42,8 @@ public class ExprMinMaxProjectionValSetWrapper extends ExprMinMaxWrapperValSet {
       case LONG:
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case DATE:
+      case TIME:
         return _longValues[i];
       case FLOAT:
         return _floatValues[i];
@@ -57,6 +59,8 @@ public class ExprMinMaxProjectionValSetWrapper extends ExprMinMaxWrapperValSet {
       case LONG_ARRAY:
       case TIMESTAMP_ARRAY:
       case TIMESTAMP_NTZ_ARRAY:
+      case DATE_ARRAY:
+      case TIME_ARRAY:
         return _longValuesMV[i].length == 0 ? null : _longValuesMV[i];
       case FLOAT_ARRAY:
         return _floatValuesMV[i].length == 0 ? null : _floatValuesMV[i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxWrapperValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxWrapperValSet.java
@@ -56,6 +56,8 @@ public class ExprMinMaxWrapperValSet {
         case LONG:
         case TIMESTAMP:
         case TIMESTAMP_NTZ:
+        case DATE:
+        case TIME:
           _longValues = blockValSet.getLongValuesSV();
           break;
         case FLOAT:
@@ -86,6 +88,8 @@ public class ExprMinMaxWrapperValSet {
         case LONG_ARRAY:
         case TIMESTAMP_ARRAY:
         case TIMESTAMP_NTZ_ARRAY:
+        case DATE_ARRAY:
+        case TIME_ARRAY:
           _longValuesMV = blockValSet.getLongValuesMV();
           break;
         case FLOAT_ARRAY:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxWrapperValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/exprminmax/ExprMinMaxWrapperValSet.java
@@ -55,6 +55,7 @@ public class ExprMinMaxWrapperValSet {
           break;
         case LONG:
         case TIMESTAMP:
+        case TIMESTAMP_NTZ:
           _longValues = blockValSet.getLongValuesSV();
           break;
         case FLOAT:
@@ -84,6 +85,7 @@ public class ExprMinMaxWrapperValSet {
           break;
         case LONG_ARRAY:
         case TIMESTAMP_ARRAY:
+        case TIMESTAMP_NTZ_ARRAY:
           _longValuesMV = blockValSet.getLongValuesMV();
           break;
         case FLOAT_ARRAY:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -24,6 +24,9 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -513,6 +516,8 @@ public class GroupByDataTableReducer implements DataTableReducer {
         return dataTable.getInt(rowId, colId) == 1;
       case TIMESTAMP:
         return new Timestamp(dataTable.getLong(rowId, colId));
+      case TIMESTAMP_NTZ:
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(dataTable.getLong(rowId, colId)), ZoneId.of("UTC"));
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -25,7 +25,9 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -518,6 +520,10 @@ public class GroupByDataTableReducer implements DataTableReducer {
         return new Timestamp(dataTable.getLong(rowId, colId));
       case TIMESTAMP_NTZ:
         return LocalDateTime.ofInstant(Instant.ofEpochMilli(dataTable.getLong(rowId, colId)), ZoneId.of("UTC"));
+      case DATE:
+        return LocalDate.ofEpochDay(dataTable.getLong(rowId, colId));
+      case TIME:
+        return LocalTime.ofNanoOfDay(dataTable.getLong(rowId, colId) * 1000000);
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.query.reduce.filter;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
@@ -76,6 +78,8 @@ public class PredicateRowMatcher implements RowMatcher {
         return _predicateEvaluator.applySV((boolean) value ? 1 : 0);
       case TIMESTAMP:
         return _predicateEvaluator.applySV(((Timestamp) value).getTime());
+      case TIMESTAMP_NTZ:
+        return _predicateEvaluator.applySV(((LocalDateTime) value).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
       case STRING:
         return _predicateEvaluator.applySV((String) value);
       case BYTES:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
@@ -20,7 +20,9 @@ package org.apache.pinot.core.query.reduce.filter;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.predicate.Predicate;
@@ -80,6 +82,10 @@ public class PredicateRowMatcher implements RowMatcher {
         return _predicateEvaluator.applySV(((Timestamp) value).getTime());
       case TIMESTAMP_NTZ:
         return _predicateEvaluator.applySV(((LocalDateTime) value).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+      case DATE:
+        return _predicateEvaluator.applySV(((LocalDate) value).toEpochDay());
+      case TIME:
+        return _predicateEvaluator.applySV(((LocalTime) value).toNanoOfDay() / 1000000);
       case STRING:
         return _predicateEvaluator.applySV((String) value);
       case BYTES:

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
@@ -86,6 +86,7 @@ public class GapfillUtils {
       case DOUBLE:
       case BOOLEAN:
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
         return dataType.convertAndFormat(0);
       case STRING:
       case JSON:
@@ -101,6 +102,7 @@ public class GapfillUtils {
         return new double[0];
       case STRING_ARRAY:
       case TIMESTAMP_ARRAY:
+      case TIMESTAMP_NTZ_ARRAY:
         return new String[0];
       case BOOLEAN_ARRAY:
         return new boolean[0];

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
@@ -87,6 +87,8 @@ public class GapfillUtils {
       case BOOLEAN:
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case DATE:
+      case TIME:
         return dataType.convertAndFormat(0);
       case STRING:
       case JSON:
@@ -103,6 +105,8 @@ public class GapfillUtils {
       case STRING_ARRAY:
       case TIMESTAMP_ARRAY:
       case TIMESTAMP_NTZ_ARRAY:
+      case DATE_ARRAY:
+      case TIME_ARRAY:
         return new String[0];
       case BOOLEAN_ARRAY:
         return new boolean[0];

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -50,6 +50,10 @@ public class DataBlockTestUtils {
           row[colId] = RANDOM.nextInt();
           break;
         case LONG:
+        case TIMESTAMP:
+        case TIMESTAMP_NTZ:
+        case DATE:
+        case TIME:
           row[colId] = RANDOM.nextLong();
           break;
         case FLOAT:
@@ -63,9 +67,6 @@ public class DataBlockTestUtils {
           break;
         case BOOLEAN:
           row[colId] = RANDOM.nextBoolean() ? 1 : 0;
-          break;
-        case TIMESTAMP:
-          row[colId] = RANDOM.nextLong();
           break;
         case STRING:
           row[colId] = RandomStringUtils.random(RANDOM.nextInt(20));
@@ -82,6 +83,10 @@ public class DataBlockTestUtils {
           row[colId] = intArray;
           break;
         case LONG_ARRAY:
+        case TIMESTAMP_ARRAY:
+        case TIMESTAMP_NTZ_ARRAY:
+        case DATE_ARRAY:
+        case TIME_ARRAY:
           length = RANDOM.nextInt(ARRAY_SIZE);
           long[] longArray = new long[length];
           for (int i = 0; i < length; i++) {
@@ -120,14 +125,6 @@ public class DataBlockTestUtils {
             booleanArray[i] = RANDOM.nextBoolean() ? 1 : 0;
           }
           row[colId] = booleanArray;
-          break;
-        case TIMESTAMP_ARRAY:
-          length = RANDOM.nextInt(ARRAY_SIZE);
-          long[] timestampArray = new long[length];
-          for (int i = 0; i < length; i++) {
-            timestampArray[i] = RANDOM.nextLong();
-          }
-          row[colId] = timestampArray;
           break;
         case MAP:
           length = RANDOM.nextInt(ARRAY_SIZE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -59,6 +59,9 @@ public class DataTableSerDeTest {
   private static final BigDecimal[] BIG_DECIMALS = new BigDecimal[NUM_ROWS];
   private static final int[] BOOLEANS = new int[NUM_ROWS];
   private static final long[] TIMESTAMPS = new long[NUM_ROWS];
+  private static final long[] TIMESTAMP_NTZS = new long[NUM_ROWS];
+  private static final long[] DATES = new long[NUM_ROWS];
+  private static final long[] TIMES = new long[NUM_ROWS];
   private static final String[] STRINGS = new String[NUM_ROWS];
   private static final String[] JSONS = new String[NUM_ROWS];
   private static final byte[][] BYTES = new byte[NUM_ROWS][];
@@ -69,6 +72,9 @@ public class DataTableSerDeTest {
   private static final double[][] DOUBLE_ARRAYS = new double[NUM_ROWS][];
   private static final int[][] BOOLEAN_ARRAYS = new int[NUM_ROWS][];
   private static final long[][] TIMESTAMP_ARRAYS = new long[NUM_ROWS][];
+  private static final long[][] TIMESTAMP_NTZ_ARRAYS = new long[NUM_ROWS][];
+  private static final long[][] DATE_ARRAYS = new long[NUM_ROWS][];
+  private static final long[][] TIME_ARRAYS = new long[NUM_ROWS][];
   private static final String[][] STRING_ARRAYS = new String[NUM_ROWS][];
   private static final Map<String, Object>[] MAPS = new Map[NUM_ROWS];
 
@@ -350,6 +356,18 @@ public class DataTableSerDeTest {
             TIMESTAMPS[rowId] = isNull ? 0 : RANDOM.nextLong();
             dataTableBuilder.setColumn(colId, TIMESTAMPS[rowId]);
             break;
+          case TIMESTAMP_NTZ:
+            TIMESTAMP_NTZS[rowId] = isNull ? 0 : RANDOM.nextLong();
+            dataTableBuilder.setColumn(colId, TIMESTAMP_NTZS[rowId]);
+            break;
+          case DATE:
+            DATES[rowId] = isNull ? 0 : RANDOM.nextLong();
+            dataTableBuilder.setColumn(colId, DATES[rowId]);
+            break;
+          case TIME:
+            TIMES[rowId] = isNull ? 0 : RANDOM.nextLong();
+            dataTableBuilder.setColumn(colId, TIMES[rowId]);
+            break;
           case BOOLEAN:
             BOOLEANS[rowId] = isNull ? 0 : RANDOM.nextInt(2);
             dataTableBuilder.setColumn(colId, BOOLEANS[rowId]);
@@ -425,6 +443,33 @@ public class DataTableSerDeTest {
             TIMESTAMP_ARRAYS[rowId] = timestampArray;
             dataTableBuilder.setColumn(colId, timestampArray);
             break;
+          case TIMESTAMP_NTZ_ARRAY:
+            length = RANDOM.nextInt(20);
+            long[] timestampNTZArray = new long[length];
+            for (int i = 0; i < length; i++) {
+              timestampNTZArray[i] = RANDOM.nextLong();
+            }
+            TIMESTAMP_NTZ_ARRAYS[rowId] = timestampNTZArray;
+            dataTableBuilder.setColumn(colId, timestampNTZArray);
+            break;
+          case DATE_ARRAY:
+            length = RANDOM.nextInt(20);
+            long[] dateArray = new long[length];
+            for (int i = 0; i < length; i++) {
+              dateArray[i] = RANDOM.nextLong();
+            }
+            DATE_ARRAYS[rowId] = dateArray;
+            dataTableBuilder.setColumn(colId, dateArray);
+            break;
+          case TIME_ARRAY:
+            length = RANDOM.nextInt(20);
+            long[] timeArray = new long[length];
+            for (int i = 0; i < length; i++) {
+              timeArray[i] = RANDOM.nextLong();
+            }
+            TIME_ARRAYS[rowId] = timeArray;
+            dataTableBuilder.setColumn(colId, timeArray);
+            break;
           case BYTES_ARRAY:
             // TODO: add once implementation of datatable bytes array support is added
             break;
@@ -497,6 +542,15 @@ public class DataTableSerDeTest {
           case TIMESTAMP:
             Assert.assertEquals(newDataTable.getLong(rowId, colId), isNull ? 0 : TIMESTAMPS[rowId], ERROR_MESSAGE);
             break;
+          case TIMESTAMP_NTZ:
+            Assert.assertEquals(newDataTable.getLong(rowId, colId), isNull ? 0 : TIMESTAMP_NTZS[rowId], ERROR_MESSAGE);
+            break;
+          case DATE:
+            Assert.assertEquals(newDataTable.getLong(rowId, colId), isNull ? 0 : DATES[rowId], ERROR_MESSAGE);
+            break;
+          case TIME:
+            Assert.assertEquals(newDataTable.getLong(rowId, colId), isNull ? 0 : TIMES[rowId], ERROR_MESSAGE);
+            break;
           case STRING:
             Assert.assertEquals(newDataTable.getString(rowId, colId), isNull ? "" : STRINGS[rowId], ERROR_MESSAGE);
             break;
@@ -537,6 +591,18 @@ public class DataTableSerDeTest {
             break;
           case TIMESTAMP_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getLongArray(rowId, colId), TIMESTAMP_ARRAYS[rowId]),
+                ERROR_MESSAGE);
+            break;
+          case TIMESTAMP_NTZ_ARRAY:
+            Assert.assertTrue(Arrays.equals(newDataTable.getLongArray(rowId, colId), TIMESTAMP_NTZ_ARRAYS[rowId]),
+                ERROR_MESSAGE);
+            break;
+          case DATE_ARRAY:
+            Assert.assertTrue(Arrays.equals(newDataTable.getLongArray(rowId, colId), DATE_ARRAYS[rowId]),
+                ERROR_MESSAGE);
+            break;
+          case TIME_ARRAY:
+            Assert.assertTrue(Arrays.equals(newDataTable.getLongArray(rowId, colId), TIME_ARRAYS[rowId]),
                 ERROR_MESSAGE);
             break;
           case BYTES_ARRAY:

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DateAndTimeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DateAndTimeQueriesTest.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Queries test for TIMESTAMP_NTZ data type.
+ */
+
+public class DateAndTimeQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "DateAndTimeQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final long BASE_DAYS = LocalDate.parse("2024-11-11").toEpochDay();
+  private static final long BASE_MILLS_OF_DAY = LocalTime.parse("11:11:11.111").toNanoOfDay() / 1000000;
+
+  private static final int NUM_RECORDS = 1000;
+
+  private static final String DATE_COLUMN = "dateColumn";
+  private static final String TIME_COLUMN = "timeColumn";
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().addSingleValueDimension(DATE_COLUMN, DataType.DATE)
+          .addSingleValueDimension(TIME_COLUMN, DataType.TIME).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      GenericRow record = new GenericRow();
+      long days = BASE_DAYS + i;
+      long mills = BASE_MILLS_OF_DAY + i;
+      // Insert data in 3 different formats
+      if (i % 3 == 0) {
+        record.putValue(DATE_COLUMN, days);
+        record.putValue(TIME_COLUMN, mills);
+      } else if (i % 3 == 1) {
+        record.putValue(DATE_COLUMN, LocalDate.ofEpochDay(days));
+        record.putValue(TIME_COLUMN, LocalTime.ofNanoOfDay(mills * 1000000));
+      } else {
+        record.putValue(DATE_COLUMN, LocalDate.ofEpochDay(days).toString());
+        record.putValue(TIME_COLUMN, LocalTime.ofNanoOfDay(mills * 1000000).toString());
+      }
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testQueries() {
+    {
+      String query = "SELECT * FROM testTable";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{DATE_COLUMN, TIME_COLUMN},
+              new ColumnDataType[]{ColumnDataType.DATE, ColumnDataType.TIME}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 2);
+        assertEquals(row[0], LocalDate.ofEpochDay(BASE_DAYS + i).toString());
+        assertEquals(row[1], LocalTime.ofNanoOfDay((BASE_MILLS_OF_DAY + i) * 1000000).toString());
+      }
+    }
+    {
+      // TODO: if use `ORDER BY dateColumn, timeColumn`, the test will fail
+      String query = "SELECT * FROM testTable ORDER BY dateColumn DESC LIMIT 40";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{DATE_COLUMN, TIME_COLUMN},
+              new ColumnDataType[]{ColumnDataType.DATE, ColumnDataType.TIME}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 40);
+      for (int i = 0; i < 10; i++) {
+        String expectedDate = LocalDate.ofEpochDay(BASE_DAYS + NUM_RECORDS - 1 - i).toString();
+        String expectedTime = LocalTime.ofNanoOfDay((BASE_MILLS_OF_DAY + NUM_RECORDS - 1 - i) * 1000000).toString();
+        for (int j = 0; j < 4; j++) {
+          Object[] row = rows.get(i * 4 + j);
+          assertEquals(row.length, 2);
+          assertEquals(row[0], expectedDate);
+          assertEquals(row[1], expectedTime);
+        }
+      }
+    }
+    {
+      String query = "SELECT DISTINCT dateColumn, timeColumn FROM testTable ORDER BY dateColumn";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{DATE_COLUMN, TIME_COLUMN},
+              new ColumnDataType[]{ColumnDataType.DATE, ColumnDataType.TIME}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 2);
+        assertEquals(row[0], LocalDate.ofEpochDay(BASE_DAYS + i).toString());
+        assertEquals(row[1], LocalTime.ofNanoOfDay((BASE_MILLS_OF_DAY + i) * 1000000).toString());
+      }
+    }
+    {
+      String query =
+          "SELECT COUNT(*) AS count, dateColumn, timeColumn FROM testTable GROUP BY dateColumn, timeColumn "
+              + "ORDER BY timeColumn DESC";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema, new DataSchema(new String[]{"count", DATE_COLUMN, TIME_COLUMN},
+          new ColumnDataType[]{ColumnDataType.LONG, ColumnDataType.DATE, ColumnDataType.TIME}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 3);
+        assertEquals(row[0], 4L);
+        assertEquals(row[1], LocalDate.ofEpochDay(BASE_DAYS + NUM_RECORDS - i - 1).toString());
+        assertEquals(row[2], LocalTime.ofNanoOfDay((BASE_MILLS_OF_DAY + NUM_RECORDS - i - 1) * 1000000).toString());
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+          throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TimestampNTZQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TimestampNTZQueriesTest.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Queries test for TIMESTAMP_NTZ data type.
+ */
+public class TimestampNTZQueriesTest extends BaseQueriesTest {
+  private static final ZoneId ZONE_ID = ZoneId.of("UTC");
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "TimestampNTZQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final long BASE_TIMESTAMP = LocalDateTime.parse("2024-11-11T11:11:11")
+      .atZone(ZONE_ID).toInstant().toEpochMilli();
+
+  private static final int NUM_RECORDS = 1000;
+
+  private static final String TIMESTAMP_NTZ_COLUMN = "timestampNTZColumn";
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().addSingleValueDimension(TIMESTAMP_NTZ_COLUMN, DataType.TIMESTAMP_NTZ).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      GenericRow record = new GenericRow();
+      long timestamp = BASE_TIMESTAMP + i;
+      // Insert data in 3 different formats
+      if (i % 3 == 0) {
+        record.putValue(TIMESTAMP_NTZ_COLUMN, timestamp);
+      } else if (i % 3 == 1) {
+        record.putValue(TIMESTAMP_NTZ_COLUMN, LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZONE_ID));
+      } else {
+        record.putValue(TIMESTAMP_NTZ_COLUMN, LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZONE_ID)
+            .toString());
+      }
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testQueries() {
+    {
+      String query = "SELECT * FROM testTable";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{TIMESTAMP_NTZ_COLUMN}, new ColumnDataType[]{ColumnDataType.TIMESTAMP_NTZ}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 1);
+        assertEquals(row[0], LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(BASE_TIMESTAMP + i), ZONE_ID).toString());
+      }
+    }
+    {
+      String query = "SELECT * FROM testTable ORDER BY timestampNTZColumn DESC LIMIT 40";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{TIMESTAMP_NTZ_COLUMN}, new ColumnDataType[]{ColumnDataType.TIMESTAMP_NTZ}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 40);
+      for (int i = 0; i < 10; i++) {
+        String expectedResult = LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(BASE_TIMESTAMP + NUM_RECORDS - 1 - i), ZONE_ID).toString();
+        for (int j = 0; j < 4; j++) {
+          Object[] row = rows.get(i * 4 + j);
+          assertEquals(row.length, 1);
+          assertEquals(row[0], expectedResult);
+        }
+      }
+    }
+    {
+      String query = "SELECT DISTINCT timestampNTZColumn FROM testTable ORDER BY timestampNTZColumn";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{TIMESTAMP_NTZ_COLUMN}, new ColumnDataType[]{ColumnDataType.TIMESTAMP_NTZ}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 1);
+        assertEquals(row[0], LocalDateTime.ofInstant(Instant.ofEpochMilli(BASE_TIMESTAMP + i), ZONE_ID).toString());
+      }
+    }
+    {
+      String query =
+          "SELECT COUNT(*) AS count, timestampNTZColumn FROM testTable GROUP BY timestampNTZColumn "
+              + "ORDER BY timestampNTZColumn DESC";
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema, new DataSchema(new String[]{"count", TIMESTAMP_NTZ_COLUMN},
+          new ColumnDataType[]{ColumnDataType.LONG, ColumnDataType.TIMESTAMP_NTZ}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 2);
+        assertEquals(row[0], 4L);
+        assertEquals(row[1], LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(BASE_TIMESTAMP + NUM_RECORDS - i - 1), ZONE_ID).toString());
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -401,6 +401,8 @@ public final class RelToPlanNodeConverter {
       case DATE:
       case TIME:
       case TIMESTAMP:
+        return isArray ? ColumnDataType.TIMESTAMP_NTZ_ARRAY : ColumnDataType.TIMESTAMP_NTZ;
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         return isArray ? ColumnDataType.TIMESTAMP_ARRAY : ColumnDataType.TIMESTAMP;
       case CHAR:
       case VARCHAR:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -399,7 +399,9 @@ public final class RelToPlanNodeConverter {
       case DOUBLE:
         return isArray ? ColumnDataType.DOUBLE_ARRAY : ColumnDataType.DOUBLE;
       case DATE:
+        return isArray ? ColumnDataType.DATE_ARRAY : ColumnDataType.DATE;
       case TIME:
+        return isArray ? ColumnDataType.TIME_ARRAY : ColumnDataType.TIME;
       case TIMESTAMP:
         return isArray ? ColumnDataType.TIMESTAMP_NTZ_ARRAY : ColumnDataType.TIMESTAMP_NTZ;
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -276,12 +276,20 @@ public class RexExpressionUtils {
         break;
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
-        value = ((Calendar) value).getTimeInMillis();
+        if (value instanceof Calendar) {
+          value = ((Calendar) value).getTimeInMillis();
+        } else if (value instanceof TimestampString) {
+          value = ((TimestampString) value).getMillisSinceEpoch();
+        } else {
+          throw new IllegalStateException("Unsupported value type: " + value.getClass().getName());
+        }
         break;
       case DATE:
+        value = ((Calendar) value).getTimeInMillis() / 86400000L;
+        break;
       case TIME:
-        // FIXME confirm value type
-        throw new IllegalStateException("value type: " + value.getClass());
+        value = ((Calendar) value).getTimeInMillis();
+        break;
       case STRING:
         value = ((NlsString) value).getValue();
         break;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -45,8 +45,10 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Sarg;
+import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
@@ -139,6 +141,16 @@ public class RexExpressionUtils {
         TimestampString tsString = TimestampString.fromMillisSinceEpoch((long) value);
         return rexBuilder.makeTimestampLiteral(tsString, 1);
       }
+      case DATE: {
+        assert value != null;
+        DateString dateString = DateString.fromDaysSinceEpoch((int) (long) value);
+        return rexBuilder.makeDateLiteral(dateString);
+      }
+      case TIME: {
+        assert value != null;
+        TimeString timeString = TimeString.fromMillisOfDay((int) (long) value);
+        return rexBuilder.makeTimeLiteral(timeString, 1);
+      }
       case JSON:
       case STRING: {
         assert value != null;
@@ -160,6 +172,8 @@ public class RexExpressionUtils {
       case STRING_ARRAY:
       case TIMESTAMP_ARRAY:
       case TIMESTAMP_NTZ_ARRAY:
+      case DATE_ARRAY:
+      case TIME_ARRAY:
       case OBJECT:
       case UNKNOWN:
       default:
@@ -264,6 +278,10 @@ public class RexExpressionUtils {
       case TIMESTAMP_NTZ:
         value = ((Calendar) value).getTimeInMillis();
         break;
+      case DATE:
+      case TIME:
+        // FIXME(idellzheng)
+        throw new IllegalStateException("value type: " + value.getClass());
       case STRING:
         value = ((NlsString) value).getValue();
         break;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -132,6 +132,11 @@ public class RexExpressionUtils {
       case TIMESTAMP: {
         assert value != null;
         TimestampString tsString = TimestampString.fromMillisSinceEpoch((long) value);
+        return rexBuilder.makeTimestampWithLocalTimeZoneLiteral(tsString, 1);
+      }
+      case TIMESTAMP_NTZ: {
+        assert value != null;
+        TimestampString tsString = TimestampString.fromMillisSinceEpoch((long) value);
         return rexBuilder.makeTimestampLiteral(tsString, 1);
       }
       case JSON:
@@ -154,6 +159,7 @@ public class RexExpressionUtils {
       case LONG_ARRAY:
       case STRING_ARRAY:
       case TIMESTAMP_ARRAY:
+      case TIMESTAMP_NTZ_ARRAY:
       case OBJECT:
       case UNKNOWN:
       default:
@@ -255,6 +261,7 @@ public class RexExpressionUtils {
         value = Boolean.TRUE.equals(value) ? BooleanUtils.INTERNAL_TRUE : BooleanUtils.INTERNAL_FALSE;
         break;
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
         value = ((Calendar) value).getTimeInMillis();
         break;
       case STRING:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -280,7 +280,7 @@ public class RexExpressionUtils {
         break;
       case DATE:
       case TIME:
-        // FIXME(idellzheng)
+        // FIXME confirm value type
         throw new IllegalStateException("value type: " + value.getClass());
       case STRING:
         value = ((NlsString) value).getValue();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
@@ -157,6 +157,8 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.BOOLEAN;
       case TIMESTAMP:
         return ColumnDataType.TIMESTAMP;
+      case TIMESTAMP_NTZ:
+        return ColumnDataType.TIMESTAMP_NTZ;
       case STRING:
         return ColumnDataType.STRING;
       case JSON:
@@ -175,6 +177,8 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.BOOLEAN_ARRAY;
       case TIMESTAMP_ARRAY:
         return ColumnDataType.TIMESTAMP_ARRAY;
+      case TIMESTAMP_NTZ_ARRAY:
+        return ColumnDataType.TIMESTAMP_NTZ_ARRAY;
       case STRING_ARRAY:
         return ColumnDataType.STRING_ARRAY;
       case BYTES_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
@@ -159,6 +159,10 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.TIMESTAMP;
       case TIMESTAMP_NTZ:
         return ColumnDataType.TIMESTAMP_NTZ;
+      case DATE:
+        return ColumnDataType.DATE;
+      case TIME:
+        return ColumnDataType.TIME;
       case STRING:
         return ColumnDataType.STRING;
       case JSON:
@@ -179,6 +183,10 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.TIMESTAMP_ARRAY;
       case TIMESTAMP_NTZ_ARRAY:
         return ColumnDataType.TIMESTAMP_NTZ_ARRAY;
+      case DATE_ARRAY:
+        return ColumnDataType.DATE_ARRAY;
+      case TIME_ARRAY:
+        return ColumnDataType.TIME_ARRAY;
       case STRING_ARRAY:
         return ColumnDataType.STRING_ARRAY;
       case BYTES_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
@@ -148,6 +148,10 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.TIMESTAMP;
       case TIMESTAMP_NTZ:
         return Expressions.ColumnDataType.TIMESTAMP_NTZ;
+      case DATE:
+        return Expressions.ColumnDataType.DATE;
+      case TIME:
+        return Expressions.ColumnDataType.TIME;
       case STRING:
         return Expressions.ColumnDataType.STRING;
       case JSON:
@@ -170,6 +174,10 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.TIMESTAMP_ARRAY;
       case TIMESTAMP_NTZ_ARRAY:
         return Expressions.ColumnDataType.TIMESTAMP_NTZ_ARRAY;
+      case DATE_ARRAY:
+        return Expressions.ColumnDataType.DATE_ARRAY;
+      case TIME_ARRAY:
+        return Expressions.ColumnDataType.TIME_ARRAY;
       case STRING_ARRAY:
         return Expressions.ColumnDataType.STRING_ARRAY;
       case BYTES_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
@@ -146,6 +146,8 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.BOOLEAN;
       case TIMESTAMP:
         return Expressions.ColumnDataType.TIMESTAMP;
+      case TIMESTAMP_NTZ:
+        return Expressions.ColumnDataType.TIMESTAMP_NTZ;
       case STRING:
         return Expressions.ColumnDataType.STRING;
       case JSON:
@@ -166,6 +168,8 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.BOOLEAN_ARRAY;
       case TIMESTAMP_ARRAY:
         return Expressions.ColumnDataType.TIMESTAMP_ARRAY;
+      case TIMESTAMP_NTZ_ARRAY:
+        return Expressions.ColumnDataType.TIMESTAMP_NTZ_ARRAY;
       case STRING_ARRAY:
         return Expressions.ColumnDataType.STRING_ARRAY;
       case BYTES_ARRAY:

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -55,8 +55,17 @@ public class RelToPlanNodeConverterTest {
             new ObjectSqlType(SqlTypeName.DOUBLE, SqlIdentifier.STAR, true, null, null)),
         DataSchema.ColumnDataType.DOUBLE);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
-            new ObjectSqlType(SqlTypeName.TIMESTAMP, SqlIdentifier.STAR, true, null, null)),
+            new ObjectSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, SqlIdentifier.STAR, true, null, null)),
         DataSchema.ColumnDataType.TIMESTAMP);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ObjectSqlType(SqlTypeName.TIMESTAMP, SqlIdentifier.STAR, true, null, null)),
+        DataSchema.ColumnDataType.TIMESTAMP_NTZ);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ObjectSqlType(SqlTypeName.DATE, SqlIdentifier.STAR, true, null, null)),
+        DataSchema.ColumnDataType.DATE);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ObjectSqlType(SqlTypeName.TIME, SqlIdentifier.STAR, true, null, null)),
+        DataSchema.ColumnDataType.TIME);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ObjectSqlType(SqlTypeName.CHAR, SqlIdentifier.STAR, true, null, null)),
         DataSchema.ColumnDataType.STRING);
@@ -118,8 +127,17 @@ public class RelToPlanNodeConverterTest {
             new ArraySqlType(new ObjectSqlType(SqlTypeName.DOUBLE, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.DOUBLE_ARRAY);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
-            new ArraySqlType(new ObjectSqlType(SqlTypeName.TIMESTAMP, SqlIdentifier.STAR, true, null, null), true)),
+            new ArraySqlType(new ObjectSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.TIMESTAMP_ARRAY);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ArraySqlType(new ObjectSqlType(SqlTypeName.TIMESTAMP, SqlIdentifier.STAR, true, null, null), true)),
+        DataSchema.ColumnDataType.TIMESTAMP_NTZ_ARRAY);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ArraySqlType(new ObjectSqlType(SqlTypeName.DATE, SqlIdentifier.STAR, true, null, null), true)),
+        DataSchema.ColumnDataType.DATE_ARRAY);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
+            new ArraySqlType(new ObjectSqlType(SqlTypeName.TIME, SqlIdentifier.STAR, true, null, null), true)),
+        DataSchema.ColumnDataType.TIME_ARRAY);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.CHAR, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.STRING_ARRAY);

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -127,7 +127,8 @@ public class RelToPlanNodeConverterTest {
             new ArraySqlType(new ObjectSqlType(SqlTypeName.DOUBLE, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.DOUBLE_ARRAY);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
-            new ArraySqlType(new ObjectSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, SqlIdentifier.STAR, true, null, null), true)),
+            new ArraySqlType(new ObjectSqlType(
+                SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.TIMESTAMP_ARRAY);
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.TIMESTAMP, SqlIdentifier.STAR, true, null, null), true)),

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
@@ -35,9 +35,11 @@ public class RexExpressionSerDeTest {
   private static final List<ColumnDataType> SUPPORTED_DATE_TYPES =
       List.of(ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.FLOAT, ColumnDataType.DOUBLE,
           ColumnDataType.BIG_DECIMAL, ColumnDataType.BOOLEAN, ColumnDataType.TIMESTAMP, ColumnDataType.STRING,
-          ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY, ColumnDataType.FLOAT_ARRAY,
+          ColumnDataType.BYTES, ColumnDataType.TIMESTAMP_NTZ, ColumnDataType.DATE, ColumnDataType.TIME,
+          ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY, ColumnDataType.FLOAT_ARRAY,
           ColumnDataType.DOUBLE_ARRAY, ColumnDataType.BOOLEAN_ARRAY, ColumnDataType.TIMESTAMP_ARRAY,
-          ColumnDataType.STRING_ARRAY, ColumnDataType.UNKNOWN);
+          ColumnDataType.STRING_ARRAY, ColumnDataType.TIMESTAMP_NTZ_ARRAY, ColumnDataType.DATE_ARRAY,
+          ColumnDataType.TIME_ARRAY, ColumnDataType.UNKNOWN);
   private static final Random RANDOM = new Random();
 
   @Test
@@ -81,6 +83,21 @@ public class RexExpressionSerDeTest {
   @Test
   public void testTimestampLiteral() {
     verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.TIMESTAMP, RANDOM.nextLong()));
+  }
+
+  @Test
+  public void testTimestampNTZLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.TIMESTAMP_NTZ, RANDOM.nextLong()));
+  }
+
+  @Test
+  public void testDateLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.DATE, RANDOM.nextLong()));
+  }
+
+  @Test
+  public void testTimeLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.TIME, RANDOM.nextLong()));
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -202,6 +202,8 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
         return FieldSpec.DataType.BIG_DECIMAL;
       case TIMESTAMP:
         return FieldSpec.DataType.TIMESTAMP;
+      case TIMESTAMP_NTZ:
+        return FieldSpec.DataType.TIMESTAMP_NTZ;
       case STRING:
         return FieldSpec.DataType.STRING;
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -204,6 +204,10 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
         return FieldSpec.DataType.TIMESTAMP;
       case TIMESTAMP_NTZ:
         return FieldSpec.DataType.TIMESTAMP_NTZ;
+      case DATE:
+        return FieldSpec.DataType.DATE;
+      case TIME:
+        return FieldSpec.DataType.TIME;
       case STRING:
         return FieldSpec.DataType.STRING;
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1382,6 +1382,11 @@ public final class TableConfigUtils {
                   "Cannot create timestamp index on column: %s, it can only be applied to timestamp columns",
                   columnName);
               break;
+            case TIMESTAMP_NTZ:
+              Preconditions.checkState(fieldSpec.getDataType() == DataType.TIMESTAMP_NTZ,
+                  "Cannot create timestamp_ntz index on column: %s, it can only be applied to timestamp_ntz columns",
+                  columnName);
+              break;
             default:
               break;
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1387,6 +1387,16 @@ public final class TableConfigUtils {
                   "Cannot create timestamp_ntz index on column: %s, it can only be applied to timestamp_ntz columns",
                   columnName);
               break;
+            case DATE:
+              Preconditions.checkState(fieldSpec.getDataType() == DataType.DATE,
+                  "Cannot create date index on column: %s, it can only be applied to date columns",
+                  columnName);
+              break;
+            case TIME:
+              Preconditions.checkState(fieldSpec.getDataType() == DataType.TIME,
+                  "Cannot create time index on column: %s, it can only be applied to time columns",
+                  columnName);
+              break;
             default:
               break;
           }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -127,7 +127,7 @@ public class FieldConfig extends BaseJsonConfig {
 
   // If null, there won't be any index
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, VECTOR, RANGE, TIMESTAMP_NTZ
+    INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, VECTOR, RANGE, TIMESTAMP_NTZ, DATE, TIME
   }
 
   public enum CompressionCodec {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -127,7 +127,7 @@ public class FieldConfig extends BaseJsonConfig {
 
   // If null, there won't be any index
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, VECTOR, RANGE
+    INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, VECTOR, RANGE, TIMESTAMP_NTZ
   }
 
   public enum CompressionCodec {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -644,11 +644,11 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           case TIMESTAMP:
             return TimestampUtils.toMillisSinceEpoch(value);
           case TIMESTAMP_NTZ:
-            return TimestampUtils.toMillsWithoutTimeZone(value);
+            return TimestampUtils.toMillisSinceEpochInUTC(value);
           case DATE:
             return TimestampUtils.toDaysSinceEpoch(value);
           case TIME:
-            return TimestampUtils.toMillsOfDay(value);
+            return TimestampUtils.toMillisOfDay(value);
           case STRING:
           case JSON:
             return value;
@@ -745,11 +745,11 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           case TIMESTAMP:
             return TimestampUtils.toMillisSinceEpoch(value);
           case TIMESTAMP_NTZ:
-            return TimestampUtils.toMillsWithoutTimeZone(value);
+            return TimestampUtils.toMillisSinceEpochInUTC(value);
           case DATE:
             return TimestampUtils.toDaysSinceEpoch(value);
           case TIME:
-            return TimestampUtils.toMillsOfDay(value);
+            return TimestampUtils.toMillisOfDay(value);
           case STRING:
           case JSON:
             return value;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -29,7 +29,9 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +82,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   public static final Integer DEFAULT_DIMENSION_NULL_VALUE_OF_BOOLEAN = 0;
   public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP = 0L;
   public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP_NTZ = 0L;
+  public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_DATE = 0L;
+  public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_TIME = 0L;
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_STRING = "null";
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_JSON = "null";
   public static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = new byte[0];
@@ -320,6 +324,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
               return DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP;
             case TIMESTAMP_NTZ:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP_NTZ;
+            case DATE:
+              return DEFAULT_DIMENSION_NULL_VALUE_OF_DATE;
+            case TIME:
+              return DEFAULT_DIMENSION_NULL_VALUE_OF_TIME;
             case STRING:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
             case JSON:
@@ -442,6 +450,12 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           jsonNode.put(key, LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) _defaultNullValue),
               ZoneId.of("UTC")).toString());
           break;
+        case DATE:
+          jsonNode.put(key, LocalDate.ofEpochDay((Long) _defaultNullValue).toString());
+          break;
+        case TIME:
+          jsonNode.put(key, LocalTime.ofNanoOfDay(((Long) _defaultNullValue) * 1000000).toString());
+          break;
         case STRING:
         case JSON:
           jsonNode.put(key, (String) _defaultNullValue);
@@ -530,6 +544,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     BOOLEAN(INT, false, true),
     TIMESTAMP(LONG, false, true),
     TIMESTAMP_NTZ(LONG, false, true),
+    DATE(LONG, false, true),
+    TIME(LONG, false, true),
     STRING(false, true),
     JSON(STRING, false, false),
     BYTES(false, false),
@@ -629,6 +645,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             return TimestampUtils.toMillisSinceEpoch(value);
           case TIMESTAMP_NTZ:
             return TimestampUtils.toMillsWithoutTimeZone(value);
+          case DATE:
+            return TimestampUtils.toDaysSinceEpoch(value);
+          case TIME:
+            return TimestampUtils.toMillsOfDay(value);
           case STRING:
           case JSON:
             return value;
@@ -660,6 +680,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case LONG:
         case TIMESTAMP:
         case TIMESTAMP_NTZ:
+        case DATE:
+        case TIME:
           return Long.compare((long) value1, (long) value2);
         case FLOAT:
           return Float.compare((float) value1, (float) value2);
@@ -724,6 +746,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             return TimestampUtils.toMillisSinceEpoch(value);
           case TIMESTAMP_NTZ:
             return TimestampUtils.toMillsWithoutTimeZone(value);
+          case DATE:
+            return TimestampUtils.toDaysSinceEpoch(value);
+          case TIME:
+            return TimestampUtils.toMillsOfDay(value);
           case STRING:
           case JSON:
             return value;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -28,6 +28,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +79,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   public static final Double DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE = Double.NEGATIVE_INFINITY;
   public static final Integer DEFAULT_DIMENSION_NULL_VALUE_OF_BOOLEAN = 0;
   public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP = 0L;
+  public static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP_NTZ = 0L;
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_STRING = "null";
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_JSON = "null";
   public static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = new byte[0];
@@ -314,6 +318,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
               return DEFAULT_DIMENSION_NULL_VALUE_OF_BOOLEAN;
             case TIMESTAMP:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP;
+            case TIMESTAMP_NTZ:
+              return DEFAULT_DIMENSION_NULL_VALUE_OF_TIMESTAMP_NTZ;
             case STRING:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
             case JSON:
@@ -432,6 +438,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case TIMESTAMP:
           jsonNode.put(key, new Timestamp((Long) _defaultNullValue).toString());
           break;
+        case TIMESTAMP_NTZ:
+          jsonNode.put(key, LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) _defaultNullValue),
+              ZoneId.of("UTC")).toString());
+          break;
         case STRING:
         case JSON:
           jsonNode.put(key, (String) _defaultNullValue);
@@ -519,6 +529,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     BIG_DECIMAL(true, true),
     BOOLEAN(INT, false, true),
     TIMESTAMP(LONG, false, true),
+    TIMESTAMP_NTZ(LONG, false, true),
     STRING(false, true),
     JSON(STRING, false, false),
     BYTES(false, false),
@@ -616,6 +627,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             return BooleanUtils.toInt(value);
           case TIMESTAMP:
             return TimestampUtils.toMillisSinceEpoch(value);
+          case TIMESTAMP_NTZ:
+            return TimestampUtils.toMillsWithoutTimeZone(value);
           case STRING:
           case JSON:
             return value;
@@ -645,6 +658,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case INT:
           return Integer.compare((int) value1, (int) value2);
         case LONG:
+        case TIMESTAMP:
+        case TIMESTAMP_NTZ:
           return Long.compare((long) value1, (long) value2);
         case FLOAT:
           return Float.compare((float) value1, (float) value2);
@@ -654,8 +669,6 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           return ((BigDecimal) value1).compareTo((BigDecimal) value2);
         case BOOLEAN:
           return Boolean.compare((boolean) value1, (boolean) value2);
-        case TIMESTAMP:
-          return Long.compare((long) value1, (long) value2);
         case STRING:
         case JSON:
           return ((String) value1).compareTo((String) value2);
@@ -709,6 +722,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             return BooleanUtils.toInt(value);
           case TIMESTAMP:
             return TimestampUtils.toMillisSinceEpoch(value);
+          case TIMESTAMP_NTZ:
+            return TimestampUtils.toMillsWithoutTimeZone(value);
           case STRING:
           case JSON:
             return value;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -122,6 +122,7 @@ public final class Schema implements Serializable {
           case BIG_DECIMAL:
           case BOOLEAN:
           case TIMESTAMP:
+          case TIMESTAMP_NTZ:
           case STRING:
           case JSON:
           case BYTES:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -123,6 +123,8 @@ public final class Schema implements Serializable {
           case BOOLEAN:
           case TIMESTAMP:
           case TIMESTAMP_NTZ:
+          case DATE:
+          case TIME:
           case STRING:
           case JSON:
           case BYTES:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
@@ -297,7 +297,7 @@ public class ArrayCopyUtils {
 
   public static void copyToLocalDateTime(String[] src, long[] dest, int length) {
     for (int i = 0; i < length; i++) {
-      dest[i] = TimestampUtils.toMillsWithoutTimeZone(src[i]);
+      dest[i] = TimestampUtils.toMillisSinceEpochInUTC(src[i]);
     }
   }
 
@@ -309,7 +309,7 @@ public class ArrayCopyUtils {
 
   public static void copyToLocalTime(String[] src, long[] dest, int length) {
     for (int i = 0; i < length; i++) {
-      dest[i] = TimestampUtils.toMillsOfDay(src[i]);
+      dest[i] = TimestampUtils.toMillisOfDay(src[i]);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
@@ -20,6 +20,9 @@ package org.apache.pinot.spi.utils;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -230,6 +233,12 @@ public class ArrayCopyUtils {
     }
   }
 
+  public static void copyFromLocalDateTime(long[] src, String[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = LocalDateTime.ofInstant(Instant.ofEpochMilli(src[i]), ZoneId.of("UTC")).toString();
+    }
+  }
+
   public static void copy(String[] src, int[] dest, int length) {
     for (int i = 0; i < length; i++) {
       dest[i] = Double.valueOf(src[i]).intValue();
@@ -269,6 +278,12 @@ public class ArrayCopyUtils {
   public static void copyToTimestamp(String[] src, long[] dest, int length) {
     for (int i = 0; i < length; i++) {
       dest[i] = TimestampUtils.toMillisSinceEpoch(src[i]);
+    }
+  }
+
+  public static void copyToLocalDateTime(String[] src, long[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = TimestampUtils.toMillsWithoutTimeZone(src[i]);
     }
   }
 
@@ -508,6 +523,14 @@ public class ArrayCopyUtils {
     }
   }
 
+  public static void copyFromLocalDateTime(long[][] src, String[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new String[rowLength];
+      copyFromLocalDateTime(src[i], dest[i], rowLength);
+    }
+  }
+
   public static void copy(String[][] src, int[][] dest, int length) {
     for (int i = 0; i < length; i++) {
       int rowLength = src[i].length;
@@ -561,6 +584,14 @@ public class ArrayCopyUtils {
       int rowLength = src[i].length;
       dest[i] = new long[rowLength];
       copyToTimestamp(src[i], dest[i], rowLength);
+    }
+  }
+
+  public static void copyToLocalDateTime(String[][] src, long[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new long[rowLength];
+      copyToLocalDateTime(src[i], dest[i], rowLength);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
@@ -21,7 +21,9 @@ package org.apache.pinot.spi.utils;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -239,6 +241,18 @@ public class ArrayCopyUtils {
     }
   }
 
+  public static void copyFromLocalDate(long[] src, String[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = LocalDate.ofEpochDay(src[i]).toString();
+    }
+  }
+
+  public static void copyFromLocalTime(long[] src, String[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = LocalTime.ofNanoOfDay(src[i] * 1000000).toString();
+    }
+  }
+
   public static void copy(String[] src, int[] dest, int length) {
     for (int i = 0; i < length; i++) {
       dest[i] = Double.valueOf(src[i]).intValue();
@@ -284,6 +298,18 @@ public class ArrayCopyUtils {
   public static void copyToLocalDateTime(String[] src, long[] dest, int length) {
     for (int i = 0; i < length; i++) {
       dest[i] = TimestampUtils.toMillsWithoutTimeZone(src[i]);
+    }
+  }
+
+  public static void copyToLocalDate(String[] src, long[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = TimestampUtils.toDaysSinceEpoch(src[i]);
+    }
+  }
+
+  public static void copyToLocalTime(String[] src, long[] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      dest[i] = TimestampUtils.toMillsOfDay(src[i]);
     }
   }
 
@@ -531,6 +557,22 @@ public class ArrayCopyUtils {
     }
   }
 
+  public static void copyFromLocalDate(long[][] src, String[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new String[rowLength];
+      copyFromLocalDate(src[i], dest[i], rowLength);
+    }
+  }
+
+  public static void copyFromLocalTime(long[][] src, String[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new String[rowLength];
+      copyFromLocalTime(src[i], dest[i], rowLength);
+    }
+  }
+
   public static void copy(String[][] src, int[][] dest, int length) {
     for (int i = 0; i < length; i++) {
       int rowLength = src[i].length;
@@ -592,6 +634,22 @@ public class ArrayCopyUtils {
       int rowLength = src[i].length;
       dest[i] = new long[rowLength];
       copyToLocalDateTime(src[i], dest[i], rowLength);
+    }
+  }
+
+  public static void copyToLocalDate(String[][] src, long[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new long[rowLength];
+      copyToLocalDate(src[i], dest[i], rowLength);
+    }
+  }
+
+  public static void copyToLocalTime(String[][] src, long[][] dest, int length) {
+    for (int i = 0; i < length; i++) {
+      int rowLength = src[i].length;
+      dest[i] = new long[rowLength];
+      copyToLocalTime(src[i], dest[i], rowLength);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -311,6 +311,8 @@ public class JsonUtils {
         return jsonValue.asBoolean();
       case TIMESTAMP:
       case TIMESTAMP_NTZ:
+      case DATE:
+      case TIME:
       case STRING:
       case JSON:
         return jsonValue.asText();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -310,6 +310,7 @@ public class JsonUtils {
       case BOOLEAN:
         return jsonValue.asBoolean();
       case TIMESTAMP:
+      case TIMESTAMP_NTZ:
       case STRING:
       case JSON:
         return jsonValue.asText();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.utils;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -99,6 +100,18 @@ public class TimestampUtils {
     }
   }
 
+  public static LocalDateTime toLocalDateTime(String timestampString) {
+    try {
+      return LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(timestampString)), ZoneId.of("UTC"));
+    } catch (Exception e) {
+    }
+    try {
+      return LocalDateTime.parse(timestampString, UNIVERSAL_DATE_TIME_FORMATTER);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid timestamp: '%s'", timestampString));
+    }
+  }
+
   /**
    * Parses the given timestamp string into millis since epoch.
    * <p>Below formats of timestamp are supported:
@@ -128,6 +141,20 @@ public class TimestampUtils {
     try {
       LocalDateTime dateTime = LocalDateTime.parse(timestampString, UNIVERSAL_DATE_TIME_FORMATTER);
       return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid timestamp: '%s'", timestampString));
+    }
+  }
+
+  public static long toMillsWithoutTimeZone(String timestampString) {
+    try {
+      return Long.parseLong(timestampString);
+    } catch (Exception e) {
+      // Try the next format
+    }
+    try {
+      LocalDateTime dateTime = LocalDateTime.parse(timestampString, UNIVERSAL_DATE_TIME_FORMATTER);
+      return dateTime.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
     } catch (Exception e) {
       throw new IllegalArgumentException(String.format("Invalid timestamp: '%s'", timestampString));
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
@@ -102,6 +102,16 @@ public class TimestampUtils {
     }
   }
 
+  /**
+   * Parses the given timestamp string into {@link LocalDateTime}.
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'yyyy-mm-dd hh:mm:ss[.fffffffff]'</li>
+   *   <li>'yyyy-MM-dd[ HH:mm[:ss]]'</li>
+   *   <li>Millis since epoch</li>
+   *   <li>ISO8601 format</li>
+   * </ul>
+   */
   public static LocalDateTime toLocalDateTime(String timestampString) {
     try {
       return LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(timestampString)), ZoneId.of("UTC"));
@@ -114,6 +124,14 @@ public class TimestampUtils {
     }
   }
 
+  /**
+   * Parses the given timestamp string into {@link LocalDate}.
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'yyyy-mm-dd'</li>
+   *   <li>Days since epoch</li>
+   * </ul>
+   */
   public static LocalDate toLocalDate(String timestampString) {
     try {
       return LocalDate.ofEpochDay(Long.parseLong(timestampString));
@@ -126,6 +144,14 @@ public class TimestampUtils {
     }
   }
 
+  /**
+   * Parses the given timestamp string into {@link LocalTime}.
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'hh:mm:ss[.fffffffff]'</li>
+   *   <li>Millis of day</li>
+   * </ul>
+   */
   public static LocalTime toLocalTime(String timestampString) {
     try {
       return LocalTime.ofNanoOfDay(Long.parseLong(timestampString) * 1000000);
@@ -172,7 +198,17 @@ public class TimestampUtils {
     }
   }
 
-  public static long toMillsWithoutTimeZone(String timestampString) {
+  /**
+   * Parses the given timestamp string into millis since epoch(UTC).
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'yyyy-mm-dd hh:mm:ss[.fffffffff]'</li>
+   *   <li>'yyyy-MM-dd[ HH:mm[:ss]]'</li>
+   *   <li>Millis since epoch</li>
+   *   <li>ISO8601 format</li>
+   * </ul>
+   */
+  public static long toMillisSinceEpochInUTC(String timestampString) {
     try {
       return Long.parseLong(timestampString);
     } catch (Exception e) {
@@ -186,6 +222,13 @@ public class TimestampUtils {
     }
   }
 
+  /**
+   * Parses the given timestamp string into days since epoch.
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'yyyy-mm-dd'</li>
+   * </ul>
+   */
   public static long toDaysSinceEpoch(String timestampString) {
     try {
       return Long.parseLong(timestampString);
@@ -198,7 +241,14 @@ public class TimestampUtils {
     }
   }
 
-  public static long toMillsOfDay(String timestampString) {
+  /**
+   * Parses the given timestamp string into millis of day.
+   * <p>Below formats of timestamp are supported:
+   * <ul>
+   *   <li>'hh:mm:ss[.fffffffff]'</li>
+   * </ul>
+   */
+  public static long toMillisOfDay(String timestampString) {
     try {
       return Long.parseLong(timestampString);
     } catch (Exception e) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
@@ -20,7 +20,9 @@ package org.apache.pinot.spi.utils;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -112,6 +114,30 @@ public class TimestampUtils {
     }
   }
 
+  public static LocalDate toLocalDate(String timestampString) {
+    try {
+      return LocalDate.ofEpochDay(Long.parseLong(timestampString));
+    } catch (Exception e) {
+    }
+    try {
+      return LocalDate.parse(timestampString);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid date: '%s'", timestampString));
+    }
+  }
+
+  public static LocalTime toLocalTime(String timestampString) {
+    try {
+      return LocalTime.ofNanoOfDay(Long.parseLong(timestampString) * 1000000);
+    } catch (Exception e) {
+    }
+    try {
+      return LocalTime.parse(timestampString);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid time: '%s'", timestampString));
+    }
+  }
+
   /**
    * Parses the given timestamp string into millis since epoch.
    * <p>Below formats of timestamp are supported:
@@ -157,6 +183,30 @@ public class TimestampUtils {
       return dateTime.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
     } catch (Exception e) {
       throw new IllegalArgumentException(String.format("Invalid timestamp: '%s'", timestampString));
+    }
+  }
+
+  public static long toDaysSinceEpoch(String timestampString) {
+    try {
+      return Long.parseLong(timestampString);
+    } catch (Exception e) {
+    }
+    try {
+      return LocalDate.parse(timestampString).toEpochDay();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid date: '%s'", timestampString));
+    }
+  }
+
+  public static long toMillsOfDay(String timestampString) {
+    try {
+      return Long.parseLong(timestampString);
+    } catch (Exception e) {
+    }
+    try {
+      return LocalTime.parse(timestampString).toNanoOfDay() / 1000000;
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Invalid time: '%s'", timestampString));
     }
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/TimestampUtilsTest.java
@@ -19,7 +19,10 @@
 package org.apache.pinot.spi.utils;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -136,5 +139,136 @@ public class TimestampUtilsTest {
 
     //Too many digits in fractional seconds
     assertThrows(IllegalArgumentException.class, () -> TimestampUtils.toTimestamp("2024-07-12T15:32:36.12345678910Z"));
+  }
+
+  @Test
+  public void testValidLocalDateTimeFormats() {
+    // Test ISO8601 variations with and without milliseconds and timezones
+    assertEquals(
+        TimestampUtils.toLocalDateTime("2024-11-11T15:32:36Z"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36));
+    assertEquals(
+        TimestampUtils.toLocalDateTime("2024-11-11 15:32:36.111Z"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36, 111000000));
+    for (int i = 1; i < 7; i++) {
+      int fraction = Integer.parseInt("1".repeat(i) + "0".repeat(9 - i));
+      assertEquals(
+          TimestampUtils.toLocalDateTime("2024-11-11T15:32:36." + fraction),
+          LocalDateTime.of(2024, 11, 11, 15, 32, 36, fraction));
+      assertEquals(
+          TimestampUtils.toLocalDateTime("2024-11-11T15:32:36." + fraction + "Z"),
+          LocalDateTime.of(2024, 11, 11, 15, 32, 36, fraction));
+    }
+
+    // Test date and time variations without 'T'
+    assertEquals(TimestampUtils.toLocalDateTime("2024-11-11 15:32:36.111"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36, 111000000));
+    assertEquals(TimestampUtils.toLocalDateTime("2024-11-11 15:32:36"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36));
+    assertEquals(TimestampUtils.toLocalDateTime("2024-11-11 15:32"),
+        LocalDateTime.of(2024, 11, 11, 15, 32));
+    assertEquals(TimestampUtils.toLocalDateTime("2024-11-11"),
+        LocalDateTime.of(2024, 11, 11, 0, 0));
+    assertEquals(TimestampUtils.toLocalDateTime("1720798356111"),
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(1720798356111L), ZoneId.of("UTC")));
+  }
+
+  @Test
+  public void testValidLocalDateFormats() {
+    // Test ISO8601 variations with and without milliseconds and timezones
+    assertEquals(TimestampUtils.toLocalDate("2024-11-11"), LocalDate.of(2024, 11, 11));
+    assertEquals(TimestampUtils.toLocalDate("10000"), LocalDate.ofEpochDay(10000));
+  }
+
+  @Test
+  public void testValidLocalTimeFormats() {
+    // Test ISO8601 variations with and without milliseconds and timezones
+    assertEquals(TimestampUtils.toLocalTime("15:32:36"), LocalTime.of(15, 32, 36));
+    assertEquals(
+        TimestampUtils.toLocalTime("15:32:36.111"),
+        LocalTime.of(15, 32, 36, 111000000));
+    for (int i = 1; i < 7; i++) {
+      int fraction = Integer.parseInt("1".repeat(i) + "0".repeat(9 - i));
+      assertEquals(
+          TimestampUtils.toLocalTime("15:32:36." + fraction),
+          LocalTime.of(15, 32, 36, fraction));
+    }
+
+    assertEquals(TimestampUtils.toLocalTime("100000"), LocalTime.ofNanoOfDay(100000 * 1000000L));
+  }
+
+  @Test
+  public void testValidMillisSinceEpochInUTCFormats() {
+    // Test ISO8601 variations with and without milliseconds and timezones
+    assertEquals(
+        TimestampUtils.toMillisSinceEpochInUTC("2024-11-11T15:32:36Z"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    assertEquals(
+        TimestampUtils.toMillisSinceEpochInUTC("2024-11-11 15:32:36.111Z"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36, 111000000)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    for (int i = 1; i < 7; i++) {
+      int fraction = Integer.parseInt("1".repeat(i) + "0".repeat(9 - i));
+      assertEquals(TimestampUtils.toMillisSinceEpochInUTC("2024-11-11 15:32:36." + fraction),
+          LocalDateTime.of(2024, 11, 11, 15, 32, 36, fraction).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+      assertEquals(
+          TimestampUtils.toMillisSinceEpochInUTC("2024-11-11T15:32:36." + fraction + "Z"),
+          LocalDateTime.of(2024, 11, 11, 15, 32, 36, fraction)
+              .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    }
+
+    // Test date and time variations without 'T'
+    // Test date and time variations without 'T'
+    assertEquals(TimestampUtils.toMillisSinceEpochInUTC("2024-11-11 15:32:36.111"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36, 111000000)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    assertEquals(TimestampUtils.toMillisSinceEpochInUTC("2024-11-11 15:32:36"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    assertEquals(TimestampUtils.toMillisSinceEpochInUTC("2024-11-11 15:32"),
+        LocalDateTime.of(2024, 11, 11, 15, 32)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    assertEquals(TimestampUtils.toMillisSinceEpochInUTC("2024-11-11"),
+        LocalDateTime.of(2024, 11, 11, 0, 0)
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli());
+    assertEquals(TimestampUtils.toMillisSinceEpochInUTC("1720798356111"), 1720798356111L);
+  }
+
+  @Test
+  public void testValidDaysSinceEpoch() {
+    assertEquals(
+        TimestampUtils.toDaysSinceEpoch("2024-11-11"),
+        LocalDate.of(2024, 11, 11).toEpochDay());
+    assertEquals(TimestampUtils.toDaysSinceEpoch("10000"), 10000);
+  }
+
+  @Test
+  public void testValidMillisOfDay() {
+    assertEquals(
+        TimestampUtils.toMillisOfDay("15:32:36"),
+        LocalTime.of(15, 32, 36).toNanoOfDay() / 1000000);
+    assertEquals(
+        TimestampUtils.toMillisOfDay("15:32:36.111"),
+        LocalTime.of(15, 32, 36, 111000000).toNanoOfDay() / 1000000);
+    for (int i = 1; i < 7; i++) {
+      int fraction = Integer.parseInt("1".repeat(i) + "0".repeat(9 - i));
+      assertEquals(
+          TimestampUtils.toMillisOfDay("15:32:36." + fraction),
+          LocalTime.of(15, 32, 36, fraction).toNanoOfDay() / 1000000);
+    }
+
+    assertEquals(TimestampUtils.toMillisOfDay("100000"), 100000);
+  }
+
+  @Test
+  public void testValidLocalDateTimeFormatsWithZone() {
+    // when cast to LocalDateTime, ignore time zone
+    assertEquals(
+        TimestampUtils.toLocalDateTime("2024-11-11T15:32:36+02:00"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36));
+    assertEquals(
+        TimestampUtils.toLocalDateTime("2024-11-11T15:32:36.111+02:00"),
+        LocalDateTime.of(2024, 11, 11, 15, 32, 36, 111000000));
   }
 }


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (i):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)

This PR add TIMESTAMP_NTZ, DATE and TIME datatype. 
For flink, TIMESTAMP does not have time zone, which corresponds to TIMESTAMP_NTZ in pinot, TIMESTAMP_LTZ has local time zone, which corresponds to TIMESTAMP in pinot.
For spark, TIMESTAMP has local time zone, which corresponds to TIMESTAMP in pinot, TIMESTAMP_NTZ does not have time zone, which corresponds to TIMESTAMP_NTZ in pinot.

In my case, the schema of my table is as follows
<img width="257" alt="image" src="https://github.com/user-attachments/assets/1749d56c-d8c9-4bfc-82e7-af6f27aa5bbb">

and the query result is as follows
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/b75b4555-7c2e-4953-8127-bfb9f20bb96b">

the schema json of TIME, DATE, TIMESTAMP_NTZ and TIMESTAMP is as follows
```
"dimensionFieldSpecs": [
    {   
      "name": "time_field",
      "dataType": "TIME"
    },  
    {   
      "name": "date_field",
      "dataType": "DATE"
    },  
    {   
      "name": "timestamp_ntz_field",
      "dataType": "TIMESTAMP_NTZ"
    },  
    {                                                                                                                      
      "name": "timestamp_ltz_field",
      "dataType": "TIMESTAMP"
    }   
  ]
```

