### PR TITLE
Show multi-stage engine explain plan for integration test query failures with the multi-stage query engine

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -786,7 +786,7 @@ public class ClusterIntegrationTestUtils {
             if (pinotNumRecordsSelected != 0) {
               throw new RuntimeException("No record selected in H2 but " + pinotNumRecordsSelected
                   + " records selected in Pinot, explain plan: " + getExplainPlan(pinotQuery, queryResourceUrl, headers,
-                  extraJsonProperties));
+                  extraJsonProperties, useMultiStageQueryEngine));
             }
 
             // Skip further comparison
@@ -809,7 +809,7 @@ public class ClusterIntegrationTestUtils {
             throw new RuntimeException(
                 "Value: " + c + " does not match, expected: " + h2Value + ", got broker value: " + brokerValue
                     + ", got client value:" + connectionValue + ", explain plan: " + getExplainPlan(pinotQuery,
-                    queryResourceUrl, headers, extraJsonProperties));
+                    queryResourceUrl, headers, extraJsonProperties, useMultiStageQueryEngine));
           }
         }
       } else {
@@ -833,7 +833,7 @@ public class ClusterIntegrationTestUtils {
                   throw new RuntimeException(
                       "Value: " + c + " does not match, expected: " + h2Value + ", got broker value: " + brokerValue
                           + ", got client value:" + connectionValue + ", explain plan: " + getExplainPlan(pinotQuery,
-                          queryResourceUrl, headers, extraJsonProperties));
+                          queryResourceUrl, headers, extraJsonProperties, useMultiStageQueryEngine));
                 }
               }
               if (!h2ResultSet.next()) {
@@ -847,12 +847,13 @@ public class ClusterIntegrationTestUtils {
   }
 
   private static String getExplainPlan(@Language("sql") String pinotQuery, String brokerUrl,
-      @Nullable Map<String, String> headers, @Nullable Map<String, String> extraJsonProperties)
+      @Nullable Map<String, String> headers, @Nullable Map<String, String> extraJsonProperties,
+      boolean useMultiStageQueryEngine)
       throws Exception {
-    JsonNode explainPlanForResponse =
-        ClusterTest.postQuery("explain plan for " + pinotQuery, getBrokerQueryApiUrl(brokerUrl, false), headers,
-            extraJsonProperties);
-    return ExplainPlanUtils.formatExplainPlan(explainPlanForResponse);
+    JsonNode explainPlanForResponse = ClusterTest.postQuery("explain plan for " + pinotQuery,
+        getBrokerQueryApiUrl(brokerUrl, useMultiStageQueryEngine), headers, extraJsonProperties);
+    return useMultiStageQueryEngine ? ExplainPlanUtils.formatMultiStageExplainPlan(explainPlanForResponse)
+        : ExplainPlanUtils.formatExplainPlan(explainPlanForResponse);
   }
 
   public static String getBrokerQueryApiUrl(String brokerBaseApiUrl, boolean useMultiStageQueryEngine) {


### PR DESCRIPTION
- Currently if there's a query related integration test failure with the multi-stage query engine, the explain plan that is displayed to aid debugging is the single-stage query engine explain plan for the same query (which might or might not even be a valid query for the single-stage query engine).
- This minor patch fixes the issue to show the appropriate explain plan depending on the query engine being used in the integration test.