### PR TITLE
Add Support to add prefix/suffix to Tasks

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -60,6 +60,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -262,7 +263,15 @@ public class PinotHelixTaskResourceManager {
     Preconditions.checkState(numConcurrentTasksPerInstance > 0);
 
     String taskType = pinotTaskConfigs.get(0).getTaskType();
-    String parentTaskName = getParentTaskName(taskType, UUID.randomUUID() + "_" + System.currentTimeMillis());
+
+    // Get task name prefix and suffix from the first task config.
+    String taskNamePrefix = pinotTaskConfigs.get(0).getConfigs()
+        .getOrDefault(BatchConfigProperties.TASK_NAME_PREFIX_KEY, UUID.randomUUID().toString());
+    String taskNameSuffix =
+        pinotTaskConfigs.get(0).getConfigs().getOrDefault(BatchConfigProperties.TASK_NAME_SUFFIX_KEY, "");
+
+    String parentTaskName =
+        getParentTaskName(taskType, taskNamePrefix + "_" + System.currentTimeMillis() + taskNameSuffix);
     return submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag, taskTimeoutMs, numConcurrentTasksPerInstance,
         maxAttemptsPerTask);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -66,6 +66,8 @@ public class BatchConfigProperties {
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
   public static final String EXCLUDE_TIME_IN_SEGMENT_NAME = "exclude.time.in.segment.name";
   public static final String BATCH_SEGMENT_UPLOAD = "batchSegmentUpload";
+  public static final String TASK_NAME_PREFIX_KEY = "taskNamePrefix";
+  public static final String TASK_NAME_SUFFIX_KEY = "taskNameSuffix";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 


### PR DESCRIPTION
## Issue

Currently there is no way to add custom prefix/suffix to task names. It can be useful to have the support to add prefix/suffix support for the tasks.


## Changes

- Add config keys `TASK_NAME_PREFIX_KEY` and `TASK_NAME_SUFFIX_KEY` in `BatchConfigProperties`.
- Add support for prefix/suffix in `PinotHelixTaskResourceManager`