### PR TITLE
log segment name at best effort upon query exception to help locate the error segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -182,15 +182,19 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
    */
   protected abstract void onProcessSegmentsFinish();
 
-  protected static void onProcessError(Operator operator, Exception e) {
+  protected static void onOperatorException(Operator operator, Exception e) {
     // Skip early termination as that's not quite related to the segments.
     if (e instanceof EarlyTerminationException) {
       return;
     }
-    // Otherwise, log out the segment name to help locate the segment when debugging query errors. Not all operators
-    // have associated segment, so do this at best effort. This method doesn't throw e up, as it's handled by caller.
+    // Otherwise, try to get the segment name to help locate the segment when debugging query errors.
+    // Not all operators have associated segment, so do this at best effort.
     IndexSegment segment = operator.getIndexSegment();
-    LOGGER.error("Caught exception: {} while doing operator: {} on segment: {}", e.getMessage(), operator.getClass(),
-        segment != null ? segment.getSegmentName() : "unknown");
+    if (segment == null) {
+      return;
+    }
+    throw new RuntimeException(
+        "Caught exception while doing operator: " + operator.getClass() + " on segment: " + segment.getSegmentName(),
+        e);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -182,16 +182,16 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
    */
   protected abstract void onProcessSegmentsFinish();
 
-  protected static void onOperatorException(Operator operator, Exception e) {
+  protected static RuntimeException wrapOperatorException(Operator operator, RuntimeException e) {
     // Skip early termination as that's not quite related to the segments.
     if (e instanceof EarlyTerminationException) {
-      return;
+      return e;
     }
     // Otherwise, try to get the segment name to help locate the segment when debugging query errors.
     // Not all operators have associated segment, so do this at best effort.
     IndexSegment segment = operator.getIndexSegment();
     if (segment == null) {
-      return;
+      return e;
     }
     throw new RuntimeException(
         "Caught exception while doing operator: " + operator.getClass() + " on segment: " + segment.getSegmentName(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -93,7 +93,7 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
         }
         resultsBlock = (T) operator.nextBlock();
       } catch (Exception e) {
-        onProcessError(operator, e);
+        onOperatorException(operator, e);
         throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -92,6 +92,9 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
           ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
         }
         resultsBlock = (T) operator.nextBlock();
+      } catch (Exception e) {
+        onProcessError(operator, e);
+        throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -92,9 +92,8 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
           ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
         }
         resultsBlock = (T) operator.nextBlock();
-      } catch (Exception e) {
-        onOperatorException(operator, e);
-        throw e;
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -188,9 +188,8 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
             mergedKeys++;
           }
         }
-      } catch (Exception e) {
-        onOperatorException(operator, e);
-        throw e;
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -189,7 +189,7 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
           }
         }
       } catch (Exception e) {
-        onProcessError(operator, e);
+        onOperatorException(operator, e);
         throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -188,6 +188,9 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
             mergedKeys++;
           }
         }
+      } catch (Exception e) {
+        onProcessError(operator, e);
+        throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -205,6 +205,9 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
           ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
         }
         resultsBlock = (SelectionResultsBlock) operator.nextBlock();
+      } catch (Exception e) {
+        onProcessError(operator, e);
+        throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -205,9 +205,8 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
           ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
         }
         resultsBlock = (SelectionResultsBlock) operator.nextBlock();
-      } catch (Exception e) {
-        onOperatorException(operator, e);
-        throw e;
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -206,7 +206,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
         }
         resultsBlock = (SelectionResultsBlock) operator.nextBlock();
       } catch (Exception e) {
-        onProcessError(operator, e);
+        onOperatorException(operator, e);
         throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -143,7 +143,7 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
           }
         }
       } catch (Exception e) {
-        onProcessError(operator, e);
+        onOperatorException(operator, e);
         throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -142,9 +142,8 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
             }
           }
         }
-      } catch (Exception e) {
-        onOperatorException(operator, e);
-        throw e;
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -142,6 +142,9 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
             }
           }
         }
+      } catch (Exception e) {
+        onProcessError(operator, e);
+        throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -216,6 +216,9 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
             mergedKeys++;
           }
         }
+      } catch (Exception e) {
+        onProcessError(operator, e);
+        throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -217,7 +217,7 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
           }
         }
       } catch (Exception e) {
-        onProcessError(operator, e);
+        onOperatorException(operator, e);
         throw e;
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -216,9 +216,8 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
             mergedKeys++;
           }
         }
-      } catch (Exception e) {
-        onOperatorException(operator, e);
-        throw e;
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
       } finally {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();


### PR DESCRIPTION
Try to log out segment name when query failed to help quickly locate the segment to help debug the query error, as sometimes the segment might have got corrupted data. One could tweak the query to narrow the search window to find the problematic segments out, but this log would help save those efforts. 