### PR TITLE
Add instance level consumer dir usage metric

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -77,7 +77,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),
   UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false),
   REALTIME_INGESTION_OFFSET_LAG("offsetLag", false),
-  CONSUMER_DIR_USAGE("bytes", true);
+  REALTIME_CONSUMER_DIR_USAGE("bytes", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -76,7 +76,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   // Needed to track if valid doc id snapshots are present for faster restarts
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),
   UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false),
-  REALTIME_INGESTION_OFFSET_LAG("offsetLag", false);
+  REALTIME_INGESTION_OFFSET_LAG("offsetLag", false),
+  CONSUMER_DIR_USAGE("bytes", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -194,4 +194,9 @@ public interface InstanceDataManager {
    * @param isServerReadyToServeQueries supplier to retrieve state of server.
    */
   void setSupplierOfIsServerReadyToServeQueries(Supplier<Boolean> isServerReadyToServeQueries);
+
+  /**
+   * Returns consumer directory paths on the instance
+   */
+  List<File> getConsumerDirPaths();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -102,7 +102,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes
   private static final String STATS_FILE_NAME = "segment-stats.ser";
-  public static final String CONSUMERS_DIR = "consumers";
+  private static final String CONSUMERS_DIR = "consumers";
 
   // Topics tend to have similar cardinality for values across partitions consumed during the same time.
   // Multiple partitions of a topic are likely to be consumed in each server, and these will tend to

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -369,6 +369,17 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   public String getConsumerDir() {
+    File consumerDir = getConsumerDirPath();
+    if (!consumerDir.exists()) {
+      if (!consumerDir.mkdirs()) {
+        _logger.error("Failed to create consumer directory {}", consumerDir.getAbsolutePath());
+      }
+    }
+
+    return consumerDir.getAbsolutePath();
+  }
+
+  public File getConsumerDirPath() {
     String consumerDirPath = _instanceDataManagerConfig.getConsumerDir();
     File consumerDir;
     // If a consumer directory has been configured, use it to create a per-table path under the consumer dir.
@@ -379,14 +390,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       consumerDirPath = _tableDataDir + File.separator + CONSUMERS_DIR;
       consumerDir = new File(consumerDirPath);
     }
-
-    if (!consumerDir.exists()) {
-      if (!consumerDir.mkdirs()) {
-        _logger.error("Failed to create consumer directory {}", consumerDir.getAbsolutePath());
-      }
-    }
-
-    return consumerDir.getAbsolutePath();
+    return consumerDir;
   }
 
   public boolean isDedupEnabled() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -102,7 +102,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes
   private static final String STATS_FILE_NAME = "segment-stats.ser";
-  private static final String CONSUMERS_DIR = "consumers";
+  public static final String CONSUMERS_DIR = "consumers";
 
   // Topics tend to have similar cardinality for values across partitions consumed during the same time.
   // Multiple partitions of a topic are likely to be consumed in each server, and these will tend to

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -713,7 +713,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _serverQueriesDisabledTracker.start();
 
     // Add metrics for consumer directory usage
-    serverMetrics.setOrUpdateGlobalGauge(ServerGauge.CONSUMER_DIR_USAGE, () -> {
+    serverMetrics.setOrUpdateGlobalGauge(ServerGauge.REALTIME_CONSUMER_DIR_USAGE, () -> {
       List<File> instanceConsumerDirs = instanceDataManager.getConsumerDirPaths();
       long totalSize = 0;
       try {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -21,6 +21,7 @@ package org.apache.pinot.server.starter.helix;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -52,6 +54,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SystemResourceInfo;
@@ -130,6 +133,7 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseServerStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseServerStarter.class);
 
+  private static final long CONSUMER_DIRECTORY_EXCEPTION_VALUE = -1L;
   protected String _helixClusterName;
   protected String _zkAddress;
   protected PinotConfiguration _serverConf;
@@ -707,6 +711,23 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _serverQueriesDisabledTracker =
         new ServerQueriesDisabledTracker(_helixClusterName, _instanceId, _helixManager, serverMetrics);
     _serverQueriesDisabledTracker.start();
+
+    // Add metrics for consumer directory usage
+    serverMetrics.setOrUpdateGlobalGauge(ServerGauge.CONSUMER_DIR_USAGE, () -> {
+      List<File> serverConsumerDirs = instanceDataManager.getConsumerDirPaths();
+      final long[] totalSize = {0};
+      try {
+        for (File consumerDir : serverConsumerDirs) {
+          if (consumerDir.exists()) {
+            totalSize[0] += FileUtils.sizeOfDirectory(consumerDir);
+          }
+        }
+        return totalSize[0];
+      } catch (Exception e) {
+        LOGGER.warn("Failed to gather size info for consumer directories", e);
+        return CONSUMER_DIRECTORY_EXCEPTION_VALUE;
+      }
+    });
   }
 
   /**

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -714,15 +714,15 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     // Add metrics for consumer directory usage
     serverMetrics.setOrUpdateGlobalGauge(ServerGauge.CONSUMER_DIR_USAGE, () -> {
-      List<File> serverConsumerDirs = instanceDataManager.getConsumerDirPaths();
-      final long[] totalSize = {0};
+      List<File> instanceConsumerDirs = instanceDataManager.getConsumerDirPaths();
+      long totalSize = 0;
       try {
-        for (File consumerDir : serverConsumerDirs) {
+        for (File consumerDir : instanceConsumerDirs) {
           if (consumerDir.exists()) {
-            totalSize[0] += FileUtils.sizeOfDirectory(consumerDir);
+            totalSize += FileUtils.sizeOfDirectory(consumerDir);
           }
         }
-        return totalSize[0];
+        return totalSize;
       } catch (Exception e) {
         LOGGER.warn("Failed to gather size info for consumer directories", e);
         return CONSUMER_DIRECTORY_EXCEPTION_VALUE;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -183,20 +183,14 @@ public class HelixInstanceDataManager implements InstanceDataManager {
 
   @Override
   public List<File> getConsumerDirPaths() {
-    String consumerDirPath = _instanceDataManagerConfig.getConsumerDir();
-
-    if (consumerDirPath != null) {
-      return Collections.singletonList(new File(consumerDirPath));
-    } else {
-      List<File> consumerDirs = new ArrayList<>();
-      String instanceDataDir = _instanceDataManagerConfig.getInstanceDataDir();
-      for (String tableNameWithType : getAllTables()) {
-        String dirPath = instanceDataDir + File.separator + tableNameWithType + File.separator
-            + RealtimeTableDataManager.CONSUMERS_DIR;
-        consumerDirs.add(new File(dirPath));
+    List<File> consumerDirs = new ArrayList<>();
+    for (TableDataManager tableDataManager : _tableDataManagerMap.values()) {
+      if (tableDataManager instanceof RealtimeTableDataManager) {
+        File consumerDir = ((RealtimeTableDataManager) tableDataManager).getConsumerDirPath();
+        consumerDirs.add(consumerDir);
       }
-      return consumerDirs;
     }
+    return consumerDirs;
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -52,6 +52,7 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploader;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.data.manager.realtime.SegmentBuildTimeLeaseExtender;
 import org.apache.pinot.core.data.manager.realtime.SegmentUploader;
 import org.apache.pinot.core.util.SegmentRefreshSemaphore;
@@ -177,6 +178,24 @@ public class HelixInstanceDataManager implements InstanceDataManager {
           }
         }
       }
+    }
+  }
+
+  @Override
+  public List<File> getConsumerDirPaths() {
+    String consumerDirPath = _instanceDataManagerConfig.getConsumerDir();
+
+    if (consumerDirPath != null) {
+      return Collections.singletonList(new File(consumerDirPath));
+    } else {
+      List<File> consumerDirs = new ArrayList<>();
+      String instanceDataDir = _instanceDataManagerConfig.getInstanceDataDir();
+      for (String tableNameWithType : getAllTables()) {
+        String dirPath = instanceDataDir + File.separator + tableNameWithType + File.separator
+            + RealtimeTableDataManager.CONSUMERS_DIR;
+        consumerDirs.add(new File(dirPath));
+      }
+      return consumerDirs;
     }
   }
 


### PR DESCRIPTION
Recently, we have seen java.lang.[InternalError](https://stackoverflow.com/questions/45536049/java-lang-internalerror-a-fault-occurred-in-a-recent-unsafe-memory-access-opera) on RT servers. This is caused by consuming segments using more off-heap memory than the max limit configured at the host level (in our case, we were using tmpfs for consumption). This puts consuming segments in ERROR state and halts consumption from the Kafka topic. 

We currently have metrics for `realtimeOffHeapMemoryUsed` for tracking off heap memory allocated (not used). 
This PR adds a metric for host-level consumer directory usage.