### PR TITLE
log the instance configs properly

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -114,7 +114,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     LOGGER.info("Initializing Helix instance data manager");
 
     _instanceDataManagerConfig = new HelixInstanceDataManagerConfig(config);
-    LOGGER.info("HelixInstanceDataManagerConfig: {}", _instanceDataManagerConfig);
+    LOGGER.info("HelixInstanceDataManagerConfig: {}", _instanceDataManagerConfig.getConfig());
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _tableDataManagerProvider = new TableDataManagerProvider(_instanceDataManagerConfig, helixManager, _segmentLocks);


### PR DESCRIPTION
A quick fix to log instance configs properly. Without this, we saw this 

```
... INFO [HelixInstanceDataManager] [main] HelixInstanceDataManagerConfig: 
org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig@46e77fb7
```