### PR TITLE
Handle kafka backward incompatible props for AWS

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigBackwardCompatibleUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigBackwardCompatibleUtils.java
@@ -25,41 +25,57 @@ import java.io.InputStreamReader;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class KafkaConfigBackwardCompatibleUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConfigBackwardCompatibleUtils.class);
 
   private KafkaConfigBackwardCompatibleUtils() {
+    // Private constructor to prevent instantiation
   }
 
-  public static final String KAFKA_COMMON_PACKAGE_PREFIX = "org.apache.kafka.common";
-  public static final String PINOT_SHADED_PACKAGE_PREFIX = "org.apache.pinot.shaded.";
-  public static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
+  private static final String KAFKA_COMMON_PACKAGE_PREFIX = "org.apache.kafka.common";
+  private static final String PINOT_SHADED_PACKAGE_PREFIX = "org.apache.pinot.shaded.";
+  private static final String AWS_PROPS_PREFIX = "software.amazon";
+  private static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
 
   /**
-   * Handle the stream config to replace the Kafka common package with the shaded version if needed.
+   * Handles the stream config to replace the Kafka common package with the shaded or unshaded version if needed.
    */
   public static void handleStreamConfig(StreamConfig streamConfig) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
-    //FIXME: This needs to be done because maven shade plugin also overwrites the constants in the classes
-    String prefixToReplace = KAFKA_COMMON_PACKAGE_PREFIX.replace(PINOT_SHADED_PACKAGE_PREFIX, "");
 
+    // Process stream configs
     for (Map.Entry<String, String> entry : streamConfigMap.entrySet()) {
       String[] valueParts = StringUtils.split(entry.getValue(), ' ');
       boolean updated = false;
+
       for (int i = 0; i < valueParts.length; i++) {
-        if (valueParts[i].startsWith(prefixToReplace)) {
-          try {
-            Class.forName(valueParts[i]);
-          } catch (ClassNotFoundException e1) {
-            // If not, replace the class with the shaded version
-            try {
-              String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + valueParts[i];
-              Class.forName(shadedClassName);
+        String className = valueParts[i];
+
+        // Handle Kafka common classes
+        if (className.startsWith(KAFKA_COMMON_PACKAGE_PREFIX)) {
+          if (!isClassAvailable(className)) {
+            String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className;
+            if (isClassAvailable(shadedClassName)) {
               valueParts[i] = shadedClassName;
               updated = true;
-            } catch (ClassNotFoundException e2) {
-              // Do nothing, shaded class is not found as well, keep the original class
+              LOGGER.info("Replaced class '{}' with shaded class '{}' in streamConfig {}", className, shadedClassName,
+                  entry.getKey());
+            }
+          }
+        }
+        // Handle AWS SDK classes differently because we are not shading them anymore
+        else if (className.startsWith(PINOT_SHADED_PACKAGE_PREFIX + AWS_PROPS_PREFIX)) {
+          if (!isClassAvailable(className)) {
+            String unshadedClassName = className.replaceFirst(PINOT_SHADED_PACKAGE_PREFIX, "");
+            if (isClassAvailable(unshadedClassName)) {
+              valueParts[i] = unshadedClassName;
+              updated = true;
+              LOGGER.info("Replaced shaded class '{}' with class '{}' in streamConfig {}", className, unshadedClassName,
+                  entry.getKey());
             }
           }
         }
@@ -70,52 +86,76 @@ public class KafkaConfigBackwardCompatibleUtils {
       }
     }
 
-    // Read the file specified by the -Djava.security.auth.login.config VM argument
+    // Process JAAS config file if specified
     String loginConfigFile = System.getProperty("java.security.auth.login.config");
-    StringBuilder jaasConfigContent = new StringBuilder();
     if (loginConfigFile != null) {
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(loginConfigFile)))) {
-        String line;
-        while ((line = br.readLine()) != null) {
-          jaasConfigContent.append(line).append("\n");
-        }
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to read JAAS config file: " + loginConfigFile, e);
-      }
-    }
+      String jaasConfigContent = readFileContent(loginConfigFile);
+      if (!jaasConfigContent.isEmpty()) {
+        boolean updated = false;
+        String[] lines = jaasConfigContent.split("\n");
 
-    // Process JAAS config content
-    if (jaasConfigContent.length() > 0) {
-      String jaasContent = jaasConfigContent.toString();
-      boolean updated = false;
-      String[] lines = jaasContent.split("\n");
-      for (int i = 0; i < lines.length; i++) {
-        if (lines[i].contains(prefixToReplace)) {
-          String className = lines[i].trim().split(" ")[0];
-          if (className.startsWith(prefixToReplace)) {
-            try {
-              Class.forName(className);
-            } catch (ClassNotFoundException e1) {
-              // If not, replace the class with the shaded version
-              try {
-                String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className.substring(prefixToReplace.length());
-                Class.forName(shadedClassName);
-                lines[i] = lines[i].replace(className, shadedClassName);
+        for (int i = 0; i < lines.length; i++) {
+          String line = lines[i].trim();
+          if (line.startsWith(KAFKA_COMMON_PACKAGE_PREFIX)) {
+            String className = line.split(" ")[0];
+            if (!isClassAvailable(className)) {
+              String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className;
+              if (isClassAvailable(shadedClassName)) {
+                lines[i] = line.replace(className, shadedClassName);
                 updated = true;
-              } catch (ClassNotFoundException e2) {
-                // Do nothing, shaded class is not found as well, keep the original class
               }
             }
           }
         }
+
+        if (updated) {
+          String updatedJaasConfig = String.join("\n", lines);
+          String jaasConfigProperty = extractJaasConfigProperty(updatedJaasConfig);
+          streamConfigMap.putIfAbsent(SASL_JAAS_CONFIG, jaasConfigProperty);
+        }
       }
-      if (updated) {
-        String updatedJaasConfig = String.join("\n", lines);
-        String jassConfigProperty =
-            updatedJaasConfig.substring(updatedJaasConfig.indexOf("{") + 1).substring(0, updatedJaasConfig.indexOf("}"))
-                .replace("\n", " ");
-        streamConfigMap.putIfAbsent(SASL_JAAS_CONFIG, jassConfigProperty);
+    }
+  }
+
+  /**
+   * Checks if a class with the given name is available in the classpath.
+   */
+  private static boolean isClassAvailable(String className) {
+    try {
+      Class.forName(className, false, KafkaConfigBackwardCompatibleUtils.class.getClassLoader());
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Reads the entire content of a file into a String.
+   */
+  private static String readFileContent(String filePath) {
+    StringBuilder content = new StringBuilder();
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath)))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        content.append(line).append("\n");
       }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read file: " + filePath, e);
+    }
+    return content.toString();
+  }
+
+  /**
+   * Extracts the JAAS config property from the updated JAAS configuration content.
+   */
+  private static String extractJaasConfigProperty(String jaasConfig) {
+    int startIndex = jaasConfig.indexOf("{");
+    int endIndex = jaasConfig.lastIndexOf("}");
+    if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
+      String config = jaasConfig.substring(startIndex + 1, endIndex).replace("\n", " ").trim();
+      return config;
+    } else {
+      throw new IllegalArgumentException("Invalid JAAS config format");
     }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigBackwardCompatibleUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigBackwardCompatibleUtils.java
@@ -30,132 +30,113 @@ import org.slf4j.LoggerFactory;
 
 
 public class KafkaConfigBackwardCompatibleUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConfigBackwardCompatibleUtils.class);
 
   private KafkaConfigBackwardCompatibleUtils() {
-    // Private constructor to prevent instantiation
   }
-
-  private static final String KAFKA_COMMON_PACKAGE_PREFIX = "org.apache.kafka.common";
-  private static final String PINOT_SHADED_PACKAGE_PREFIX = "org.apache.pinot.shaded.";
-  private static final String AWS_PROPS_PREFIX = "software.amazon";
-  private static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConfigBackwardCompatibleUtils.class);
+  public static final String KAFKA_COMMON_PACKAGE_PREFIX = "org.apache.kafka.common";
+  public static final String PINOT_SHADED_PACKAGE_PREFIX = "org.apache.pinot.shaded.";
+  public static final String AWS_PROPS_PREFIX = "software.amazon";
+  public static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
 
   /**
-   * Handles the stream config to replace the Kafka common package with the shaded or unshaded version if needed.
+   * Handle the stream config to replace the Kafka common package with the shaded version if needed.
    */
   public static void handleStreamConfig(StreamConfig streamConfig) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
+    //FIXME: This needs to be done because maven shade plugin also overwrites the constants in the classes
+    String prefixToReplace = KAFKA_COMMON_PACKAGE_PREFIX.replace(PINOT_SHADED_PACKAGE_PREFIX, "");
 
-    // Process stream configs
     for (Map.Entry<String, String> entry : streamConfigMap.entrySet()) {
       String[] valueParts = StringUtils.split(entry.getValue(), ' ');
       boolean updated = false;
-
       for (int i = 0; i < valueParts.length; i++) {
-        String className = valueParts[i];
-
-        // Handle Kafka common classes
-        if (className.startsWith(KAFKA_COMMON_PACKAGE_PREFIX)) {
-          if (!isClassAvailable(className)) {
-            String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className;
-            if (isClassAvailable(shadedClassName)) {
+        if (valueParts[i].startsWith(prefixToReplace)) {
+          try {
+            Class.forName(valueParts[i]);
+          } catch (ClassNotFoundException e1) {
+            // If not, replace the class with the shaded version
+            try {
+              String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + valueParts[i];
+              Class.forName(shadedClassName);
               valueParts[i] = shadedClassName;
               updated = true;
-              LOGGER.info("Replaced class '{}' with shaded class '{}' in streamConfig {}", className, shadedClassName,
-                  entry.getKey());
+            } catch (ClassNotFoundException e2) {
+              // Do nothing, shaded class is not found as well, keep the original class
             }
           }
-        }
-        // Handle AWS SDK classes differently because we are not shading them anymore
-        else if (className.startsWith(PINOT_SHADED_PACKAGE_PREFIX + AWS_PROPS_PREFIX)) {
-          if (!isClassAvailable(className)) {
-            String unshadedClassName = className.replaceFirst(PINOT_SHADED_PACKAGE_PREFIX, "");
-            if (isClassAvailable(unshadedClassName)) {
-              valueParts[i] = unshadedClassName;
+        } else if (valueParts[i].startsWith(PINOT_SHADED_PACKAGE_PREFIX + AWS_PROPS_PREFIX)) {
+          // Replace the AWS SDK classes with the shaded version
+          try {
+            Class.forName(valueParts[i]);
+          } catch (ClassNotFoundException e1) {
+            // If not, replace the class with the unshaded version
+            try {
+              String unShadedClassName = valueParts[i].replace(PINOT_SHADED_PACKAGE_PREFIX, "");
+              Class.forName(unShadedClassName);
+              valueParts[i] = unShadedClassName;
               updated = true;
-              LOGGER.info("Replaced shaded class '{}' with class '{}' in streamConfig {}", className, unshadedClassName,
-                  entry.getKey());
+            } catch (ClassNotFoundException e2) {
+              // Do nothing, shaded class is not found as well, keep the original class
             }
           }
         }
       }
 
       if (updated) {
+        String originalValue = entry.getValue();
         entry.setValue(String.join(" ", valueParts));
+        LOGGER.info("Updated stream config key: {} fromValue: {} toValue: {}", entry.getKey(), originalValue,
+            entry.getValue());
       }
     }
 
-    // Process JAAS config file if specified
+    // Read the file specified by the -Djava.security.auth.login.config VM argument
     String loginConfigFile = System.getProperty("java.security.auth.login.config");
+    StringBuilder jaasConfigContent = new StringBuilder();
     if (loginConfigFile != null) {
-      String jaasConfigContent = readFileContent(loginConfigFile);
-      if (!jaasConfigContent.isEmpty()) {
-        boolean updated = false;
-        String[] lines = jaasConfigContent.split("\n");
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(loginConfigFile)))) {
+        String line;
+        while ((line = br.readLine()) != null) {
+          jaasConfigContent.append(line).append("\n");
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to read JAAS config file: " + loginConfigFile, e);
+      }
+    }
 
-        for (int i = 0; i < lines.length; i++) {
-          String line = lines[i].trim();
-          if (line.startsWith(KAFKA_COMMON_PACKAGE_PREFIX)) {
-            String className = line.split(" ")[0];
-            if (!isClassAvailable(className)) {
-              String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className;
-              if (isClassAvailable(shadedClassName)) {
-                lines[i] = line.replace(className, shadedClassName);
+    // Process JAAS config content
+    if (jaasConfigContent.length() > 0) {
+      String jaasContent = jaasConfigContent.toString();
+      boolean updated = false;
+      String[] lines = jaasContent.split("\n");
+      for (int i = 0; i < lines.length; i++) {
+        if (lines[i].contains(prefixToReplace)) {
+          String className = lines[i].trim().split(" ")[0];
+          if (className.startsWith(prefixToReplace)) {
+            try {
+              Class.forName(className);
+            } catch (ClassNotFoundException e1) {
+              // If not, replace the class with the shaded version
+              try {
+                String shadedClassName = PINOT_SHADED_PACKAGE_PREFIX + className.substring(prefixToReplace.length());
+                Class.forName(shadedClassName);
+                lines[i] = lines[i].replace(className, shadedClassName);
                 updated = true;
+              } catch (ClassNotFoundException e2) {
+                // Do nothing, shaded class is not found as well, keep the original class
               }
             }
           }
         }
-
-        if (updated) {
-          String updatedJaasConfig = String.join("\n", lines);
-          String jaasConfigProperty = extractJaasConfigProperty(updatedJaasConfig);
-          streamConfigMap.putIfAbsent(SASL_JAAS_CONFIG, jaasConfigProperty);
-        }
       }
-    }
-  }
-
-  /**
-   * Checks if a class with the given name is available in the classpath.
-   */
-  private static boolean isClassAvailable(String className) {
-    try {
-      Class.forName(className, false, KafkaConfigBackwardCompatibleUtils.class.getClassLoader());
-      return true;
-    } catch (ClassNotFoundException e) {
-      return false;
-    }
-  }
-
-  /**
-   * Reads the entire content of a file into a String.
-   */
-  private static String readFileContent(String filePath) {
-    StringBuilder content = new StringBuilder();
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath)))) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        content.append(line).append("\n");
+      if (updated) {
+        String updatedJaasConfig = String.join("\n", lines);
+        String jassConfigProperty =
+            updatedJaasConfig.substring(updatedJaasConfig.indexOf("{") + 1).substring(0, updatedJaasConfig.indexOf("}"))
+                .replace("\n", " ");
+        streamConfigMap.putIfAbsent(SASL_JAAS_CONFIG, jassConfigProperty);
       }
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to read file: " + filePath, e);
-    }
-    return content.toString();
-  }
-
-  /**
-   * Extracts the JAAS config property from the updated JAAS configuration content.
-   */
-  private static String extractJaasConfigProperty(String jaasConfig) {
-    int startIndex = jaasConfig.indexOf("{");
-    int endIndex = jaasConfig.lastIndexOf("}");
-    if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
-      String config = jaasConfig.substring(startIndex + 1, endIndex).replace("\n", " ").trim();
-      return config;
-    } else {
-      throw new IllegalArgumentException("Invalid JAAS config format");
     }
   }
 }


### PR DESCRIPTION
Earlier we were adding shaded prefix to some stream config properties such as `PlainLoginModule` in jaas, so that older kafka tables work properly. 

However, now we need to do the opposite as well for some other prefixes because we have made substantial changes to shading in Pinot. 