### PR TITLE
[timeseries] Fix Server Selection Bug + Enforce Timeout

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -90,6 +90,8 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
   @Override
   public PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
       RequestContext requestContext) {
+    requestContext.setBrokerId(_brokerId);
+    requestContext.setRequestId(_requestIdGenerator.get());
     RangeTimeSeriesRequest timeSeriesRequest = null;
     try {
       timeSeriesRequest = buildRangeTimeSeriesRequest(lang, rawQueryParamString);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -267,7 +267,7 @@ public class QueryRunner {
       BaseTimeSeriesPlanNode rootNode = TimeSeriesPlanSerde.deserialize(serializedPlan);
       TimeSeriesExecutionContext context = new TimeSeriesExecutionContext(
           metadata.get(WorkerRequestMetadataKeys.LANGUAGE), extractTimeBuckets(metadata),
-          extractPlanToSegmentMap(metadata), timeoutMs);
+          extractPlanToSegmentMap(metadata), timeoutMs, metadata);
       BaseTimeSeriesOperator operator = PhysicalTimeSeriesPlanVisitor.INSTANCE.compile(rootNode, context);
       // Run the operator using the same executor service as OpChainSchedulerService
       _executorService.submit(() -> {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
 import java.nio.charset.StandardCharsets;
@@ -259,11 +260,14 @@ public class QueryRunner {
       responseObserver.onCompleted();
     };
     try {
+      final long timeoutMs = extractTimeoutMs(metadata);
+      Preconditions.checkState(timeoutMs > 0,
+          "Query timed out before getting processed in server. Remaining time: %s", timeoutMs);
       // Deserialize plan, and compile to create a tree of operators.
       BaseTimeSeriesPlanNode rootNode = TimeSeriesPlanSerde.deserialize(serializedPlan);
       TimeSeriesExecutionContext context = new TimeSeriesExecutionContext(
           metadata.get(WorkerRequestMetadataKeys.LANGUAGE), extractTimeBuckets(metadata),
-          extractPlanToSegmentMap(metadata));
+          extractPlanToSegmentMap(metadata), timeoutMs);
       BaseTimeSeriesOperator operator = PhysicalTimeSeriesPlanVisitor.INSTANCE.compile(rootNode, context);
       // Run the operator using the same executor service as OpChainSchedulerService
       _executorService.submit(() -> {
@@ -284,26 +288,6 @@ public class QueryRunner {
       LOGGER.error("Error running time-series query", t);
       handleErrors.accept(t);
     }
-  }
-
-  public TimeBuckets extractTimeBuckets(Map<String, String> metadataMap) {
-    long startTimeSeconds = Long.parseLong(metadataMap.get(WorkerRequestMetadataKeys.START_TIME_SECONDS));
-    long windowSeconds = Long.parseLong(metadataMap.get(WorkerRequestMetadataKeys.WINDOW_SECONDS));
-    int numElements = Integer.parseInt(metadataMap.get(WorkerRequestMetadataKeys.NUM_ELEMENTS));
-    return TimeBuckets.ofSeconds(startTimeSeconds, Duration.ofSeconds(windowSeconds), numElements);
-  }
-
-  public Map<String, List<String>> extractPlanToSegmentMap(Map<String, String> metadataMap) {
-    Map<String, List<String>> result = new HashMap<>();
-    for (var entry : metadataMap.entrySet()) {
-      if (WorkerRequestMetadataKeys.isKeySegmentList(entry.getKey())) {
-        String planId = WorkerRequestMetadataKeys.decodeSegmentListKey(entry.getKey());
-        String[] segments = entry.getValue().split(",");
-        result.put(planId,
-            Stream.of(segments).map(String::strip).collect(Collectors.toList()));
-      }
-    }
-    return result;
   }
 
   private Map<String, String> consolidateMetadata(Map<String, String> customProperties,
@@ -414,5 +398,32 @@ public class QueryRunner {
     } else {
       return node;
     }
+  }
+
+  // Time series related utility methods below
+
+  private long extractTimeoutMs(Map<String, String> metadataMap) {
+    long deadlineMs = Long.parseLong(metadataMap.get(WorkerRequestMetadataKeys.DEADLINE_MS));
+    return deadlineMs - System.currentTimeMillis();
+  }
+
+  private TimeBuckets extractTimeBuckets(Map<String, String> metadataMap) {
+    long startTimeSeconds = Long.parseLong(metadataMap.get(WorkerRequestMetadataKeys.START_TIME_SECONDS));
+    long windowSeconds = Long.parseLong(metadataMap.get(WorkerRequestMetadataKeys.WINDOW_SECONDS));
+    int numElements = Integer.parseInt(metadataMap.get(WorkerRequestMetadataKeys.NUM_ELEMENTS));
+    return TimeBuckets.ofSeconds(startTimeSeconds, Duration.ofSeconds(windowSeconds), numElements);
+  }
+
+  private Map<String, List<String>> extractPlanToSegmentMap(Map<String, String> metadataMap) {
+    Map<String, List<String>> result = new HashMap<>();
+    for (var entry : metadataMap.entrySet()) {
+      if (WorkerRequestMetadataKeys.isKeySegmentList(entry.getKey())) {
+        String planId = WorkerRequestMetadataKeys.decodeSegmentListKey(entry.getKey());
+        String[] segments = entry.getValue().split(",");
+        result.put(planId,
+            Stream.of(segments).map(String::strip).collect(Collectors.toList()));
+      }
+    }
+    return result;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.timeseries;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +31,7 @@ import org.apache.pinot.common.request.context.TimeSeriesContext;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
 import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
@@ -96,7 +98,7 @@ public class PhysicalTimeSeriesPlanVisitor {
         .setFilter(filterContext)
         .setGroupByExpressions(groupByExpressions)
         .setSelectExpressions(Collections.emptyList())
-        .setQueryOptions(Collections.emptyMap())
+        .setQueryOptions(ImmutableMap.of(QueryOptionKey.TIMEOUT_MS, Long.toString(context.getTimeoutMs())))
         .setAliasList(Collections.emptyList())
         .setTimeSeriesContext(timeSeriesContext)
         .setLimit(Integer.MAX_VALUE)

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
@@ -27,12 +27,14 @@ public class TimeSeriesExecutionContext {
   private final String _language;
   private final TimeBuckets _initialTimeBuckets;
   private final Map<String, List<String>> _planIdToSegmentsMap;
+  private final long _timeoutMs;
 
   public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets,
-      Map<String, List<String>> planIdToSegmentsMap) {
+      Map<String, List<String>> planIdToSegmentsMap, long timeoutMs) {
     _language = language;
     _initialTimeBuckets = initialTimeBuckets;
     _planIdToSegmentsMap = planIdToSegmentsMap;
+    _timeoutMs = timeoutMs;
   }
 
   public String getLanguage() {
@@ -45,5 +47,9 @@ public class TimeSeriesExecutionContext {
 
   public Map<String, List<String>> getPlanIdToSegmentsMap() {
     return _planIdToSegmentsMap;
+  }
+
+  public long getTimeoutMs() {
+    return _timeoutMs;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
@@ -28,13 +28,15 @@ public class TimeSeriesExecutionContext {
   private final TimeBuckets _initialTimeBuckets;
   private final Map<String, List<String>> _planIdToSegmentsMap;
   private final long _timeoutMs;
+  private final Map<String, String> _metadataMap;
 
   public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets,
-      Map<String, List<String>> planIdToSegmentsMap, long timeoutMs) {
+      Map<String, List<String>> planIdToSegmentsMap, long timeoutMs, Map<String, String> metadataMap) {
     _language = language;
     _initialTimeBuckets = initialTimeBuckets;
     _planIdToSegmentsMap = planIdToSegmentsMap;
     _timeoutMs = timeoutMs;
+    _metadataMap = metadataMap;
   }
 
   public String getLanguage() {
@@ -51,5 +53,9 @@ public class TimeSeriesExecutionContext {
 
   public long getTimeoutMs() {
     return _timeoutMs;
+  }
+
+  public Map<String, String> getMetadataMap() {
+    return _metadataMap;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.tsdb.spi.AggInfo;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 import org.apache.pinot.tsdb.spi.plan.LeafTimeSeriesPlanNode;
@@ -32,6 +33,8 @@ import static org.testng.Assert.assertNotNull;
 
 
 public class PhysicalTimeSeriesPlanVisitorTest {
+  private static final int DUMMY_TIMEOUT_MS = 10_000;
+
   @Test
   public void testCompileQueryContext() {
     final String planId = "id";
@@ -43,7 +46,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap());
+              Collections.emptyMap(), DUMMY_TIMEOUT_MS);
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 0L,
               filterExpr, "orderCount", aggInfo, Collections.singletonList("cityName"));
@@ -55,12 +58,13 @@ public class PhysicalTimeSeriesPlanVisitorTest {
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().getIdentifier(), "orderCount");
       assertEquals(queryContext.getFilter().toString(),
           "(cityName = 'Chicago' AND orderTime > '990' AND orderTime <= '1990')");
+      assertEquals(Long.parseLong(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)), DUMMY_TIMEOUT_MS);
     }
     // Case-2: With offset, complex group-by expression, complex value, and non-empty filter
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap());
+              Collections.emptyMap(), DUMMY_TIMEOUT_MS);
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 10L,
               filterExpr, "orderCount*2", aggInfo, Collections.singletonList("concat(cityName, stateName, '-')"));
@@ -76,6 +80,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
       assertNotNull(queryContext.getFilter());
       assertEquals(queryContext.getFilter().toString(),
           "(cityName = 'Chicago' AND orderTime > '980' AND orderTime <= '1980')");
+      assertEquals(Long.parseLong(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)), DUMMY_TIMEOUT_MS);
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitorTest.java
@@ -46,7 +46,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap(), DUMMY_TIMEOUT_MS);
+              Collections.emptyMap(), DUMMY_TIMEOUT_MS, Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 0L,
               filterExpr, "orderCount", aggInfo, Collections.singletonList("cityName"));
@@ -64,7 +64,7 @@ public class PhysicalTimeSeriesPlanVisitorTest {
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap(), DUMMY_TIMEOUT_MS);
+              Collections.emptyMap(), DUMMY_TIMEOUT_MS, Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 10L,
               filterExpr, "orderCount*2", aggInfo, Collections.singletonList("concat(cityName, stateName, '-')"));

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
@@ -32,6 +32,7 @@ public class TimeSeriesPlanConstants {
     public static final String START_TIME_SECONDS = "startTimeSeconds";
     public static final String WINDOW_SECONDS = "windowSeconds";
     public static final String NUM_ELEMENTS = "numElements";
+    public static final String DEADLINE_MS = "deadlineMs";
 
     public static boolean isKeySegmentList(String key) {
       return key.startsWith(SEGMENT_MAP_ENTRY_PREFIX);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -77,8 +77,7 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);
     final QuickstartRunner runner =
-        new QuickstartRunner(quickstartTableRequests, 1, 1, getNumQuickstartRunnerServers(),
-            1, quickstartRunnerDir, getConfigOverrides());
+        new QuickstartRunner(quickstartTableRequests, 1, 1, 1, 1, quickstartRunnerDir, getConfigOverrides());
 
     startKafka();
     startAllDataStreams(_kafkaStarter, quickstartTmpDir);
@@ -105,9 +104,5 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     runSampleQueries(runner);
 
     printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
-  }
-
-  protected int getNumQuickstartRunnerServers() {
-    return 2;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -77,7 +77,8 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);
     final QuickstartRunner runner =
-        new QuickstartRunner(quickstartTableRequests, 1, 1, 1, 1, quickstartRunnerDir, getConfigOverrides());
+        new QuickstartRunner(quickstartTableRequests, 1, 1, getNumQuickstartRunnerServers(),
+            1, quickstartRunnerDir, getConfigOverrides());
 
     startKafka();
     startAllDataStreams(_kafkaStarter, quickstartTmpDir);
@@ -104,5 +105,9 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     runSampleQueries(runner);
 
     printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+  }
+
+  protected int getNumQuickstartRunnerServers() {
+    return 2;
   }
 }


### PR DESCRIPTION
### Summary

* Fixes bug that was causing the queries to go to always the same server. This was because requestId wasn't set in the RequestContext.
* Made changes to actually honor the passed timeout in the servers. Timeout is now passed to the Combine operator, and in case of expensive queries, additional per-segment operators will not be run when the timeout has elapsed. (this is standard/expected behavior)
* Made changes to pass brokerId and requestId to server from the broker.

### Test Plan

Tested on local. Successful queries continue to work and the timeout is being passed E2E.

Screenshot showing the combine operator timeout. The timeout set was 1s for this query, and it is propagated via QueryContext#queryOptions, which is used in ServerQueryExecutorV1Impl to compute the query endTimeMs.

![image](https://github.com/user-attachments/assets/60804c97-5560-4d2d-a6fa-37b581e5bec3)

Screenshot showing that the broker-id/request-id are passed successfully to the server.

![image](https://github.com/user-attachments/assets/d0e509c1-0cec-4966-9687-8d0f378f3993)

And finally, you can take a look at an example timeout error below. This is the same as before, except that before we were always using the broker default timeout.

```
{"status":"error","data":{"resultType":"","result":[]},"errorType":"TimeoutException","error":"Timed out waiting for response"}
```