### PR TITLE
Controller AccessControl interface accepts Request parameter

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -254,7 +254,7 @@ public class PinotBrokerDebug {
     // TODO: Handle nested queries
     if (brokerRequest.isSetQuerySource() && brokerRequest.getQuerySource().isSetTableName()) {
       if (!_accessControlFactory.create()
-          .hasAccess(httpHeaders, TargetType.TABLE, brokerRequest.getQuerySource().getTableName(),
+          .hasAccess(httpHeaders, null, TargetType.TABLE, brokerRequest.getQuerySource().getTableName(),
               Actions.Table.GET_ROUTING_TABLE)) {
         throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AuthenticationFilter.java
@@ -99,7 +99,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
           Response.Status.FORBIDDEN);
     }
 
-    FineGrainedAuthUtils.validateFineGrainedAuth(endpointMethod, uriInfo, _httpHeaders, accessControl);
+    FineGrainedAuthUtils.validateFineGrainedAuth(endpointMethod, uriInfo, _httpHeaders, null, accessControl);
   }
 
   private static boolean isBaseFile(String path) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -239,7 +239,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     TableAuthorizationResult tableAuthorizationResult = accessControl.authorize(requesterIdentity, tableNames);
 
     Set<String> failedTables = tableNames.stream()
-        .filter(table -> !accessControl.hasAccess(httpHeaders, TargetType.TABLE, table, Actions.Table.QUERY))
+        .filter(table -> !accessControl.hasAccess(httpHeaders, null, TargetType.TABLE, table, Actions.Table.QUERY))
         .collect(Collectors.toSet());
 
     failedTables.addAll(tableAuthorizationResult.getFailedTables());

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -84,6 +84,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.access;
 
 import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.core.auth.FineGrainedAccessControl;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
@@ -40,6 +41,7 @@ public interface AccessControl extends FineGrainedAccessControl {
    * @param endpointUrl the request url for which this access control is called
    * @return whether the client has permission
    */
+  @Deprecated
   default boolean hasAccess(@Nullable String tableName, AccessType accessType, HttpHeaders httpHeaders,
       String endpointUrl) {
     return true;
@@ -53,8 +55,38 @@ public interface AccessControl extends FineGrainedAccessControl {
    * @param endpointUrl the request url for which this access control is called
    * @return whether the client has permission
    */
+  @Deprecated
   default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
     return hasAccess(null, accessType, httpHeaders, endpointUrl);
+  }
+
+  /**
+   * Return whether the client has permission to the given table
+   *
+   * @param tableName   name of the table to be accessed
+   * @param accessType  type of the access
+   * @param httpHeaders HTTP headers containing requester identity
+   * @param request     the request for which this access control is called
+   * @param endpointUrl the request url for which this access control is called
+   * @return whether the client has permission
+   */
+  default boolean hasAccess(@Nullable String tableName, AccessType accessType, HttpHeaders httpHeaders,
+      @Nullable HttpServletRequest request, @Nullable String endpointUrl) {
+    return hasAccess(tableName, accessType, httpHeaders, endpointUrl);
+  }
+
+  /**
+   * Return whether the client has permission to access the endpoints with are not table level
+   *
+   * @param accessType  type of the access
+   * @param httpHeaders HTTP headers
+   * @param request     the request for which this access control is called
+   * @param endpointUrl the request url for which this access control is called
+   * @return whether the client has permission
+   */
+  default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, @Nullable HttpServletRequest request,
+      @Nullable String endpointUrl) {
+    return hasAccess(null, accessType, httpHeaders, request, endpointUrl);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.controller.api.access;
 
 import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -46,21 +47,23 @@ public final class AccessControlUtils {
    * @param tableName name of the table to be accessed (post database name translation)
    * @param accessType type of the access
    * @param httpHeaders HTTP headers containing requester identity required by access control object
+   * @param request the request for which this access control is called
    * @param endpointUrl the request url for which this access control is called
    * @param accessControl AccessControl object which does the actual validation
    */
   public static void validatePermission(@Nullable String tableName, AccessType accessType,
-      @Nullable HttpHeaders httpHeaders, String endpointUrl, AccessControl accessControl) {
+      @Nullable HttpHeaders httpHeaders, HttpServletRequest request, String endpointUrl,
+      AccessControl accessControl) {
     String userMessage = getUserMessage(tableName, accessType, endpointUrl);
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
 
     try {
       if (rawTableName == null) {
-        if (accessControl.hasAccess(accessType, httpHeaders, endpointUrl)) {
+        if (accessControl.hasAccess(accessType, httpHeaders, request, endpointUrl)) {
           return;
         }
       } else {
-        if (accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl)) {
+        if (accessControl.hasAccess(rawTableName, accessType, httpHeaders, request, endpointUrl)) {
           return;
         }
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -105,9 +105,11 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       tableName = DatabaseUtils.translateTableName(tableName, _httpHeaders);
     }
     AccessType accessType = extractAccessType(endpointMethod);
-    AccessControlUtils.validatePermission(tableName, accessType, _httpHeaders, endpointUrl, accessControl);
+    AccessControlUtils.validatePermission(tableName, accessType, _httpHeaders, GrizzlyRequestAdapter.wrap(request),
+        endpointUrl, accessControl);
 
-    FineGrainedAuthUtils.validateFineGrainedAuth(endpointMethod, uriInfo, _httpHeaders, accessControl);
+    FineGrainedAuthUtils.validateFineGrainedAuth(endpointMethod, uriInfo, _httpHeaders,
+        GrizzlyRequestAdapter.wrap(request), accessControl);
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.common.auth.BasicAuthTokenUtils;
@@ -80,13 +81,15 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
-      return getPrincipal(httpHeaders)
-          .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders,
+        HttpServletRequest request, String endpointUrl) {
+      return getPrincipal(httpHeaders).filter(
+          p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
-    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, HttpServletRequest request,
+        String endpointUrl) {
       if (getPrincipal(httpHeaders).isEmpty()) {
         throw new NotAuthorizedException("Basic");
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/GrizzlyRequestAdapter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/GrizzlyRequestAdapter.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Enumeration;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.glassfish.grizzly.http.server.Request;
+
+
+public final class GrizzlyRequestAdapter extends HttpServletRequestWrapper {
+  private final Request _grizzlyRequest;
+
+  private GrizzlyRequestAdapter(Request grizzlyRequest) {
+    super(createDummyRequest());
+    _grizzlyRequest = grizzlyRequest;
+  }
+
+  @Nullable
+  public static HttpServletRequest wrap(@Nullable Request request) {
+    if (request == null) {
+      return null;
+    }
+    return new GrizzlyRequestAdapter(request);
+  }
+
+  @Override
+  public Object getAttribute(String name) {
+    return _grizzlyRequest.getAttribute(name);
+  }
+
+  @Override
+  public String getRemoteAddr() {
+    return _grizzlyRequest.getRemoteAddr();
+  }
+
+  @Override
+  public StringBuffer getRequestURL() {
+    return new StringBuffer(_grizzlyRequest.getRequestURL().toString());
+  }
+
+  @Override
+  public String getRequestURI() {
+    return _grizzlyRequest.getRequestURI();
+  }
+
+  @Override
+  public String getContextPath() {
+    return _grizzlyRequest.getContextPath();
+  }
+
+  @Override
+  public String getHeader(String name) {
+    return _grizzlyRequest.getHeader(name);
+  }
+
+  @Override
+  public Enumeration<String> getHeaders(String name) {
+    String value = _grizzlyRequest.getHeader(name);
+    if (value == null) {
+      return Collections.emptyEnumeration();
+    }
+    return Collections.enumeration(Collections.singletonList(value));
+  }
+
+  private static HttpServletRequest createDummyRequest() {
+    Object proxy = Proxy.newProxyInstance(
+        HttpServletRequest.class.getClassLoader(),
+        new Class<?>[]{HttpServletRequest.class},
+        (p, method, args) -> {
+          throw new UnsupportedOperationException(
+              "Method " + method.getName() + " is not supported by GrizzlyRequestAdapter");
+        });
+    return HttpServletRequest.class.cast(proxy);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.auth.BasicAuthTokenUtils;
@@ -82,10 +83,11 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders,
+        HttpServletRequest request, String endpointUrl) {
       return getPrincipal(httpHeaders).filter(
-          p -> p.hasTable(TableNameBuilder.extractRawTableName(tableName))
-              && p.hasPermission(Objects.toString(accessType))).isPresent();
+          p -> p.hasTable(TableNameBuilder.extractRawTableName(tableName)) && p.hasPermission(
+              Objects.toString(accessType))).isPresent();
     }
 
     @Override
@@ -94,7 +96,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
-    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, HttpServletRequest request,
+        String endpointUrl) {
       return getPrincipal(httpHeaders).isPresent();
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -39,9 +39,11 @@ import javax.ws.rs.core.MediaType;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.GrizzlyRequestAdapter;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.glassfish.grizzly.http.server.Request;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -58,6 +60,9 @@ public class PinotControllerAuthResource {
 
   @Context
   HttpHeaders _httpHeaders;
+
+  @Context
+  Request _request;
 
   /**
    * Verify a token is both authenticated and authorized to perform an operation.
@@ -82,7 +87,8 @@ public class PinotControllerAuthResource {
       @ApiParam(value = "API access type") @DefaultValue("READ") @QueryParam("accessType") AccessType accessType,
       @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {
     AccessControl accessControl = _accessControlFactory.create();
-    return accessControl.hasAccess(tableName, accessType, _httpHeaders, endpointUrl);
+    return accessControl.hasAccess(tableName, accessType, _httpHeaders, GrizzlyRequestAdapter.wrap(_request),
+        endpointUrl);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ResourceUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ResourceUtils.java
@@ -33,6 +33,7 @@ import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessControlUtils;
 import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.GrizzlyRequestAdapter;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.TargetType;
@@ -86,8 +87,10 @@ public class ResourceUtils {
       AccessType accessType, String action, AccessControlFactory accessControlFactory, Logger logger) {
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = accessControlFactory.create();
-    AccessControlUtils.validatePermission(typeName, accessType, httpHeaders, endpointUrl, accessControl);
-    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, typeName, action)) {
+    AccessControlUtils.validatePermission(typeName, accessType, httpHeaders, GrizzlyRequestAdapter.wrap(request),
+        endpointUrl, accessControl);
+    if (!accessControl.hasAccess(httpHeaders, GrizzlyRequestAdapter.wrap(request), TargetType.TABLE, typeName,
+        action)) {
       throw new ControllerApplicationException(logger, "Permission denied", Response.Status.FORBIDDEN);
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -60,6 +60,7 @@ import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessControlUtils;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
+import org.apache.pinot.controller.api.access.GrizzlyRequestAdapter;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
@@ -229,9 +230,10 @@ public class TableConfigsRestletResource {
       // validate permission
       String endpointUrl = request.getRequestURL().toString();
       AccessControl accessControl = _accessControlFactory.create();
-      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl,
-          accessControl);
-      if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
+      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders,
+          GrizzlyRequestAdapter.wrap(request), endpointUrl, accessControl);
+      if (!accessControl.hasAccess(httpHeaders, GrizzlyRequestAdapter.wrap(request), TargetType.TABLE, rawTableName,
+          Actions.Table.CREATE_TABLE)) {
         throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
       }
 
@@ -468,8 +470,10 @@ public class TableConfigsRestletResource {
     // validate permission
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
-    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.VALIDATE_TABLE_CONFIGS)) {
+    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders,
+        GrizzlyRequestAdapter.wrap(request), endpointUrl, accessControl);
+    if (!accessControl.hasAccess(httpHeaders, GrizzlyRequestAdapter.wrap(request), TargetType.TABLE, rawTableName,
+        Actions.Table.VALIDATE_TABLE_CONFIGS)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AccessControlUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.access;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
@@ -35,21 +36,23 @@ public class AccessControlUtilsTest {
   public void testValidatePermissionAllowed() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint)).thenReturn(true);
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint)).thenReturn(true);
 
-    AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+    AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint, ac);
   }
 
   @Test
   public void testValidatePermissionDenied() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint)).thenReturn(false);
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint)).thenReturn(false);
 
     try {
-      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint, ac);
       Assert.fail("Expected ControllerApplicationException");
     } catch (ControllerApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Permission is denied"));
@@ -61,12 +64,13 @@ public class AccessControlUtilsTest {
   public void testValidatePermissionWithNoSuchMethodError() {
     AccessControl ac = Mockito.mock(AccessControl.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
+    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
 
-    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, _endpoint))
+    Mockito.when(ac.hasAccess(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint))
         .thenThrow(new NoSuchMethodError("Method not found"));
 
     try {
-      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, _endpoint, ac);
+      AccessControlUtils.validatePermission(_table, AccessType.READ, mockHttpHeaders, mockRequest, _endpoint, ac);
     } catch (ControllerApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Caught exception while validating permission"));
       Assert.assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -38,6 +38,11 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-segment-local</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Netty dependencies -->
     <dependency>

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.auth;
 
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
@@ -36,8 +38,24 @@ public interface FineGrainedAccessControl {
    * @param action type to validate
    * @return true if user is allowed to perform the action
    */
+  @Deprecated
   default boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId, String action) {
     return true;
+  }
+
+  /**
+   * Checks whether the user has access to perform action on the particular resource
+   *
+   * @param httpHeaders HTTP headers
+   * @param request     the HTTP request for which this access control is called
+   * @param targetType type of resource being accessed
+   * @param targetId id of the resource
+   * @param action type to validate
+   * @return true if user is allowed to perform the action
+   */
+  default boolean hasAccess(HttpHeaders httpHeaders, @Nullable HttpServletRequest request, TargetType targetType,
+      String targetId, String action) {
+    return hasAccess(httpHeaders, targetType, targetId, action);
   }
 
   /**
@@ -62,9 +80,25 @@ public interface FineGrainedAccessControl {
    * @param action type to validate
    * @return An AuthorizationResult object, encapsulating whether the access is granted or not.
    */
+  @Deprecated
   default AuthorizationResult authorize(HttpHeaders httpHeaders, TargetType targetType, String targetId,
       String action) {
     return new BasicAuthorizationResultImpl(hasAccess(httpHeaders, targetType, targetId, action));
+  }
+
+  /**
+   * Verifies if the user has access to perform a specific action on a particular resource.
+   *
+   * @param httpHeaders HTTP headers
+   * @param request     the HTTP request for which this access control is called
+   * @param targetType type of resource being accessed
+   * @param targetId id of the resource
+   * @param action type to validate
+   * @return An AuthorizationResult object, encapsulating whether the access is granted or not.
+   */
+  default AuthorizationResult authorize(HttpHeaders httpHeaders, @Nullable HttpServletRequest request,
+      TargetType targetType, String targetId, String action) {
+    return authorize(httpHeaders, targetType, targetId, action);
   }
 
   /**
@@ -73,7 +107,21 @@ public interface FineGrainedAccessControl {
    * If the return is false, then API will be terminated by the filter.
    * @return true to allow
    */
+  @Deprecated
   default boolean defaultAccess(HttpHeaders httpHeaders) {
     return true;
+  }
+
+  /**
+   * If an API is neither annotated with Authorize nor ManualAuthorization,
+   * this method will be called to check the default authorization.
+   * If the return is false, then API will be terminated by the filter.
+   *
+   * @param httpHeaders HTTP headers
+   * @param request     the HTTP request for which this access control is called
+   * @return true to allow
+   */
+  default boolean defaultAccess(HttpHeaders httpHeaders, @Nullable HttpServletRequest request) {
+    return defaultAccess(httpHeaders);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -33,26 +33,26 @@ public class FineGrainedAuthUtilsTest {
   @Test
   public void testValidateFineGrainedAuthAllowed() {
     FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
-    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(true);
+    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(TargetType.class),
+        Mockito.any(), Mockito.any())).thenReturn(true);
 
     UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
-    FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
+    FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, null, ac);
   }
 
   @Test
   public void testValidateFineGrainedAuthDenied() {
     FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
-    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(false);
+    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(TargetType.class),
+        Mockito.any(), Mockito.any())).thenReturn(false);
 
     UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
     try {
-      FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
+      FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, null, ac);
       Assert.fail("Expected WebApplicationException");
     } catch (WebApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Access denied to getCluster in the cluster"));
@@ -63,14 +63,14 @@ public class FineGrainedAuthUtilsTest {
   @Test
   public void testValidateFineGrainedAuthWithNoSuchMethodError() {
     FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
-    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenThrow(new NoSuchMethodError("Method not found"));
+    Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(TargetType.class),
+        Mockito.any(), Mockito.any())).thenThrow(new NoSuchMethodError("Method not found"));
 
     UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
     HttpHeaders mockHttpHeaders = Mockito.mock(HttpHeaders.class);
 
     try {
-      FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, ac);
+      FineGrainedAuthUtils.validateFineGrainedAuth(getAnnotatedMethod(), mockUriInfo, mockHttpHeaders, null, ac);
       Assert.fail("Expected WebApplicationException");
     } catch (WebApplicationException e) {
       Assert.assertTrue(e.getMessage().contains("Failed to check for access"));


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds HttpServletRequest parameter to AccessControl methods, adapting Grizzly requests via GrizzlyRequestAdapter for fine‑grained authorization\.

```mermaid
flowchart TD
  N0["Controller receives Grizzly Request #40;F14#41;"]:::stRemoved
  N1["GrizzlyRequestAdapter wraps Request #8594; HttpServletRequest #40;F8#41;"]:::stAdded
  N2["AccessControlUtils#46;validatePermission called with HttpServletRequest #40;F6#41;"]:::stModified
  N3["AccessControl#46;hasAccess overload with HttpServletRequest #40;F4#41;"]:::stModified
  N4["Delegates to legacy hasAccess #40;no request#41; #40;F4#41;"]:::stModified
  N5["Returns boolean authorization decision #40;F4#41;"]:::stModified
  N0 -->|"wraps"| N1
  N1 -->|"passes request"| N2
  N2 -->|"calls"| N3
  N3 -->|"delegates to"| N4
  N4 -->|"returns"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl\.java — [before](https://github.com/apache/pinot/blob/0f93d52ef0bfa1c2dc367b31f137a63bd25f9d2f/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java) · [after](https://github.com/apache/pinot/blob/83e2c087a6cfcf3b33ff5c3a9d4940256e1e428c/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java)
- F6: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter\.java — [before](https://github.com/apache/pinot/blob/0f93d52ef0bfa1c2dc367b31f137a63bd25f9d2f/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java) · [after](https://github.com/apache/pinot/blob/83e2c087a6cfcf3b33ff5c3a9d4940256e1e428c/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java)
- F8: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/GrizzlyRequestAdapter\.java — [after](https://github.com/apache/pinot/blob/83e2c087a6cfcf3b33ff5c3a9d4940256e1e428c/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/GrizzlyRequestAdapter.java)
- F14: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource\.java — [before](https://github.com/apache/pinot/blob/0f93d52ef0bfa1c2dc367b31f137a63bd25f9d2f/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java) · [after](https://github.com/apache/pinot/blob/83e2c087a6cfcf3b33ff5c3a9d4940256e1e428c/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjBmOTNkNTJlZjBiZmExYzJkYzM2N2IzMWYxMzdhNjNiZDI1ZjlkMmYiLCJjb250ZXh0X2hhc2giOiIzOWQyY2RiNjhiN2ViNjFmMDk5YmU2M2JkNDgyNWM2ZGFmY2JhOTEzZTU5ODA5OTY3NmUzZTIzZjQ4NjY5Y2JlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTkwNzI4LCJoZWFkX3NoYSI6IjgzZTJjMDg3YTZjZmNmM2IzM2ZmNWMzYTlkNDk0MDI1NmUxZTQyOGMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1YmUwMWVmYjY5Mzc4NTMwYWNlMzQzMDdkNGYwOGJlNWMxYThmNDM1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e24facd567904b3787bf6c5fc2ca46a714c616ab9c926ea4f8fa03ec4a8719ce -->
<!-- pinot-pr-flow:end -->

### Labels:
* `feature`
* `release-notes` (backward compatible, note the deprecation, later on major semver remove the deprecation)

### Context
* https://github.com/apache/pinot/issues/13556

This allows for using properties of the `HttpServletRequest` object in the `AccessControl` to achieve things like using the SSL/TLS certificates to assign roles ( tested and running in Production with this PR on our cluster using `HttpServletRequest`)

### Notes
* Backward compatible - Existing users of `AccessControl` and `FineGrainedAccessControl` interface who only define the deprecated methods have the exact same behavior as well (ignoring the `HttpServletRequest` essentially)
* Updated the usage of `AccessControl` and  `FineGrainedAccessControl` across Pinot source with the new methods only (the deprecated methods are not used in the Pinot source anymore - comes in very handy at dropping the deprecation)
* Can the required feature be obtained using only the `HttpHeaders`? No
  * `HttpHeaders`: headers, cookies, content type/length, accept/language negotiation
  * `HttpServletRequest`: all of the above in `HttpHeaders`, plus remote IP, request URL/URI, HTTP method, query parameters, request body, SSL certificates, request attributes, session, auth principal, character encoding, protocol/scheme, server
  name/port, context path 
* Infact, `HttpHeaders` can be dropped completely and just `HttpServletRequest` just exist (but is a minor deprecating change for implementors since it is not just a signature change but have to update code like 
```
 httpHeaders.getHeaderString("Authorization") 
becomes
request.getHeader("Authorization")
```
* Not quite sure on how to sequence dropping the deprecation in a next major version release, would a Github issue or a release tracker note be the right way? 