### PR TITLE
Using local copy of segment instead of downloading from remote

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -55,6 +55,7 @@ import org.apache.pinot.segment.local.utils.SegmentPushUtils;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
@@ -79,6 +80,7 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseMultipleSegmentsConversionExecutor.class);
   private static final String CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID = "lineageEntryId";
+  private static final PinotFS LOCAL_PINOT_FS = new LocalPinotFS();
 
   private static final int DEFUALT_PUSH_ATTEMPTS = 5;
   private static final int DEFAULT_PUSH_PARALLELISM = 1;
@@ -284,14 +286,11 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
             String.format("Uploading segment: %s (%d out of %d)", resultSegmentName, (i + 1), numOutputSegments));
         String pushMode = taskConfigs.getOrDefault(BatchConfigProperties.PUSH_MODE,
             BatchConfigProperties.SegmentPushType.TAR.name());
-        URI outputSegmentTarURI;
         if (BatchConfigProperties.SegmentPushType.valueOf(pushMode.toUpperCase())
             != BatchConfigProperties.SegmentPushType.TAR) {
-          outputSegmentTarURI = moveSegmentToOutputPinotFS(taskConfigs, convertedTarredSegmentFile);
+          URI outputSegmentTarURI = moveSegmentToOutputPinotFS(taskConfigs, convertedTarredSegmentFile);
           LOGGER.info("Moved generated segment from [{}] to location: [{}]", convertedTarredSegmentFile,
               outputSegmentTarURI);
-        } else {
-          outputSegmentTarURI = convertedTarredSegmentFile.toURI();
         }
 
         // Set segment ZK metadata custom map modifier into HTTP header to modify the segment ZK metadata
@@ -316,11 +315,12 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         }
 
         if (batchSegmentUpload) {
-          updateSegmentUriToTarPathMap(taskConfigs, outputSegmentTarURI, segmentConversionResult,
+          updateSegmentUriToTarPathMap(taskConfigs, convertedTarredSegmentFile.toURI(), segmentConversionResult,
               segmentUriToTarPathMap, pushJobSpec);
         } else {
           String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-          pushSegment(rawTableName, taskConfigs, outputSegmentTarURI, httpHeaders, parameters, segmentConversionResult);
+          pushSegment(rawTableName, taskConfigs, convertedTarredSegmentFile.toURI(), httpHeaders, parameters,
+              segmentConversionResult);
           if (!FileUtils.deleteQuietly(convertedTarredSegmentFile)) {
             LOGGER.warn("Failed to delete tarred converted segment: {}", convertedTarredSegmentFile.getAbsolutePath());
           }
@@ -438,18 +438,15 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     List<Header> headers = getSegmentPushCommonHeaders(pinotTaskConfig, authProvider, segmentConversionResults);
     List<NameValuePair> parameters = getSegmentPushCommonParams(tableNameWithType);
 
-    URI outputSegmentDirURI = URI.create(taskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI));
-    try (PinotFS outputFileFS = MinionTaskUtils.getOutputPinotFS(taskConfigs, outputSegmentDirURI)) {
-      SegmentPushUtils.sendSegmentsUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap, headers, parameters);
-    }
+    SegmentPushUtils.sendSegmentsUriAndMetadata(spec, LOCAL_PINOT_FS, segmentUriToTarPathMap, headers, parameters);
   }
 
-  private void pushSegment(String tableName, Map<String, String> taskConfigs, URI outputSegmentTarURI,
+  private void pushSegment(String tableName, Map<String, String> taskConfigs, URI localSegmentTarURI,
       List<Header> headers, List<NameValuePair> parameters, SegmentConversionResult segmentConversionResult)
       throws Exception {
     String pushMode =
         taskConfigs.getOrDefault(BatchConfigProperties.PUSH_MODE, BatchConfigProperties.SegmentPushType.TAR.name());
-    LOGGER.info("Trying to push Pinot segment with push mode {} from {}", pushMode, outputSegmentTarURI);
+    LOGGER.info("Trying to push Pinot segment with push mode {} from {}", pushMode, localSegmentTarURI);
 
     PushJobSpec pushJobSpec = new PushJobSpec();
     pushJobSpec.setPushAttempts(DEFUALT_PUSH_ATTEMPTS);
@@ -462,7 +459,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
     switch (BatchConfigProperties.SegmentPushType.valueOf(pushMode.toUpperCase())) {
       case TAR:
-        File tarFile = new File(outputSegmentTarURI);
+        File tarFile = new File(localSegmentTarURI);
         String segmentName = segmentConversionResult.getSegmentName();
         String tableNameWithType = segmentConversionResult.getTableNameWithType();
         String uploadURL = taskConfigs.get(MinionConstants.UPLOAD_URL_KEY);
@@ -472,12 +469,10 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
       case METADATA:
         if (taskConfigs.containsKey(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI)) {
           URI outputSegmentDirURI = URI.create(taskConfigs.get(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI));
-          try (PinotFS outputFileFS = MinionTaskUtils.getOutputPinotFS(taskConfigs, outputSegmentDirURI)) {
-            Map<String, String> segmentUriToTarPathMap =
-                SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI, pushJobSpec,
-                    new String[]{outputSegmentTarURI.toString()});
-            SegmentPushUtils.sendSegmentUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap, headers, parameters);
-          }
+          Map<String, String> segmentUriToTarPathMap =
+              SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI, pushJobSpec,
+                  new String[]{localSegmentTarURI.toString()});
+          SegmentPushUtils.sendSegmentUriAndMetadata(spec, LOCAL_PINOT_FS, segmentUriToTarPathMap, headers, parameters);
         } else {
           throw new RuntimeException("Output dir URI missing for metadata push");
         }


### PR DESCRIPTION
Re-introducing [PR-12863](https://github.com/apache/pinot/pull/12863) post testing in an internal cluster.


### Testing
**Minion Logs**
```
2024/11/12 17:04:12.231 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Generated 1 segments with duration: 12261ms

2024/11/12 17:04:12.239 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Adding new segments: 1 created from multiple input files: 1

2024/11/12 17:04:12.273 INFO [HttpClient] [TaskStateModelFactory-task_thread-0] Sending request: /segments/suspects001/startDataIngestRequest?tableType=OFFLINE&taskType=FileIngestionTask to controller: pinot-pinot-controller-0.pinot-pinot-controller-headless.managed.svc.cluster.local, version: Unknown

2024/11/12 17:04:12.273 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Submitted checkpoint: FileIngestionTask_1731431035906_0 for table: suspects001_OFFLINE with new segments: [suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0]

2024/11/12 17:04:14.949 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Total uncompressed segment size for task 60613536 bytes

2024/11/12 17:04:14.949 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Compressed segments with duration: 2676ms

2024/11/12 17:04:14.951 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Uploading compressed segment: suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz with name: suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0

2024/11/12 17:04:14.953 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Using push mode: METADATA to upload segment: /home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz

2024/11/12 17:04:15.102 INFO [S3PinotFS] [TaskStateModelFactory-task_thread-0] Copy /home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz from local to s3://sc-dev-dmtest-testdm-pinot-fs/sc-dev/managed/pinot/suspects001/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz

2024/11/12 17:04:15.411 INFO [IngestionTaskUtils] [TaskStateModelFactory-task_thread-0] Moved generated segment from: /home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz to: s3://sc-dev-dmtest-testdm-pinot-fs/sc-dev/managed/pinot/suspects001/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz

2024/11/12 17:04:15.412 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Start pushing segment metadata: {s3://sc-dev-dmtest-testdm-pinot-fs/sc-dev/managed/pinot/suspects001/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz=/home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz} to locations: [org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec@4d2aba53] for table: suspects001_OFFLINE

2024/11/12 17:04:15.413 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Checking if metadata tar gz file /home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.metadata.tar.gz exists
```

```
2024/11/12 17:04:15.413 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Trying to untar Metadata file from: [/home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz] to [/tmp/segmentMetadataDir-18f05bf5-6295-4c98-b96b-f84efe53110a]
```
**[Metadata file getting generated from the local segment file]**

```
2024/11/12 17:04:15.419 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Trying to untar CreationMeta file from: [/home/pinot/data/minionData/FileIngestionTask/tmp-97a38a61-a5bd-4ab7-af46-50fc537c5214/workingDir/tarredSegments/suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz] to [/tmp/segmentMetadataDir-18f05bf5-6295-4c98-b96b-f84efe53110a]

2024/11/12 17:04:15.574 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Trying to tar segment metadata dir [/tmp/segmentMetadataDir-18f05bf5-6295-4c98-b96b-f84efe53110a] to [/tmp/segmentMetadata-18f05bf5-6295-4c98-b96b-f84efe53110a.tar.gz]

2024/11/12 17:04:15.580 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Pushing segments: [suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0] to location: https://pinot-pinot-controller-headless.managed.svc.cluster.local:9000 for table: suspects001_OFFLINE

2024/11/12 17:04:15.832 INFO [HttpClient] [TaskStateModelFactory-task_thread-0] Sending request: /segments/batchUpload?tableName=suspects001_OFFLINE&tableType=OFFLINE to controller: pinot-pinot-controller-0.pinot-pinot-controller-headless.managed.svc.cluster.local, version: Unknown

2024/11/12 17:04:15.833 INFO [SegmentPushUtils] [TaskStateModelFactory-task_thread-0] Response for pushing table suspects001_OFFLINE segments [suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0] to location https://pinot-pinot-controller-headless.managed.svc.cluster.local:9000 - 200: {"status":"Successfully uploaded segments: [suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0] of table: suspects001_OFFLINE in 206 ms"}

2024/11/12 17:04:15.833 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Uploaded compressed segment: suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0.tar.gz with name: suspects001_2014-06-01_2022-12-12_FileIngestionTask_1731431035906_0_0

2024/11/12 17:04:15.838 INFO [FileIngestionTaskExecutor] [TaskStateModelFactory-task_thread-0] Uploaded segments: 1 with duration: 886ms

2024/11/12 17:04:15.874 INFO [HttpClient] [TaskStateModelFactory-task_thread-0] Sending request: /segments/suspects001/endDataIngestRequest?tableType=OFFLINE&taskType=FileIngestionTask&checkpointEntryKey=FileIngestionTask_1731431035906_0 to controller: pinot-pinot-controller-0.pinot-pinot-controller-headless.managed.svc.cluster.local, version: Unknown
```