### PR TITLE
Allow override of segment name when uploading a segment tar file

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -238,7 +238,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   private SuccessResponse uploadSegment(@Nullable String tableName, TableType tableType,
       @Nullable FormDataMultiPart multiPart, boolean copySegmentToFinalLocation, boolean enableParallelPushProtection,
-      boolean allowRefresh, HttpHeaders headers, Request request, String altSegmentName) {
+      boolean allowRefresh, HttpHeaders headers, Request request, @Nullable String segmentNameOverride) {
     if (StringUtils.isNotEmpty(tableName)) {
       TableType tableTypeFromTableName = TableNameBuilder.getTableTypeFromTableName(tableName);
       if (tableTypeFromTableName != null && tableTypeFromTableName != tableType) {
@@ -343,8 +343,8 @@ public class PinotSegmentUploadDownloadRestletResource {
 
       // Fetch segment name
       String segmentName = segmentMetadata.getName();
-      if (altSegmentName != null) {
-        segmentName = altSegmentName;
+      if (segmentNameOverride != null) {
+        segmentName = segmentNameOverride;
         segmentMetadata.setName(segmentName);
       }
 
@@ -856,7 +856,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
-      @ApiParam(value = "Alternate Segment Name") @QueryParam("altSegmentName") String altSegmentName,
+      @ApiParam(value = "Segment Name") @QueryParam("altSegmentName") String segmentName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
       boolean enableParallelPushProtection,
@@ -865,7 +865,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, true,
-          enableParallelPushProtection, allowRefresh, headers, request, altSegmentName));
+          enableParallelPushProtection, allowRefresh, headers, request, segmentName));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -232,6 +232,13 @@ public class PinotSegmentUploadDownloadRestletResource {
   private SuccessResponse uploadSegment(@Nullable String tableName, TableType tableType,
       @Nullable FormDataMultiPart multiPart, boolean copySegmentToFinalLocation, boolean enableParallelPushProtection,
       boolean allowRefresh, HttpHeaders headers, Request request) {
+    return uploadSegment(tableName, tableType, multiPart, copySegmentToFinalLocation, enableParallelPushProtection,
+        allowRefresh, headers, request, null);
+  }
+
+  private SuccessResponse uploadSegment(@Nullable String tableName, TableType tableType,
+      @Nullable FormDataMultiPart multiPart, boolean copySegmentToFinalLocation, boolean enableParallelPushProtection,
+      boolean allowRefresh, HttpHeaders headers, Request request, String altSegmentName) {
     if (StringUtils.isNotEmpty(tableName)) {
       TableType tableTypeFromTableName = TableNameBuilder.getTableTypeFromTableName(tableName);
       if (tableTypeFromTableName != null && tableTypeFromTableName != tableType) {
@@ -336,6 +343,10 @@ public class PinotSegmentUploadDownloadRestletResource {
 
       // Fetch segment name
       String segmentName = segmentMetadata.getName();
+      if (altSegmentName != null) {
+        segmentName = altSegmentName;
+        segmentMetadata.setName(segmentName);
+      }
 
       // Fetch table name. Try to derive the table name from the parameter and then from segment metadata
       String rawTableName;
@@ -845,6 +856,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       String tableName,
       @ApiParam(value = "Type of the table") @QueryParam(FileUploadDownloadClient.QueryParameters.TABLE_TYPE)
       @DefaultValue("OFFLINE") String tableType,
+      @ApiParam(value = "Alternate Segment Name") @QueryParam("altSegmentName") String altSegmentName,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
       boolean enableParallelPushProtection,
@@ -853,7 +865,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, true,
-          enableParallelPushProtection, allowRefresh, headers, request));
+          enableParallelPushProtection, allowRefresh, headers, request, altSegmentName));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -49,6 +49,8 @@ public interface SegmentMetadata {
 
   String getName();
 
+  void setName(String name);
+
   String getTimeColumn();
 
   long getStartTime();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -314,6 +314,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   }
 
   @Override
+  public void setName(String name) {
+    _segmentName = name;
+  }
+
+  @Override
   public String getTimeColumn() {
     return _timeColumn;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -74,8 +74,9 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @CommandLine.Option(names = {"-segmentDir"}, required = true, description = "Path to segment directory.")
   private String _segmentDir = null;
 
-  @CommandLine.Option(names = {"-segmentNameSuffix"}, description = "Add an optional suffix to the segment name.")
-  private String _segmentNameSuffix = null;
+  @CommandLine.Option(names = {"-segmentName"}, description = "Name to use for the segment. If not specified, it will"
+      + " be same as file name.")
+  private String _segmentName = null;
 
   @CommandLine.Option(names = {"-tableName"}, required = false, description = "Table name to upload")
   private String _tableName = null;
@@ -183,8 +184,8 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
         }
 
         List<NameValuePair> parameters = null;
-        if (_segmentNameSuffix != null) {
-          parameters = List.of(new BasicNameValuePair("altSegmentName", segmentFile.getName() + _segmentNameSuffix));
+        if (_segmentName != null) {
+          parameters = List.of(new BasicNameValuePair("altSegmentName", segmentFile.getName() + _segmentName));
         }
 
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -95,7 +95,8 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Override
   public String toString() {
     return ("UploadSegment -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
-        + " -controllerPort " + _controllerPort + " -segmentDir " + _segmentDir);
+        + " -controllerPort " + _controllerPort + " -segmentDir " + _segmentDir
+        + " -segmentName " + _segmentName);
   }
 
   @Override
@@ -163,7 +164,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
     FileUtils.deleteQuietly(tempDir);
     FileUtils.forceMkdir(tempDir);
 
-    LOGGER.info("Executing command: {}", toString());
+    LOGGER.info("Executing command: {}", this);
     File segmentDir = new File(_segmentDir);
     File[] segmentFiles = segmentDir.listFiles();
     Preconditions.checkNotNull(segmentFiles);


### PR DESCRIPTION
In segment tar upload operation, the name of the segment is the file (or dir) name. Allow the client to specify a segment name instead. This feature is useful when writing tests or to simulate production workloads.