### PR TITLE
Fix Flaky test # 14456

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -720,11 +720,11 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     String reloadJob;
     //tests that reload is needed on the table from controller api segments/{tableNameWithType}/needReload
     if (includeOfflineTable) {
-      testNeedReloadTableTrue(tableNameWithTypeOffline);
+      testTableNeedReloadTrue(tableNameWithTypeOffline);
       // Reload the table
       reloadJob = reloadTableAndValidateResponse(rawTableName, TableType.OFFLINE, false);
     }
-    testNeedReloadTableTrue(tableNameWithTypeRealtime);
+    testTableNeedReloadTrue(tableNameWithTypeRealtime);
     reloadJob = reloadTableAndValidateResponse(rawTableName, TableType.REALTIME, false);
 
     // Wait for all segments to finish reloading, and test filter on all newly added columns
@@ -770,9 +770,9 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     //tests that reload is not needed on the table after reloading all segments from controller api
     // segments/{tableNameWithType}/needReload
     if (includeOfflineTable) {
-      testNeedReloadFalse(tableNameWithTypeOffline);
+      testTableNeedReloadFalse(tableNameWithTypeOffline);
     }
-    testNeedReloadFalse(tableNameWithTypeRealtime);
+    testTableNeedReloadFalse(tableNameWithTypeRealtime);
   }
 
   private void addNewSchemaFields(Schema schema)
@@ -796,7 +796,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     addSchema(schema);
   }
 
-  private void testNeedReloadFalse(String tableNameWithTypeOffline)
+  private void testTableNeedReloadFalse(String tableNameWithTypeOffline)
       throws IOException {
     String needAfterReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
     String needAfterReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);
@@ -809,7 +809,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     assertFalse(jsonNeedReloadResponseAfterWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
   }
 
-  private JsonNode testNeedReloadTableTrue(String tableNameWithTypeOffline)
+  private JsonNode testTableNeedReloadTrue(String tableNameWithTypeOffline)
       throws IOException {
     String needBeforeReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
     String needBeforeReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -714,6 +714,69 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     assertEquals(queryResponse.get("resultTable").get("dataSchema").get("columnNames").size(), schema.size());
     long numTotalDocs = queryResponse.get("totalDocs").asLong();
 
+    addNewSchemaFields(schema);
+    String tableNameWithTypeOffline = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
+    String tableNameWithTypeRealtime = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
+    String reloadJob;
+    //tests that reload is needed on the table from controller api segments/{tableNameWithType}/needReload
+    if (includeOfflineTable) {
+      testNeedReloadTableTrue(tableNameWithTypeOffline);
+      // Reload the table
+      reloadJob = reloadTableAndValidateResponse(rawTableName, TableType.OFFLINE, false);
+    }
+    testNeedReloadTableTrue(tableNameWithTypeRealtime);
+    reloadJob = reloadTableAndValidateResponse(rawTableName, TableType.REALTIME, false);
+
+    // Wait for all segments to finish reloading, and test filter on all newly added columns
+    // NOTE: Use count query to prevent schema inconsistency error
+    String testQuery = "SELECT COUNT(*) FROM " + rawTableName
+        + " WHERE NewIntSVDimension < 0 AND NewLongSVDimension < 0 AND NewFloatSVDimension < 0 AND "
+        + "NewDoubleSVDimension < 0 AND NewStringSVDimension = 'null' AND NewIntMVDimension < 0 AND "
+        + "NewLongMVDimension < 0 AND NewFloatMVDimension < 0 AND NewDoubleMVDimension < 0 AND "
+        + "NewStringMVDimension = 'null' AND NewIntMetric = 0 AND NewLongMetric = 0 AND NewFloatMetric = 0 "
+        + "AND NewDoubleMetric = 0 AND NewBytesMetric = ''";
+    long countStarResult = getCountStarResult();
+    String finalReloadJob = reloadJob;
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode testQueryResponse = postQuery(testQuery);
+        // Should not throw exception during reload
+        assertEquals(testQueryResponse.get("exceptions").size(), 0,
+            String.format("Found exceptions when testing reload for query: %s and response: %s", testQuery,
+                testQueryResponse));
+        // Total docs should not change during reload
+        assertEquals(testQueryResponse.get("totalDocs").asLong(), numTotalDocs,
+            String.format("Total docs changed after reload, query: %s and response: %s", testQuery, testQueryResponse));
+        return testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult && isReloadJobCompleted(
+            finalReloadJob);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to generate default values for new columns");
+
+    // Select star query should return all the columns
+    queryResponse = postQuery(selectStarQuery);
+    assertEquals(queryResponse.get("exceptions").size(), 0);
+    JsonNode resultTable = queryResponse.get("resultTable");
+    assertEquals(resultTable.get("dataSchema").get("columnNames").size(), schema.size());
+    assertEquals(resultTable.get("rows").size(), 10);
+    assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+
+    // Test aggregation query to include querying all segemnts (including realtime)
+    String aggregationQuery = "SELECT SUMMV(NewIntMVDimension) FROM " + rawTableName;
+    queryResponse = postQuery(aggregationQuery);
+    assertEquals(queryResponse.get("exceptions").size(), 0);
+
+    //tests that reload is not needed on the table after reloading all segments from controller api
+    // segments/{tableNameWithType}/needReload
+    if (includeOfflineTable) {
+      testNeedReloadFalse(tableNameWithTypeOffline);
+    }
+    testNeedReloadFalse(tableNameWithTypeRealtime);
+  }
+
+  private void addNewSchemaFields(Schema schema)
+      throws IOException {
     schema.addField(constructNewDimension(FieldSpec.DataType.INT, true));
     schema.addField(constructNewDimension(FieldSpec.DataType.LONG, true));
     schema.addField(constructNewDimension(FieldSpec.DataType.FLOAT, true));
@@ -729,102 +792,34 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     schema.addField(constructNewMetric(FieldSpec.DataType.FLOAT));
     schema.addField(constructNewMetric(FieldSpec.DataType.DOUBLE));
     schema.addField(constructNewMetric(FieldSpec.DataType.BYTES));
-
     // Upload the schema with extra columns
     addSchema(schema);
-    String tableNameWithTypeOffline = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
-    String tableNameWithTypeRealtime = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
-    // Reload the table
-    if (includeOfflineTable) {
-      //test controller api which gives responses if reload is needed on any of the server segments when default
-      // columns are added
-      String needBeforeReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
-      String needBeforeReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);
-      JsonNode jsonNeedReloadResponseWithNoVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithNoVerbose);
-      JsonNode jsonNeedReloadResponseWithVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithVerbose);
-      //test to check if reload is needed i.e true
-      assertTrue(jsonNeedReloadResponseWithNoVerbose.get("needReload").asBoolean());
-      assertTrue(jsonNeedReloadResponseWithVerbose.get("needReload").asBoolean());
-      assertFalse(jsonNeedReloadResponseWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
-      reloadOfflineTable(rawTableName);
-    }
-    //test controller api which gives responses if reload is needed on any of the server segments when default
-    // columns are added
-    String needBeforeReloadResponseRealtimeWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeRealtime, false);
-    String needBeforeReloadResponseRealtimeWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeRealtime, true);
-    JsonNode jsonNeedReloadResponseRealTimeWithNoVerbose =
-        JsonUtils.stringToJsonNode(needBeforeReloadResponseRealtimeWithNoVerbose);
-    JsonNode jsonNeedReloadResponseRealTimeWithVerbose =
-        JsonUtils.stringToJsonNode(needBeforeReloadResponseRealtimeWithVerbose);
+  }
+
+  private void testNeedReloadFalse(String tableNameWithTypeOffline)
+      throws IOException {
+    String needAfterReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
+    String needAfterReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);
+    JsonNode jsonNeedReloadResponseAfterWithNoVerbose =
+        JsonUtils.stringToJsonNode(needAfterReloadResponseWithNoVerbose);
+    JsonNode jsonNeedReloadResponseAfterWithVerbose = JsonUtils.stringToJsonNode(needAfterReloadResponseWithVerbose);
+    //test to check if reload on offline table is needed i.e false after reload is finished
+    assertFalse(jsonNeedReloadResponseAfterWithNoVerbose.get("needReload").asBoolean());
+    assertFalse(jsonNeedReloadResponseAfterWithVerbose.get("needReload").asBoolean());
+    assertFalse(jsonNeedReloadResponseAfterWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
+  }
+
+  private JsonNode testNeedReloadTableTrue(String tableNameWithTypeOffline)
+      throws IOException {
+    String needBeforeReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
+    String needBeforeReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);
+    JsonNode jsonNeedReloadResponseWithNoVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithNoVerbose);
+    JsonNode jsonNeedReloadResponseWithVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithVerbose);
     //test to check if reload is needed i.e true
-    assertTrue(jsonNeedReloadResponseRealTimeWithNoVerbose.get("needReload").asBoolean());
-    assertTrue(jsonNeedReloadResponseRealTimeWithVerbose.get("needReload").asBoolean());
-    assertFalse(jsonNeedReloadResponseRealTimeWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
-    reloadRealtimeTable(rawTableName);
-
-    // Wait for all segments to finish reloading, and test querying the new columns
-    // NOTE: Use count query to prevent schema inconsistency error
-    String testQuery = "SELECT COUNT(*) FROM " + rawTableName + " WHERE NewIntSVDimension < 0";
-    long countStarResult = getCountStarResult();
-    TestUtils.waitForCondition(aVoid -> {
-      try {
-        JsonNode testQueryResponse = postQuery(testQuery);
-        // Should not throw exception during reload
-        assertEquals(testQueryResponse.get("exceptions").size(), 0,
-            String.format("Found exceptions when testing reload for query: %s and response: %s", testQuery,
-                testQueryResponse));
-        // Total docs should not change during reload
-        assertEquals(testQueryResponse.get("totalDocs").asLong(), numTotalDocs,
-            String.format("Total docs changed after reload, query: %s and response: %s", testQuery, testQueryResponse));
-        return testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, 600_000L, "Failed to generate default values for new columns");
-
-    // Select star query should return all the columns
-    queryResponse = postQuery(selectStarQuery);
-    assertEquals(queryResponse.get("exceptions").size(), 0);
-    JsonNode resultTable = queryResponse.get("resultTable");
-    assertEquals(resultTable.get("dataSchema").get("columnNames").size(), schema.size());
-    assertEquals(resultTable.get("rows").size(), 10);
-    // Test aggregation query to include querying all segemnts (including realtime)
-    String aggregationQuery = "SELECT SUMMV(NewIntMVDimension) FROM " + rawTableName;
-    queryResponse = postQuery(aggregationQuery);
-    assertEquals(queryResponse.get("exceptions").size(), 0);
-
-    // Test filter on all new added columns
-    String countStarQuery = "SELECT COUNT(*) FROM " + rawTableName
-        + " WHERE NewIntSVDimension < 0 AND NewLongSVDimension < 0 AND NewFloatSVDimension < 0 AND "
-        + "NewDoubleSVDimension < 0 AND NewStringSVDimension = 'null' AND NewIntMVDimension < 0 AND "
-        + "NewLongMVDimension < 0 AND NewFloatMVDimension < 0 AND NewDoubleMVDimension < 0 AND "
-        + "NewStringMVDimension = 'null' AND NewIntMetric = 0 AND NewLongMetric = 0 AND NewFloatMetric = 0 "
-        + "AND NewDoubleMetric = 0 AND NewBytesMetric = ''";
-    queryResponse = postQuery(countStarQuery);
-    assertEquals(queryResponse.get("exceptions").size(), 0);
-    assertEquals(queryResponse.get("resultTable").get("rows").get(0).get(0).asLong(), countStarResult);
-    if (includeOfflineTable) {
-      String needAfterReloadResponseWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, false);
-      String needAfterReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeOffline, true);
-      JsonNode jsonNeedReloadResponseAfterWithNoVerbose =
-          JsonUtils.stringToJsonNode(needAfterReloadResponseWithNoVerbose);
-      JsonNode jsonNeedReloadResponseAfterWithVerbose = JsonUtils.stringToJsonNode(needAfterReloadResponseWithVerbose);
-      //test to check if reload on offline table is needed i.e false after reload is finished
-      assertFalse(jsonNeedReloadResponseAfterWithNoVerbose.get("needReload").asBoolean());
-      assertFalse(jsonNeedReloadResponseAfterWithVerbose.get("needReload").asBoolean());
-      assertFalse(jsonNeedReloadResponseRealTimeWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
-    }
-    String needAfterReloadResponseRealtimeWithNoVerbose = checkIfReloadIsNeeded(tableNameWithTypeRealtime, false);
-    String needAfterReloadResponseRealTimeWithVerbose = checkIfReloadIsNeeded(tableNameWithTypeRealtime, true);
-    JsonNode jsonNeedReloadResponseRealtimeAfterWithNoVerbose =
-        JsonUtils.stringToJsonNode(needAfterReloadResponseRealtimeWithNoVerbose);
-    JsonNode jsonNeedReloadResponseRealtimeAfterWithVerbose =
-        JsonUtils.stringToJsonNode(needAfterReloadResponseRealTimeWithVerbose);
-
-    //test to check if reload on real time table is needed i.e false after reload is finished
-    assertFalse(jsonNeedReloadResponseRealtimeAfterWithNoVerbose.get("needReload").asBoolean());
-    assertFalse(jsonNeedReloadResponseRealtimeAfterWithVerbose.get("needReload").asBoolean());
-    assertFalse(jsonNeedReloadResponseRealtimeAfterWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
+    assertTrue(jsonNeedReloadResponseWithNoVerbose.get("needReload").asBoolean());
+    assertTrue(jsonNeedReloadResponseWithVerbose.get("needReload").asBoolean());
+    assertFalse(jsonNeedReloadResponseWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
+    return jsonNeedReloadResponseWithNoVerbose;
   }
 
   private DimensionFieldSpec constructNewDimension(FieldSpec.DataType dataType, boolean singleValue) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -802,7 +802,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     String needBeforeReloadResponseWithVerbose = checkIfReloadIsNeeded(tableNameWithType, true);
     JsonNode jsonNeedReloadResponseWithNoVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithNoVerbose);
     JsonNode jsonNeedReloadResponseWithVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithVerbose);
-    //test to check if reload is needed i.e true
+    // Tests if reload is needed on the table
     assertEquals(jsonNeedReloadResponseWithNoVerbose.get("needReload").asBoolean(), expectedNeedReload);
     assertEquals(jsonNeedReloadResponseWithVerbose.get("needReload").asBoolean(), expectedNeedReload);
     assertFalse(jsonNeedReloadResponseWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -747,8 +747,8 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
         // Total docs should not change during reload
         assertEquals(testQueryResponse.get("totalDocs").asLong(), numTotalDocs,
             String.format("Total docs changed after reload, query: %s and response: %s", testQuery, testQueryResponse));
-        return testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult && isReloadJobCompleted(
-            finalReloadJob);
+        return testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult
+            && isReloadJobCompleted(finalReloadJob);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -803,8 +803,8 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     JsonNode jsonNeedReloadResponseWithNoVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithNoVerbose);
     JsonNode jsonNeedReloadResponseWithVerbose = JsonUtils.stringToJsonNode(needBeforeReloadResponseWithVerbose);
     //test to check if reload is needed i.e true
-    assertEquals(jsonNeedReloadResponseWithNoVerbose.get("expectedNeedReload").asBoolean(), expectedNeedReload);
-    assertEquals(jsonNeedReloadResponseWithVerbose.get("expectedNeedReload").asBoolean(), expectedNeedReload);
+    assertEquals(jsonNeedReloadResponseWithNoVerbose.get("needReload").asBoolean(), expectedNeedReload);
+    assertEquals(jsonNeedReloadResponseWithVerbose.get("needReload").asBoolean(), expectedNeedReload);
     assertFalse(jsonNeedReloadResponseWithVerbose.get("serverToSegmentsCheckReloadList").isEmpty());
   }
 


### PR DESCRIPTION
Reference issue: https://github.com/apache/pinot/issues/14456

This fix mainly addresses below points:
1) Checks totalDocs from select count(*) query which addresses through all newly added columns instead of just single column in the wait
2) Add additional check in the wait to see the status of all segments reload is successful from the jobId before hitting needReload check for the segments after reload

Also Refactored the test a bit