### PR TITLE
Fix flaky upsert integration tests

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -59,8 +59,6 @@ import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
-import org.apache.pinot.spi.stream.StreamDataProducer;
-import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -568,61 +566,22 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     return TarCompressionUtils.untar(inputStream, outputDir);
   }
 
-  /**
-   * Pushes the data in the given Avro files into a Kafka stream.
-   *
-   * @param avroFiles List of Avro files
-   */
   protected void pushAvroIntoKafka(List<File> avroFiles)
       throws Exception {
     ClusterIntegrationTestUtils.pushAvroIntoKafka(avroFiles, "localhost:" + getKafkaPort(), getKafkaTopic(),
         getMaxNumKafkaMessagesPerBatch(), getKafkaMessageHeader(), getPartitionColumn(), injectTombstones());
   }
 
-  /**
-   * Pushes the data in the given Avro files into a Kafka stream.
-   *
-   * @param csvFile List of CSV strings
-   */
   protected void pushCsvIntoKafka(File csvFile, String kafkaTopic, @Nullable Integer partitionColumnIndex)
       throws Exception {
-    String kafkaBroker = "localhost:" + getKafkaPort();
-    StreamDataProducer producer = null;
-    try {
-      producer = StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME,
-          getDefaultKafkaProducerProperties(kafkaBroker));
-      ClusterIntegrationTestUtils.pushCsvIntoKafka(csvFile, kafkaTopic, partitionColumnIndex, injectTombstones(),
-          producer);
-    } catch (Exception e) {
-      if (producer != null) {
-        producer.close();
-      }
-      throw e;
-    }
+    ClusterIntegrationTestUtils.pushCsvIntoKafka(csvFile, "localhost:" + getKafkaPort(), kafkaTopic,
+        partitionColumnIndex, injectTombstones());
   }
 
-  protected void pushCsvIntoKafka(List<String> csvRecords, String kafkaTopic, @Nullable Integer partitionColumnIndex) {
-    String kafkaBroker = "localhost:" + getKafkaPort();
-    StreamDataProducer producer = null;
-    try {
-      producer = StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME,
-          getDefaultKafkaProducerProperties(kafkaBroker));
-      ClusterIntegrationTestUtils.pushCsvIntoKafka(csvRecords, kafkaTopic, partitionColumnIndex, injectTombstones(),
-          producer);
-    } catch (Exception e) {
-      if (producer != null) {
-        producer.close();
-      }
-    }
-  }
-
-  private Properties getDefaultKafkaProducerProperties(String kafkaBroker) {
-    Properties properties = new Properties();
-    properties.put("metadata.broker.list", kafkaBroker);
-    properties.put("serializer.class", "kafka.serializer.DefaultEncoder");
-    properties.put("request.required.acks", "1");
-    properties.put("partitioner.class", "kafka.producer.ByteArrayPartitioner");
-    return properties;
+  protected void pushCsvIntoKafka(List<String> csvRecords, String kafkaTopic, @Nullable Integer partitionColumnIndex)
+      throws Exception {
+    ClusterIntegrationTestUtils.pushCsvIntoKafka(csvRecords, "localhost:" + getKafkaPort(), kafkaTopic,
+        partitionColumnIndex, injectTombstones());
   }
 
   protected boolean injectTombstones() {
@@ -661,14 +620,21 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected void startKafka() {
-    startKafka(KafkaStarterUtils.DEFAULT_KAFKA_PORT);
+    startKafkaWithoutTopic();
+    createKafkaTopic(getKafkaTopic());
   }
 
-  protected void startKafka(int port) {
-    Properties kafkaConfig = KafkaStarterUtils.getDefaultKafkaConfiguration();
-    _kafkaStarters = KafkaStarterUtils.startServers(getNumKafkaBrokers(), port, getKafkaZKAddress(), kafkaConfig);
-    _kafkaStarters.get(0)
-        .createTopic(getKafkaTopic(), KafkaStarterUtils.getTopicCreationProps(getNumKafkaPartitions()));
+  protected void startKafkaWithoutTopic() {
+    startKafkaWithoutTopic(KafkaStarterUtils.DEFAULT_KAFKA_PORT);
+  }
+
+  protected void startKafkaWithoutTopic(int port) {
+    _kafkaStarters = KafkaStarterUtils.startServers(getNumKafkaBrokers(), port, getKafkaZKAddress(),
+        KafkaStarterUtils.getDefaultKafkaConfiguration());
+  }
+
+  protected void createKafkaTopic(String topic) {
+    _kafkaStarters.get(0).createTopic(topic, KafkaStarterUtils.getTopicCreationProps(getNumKafkaPartitions()));
   }
 
   protected void stopKafka() {
@@ -706,7 +672,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected void waitForDocsLoaded(long timeoutMs, boolean raiseError, String tableName) {
-    final long countStarResult = getCountStarResult();
+    long countStarResult = getCountStarResult();
     TestUtils.waitForCondition(() -> getCurrentCountStarResult(tableName) == countStarResult, 100L, timeoutMs,
         "Failed to load " + countStarResult + " documents", raiseError, Duration.ofMillis(timeoutMs / 10));
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
@@ -28,7 +28,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 /**
  * StreamDataProducer is the interface for stream data sources. E.g. KafkaDataProducer.
  */
-public interface StreamDataProducer {
+public interface StreamDataProducer extends AutoCloseable {
   void init(Properties props);
 
   void produce(String topic, byte[] payload);


### PR DESCRIPTION
The core reason for the flakiness is that snapshot is not guaranteed for the just committed segment.

Made the following enhancements:
1. Ensure snapshot is taken by pause/resume consumption
2. Fix resource leaks for kafka producer
3. Make `UpsertTableIntegrationTest` properly partitioned across 2 servers
4. Fix the flakiness of `UpsertTableSegmentPreloadIntegrationTest` snapshot check