### PR TITLE
Realtime segment size threshold metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -165,6 +165,16 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   TABLE_DISABLED("tableDisabled", false),
 
+  // A per-table metric that shows the number of rows we expect to consume for the next segment of
+  // any partition in the realtime table. This metric is emitted from the segment size based threshold
+  // computer.
+  NUM_ROWS_THRESHOLD("numRowsThreshold", false),
+
+  // The actual segment size for committing segments. These may be shorter than expected when the administrator
+  // issues a force-commit, or zero when new partitions are detected in the stream (since there is no completing
+  // segment when the partition is first detected).
+  COMMITTING_SEGMENT_SIZE("numRowsThreshold", false),
+
   TABLE_REBALANCE_IN_PROGRESS("tableRebalanceInProgress", false);
 
   private final String _gaugeName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -173,7 +173,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // The actual segment size for committing segments. These may be shorter than expected when the administrator
   // issues a force-commit, or zero when new partitions are detected in the stream (since there is no completing
   // segment when the partition is first detected).
-  COMMITTING_SEGMENT_SIZE("numRowsThreshold", false),
+  COMMITTING_SEGMENT_SIZE("committingSegmentSize", false),
 
   TABLE_REBALANCE_IN_PROGRESS("tableRebalanceInProgress", false);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -61,7 +61,7 @@ public class FlushThresholdUpdateManager {
     long flushThresholdSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
     if (flushThresholdRows == 0 || flushThresholdSegmentSizeBytes > 0) {
       return _flushThresholdUpdaterMap.computeIfAbsent(realtimeTableName,
-          k -> new SegmentSizeBasedFlushThresholdUpdater());
+          k -> new SegmentSizeBasedFlushThresholdUpdater(realtimeTableName));
     } else {
       _flushThresholdUpdaterMap.remove(realtimeTableName);
       return new DefaultFlushThresholdUpdater(StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -20,7 +20,10 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,9 +39,13 @@ import org.slf4j.LoggerFactory;
 public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpdater {
   public static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
   private final SegmentFlushThresholdComputer _flushThresholdComputer;
+  private final String _rawTableName;
 
-  public SegmentSizeBasedFlushThresholdUpdater() {
+  private final ControllerMetrics _controllerMetrics = ControllerMetrics.get();
+
+  public SegmentSizeBasedFlushThresholdUpdater(String realtimeTableName) {
     _flushThresholdComputer = new SegmentFlushThresholdComputer();
+    _rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
   }
 
   // synchronized since this method could be called for multiple partitions of the same table in different threads
@@ -50,5 +57,9 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
         _flushThresholdComputer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
             newSegmentZKMetadata.getSegmentName());
     newSegmentZKMetadata.setSizeThresholdToFlushSegment(threshold);
+
+    _controllerMetrics.setOrUpdateTableGauge(_rawTableName, ControllerGauge.NUM_ROWS_THRESHOLD, threshold);
+    _controllerMetrics.setOrUpdateTableGauge(_rawTableName, ControllerGauge.COMMITTING_SEGMENT_SIZE,
+        committingSegmentDescriptor.getSegmentSizeBytes());
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -139,7 +139,8 @@ public class FlushThresholdUpdaterTest {
 
     for (long[] segmentSizesMB : Arrays.asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB,
         STEPS_SEGMENT_SIZES_MB)) {
-      SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+      SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
+          new SegmentSizeBasedFlushThresholdUpdater(REALTIME_TABLE_NAME);
 
       // Start consumption
       SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
@@ -176,7 +177,8 @@ public class FlushThresholdUpdaterTest {
 
     for (long[] segmentSizesMB : Arrays.asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB,
         STEPS_SEGMENT_SIZES_MB)) {
-      SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+      SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
+          new SegmentSizeBasedFlushThresholdUpdater(REALTIME_TABLE_NAME);
 
       // Start consumption
       SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(1);
@@ -236,7 +238,8 @@ public class FlushThresholdUpdaterTest {
 
   @Test
   public void testTimeThreshold() {
-    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
+        new SegmentSizeBasedFlushThresholdUpdater(REALTIME_TABLE_NAME);
     StreamConfig streamConfig = mockDefaultAutotuneStreamConfig();
 
     // Start consumption
@@ -269,7 +272,8 @@ public class FlushThresholdUpdaterTest {
 
   @Test
   public void testMinThreshold() {
-    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater =
+        new SegmentSizeBasedFlushThresholdUpdater(REALTIME_TABLE_NAME);
     StreamConfig streamConfig = mockDefaultAutotuneStreamConfig();
 
     // Start consumption
@@ -301,7 +305,8 @@ public class FlushThresholdUpdaterTest {
 
   @Test
   public void testSegmentSizeBasedUpdaterWithModifications() {
-    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater
+        = new SegmentSizeBasedFlushThresholdUpdater(REALTIME_TABLE_NAME);
 
     // Use customized stream config
     long flushSegmentDesiredSizeBytes = StreamConfig.DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES / 2;


### PR DESCRIPTION
Added a couple of metrics for observing the actual segment size and the predicted number of rows we indicate to the servers. The metrics should help us improve the prediction algorithm for new use cases.