### PR TITLE
Use Picocli to generate help

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class AutoAddInvertedIndexTool extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-zkAddress"}, required = true, description = "Address of the Zookeeper (host:port)")
   private String _zkAddress;
@@ -65,15 +65,6 @@ public class AutoAddInvertedIndexTool extends AbstractBaseCommand implements Com
       description = "Optional max number of inverted index added, default: "
           + AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED)
   private int _maxNumInvertedIndex = AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Command.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Command.java
@@ -33,14 +33,10 @@ public interface Command extends Callable<Integer> {
     return execute() ? 0 : -1;
   }
 
-  public boolean execute()
+  boolean execute()
       throws Exception;
 
-  public void printUsage();
+  void printUsage();
 
-  public String description();
-
-  // Should return true if -help option is specified for the command, false otherwise.
-  // This is to facilitate PinotAdministrator to print help for individual commands.
-  public boolean getHelp();
+  String description();
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -38,7 +38,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 import picocli.CommandLine;
 
 
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class SegmentDumpTool extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-path"}, required = true, description = "Path of the folder containing the segment"
       + " file")
@@ -49,10 +49,6 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
 
   @CommandLine.Option(names = {"-dumpStarTree"})
   private boolean _dumpStarTree = false;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true, description =
-      "Print this message.")
-  private boolean _help = false;
 
   private void dump()
       throws Exception {
@@ -179,10 +175,5 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
   @Override
   public String description() {
     return "Dump the segment content of the given path.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpdateSegmentState.class);
   private static final String CMD_NAME = "UpdateSegmentState";
@@ -60,17 +60,8 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-fix"}, required = false, description = "Update IDEALSTATE values (OFFLINE->ONLINE).")
   private boolean _fix = false;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   public UpdateSegmentState() {
     super();
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
@@ -23,7 +23,7 @@ import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class ValidateTableRetention extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-zkAddress"}, required = true, description = "Address of the Zookeeper (host:port)")
   private String _zkAddress;
@@ -39,15 +39,6 @@ public class ValidateTableRetention extends AbstractBaseCommand implements Comma
       description = "Optional duration in days threshold to log a warning for table with too large retention time,"
           + " default: " + TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD)
   private long _durationInDaysThreshold = TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.Utils;
@@ -196,6 +197,11 @@ public class PinotAdministrator {
 
   public Map<String, Command> getSubCommands() {
     return SUBCOMMAND_MAP;
+  }
+
+  @VisibleForTesting
+  public int getStatus() {
+    return _status;
   }
 
   public static void main(String[] args) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractDatabaseBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractDatabaseBaseAdminCommand.java
@@ -67,10 +67,6 @@ public abstract class AbstractDatabaseBaseAdminCommand extends AbstractBaseAdmin
   @CommandLine.Option(names = {"-database"}, required = false, description = "Corresponding database.")
   protected String _database;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
-      + "this message.")
-  private boolean _help = false;
-
   public AbstractDatabaseBaseAdminCommand setControllerHost(String controllerHost) {
     _controllerHost = controllerHost;
     return this;
@@ -129,11 +125,6 @@ public abstract class AbstractDatabaseBaseAdminCommand extends AbstractBaseAdmin
   public AbstractDatabaseBaseAdminCommand setExecute(boolean exec) {
     _exec = exec;
     return this;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "AddSchema")
+@CommandLine.Command(name = "AddSchema", mixinStandardHelpOptions = true)
 public class AddSchemaCommand extends AbstractDatabaseBaseAdminCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(AddSchemaCommand.class);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -40,7 +40,7 @@ import picocli.CommandLine;
  * Class to implement CreateResource command.
  *
  */
-@CommandLine.Command(name = "AddTable")
+@CommandLine.Command(name = "AddTable", mixinStandardHelpOptions = true)
 public class AddTableCommand extends AbstractDatabaseBaseAdminCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(AddTableCommand.class);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "AddTenant")
+@CommandLine.Command(name = "AddTenant", mixinStandardHelpOptions = true)
 public class AddTenantCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(AddTenantCommand.class);
 
@@ -75,10 +75,6 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
 
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   private String _controllerAddress;
 
@@ -174,11 +170,6 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
   @Override
   public String getName() {
     return "AddTenant";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
@@ -77,13 +77,6 @@ public class AnonymizeDataCommand extends AbstractBaseAdminCommand implements Co
           + " but with additional heap overhead. True by default")
   private boolean _mapBasedGlobalDictionaries = true;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message")
-  private boolean _help = false;
-
-  public boolean getHelp() {
-    return _help;
-  }
-
   @Override
   public String getName() {
     return "AnonymizeData";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AnonymizeDataCommand.java
@@ -31,7 +31,7 @@ import picocli.CommandLine;
 
 
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
-@CommandLine.Command(name = "AnonymizeData")
+@CommandLine.Command(name = "AnonymizeData", mixinStandardHelpOptions = true)
 public class AnonymizeDataCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(AnonymizeDataCommand.class);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -42,7 +42,7 @@ import picocli.CommandLine;
  * automatically do this, the intention is to get most of the work done by this class, and require any
  * manual editing on top.
  */
-@CommandLine.Command(name = "AvroSchemaToPinotSchema")
+@CommandLine.Command(name = "AvroSchemaToPinotSchema", mixinStandardHelpOptions = true)
 public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(AvroSchemaToPinotSchema.class);
 
@@ -86,10 +86,6 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
       + "JSON string, can be NONE/NON_PRIMITIVE/ALL")
   String _collectionNotUnnestedToJson;
 
-  @SuppressWarnings("FieldCanBeLocal")
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
   @Override
   public boolean execute()
       throws Exception {
@@ -130,11 +126,6 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   @Override
   public String description() {
     return "Extracting Pinot schema file from Avro schema or data file.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -63,7 +63,7 @@ import picocli.CommandLine;
  * <table_name>/rawdata/...
  * ```
  */
-@CommandLine.Command(name = "BootstrapTable")
+@CommandLine.Command(name = "BootstrapTable", mixinStandardHelpOptions = true)
 public class BootstrapTableCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(BootstrapTableCommand.class.getName());
 
@@ -92,16 +92,7 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   private AuthProvider _authProvider;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeNumReplicasCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeNumReplicasCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "ChangeNumReplicas")
+@CommandLine.Command(name = "ChangeNumReplicas", mixinStandardHelpOptions = true)
 public class ChangeNumReplicasCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ChangeNumReplicasCommand.class);
 
@@ -41,14 +41,6 @@ public class ChangeNumReplicasCommand extends AbstractBaseAdminCommand implement
 
   @CommandLine.Option(names = {"-exec"}, required = false, description = "Execute command (Run the replica changer)")
   private boolean _exec;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "ChangeTableState")
+@CommandLine.Command(name = "ChangeTableState", mixinStandardHelpOptions = true)
 public class ChangeTableState extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ChangeTableState.class);
 
@@ -65,10 +65,6 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
 
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   private AuthProvider _authProvider;
 
@@ -112,10 +108,6 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
   @Override
   public String description() {
     return "Change the state (enable|disable|drop) of Pinot table";
-  }
-
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -49,7 +49,7 @@ import picocli.CommandLine;
  * Class to implement CreateSegment command.
  */
 @SuppressWarnings("unused")
-@CommandLine.Command(name = "CreateSegment")
+@CommandLine.Command(name = "CreateSegment", mixinStandardHelpOptions = true)
 public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(CreateSegmentCommand.class);
 
@@ -89,10 +89,6 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   @CommandLine.Option(names = {"-numThreads"}, description = "Parallelism while generating segments, default is 1.")
   private int _numThreads = 1;
-
-  @SuppressWarnings("FieldCanBeLocal")
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
 
   public CreateSegmentCommand setDataDir(String dataDir) {
     _dataDir = dataDir;
@@ -166,11 +162,6 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Override
   public String description() {
     return "Create pinot segments from the provided data files.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DataImportDryRunCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DataImportDryRunCommand.java
@@ -37,7 +37,7 @@ import picocli.CommandLine;
  * Class for command to do a dry run of data ingestion so that we can see how transformation functions and
  * complex config will be applied.
  */
-@CommandLine.Command(name = "DataImportDryRun")
+@CommandLine.Command(name = "DataImportDryRun", mixinStandardHelpOptions = true)
 public class DataImportDryRunCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataImportDryRunCommand.class);
 
@@ -46,10 +46,6 @@ public class DataImportDryRunCommand extends AbstractBaseAdminCommand implements
 
   @CommandLine.Option(names = {"-tableConfigFile"}, required = true, description = "Path to table config file.")
   String _tableConfigFile;
-
-  @SuppressWarnings("FieldCanBeLocal")
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
 
   @Override
   public boolean execute() throws Exception {
@@ -82,10 +78,5 @@ public class DataImportDryRunCommand extends AbstractBaseAdminCommand implements
   @Override
   public String description() {
     return "Dry run of data import";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteClusterCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteClusterCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "DeleteCluster")
+@CommandLine.Command(name = "DeleteCluster", mixinStandardHelpOptions = true)
 public class DeleteClusterCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(DeleteClusterCommand.class);
 
@@ -35,10 +35,6 @@ public class DeleteClusterCommand extends AbstractBaseAdminCommand implements Co
   @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "Http address of Zookeeper.")
   private String _zkAddress = DEFAULT_ZK_ADDRESS;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   @Override
   public String toString() {
     return ("DeleteCluster -clusterName " + _clusterName + " -zkAddress " + _zkAddress);
@@ -47,11 +43,6 @@ public class DeleteClusterCommand extends AbstractBaseAdminCommand implements Co
   @Override
   public String description() {
     return "Remove the Pinot Cluster from Helix.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "DeleteSchema")
+@CommandLine.Command(name = "DeleteSchema", mixinStandardHelpOptions = true)
 public class DeleteSchemaCommand extends AbstractDatabaseBaseAdminCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(DeleteSchemaCommand.class);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "DeleteTable")
+@CommandLine.Command(name = "DeleteTable", mixinStandardHelpOptions = true)
 public class DeleteTableCommand extends AbstractDatabaseBaseAdminCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(DeleteTableCommand.class);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
@@ -35,7 +35,7 @@ import picocli.CommandLine;
     CopyFiles.class,
     MoveFiles.class,
     DeleteFiles.class
-})
+}, mixinStandardHelpOptions = true)
 public class FileSystemCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemCommand.class.getName());
 
@@ -43,20 +43,11 @@ public class FileSystemCommand extends AbstractBaseAdminCommand implements Comma
       CommandLine.ScopeType.INHERIT, description = "PinotFS Config file.")
   private String _configFile;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true, description = "Print this message.",
-      scope = CommandLine.ScopeType.INHERIT)
-  private boolean _help = false;
-
   @CommandLine.Parameters
   private String[] _parameters;
 
   public FileSystemCommand setConfigFile(String configFile) {
     _configFile = configFile;
-    return this;
-  }
-
-  public FileSystemCommand setHelp(boolean help) {
-    _help = help;
     return this;
   }
 
@@ -67,11 +58,6 @@ public class FileSystemCommand extends AbstractBaseAdminCommand implements Comma
   public FileSystemCommand setParameters(String[] parameters) {
     _parameters = parameters;
     return this;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -42,7 +42,7 @@ import picocli.CommandLine;
  * Class to implement GenerateData command.
  *
  */
-@CommandLine.Command(name = "GenerateData")
+@CommandLine.Command(name = "GenerateData", mixinStandardHelpOptions = true)
 public class GenerateDataCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(GenerateDataCommand.class);
 
@@ -69,18 +69,9 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
   @CommandLine.Option(names = {"-overwrite"}, required = false, description = "Overwrite, if directory exists")
   boolean _overwrite;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   @CommandLine.Option(names = {"-format"}, required = false, help = true,
       description = "Output format ('AVRO' or 'CSV' or 'JSON').")
   private String _format = FORMAT_AVRO;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   public void init(int numRecords, int numFiles, String schemaFile, String outDir) {
     _numRecords = numRecords;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 /**
  * Command to run GitHubEventsQuickStart
  */
-@CommandLine.Command(name = "GitHubEventsQuickStart")
+@CommandLine.Command(name = "GitHubEventsQuickStart", mixinStandardHelpOptions = true)
 public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand implements Command {
 
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
@@ -37,20 +37,12 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
       description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
   public void setPersonalAccessToken(String personalAccessToken) {
     _personalAccessToken = personalAccessToken;
   }
 
   public void setSourceType(String sourceType) {
     _sourceType = sourceType;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -56,7 +56,7 @@ import picocli.CommandLine;
  * Class to implement ImportData command.
  */
 @SuppressWarnings("unused")
-@CommandLine.Command(name = "ImportData")
+@CommandLine.Command(name = "ImportData", mixinStandardHelpOptions = true)
 public class ImportDataCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportDataCommand.class);
   private static final String SEGMENT_NAME = "segment.name";
@@ -97,10 +97,6 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @CommandLine.Option(names = {"-additionalConfigs"}, arity = "1..*", description = "Additional configs to be set.")
   private List<String> _additionalConfigs;
 
-  @SuppressWarnings("FieldCanBeLocal")
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
   private AuthProvider _authProvider;
 
   public ImportDataCommand setDataFilePath(String dataFilePath) {
@@ -119,10 +115,6 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
 
   public void setSegmentNameGeneratorType(String segmentNameGeneratorType) {
     _segmentNameGeneratorType = segmentNameGeneratorType;
-  }
-
-  public void setHelp(boolean help) {
-    _help = help;
   }
 
   public ImportDataCommand setTable(String table) {
@@ -203,11 +195,6 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @Override
   public String description() {
     return "Insert data into Pinot cluster.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/JsonToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/JsonToPinotSchema.java
@@ -42,7 +42,7 @@ import picocli.CommandLine;
  * automatically do this, the intention is to get most of the work done by this class, and require any
  * manual editing on top.
  */
-@CommandLine.Command(name = "JsonToPinotSchema")
+@CommandLine.Command(name = "JsonToPinotSchema", mixinStandardHelpOptions = true)
 public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(JsonToPinotSchema.class);
 
@@ -78,10 +78,6 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
       + "JSON string, can be NONE/NON_PRIMITIVE/ALL")
   String _collectionNotUnnestedToJson;
 
-  @SuppressWarnings("FieldCanBeLocal")
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
   @Override
   public boolean execute()
       throws Exception {
@@ -114,11 +110,6 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
   @Override
   public String description() {
     return "Extracting Pinot schema file from JSON data file.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -39,12 +39,9 @@ import picocli.CommandLine;
  * Class to implement LaunchDataIngestionJob command.
  *
  */
-@CommandLine.Command(name = "LaunchDataIngestionJob")
+@CommandLine.Command(name = "LaunchDataIngestionJob", mixinStandardHelpOptions = true)
 public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(LaunchDataIngestionJobCommand.class);
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
   @CommandLine.Option(names = {"-jobSpecFile", "-jobSpec"}, required = true,
       description = "Ingestion job spec file")
   private String _jobSpecFile;
@@ -91,15 +88,6 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   public void setAuthProvider(AuthProvider authProvider) {
     _authProvider = authProvider;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
-
-  public void setHelp(boolean help) {
-    _help = help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -50,7 +50,7 @@ import picocli.CommandLine;
  * Class to implement LaunchDataIngestionJob command.
  *
  */
-@CommandLine.Command(name = "LaunchSparkDataIngestionJob")
+@CommandLine.Command(name = "LaunchSparkDataIngestionJob", mixinStandardHelpOptions = true)
 public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(LaunchSparkDataIngestionJobCommand.class);
   public static final String MAIN_CLASS = "org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand";
@@ -59,9 +59,6 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
   public static final String LOCAL_FILE_PREFIX = "local://";
   public static final String PINOT_MAIN_JAR_PREFIX = "pinot-all";
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
-      + "this message.")
-  private boolean _help = false;
   @CommandLine.Option(names = {"-jobSpecFile", "-jobSpec"}, required = true, description = "Ingestion job spec file")
   private String _jobSpecFile;
   @CommandLine.Option(names = {"-values"}, required = false, arity = "1..*", description = "Context values set to the"
@@ -128,15 +125,6 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
 
   public void setAuthProvider(AuthProvider authProvider) {
     _authProvider = authProvider;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
-
-  public void setHelp(boolean help) {
-    _help = help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
@@ -60,7 +60,7 @@ import picocli.CommandLine;
  * This command is intended to be run multiple times to migrate all the replicas of a table to the destination
  * servers (if intended).
  */
-@CommandLine.Command(name = "MoveReplicaGroup")
+@CommandLine.Command(name = "MoveReplicaGroup", mixinStandardHelpOptions = true)
 public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(MoveReplicaGroup.class);
 
@@ -92,16 +92,8 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
       description = "Execute replica group move. dryRun(default) if not specified")
   private boolean _exec = false;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, description = "Prints help")
-  private boolean _help = false;
-
   private ZKHelixAdmin _helix;
   private PinotZKChanger _zkChanger;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OfflineSegmentIntervalCheckerCommand.java
@@ -42,7 +42,7 @@ import picocli.CommandLine;
 /**
  * Pinot admin command to list all offline segments with invalid intervals, group by table name
  */
-@CommandLine.Command(name = "OfflineSegmentIntervalChecker")
+@CommandLine.Command(name = "OfflineSegmentIntervalChecker", mixinStandardHelpOptions = true)
 public class OfflineSegmentIntervalCheckerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(OfflineSegmentIntervalCheckerCommand.class);
 
@@ -57,14 +57,6 @@ public class OfflineSegmentIntervalCheckerCommand extends AbstractBaseAdminComma
   @CommandLine.Option(names = {"-tableNames"},
       description = "Comma separated list of tables to check for invalid segment intervals")
   private String _tableNames;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String toString() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "OperateClusterConfig")
+@CommandLine.Command(name = "OperateClusterConfig", mixinStandardHelpOptions = true)
 public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(OperateClusterConfigCommand.class.getName());
 
@@ -67,16 +67,7 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
       description = "Operation to take for Cluster config, currently support GET/ADD/UPDATE/DELETE.")
   private String _operation;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   private AuthProvider _authProvider;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "PostQuery")
+@CommandLine.Command(name = "PostQuery", mixinStandardHelpOptions = true)
 public class PostQueryCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostQueryCommand.class.getName());
 
@@ -60,19 +60,10 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
-      + "this message.")
-  private boolean _help = false;
-
   @CommandLine.Option(names = {"-o", "-option"}, required = false, description = "Additional options '-o key=value'")
   private Map<String, String> _additionalOptions = new HashMap<>();
 
   private AuthProvider _authProvider;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "QuickStart")
+@CommandLine.Command(name = "QuickStart", mixinStandardHelpOptions = true)
 public class QuickStartCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(QuickStartCommand.class.getName());
 
@@ -54,15 +54,6 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
   @CommandLine.Option(names = {"-configFile", "-configFilePath"}, required = false,
       description = "Config file path to override default pinot configs")
   private String _configFilePath;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -43,7 +43,7 @@ import picocli.CommandLine;
  * Given a set of input params, output a table of num hosts to num hours and the memory required per host
  *
  */
-@CommandLine.Command(name = "RealtimeProvisioningHelper")
+@CommandLine.Command(name = "RealtimeProvisioningHelper", mixinStandardHelpOptions = true)
 public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand implements Command {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeProvisioningHelperCommand.class);
@@ -102,9 +102,6 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
   @CommandLine.Option(names = {"-maxUsableHostMemory"}, required = false,
       description = "Maximum memory per host that can be used for pinot data (e.g. 250G, 100M). Default 48g")
   private String _maxUsableHostMemory = "48G";
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true)
-  private boolean _help = false;
 
   public RealtimeProvisioningHelperCommand setTableConfigFile(String tableConfigFile) {
     _tableConfigFile = tableConfigFile;
@@ -186,11 +183,6 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
         + "of hours to consume and hosts. "
         + "Instead of a completed segment, if schema with characteristics of data is provided, a segment will be "
         + "generated and used for memory estimation.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -32,7 +32,7 @@ import picocli.CommandLine;
  * A sub-command for pinot-admin tool to rebalance a specific table
  */
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
-@CommandLine.Command(name = "RebalanceTable")
+@CommandLine.Command(name = "RebalanceTable", mixinStandardHelpOptions = true)
 public class RebalanceTableCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(RebalanceTableCommand.class);
 
@@ -94,13 +94,6 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
       description = "How long to wait till external view converges with ideal view")
   private long _externalViewStabilizationTimeoutInMs =
       RebalanceConfig.DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message")
-  private boolean _help = false;
-
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/SegmentProcessorFrameworkCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/SegmentProcessorFrameworkCommand.java
@@ -43,7 +43,7 @@ import picocli.CommandLine;
 /**
  * Command to run {@link org.apache.pinot.core.segment.processing.framework.SegmentProcessorFramework}
  */
-@CommandLine.Command(name = "SegmentProcessorFramework")
+@CommandLine.Command(name = "SegmentProcessorFramework", mixinStandardHelpOptions = true)
 public class SegmentProcessorFrameworkCommand extends AbstractBaseAdminCommand implements Command {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentProcessorFrameworkCommand.class);
@@ -51,14 +51,6 @@ public class SegmentProcessorFrameworkCommand extends AbstractBaseAdminCommand i
   @CommandLine.Option(names = {"-segmentProcessorFrameworkSpec"}, required = true,
       description = "Path to SegmentProcessorFrameworkSpec json file")
   private String _segmentProcessorFrameworkSpec;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ShowClusterInfoCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ShowClusterInfoCommand.java
@@ -48,7 +48,7 @@ import org.yaml.snakeyaml.Yaml;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "ShowClusterInfo")
+@CommandLine.Command(name = "ShowClusterInfo", mixinStandardHelpOptions = true)
 public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShowClusterInfoCommand.class.getName());
 
@@ -63,10 +63,6 @@ public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements 
 
   @CommandLine.Option(names = {"-tags"}, required = false, description = "Commaa separated tag names.")
   private String _tags = "";
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   @Override
   public boolean execute()
@@ -190,11 +186,6 @@ public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements 
   @Override
   public String description() {
     return "Show Pinot Cluster information.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -38,12 +38,9 @@ import picocli.CommandLine;
  * Class to implement StartBroker command.
  *
  */
-@CommandLine.Command(name = "StartBroker")
+@CommandLine.Command(name = "StartBroker", mixinStandardHelpOptions = true)
 public class StartBrokerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartBrokerCommand.class);
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   @CommandLine.Option(names = {"-brokerHost"}, required = false, description = "host name for broker.")
   private String _brokerHost;
@@ -69,10 +66,6 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   @CommandLine.Option(names = {"-configOverrides"}, required = false, split = ",",
       description = "Proxy config overrides")
   private Map<String, Object> _configOverrides = new HashMap<>();
-
-  public boolean getHelp() {
-    return _help;
-  }
 
   public String getBrokerHost() {
     return _brokerHost;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -38,15 +38,12 @@ import picocli.CommandLine;
  * Class to implement StartController command.
  *
  */
-@CommandLine.Command(name = "StartController")
+@CommandLine.Command(name = "StartController", mixinStandardHelpOptions = true)
 public class StartControllerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartControllerCommand.class);
 
   @CommandLine.Option(names = {"-controllerMode"}, description = "Pinot controller mode.")
   private ControllerConf.ControllerMode _controllerMode = ControllerConf.ControllerMode.DUAL;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, description = "Print this message.")
-  private boolean _help = false;
 
   @CommandLine.Option(names = {"-controllerHost"}, required = false, description = "host name for controller.")
   private String _controllerHost;
@@ -75,11 +72,6 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
 
   @CommandLine.Option(names = {"-configOverride"}, required = false, split = ",")
   private Map<String, Object> _configOverrides = new HashMap<>();
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   public ControllerConf.ControllerMode getControllerMode() {
     return _controllerMode;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
@@ -33,16 +33,12 @@ import picocli.CommandLine;
 /**
  * Class for command to start Kafka.
  */
-@CommandLine.Command(name = "StartKafka")
+@CommandLine.Command(name = "StartKafka", mixinStandardHelpOptions = true)
 public class StartKafkaCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartKafkaCommand.class);
 
   @CommandLine.Option(names = {"-port"}, required = false, description = "Port to start Kafka server on.")
   private int _port = KafkaStarterUtils.DEFAULT_KAFKA_PORT;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   @CommandLine.Option(names = {"-brokerId"}, required = false, description = "Kafka broker ID.")
   private int _brokerId = KafkaStarterUtils.DEFAULT_BROKER_ID;
@@ -50,11 +46,6 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
   @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "Address of Zookeeper.")
   private String _zkAddress = KafkaStarterUtils.getDefaultKafkaZKAddress();
   private StreamDataServerStartable _kafkaStarter;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -38,12 +38,9 @@ import picocli.CommandLine;
  * Class to implement StartMinion command.
  *
  */
-@CommandLine.Command(name = "StartMinion")
+@CommandLine.Command(name = "StartMinion", mixinStandardHelpOptions = true)
 public class StartMinionCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartMinionCommand.class);
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
   @CommandLine.Option(names = {"-minionHost"}, required = false, description = "Host name for minion.")
   private String _minionHost;
   @CommandLine.Option(names = {"-minionPort"}, required = false, description = "Port number to start the minion at.")
@@ -62,10 +59,6 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
   public StartMinionCommand setConfigOverrides(Map<String, Object> configs) {
     _configOverrides = configs;
     return this;
-  }
-
-  public boolean getHelp() {
-    return _help;
   }
 
   public String getMinionHost() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -38,13 +38,9 @@ import picocli.CommandLine;
  * Class to implement StartServer command.
  *
  */
-@CommandLine.Command(name = "StartServer")
+@CommandLine.Command(name = "StartServer", mixinStandardHelpOptions = true)
 public class StartServerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartServerCommand.class);
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   @CommandLine.Option(names = {"-serverHost"}, required = false, description = "Host name for server.")
   private String _serverHost;
 
@@ -87,11 +83,6 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
 
   @CommandLine.Option(names = {"-configOverride"}, required = false, split = ",")
   private Map<String, Object> _configOverrides = new HashMap<>();
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   public String getServerHost() {
     return _serverHost;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -52,7 +52,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.Helix.PINOT_SERVICE_ROL
  * <li>All remaining bootstrap services in parallel</li>
  * </ol>
  */
-@CommandLine.Command(name = "StartServiceManager")
+@CommandLine.Command(name = "StartServiceManager", mixinStandardHelpOptions = true)
 public class StartServiceManagerCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartServiceManagerCommand.class);
   private static final long START_TICK = System.nanoTime();
@@ -60,9 +60,6 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   // multiple instances allowed per role for testing many minions
   private final List<Entry<ServiceRole, Map<String, Object>>> _bootstrapConfigurations = new ArrayList<>();
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help;
   @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "Http address of Zookeeper.")
   // TODO: support forbids = {"-bootstrapConfigPaths", "-bootstrapServices"})
   private String _zkAddress = DEFAULT_ZK_ADDRESS;
@@ -128,15 +125,6 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   public StartServiceManagerCommand setBootstrapServices(String[] bootstrapServices) {
     _bootstrapServices = bootstrapServices;
     return this;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
-
-  public void setHelp(boolean help) {
-    _help = help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
@@ -34,7 +34,7 @@ import picocli.CommandLine;
  *
  *
  */
-@CommandLine.Command(name = "StartZookeeper")
+@CommandLine.Command(name = "StartZookeeper", mixinStandardHelpOptions = true)
 public class StartZookeeperCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StartZookeeperCommand.class);
 
@@ -43,15 +43,6 @@ public class StartZookeeperCommand extends AbstractBaseAdminCommand implements C
 
   @CommandLine.Option(names = {"-dataDir"}, required = false, description = "Directory for zookeper data.")
   private String _dataDir = PinotConfigUtils.TMP_DIR + "PinotAdmin/zkData";
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StopProcessCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StopProcessCommand.java
@@ -37,7 +37,7 @@ import picocli.CommandLine;
  *
  *
  */
-@CommandLine.Command(name = "StopProcess")
+@CommandLine.Command(name = "StopProcess", mixinStandardHelpOptions = true)
 public class StopProcessCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StopProcessCommand.class);
 
@@ -55,10 +55,6 @@ public class StopProcessCommand extends AbstractBaseAdminCommand implements Comm
 
   @CommandLine.Option(names = {"-kafka"}, required = false, description = "Stop the Kafka process.")
   private boolean _kafka = false;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Stop the PinotServer.")
-  private boolean _help = false;
 
   public StopProcessCommand() {
   }
@@ -171,11 +167,6 @@ public class StopProcessCommand extends AbstractBaseAdminCommand implements Comm
     }
 
     return ret;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamAvroIntoKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamAvroIntoKafkaCommand.java
@@ -45,15 +45,11 @@ import picocli.CommandLine;
 /**
  * Class for command to stream Avro data into Kafka.
  */
-@CommandLine.Command(name = "StreamAvroIntoKafka")
+@CommandLine.Command(name = "StreamAvroIntoKafka", mixinStandardHelpOptions = true)
 public class StreamAvroIntoKafkaCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamAvroIntoKafkaCommand.class);
   @CommandLine.Option(names = {"-avroFile"}, required = true, description = "Avro file to stream.")
   private String _avroFile = null;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   @CommandLine.Option(names = {"-kafkaBrokerList"}, required = false, description = "Kafka broker list.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
@@ -71,11 +67,6 @@ public class StreamAvroIntoKafkaCommand extends AbstractBaseAdminCommand impleme
   @CommandLine.Option(names = {"-millisBetweenMessages"}, required = false,
       description = "Delay in milliseconds between messages (default 1000 ms)")
   private String _millisBetweenMessages = "1000";
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -30,7 +30,7 @@ import picocli.CommandLine;
 /**
  * Command to stream GitHub events into a kafka topic or kinesis stream
  */
-@CommandLine.Command(name = "StreamGitHubEvents")
+@CommandLine.Command(name = "StreamGitHubEvents", mixinStandardHelpOptions = true)
 public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implements Command {
 
   private static final String PULL_REQUEST_MERGED_EVENT_TYPE = "pullRequestMergedEvent";
@@ -89,9 +89,6 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
       + "By default uses examples/stream/pullRequestMergedEvents/pullRequestMergedEvents_schema.json")
   private String _schemaFile;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
-  private boolean _help = false;
-
   public void setPersonalAccessToken(String personalAccessToken) {
     _personalAccessToken = personalAccessToken;
   }
@@ -110,11 +107,6 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
 
   public void setSchemaFile(String schemaFile) {
     _schemaFile = schemaFile;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -43,7 +43,7 @@ import picocli.CommandLine;
  *
  *
  */
-@CommandLine.Command(name = "UploadSegment")
+@CommandLine.Command(name = "UploadSegment", mixinStandardHelpOptions = true)
 public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(UploadSegmentCommand.class);
   private static final String SEGMENT_UPLOADER = "segmentUploader";
@@ -79,16 +79,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
       description = "Table type to upload. Can be OFFLINE or REALTIME")
   private TableType _tableType = TableType.OFFLINE;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   private AuthProvider _authProvider;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
@@ -47,7 +47,7 @@ import picocli.CommandLine;
  *   <li>Schema</li>
  * </ul>
  */
-@CommandLine.Command(name = "ValidateConfig")
+@CommandLine.Command(name = "ValidateConfig", mixinStandardHelpOptions = true)
 public class ValidateConfigCommand extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ValidateConfigCommand.class);
 
@@ -75,15 +75,6 @@ public class ValidateConfigCommand extends AbstractBaseCommand implements Comman
   @CommandLine.Option(names = {"-schemaNames"}, required = false,
       description = "Space separated schema names to be validated (default to validate ALL)")
   private String _schemaNames;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifyClusterStateCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifyClusterStateCommand.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "VerifyClusterState")
+@CommandLine.Command(name = "VerifyClusterState", mixinStandardHelpOptions = true)
 public class VerifyClusterStateCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(VerifyClusterStateCommand.class);
 
@@ -41,10 +41,6 @@ public class VerifyClusterStateCommand extends AbstractBaseAdminCommand implemen
 
   @CommandLine.Option(names = {"-timeoutSec"}, required = false, description = "Maximum timeout in second.")
   private long _timeoutSec = 300L;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
 
   @Override
   public String getName() {
@@ -83,10 +79,5 @@ public class VerifyClusterStateCommand extends AbstractBaseAdminCommand implemen
   @Override
   public String description() {
     return "Verify cluster's state after shutting down several nodes randomly.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "VerifySegmentState")
+@CommandLine.Command(name = "VerifySegmentState", mixinStandardHelpOptions = true)
 public class VerifySegmentState extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(VerifySegmentState.class);
 
@@ -46,14 +46,6 @@ public class VerifySegmentState extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-tablePrefix"}, required = false,
       description = "Table name prefix. (Ex: myTable, my or myTable_OFFLINE)")
   String _tablePrefix = "";
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public boolean execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/BaseFileOperation.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/BaseFileOperation.java
@@ -50,9 +50,4 @@ public abstract class BaseFileOperation implements Command {
     PinotFSFactory.init(new PinotConfiguration(configs));
     QuickstartRunner.registerDefaultPinotFS();
   }
-
-  @Override
-  public boolean getHelp() {
-    return _parent.getHelp();
-  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkRunner.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class PinotFSBenchmarkRunner extends AbstractBaseCommand implements Command {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotFSBenchmarkRunner.class);
@@ -57,10 +57,6 @@ public class PinotFSBenchmarkRunner extends AbstractBaseCommand implements Comma
       description = "The number of trials of operations when running a benchmark.")
   private Integer _numOps;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
   @Override
   public boolean execute()
       throws Exception {
@@ -79,10 +75,5 @@ public class PinotFSBenchmarkRunner extends AbstractBaseCommand implements Comma
   @Override
   public String description() {
     return "Run Filesystem benchmark";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -34,7 +34,7 @@ import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PerfBenchmarkRunner.class);
 
@@ -91,15 +91,6 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
 
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
-      description = "Print this message.")
-  private boolean _help = false;
-
-  @Override
-  public boolean getHelp() {
-    return _help;
-  }
 
   @Override
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -45,7 +45,7 @@ import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
-@CommandLine.Command
+@CommandLine.Command(mixinStandardHelpOptions = true)
 public class QueryRunner extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRunner.class);
   private static final int MILLIS_PER_SECOND = 1000;
@@ -108,17 +108,9 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
   private String _authToken;
   @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
   private String _authTokenUrl;
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
-      + "this message.")
-  private boolean _help;
 
   private enum QueryMode {
     FULL, RESAMPLE
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 
   @Override
@@ -964,10 +956,6 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     QueryRunner queryRunner = new QueryRunner();
     CommandLine commandLine = new CommandLine(queryRunner);
     commandLine.parseArgs(args);
-    if (queryRunner._help) {
-      queryRunner.printUsage();
-    } else {
-      queryRunner.execute();
-    }
+    queryRunner.execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
@@ -41,7 +41,7 @@ import picocli.CommandLine;
  * </ul>
  */
 @SuppressWarnings("FieldCanBeLocal")
-@CommandLine.Command(name = "PinotSegmentConvert")
+@CommandLine.Command(name = "PinotSegmentConvert", mixinStandardHelpOptions = true)
 public class PinotSegmentConvertCommand extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentConvertCommand.class);
   private static final String TEMP_DIR_NAME = "temp";
@@ -70,10 +70,6 @@ public class PinotSegmentConvertCommand extends AbstractBaseCommand implements C
   @CommandLine.Option(names = {"-overwrite"}, required = false,
       description = "Overwrite the existing file (default false).")
   private boolean _overwrite;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
-      description = "Print this message.")
-  private boolean _help;
 
   @Override
   public boolean execute()
@@ -157,10 +153,5 @@ public class PinotSegmentConvertCommand extends AbstractBaseCommand implements C
   @Override
   public String description() {
     return "Convert Pinot segments to another format such as AVRO/CSV/JSON.";
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
   }
 }

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestCommandHelp.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestCommandHelp.java
@@ -1,0 +1,33 @@
+package org.apache.pinot.tools.admin.command;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class TestCommandHelp {
+  @DataProvider(name = "subCommands")
+  Object[][] subCommands() {
+    PinotAdministrator administrator = new PinotAdministrator();
+    List<Object[]> inputs = new ArrayList<>();
+    for (Map.Entry<String, Command> subCommand : administrator.getSubCommands().entrySet()) {
+      inputs.add(new Object[]{subCommand.getKey()});
+    }
+
+    return inputs.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "subCommands")
+  void testHelp(String subCommand) {
+    PinotAdministrator administrator = new PinotAdministrator();
+    String[] args = {subCommand, "--help"};
+    administrator.execute(args);
+    assertEquals(administrator.getStatus(), 0);
+  }
+}

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestCommandHelp.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestCommandHelp.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.admin.command;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Currently `pinot-admin` command help either throws an NPE or executes the command. Example:

```
pinot-admin.sh GenerateData --help

2024/11/11 12:04:07.820 INFO [GenerateDataCommand] [main] Executing command: GenerateData -numRecords 0 -numFiles  0 -schemaFile null -outDir null -schemaAnnotationFile null
java.lang.NullPointerException
        at java.base/java.io.File.<init>(File.java:278)
        at org.apache.pinot.tools.admin.command.GenerateDataCommand.execute(GenerateDataCommand.java:122)
        at org.apache.pinot.tools.Command.call(Command.java:33)
        at org.apache.pinot.tools.Command.call(Command.java:29)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:173)
        at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:204)

pinot-admin.sh AddTable --help
2024/11/11 11:58:58.253 WARN [AddTableCommand] [main] Dry Running Command: AddTable -tableConfigFile null -offlineTableConfigFile null -realtimeTableConfigFile null -schemaFile null -controllerProtocol http -controllerHost null -controllerPort 9000 -controllerProtocol http -database null -user null -password [hidden]
2024/11/11 11:58:58.253 WARN [AddTableCommand] [main] Use the -exec option to actually execute the command.
```

This is because the help code was not moved to use picocli in https://github.com/apache/pinot/commit/d7c0944ad76b02ca8a695caa3f0205b3c7a8b49a

This commit removes the old code to display the help message and uses Picocli to generate it. With the change help message examples are:

```
❯ ./build/bin/pinot-admin.sh GenerateData --help
Usage: <main class> GenerateData [-hV] [-overwrite] -numFiles=<_numFiles>
                                 -numRecords=<_numRecords> -outDir=<_outDir>
                                 [-schemaAnnotationFile=<_schemaAnnFile>]
                                 -schemaFile=<_schemaFile> [-format=<_format>]
  -h, --help              Show this help message and exit.
      -numFiles=<_numFiles>
                          Number of files to generate.
      -numRecords=<_numRecords>
                          Number of records to generate.
      -outDir=<_outDir>   Directory where data would be generated.
      -overwrite          Overwrite, if directory exists
      -schemaAnnotationFile=<_schemaAnnFile>
                          File containing dim/metrics for columns.
      -schemaFile=<_schemaFile>
                          File containing schema for data.
  -V, --version           Print version information and exit.
      -format=<_format>   Output format ('AVRO' or 'CSV' or 'JSON').

❯ ./build/bin/pinot-admin.sh AddTable --help
Usage: <main class> AddTable [-hV] [-exec] [-skipControllerCertValidation]
                             [-update] [-authToken=<_authToken>]
                             [-authTokenUrl=<_authTokenUrl>]
                             [-controllerHost=<_controllerHost>]
                             [-controllerPort=<_controllerPort>]
                             [-controllerProtocol=<_controllerProtocol>]
                             [-database=<_database>]
                             [-filePath=<_tableConfigFile>]
                             [-offlineFilePath=<_offlineTableConfigFile>]
                             [-password=<_password>]
                             [-realtimeFilePath=<_realtimeTableConfigFile>]
                             [-schema=<_schemaFile>] [-user=<_user>]
      -authToken=<_authToken>
                      Http auth token.
      -authTokenUrl=<_authTokenUrl>
                      Http auth token url.
      -controllerHost=<_controllerHost>
                      Host name for controller.
      -controllerPort=<_controllerPort>
                      Port number for controller.
      -controllerProtocol=<_controllerProtocol>
                      Protocol for controller.
      -database=<_database>
                      Corresponding database.
      -exec           Execute the command.
      -filePath, -tableConf, -tableConfig, -tableConfigFile=<_tableConfigFile>
                      Path to table config file.
  -h, --help          Show this help message and exit.
      -offlineFilePath, -offlineTableConf, -offlineTableConfig,
        -offlineTableConfigFile=<_offlineTableConfigFile>
                      Path to offline table config file.
      -password=<_password>
                      Password for basic auth.
      -realtimeFilePath, -realtimeTableConf, -realtimeTableConfig,
        -realtimeTableConfigFile=<_realtimeTableConfigFile>
                      Path to realtime table config file.
      -schema, -schemaFile, -schemaFileName=<_schemaFile>
                      Path to table schema file.
      -skipControllerCertValidation
                      Whether to skip controller certification validation.
      -update         Update the existing table instead of creating new one
      -user=<_user>   Username for basic auth.
  -V, --version       Print version information and exit.
```

Moreover, picocli color codes the message if the terminal supports it.

![Screenshot 2024-11-11 at 11 59 42 AM](https://github.com/user-attachments/assets/ddbf1a83-f94d-4b09-8a6e-e0077f2d692f)

While the diff is big, most of the diff adds a mixin as specified in https://picocli.info/#_printing_help_automatically AND it removes the old help message option. The picocli message is more helpful.

A test has also been added to make sure the changes are correct.
