### PR TITLE
Spark upsert table backfill support

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -48,6 +48,7 @@ public class SegmentGenerationUtils {
   }
 
   private static final String OFFLINE = "OFFLINE";
+  private static final String REALTIME = "REALTIME";
   public static final String PINOT_PLUGINS_TAR_GZ = "pinot-plugins.tar.gz";
   public static final String PINOT_PLUGINS_DIR = "pinot-plugins-dir";
 
@@ -139,6 +140,8 @@ public class SegmentGenerationUtils {
     }
     if (tableJsonNode.has(OFFLINE)) {
       tableJsonNode = tableJsonNode.get(OFFLINE);
+    } else if (tableJsonNode.has(REALTIME)) {
+      tableJsonNode = tableJsonNode.get(REALTIME);
     }
     try {
       return JsonUtils.jsonNodeToObject(tableJsonNode, TableConfig.class);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -185,7 +185,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
         try {
           partitionId = Integer.parseInt(segmentNameGeneratorConfigs.get(SEGMENT_PARTITION_ID));
         } catch (NumberFormatException e) {
-          throw new IllegalArgumentException("Partition Id must be a valid long value in segmentNameGeneratorSpec");
+          throw new IllegalArgumentException("Partition Id must be a valid integer value in segmentNameGeneratorSpec");
         }
         return new UploadedRealtimeSegmentNameGenerator(tableName, partitionId, creationTime,
                 segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -167,13 +167,17 @@ public class SegmentGenerationTaskRunner implements Serializable {
         return new InputFileSegmentNameGenerator(segmentNameGeneratorConfigs.get(FILE_PATH_PATTERN),
             segmentNameGeneratorConfigs.get(SEGMENT_NAME_TEMPLATE), inputFileUri, appendUUIDToSegmentName);
       case BatchConfigProperties.SegmentNameGeneratorType.UPLOADED_REALTIME:
-        Preconditions.checkState(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_UPLOAD_TIME_MS) != null,
-            "Upload time must be set for uploaded realtime segment name generator");
         Preconditions.checkState(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_PARTITION_ID) != null,
             "Valid partition id must be set for uploaded realtime segment name generator");
+        String uploadTimeString = segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_UPLOAD_TIME_MS);
+        if (uploadTimeString == null) {
+          uploadTimeString = segmentGeneratorConfig.getCreationTime();
+        }
+        Preconditions.checkState(uploadTimeString != null,
+                "Upload time must be set for uploaded realtime segment name generator");
         long uploadTime;
         try {
-          uploadTime = Long.parseLong(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_UPLOAD_TIME_MS));
+          uploadTime = Long.parseLong(uploadTimeString);
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException("Upload time must be a valid long value in segmentNameGeneratorSpec");
         }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -62,10 +62,6 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String FILE_PATH_PATTERN = "file.path.pattern";
   public static final String SEGMENT_NAME_TEMPLATE = "segment.name.template";
 
-  // For UploadedRealtimeSegmentNameGenerator
-  public static final String SEGMENT_PARTITION_ID = "segment.partitionId";
-  public static final String SEGMENT_UPLOAD_TIME_MS = "segment.uploadTimeMs";
-
   // Assign sequence ids to input files based at each local directory level
   @Deprecated
   public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
@@ -171,23 +167,23 @@ public class SegmentGenerationTaskRunner implements Serializable {
         return new InputFileSegmentNameGenerator(segmentNameGeneratorConfigs.get(FILE_PATH_PATTERN),
             segmentNameGeneratorConfigs.get(SEGMENT_NAME_TEMPLATE), inputFileUri, appendUUIDToSegmentName);
       case BatchConfigProperties.SegmentNameGeneratorType.UPLOADED_REALTIME:
-        Preconditions.checkState(segmentNameGeneratorConfigs.get(SEGMENT_UPLOAD_TIME_MS) != null,
-            "Creation time must be set for uploaded realtime segment name generator");
-        Preconditions.checkState(segmentNameGeneratorConfigs.get(SEGMENT_PARTITION_ID) != null,
+        Preconditions.checkState(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_UPLOAD_TIME_MS) != null,
+            "Upload time must be set for uploaded realtime segment name generator");
+        Preconditions.checkState(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_PARTITION_ID) != null,
             "Valid partition id must be set for uploaded realtime segment name generator");
-        long creationTime;
+        long uploadTime;
         try {
-          creationTime = Long.parseLong(segmentNameGeneratorConfigs.get(SEGMENT_UPLOAD_TIME_MS));
+          uploadTime = Long.parseLong(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_UPLOAD_TIME_MS));
         } catch (NumberFormatException e) {
-          throw new IllegalArgumentException("Creation time must be a valid long value in segmentNameGeneratorSpec");
+          throw new IllegalArgumentException("Upload time must be a valid long value in segmentNameGeneratorSpec");
         }
         int partitionId;
         try {
-          partitionId = Integer.parseInt(segmentNameGeneratorConfigs.get(SEGMENT_PARTITION_ID));
+          partitionId = Integer.parseInt(segmentNameGeneratorConfigs.get(BatchConfigProperties.SEGMENT_PARTITION_ID));
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException("Partition Id must be a valid integer value in segmentNameGeneratorSpec");
         }
-        return new UploadedRealtimeSegmentNameGenerator(tableName, partitionId, creationTime,
+        return new UploadedRealtimeSegmentNameGenerator(tableName, partitionId, uploadTime,
                 segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),
                 segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX));
       default:

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -174,7 +174,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
           uploadTimeString = segmentGeneratorConfig.getCreationTime();
         }
         Preconditions.checkState(uploadTimeString != null,
-                "Upload time must be set for uploaded realtime segment name generator");
+            "Upload time must be set for uploaded realtime segment name generator");
         long uploadTime;
         try {
           uploadTime = Long.parseLong(uploadTimeString);
@@ -188,8 +188,8 @@ public class SegmentGenerationTaskRunner implements Serializable {
           throw new IllegalArgumentException("Partition Id must be a valid integer value in segmentNameGeneratorSpec");
         }
         return new UploadedRealtimeSegmentNameGenerator(tableName, partitionId, uploadTime,
-                segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),
-                segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX));
+            segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),
+            segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX));
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);
     }


### PR DESCRIPTION
`bugfix`

### Summary
- `SegmentNameGenerator` for `UPLOADED_REALTIME` should get parameters from job spec instead of table config. This PR fixes this issue https://github.com/apache/pinot/issues/14083
- `getTableConfig` doesn't handle realtime table which looks like `{"REALTIME": {...)}`, `SparkSegmentGenerationJobRunner` uses it to decode table config and create segments

This PR fills gaps of backfilling upsert table with batch data using Spark

### Test
I uploaded a segment with one row of fake data using Spark ingestion pipeline, verified query returns fake data for this primary key `charge_id` now.
<img width="1367" alt="Screenshot 2024-11-13 at 1 56 36 PM" src="https://github.com/user-attachments/assets/af65f648-eaa9-4037-a9d0-5af6f0d2ea6f">


