### PR TITLE
Pauseless consumption

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/PauselessConsumptionMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/PauselessConsumptionMessage.java
@@ -1,0 +1,53 @@
+package org.apache.pinot.common.messages;
+
+import java.util.UUID;
+import org.apache.helix.model.Message;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+
+
+// FIXME add a description
+public class PauselessConsumptionMessage extends Message {
+  public static final String PAUSELESS_CONSUMPTION_MSG_SUB_TYPE = "PAUSELESS_CONSUMPTION";
+  public static final String TABLE_NAME_WITH_TYPE = "tableNameWithType";
+  public static final String COMMITTING_SEGMENT_NAME = "committingSegmentName";
+  public static final String NEW_CONSUMING_SEGMENT_NAME = "newConsumingSegmentName";
+
+  public PauselessConsumptionMessage(String tableNameWithType, String committingSegmentName,
+      String newConsumingSegmentName) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setMsgSubType(PAUSELESS_CONSUMPTION_MSG_SUB_TYPE);
+    setExecutionTimeout(-1); // no timeout
+    ZNRecord znRecord = getRecord();
+    znRecord.setSimpleField(TABLE_NAME_WITH_TYPE, tableNameWithType);
+    znRecord.setSimpleField(COMMITTING_SEGMENT_NAME, committingSegmentName);
+    znRecord.setSimpleField(NEW_CONSUMING_SEGMENT_NAME, newConsumingSegmentName);
+  }
+
+  public PauselessConsumptionMessage(Message message) {
+    super(message.getRecord());
+    String msgSubType = message.getMsgSubType();
+    if (!msgSubType.equals(PAUSELESS_CONSUMPTION_MSG_SUB_TYPE)) {
+      throw new IllegalArgumentException(
+          "Invalid message sub type: " + msgSubType + " for PauselessConsumptionMessage");
+    }
+  }
+
+  public String getTableNameWithType() {
+    return getRecord().getSimpleField(TABLE_NAME_WITH_TYPE);
+  }
+
+  public String getCommittingSegmentName() {
+    return getRecord().getSimpleField(COMMITTING_SEGMENT_NAME);
+  }
+
+  public String getNewConsumingSegmentName() {
+    return getRecord().getSimpleField(NEW_CONSUMING_SEGMENT_NAME);
+  }
+
+  @Override
+  public String toString() {
+    return "PauselessConsumptionMessage{" + "tableNameWithType='" + getTableNameWithType() + '\''
+        + ", committingSegmentName='" + getCommittingSegmentName() + '\'' + ", newConsumingSegmentName='"
+        + getNewConsumingSegmentName() + '\'' + '}';
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PauselessConsumptionManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PauselessConsumptionManager.java
@@ -1,0 +1,62 @@
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+// FIXME add a description
+public class PauselessConsumptionManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PauselessConsumptionManager.class);
+
+  private final Map<String, String> _committingSegmentToHiddenConsumingSegmentMap = new ConcurrentHashMap<>();
+
+  public PauselessConsumptionManager() {
+  }
+
+  public void addAssociation(String committingSegment, String hiddenConsumingSegment) {
+    _committingSegmentToHiddenConsumingSegmentMap.put(committingSegment, hiddenConsumingSegment);
+  }
+
+  public boolean removeAssociationForHiddenConsumingSegment(String targetHiddenConsumingSegment) {
+    StringBuilder committingSegmentName = new StringBuilder();
+    _committingSegmentToHiddenConsumingSegmentMap.forEach((committingSegment, hiddenConsumingSegment) -> {
+      if (targetHiddenConsumingSegment.equals(hiddenConsumingSegment)) {
+        committingSegmentName.append(committingSegment);
+      }
+    });
+    if (committingSegmentName.length() > 0) {
+      _committingSegmentToHiddenConsumingSegmentMap.remove(committingSegmentName.toString());
+      // TODO: add proper log
+      return true;
+    }
+    return false;
+  }
+
+  public boolean removeAssociationForCommittingSegment(String committingSegment) {
+    return _committingSegmentToHiddenConsumingSegmentMap.remove(committingSegment) != null;
+  }
+
+  public void updateSegmentsToQuery(List<String> segmentsToQuery, List<String> optionalSegments) {
+    Set<String> segmentsToBeAdded = new HashSet<>();
+    for (String segmentToQuery : segmentsToQuery) {
+      String newConsumingSegment = _committingSegmentToHiddenConsumingSegmentMap.get(segmentToQuery);
+      if (newConsumingSegment != null) {
+        segmentsToBeAdded.add(newConsumingSegment);
+      }
+    }
+    if (optionalSegments != null) {
+      optionalSegments.forEach(segmentsToBeAdded::remove);
+    }
+    segmentsToQuery.addAll(segmentsToBeAdded);
+  }
+
+  public String getExistingAssociatedSegment(String committingSegment) {
+    return _committingSegmentToHiddenConsumingSegmentMap.get(committingSegment);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1631,8 +1631,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger
           .info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", llcSegmentName,
               _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
-      _allowConsumptionDuringCommit = !_realtimeTableDataManager.isPartialUpsertEnabled() ? true
-          : _tableConfig.getUpsertConfig().isAllowPartialUpsertConsumptionDuringCommit();
+      _allowConsumptionDuringCommit = shouldAllowConsumptionDuringCommit();
     } catch (Exception e) {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
@@ -1663,6 +1662,14 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       }).start();
       throw e;
     }
+  }
+
+  private boolean shouldAllowConsumptionDuringCommit() {
+    if (_streamConfig.isPauselessConsumptionEnabled()) {
+      return true;
+    }
+    return !_realtimeTableDataManager.isPartialUpsertEnabled() ? true
+        : _tableConfig.getUpsertConfig().isAllowPartialUpsertConsumptionDuringCommit();
   }
 
   private void setConsumeEndTime(SegmentZKMetadata segmentZKMetadata, long now) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -49,6 +49,7 @@ import org.apache.pinot.core.common.ExplainPlanRowData;
 import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.realtime.PauselessConsumptionManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.operator.InstanceResponseOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
@@ -209,6 +210,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     List<String> segmentsToQuery = queryRequest.getSegmentsToQuery();
     List<String> optionalSegments = queryRequest.getOptionalSegments();
+    if (tableDataManager instanceof RealtimeTableDataManager) {
+      PauselessConsumptionManager pcManager =
+          ((RealtimeTableDataManager) tableDataManager).getPauselessConsumptionManager();
+      pcManager.updateSegmentsToQuery(segmentsToQuery, optionalSegments);
+    }
     List<String> notAcquiredSegments = new ArrayList<>();
     int numSegmentsAcquired;
     List<SegmentDataManager> segmentDataManagers;

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -114,7 +114,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    */
 
   protected String getTableName() {
-    return DEFAULT_TABLE_NAME;
+    return "mytable";//DEFAULT_TABLE_NAME;
   }
 
   protected String getSchemaFileName() {
@@ -143,7 +143,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected int getRealtimeSegmentFlushSize() {
-    return DEFAULT_LLC_SEGMENT_FLUSH_SIZE;
+    return 5;//DEFAULT_LLC_SEGMENT_FLUSH_SIZE;
   }
 
   protected int getNumKafkaBrokers() {
@@ -160,7 +160,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected int getNumKafkaPartitions() {
-    return DEFAULT_LLC_NUM_KAFKA_PARTITIONS;
+    return 1;//DEFAULT_LLC_NUM_KAFKA_PARTITIONS;
   }
 
   protected String getKafkaTopic() {
@@ -212,7 +212,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected int getNumReplicas() {
-    return DEFAULT_NUM_REPLICAS;
+    return 1;//DEFAULT_NUM_REPLICAS;
   }
 
   @Nullable
@@ -338,6 +338,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         Integer.toString(getRealtimeSegmentFlushSize()));
     streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
         StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), "smallest");
+    streamConfigMap.put(StreamConfigProperties.PAUSELESS_CONSUMPTION_ENABLED, "true");
     return streamConfigMap;
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -252,7 +252,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
   }
 
   private void changeCrcInSegmentZKMetadata(String tableName, String segmentFilePath) {
-    int startIdx = segmentFilePath.indexOf("mytable_");
+    int startIdx = segmentFilePath.indexOf(getTableName() + "_");
     int endIdx = segmentFilePath.indexOf(".tar.gz");
     String segmentName = segmentFilePath.substring(startIdx, endIdx);
     String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
@@ -511,7 +511,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
       int partition = partitionGroupConsumptionStatus.getPartitionGroupId();
       boolean exceptionDuringConsume = false;
       int seqNum = getSegmentSeqNum(partition);
-      if (partition == PARTITION_FOR_EXCEPTIONS) {
+      if (partition == -1) {// PARTITION_FOR_EXCEPTIONS) {
         if (seqNum == SEQ_NUM_FOR_CREATE_EXCEPTION) {
           throw new RuntimeException("TestException during consumer creation");
         } else if (seqNum == SEQ_NUM_FOR_CONSUME_EXCEPTION) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -87,6 +87,8 @@ public class StreamConfig {
   // level config
   private final Boolean _serverUploadToDeepStore;
 
+  private final Boolean _pauselessConsumptionEnabled;
+
   /**
    * Initializes a StreamConfig using the map of stream configs from the table config
    */
@@ -201,6 +203,9 @@ public class StreamConfig {
 
     String rate = streamConfigMap.get(StreamConfigProperties.TOPIC_CONSUMPTION_RATE_LIMIT);
     _topicConsumptionRateLimit = rate != null ? Double.parseDouble(rate) : CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED;
+
+    _pauselessConsumptionEnabled =
+        Boolean.valueOf(streamConfigMap.getOrDefault(StreamConfigProperties.PAUSELESS_CONSUMPTION_ENABLED, "false"));
 
     _streamConfigMap.putAll(streamConfigMap);
   }
@@ -413,6 +418,10 @@ public class StreamConfig {
     return _tableNameWithType;
   }
 
+  public Boolean isPauselessConsumptionEnabled() {
+    return _pauselessConsumptionEnabled;
+  }
+
   public Map<String, String> getStreamConfigsMap() {
     return _streamConfigMap;
   }
@@ -429,7 +438,8 @@ public class StreamConfig {
         + ", _flushThresholdVarianceFraction=" + _flushThresholdVarianceFraction
         + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='" + _groupId + '\''
         + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _streamConfigMap=" + _streamConfigMap
-        + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore + '}';
+        + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore
+        + ", _pauselessConsumptionEnabled=" + _pauselessConsumptionEnabled + '}';
   }
 
   @Override
@@ -453,7 +463,8 @@ public class StreamConfig {
         && Objects.equals(_consumerFactoryClassName, that._consumerFactoryClassName) && Objects.equals(_decoderClass,
         that._decoderClass) && Objects.equals(_decoderProperties, that._decoderProperties) && Objects.equals(_groupId,
         that._groupId) && Objects.equals(_streamConfigMap, that._streamConfigMap) && Objects.equals(_offsetCriteria,
-        that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction);
+        that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction)
+        && Objects.equals(_pauselessConsumptionEnabled, that._pauselessConsumptionEnabled);
   }
 
   @Override
@@ -462,6 +473,6 @@ public class StreamConfig {
         _decoderProperties, _connectionTimeoutMillis, _fetchTimeoutMillis, _idleTimeoutMillis, _flushThresholdRows,
         _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
         _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
-        _serverUploadToDeepStore, _flushThresholdVarianceFraction);
+        _serverUploadToDeepStore, _flushThresholdVarianceFraction, _pauselessConsumptionEnabled);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -51,6 +51,7 @@ public class StreamConfigProperties {
   public static final String PARTITION_MSG_OFFSET_FACTORY_CLASS = "partition.offset.factory.class.name";
   public static final String TOPIC_CONSUMPTION_RATE_LIMIT = "topic.consumption.rate.limit";
   public static final String METADATA_POPULATE = "metadata.populate";
+  public static final String PAUSELESS_CONSUMPTION_ENABLED = "pauseless.consumption.enabled";
 
   /**
    * Time threshold that will keep the realtime segment open for before we complete the segment


### PR DESCRIPTION
**[DRAFT]**

This PR introduces the pauseless consumption feature based on the design described in issue #10147 

The only difference from the design in the issue is that, once the winner replica is identified, a custom Helix message _PauselessConsumptionMessage_ is sent only to servers that will continue hosting consuming segments for the same partitions they previously hosted. This minimizes changes to the segment commit protocol.

The pauseless consumption feature is controlled via a configuration in _StreamConfigs_. Making this feature configurable helps mitigate the additional memory requirements for use cases that are less sensitive to ingestion delays. Specifically, during segment commit, pauseless consumption requires twice the off-heap memory for consuming segments.

Lastly, while this PR is still in draft mode and some aspects remain to be completed - such as adding detailed logging, refactoring _RealtimeSegmentValidationManager_ to accommodate the new changes, and updating _segmentFlushThresholdComputer_ - the core functionality has been verified through integration tests.