### PR TITLE
Fix BitmapCollection::orCardinality API when combining a non-inverted bitmap with an inverted one

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapCollection.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapCollection.java
@@ -86,11 +86,10 @@ public class BitmapCollection {
       if (!bitmaps._inverted) {
         return ImmutableRoaringBitmap.orCardinality(left, right);
       }
-      return _numDocs - right.getCardinality() - ImmutableRoaringBitmap.andCardinality(left, right);
+      return _numDocs - right.getCardinality() + ImmutableRoaringBitmap.andCardinality(left, right);
     } else {
       if (!bitmaps._inverted) {
-        return _numDocs - left.getCardinality()
-            + ImmutableRoaringBitmap.andCardinality(right, left);
+        return _numDocs - left.getCardinality() + ImmutableRoaringBitmap.andCardinality(right, left);
       }
       return _numDocs - ImmutableRoaringBitmap.andCardinality(left, right);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BitmapCollectionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BitmapCollectionTest.java
@@ -171,7 +171,7 @@ public class BitmapCollectionTest {
         },
         {
             10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
-            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 7
+            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 9
         },
         {
             10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/14486.
- The existing API incorrectly calculates `n(b1 ∪ b2')` as `numDocs - n(b2) - n(b1 ∩ b2)`. It should instead be `numDocs - n(b2) + n(b1 ∩ b2)`. The following Venn diagram clearly demonstrates the issue:
![image](https://github.com/user-attachments/assets/619e2f3b-9b03-4606-b231-86814a97d75e)
- There was a unit test in `BitmapCollectionTest` that covered this case but the unit test itself was also buggy unfortunately. It combines a non-inverted bitmap `[0, 5]` with an inverted bitmap `[0, 4]` (i.e., bitmap `[1, 2, 3, 5, 6, 7, 8, 9]`) which should result in bitmap `[0, 1, 2, 3, 5, 6, 7, 8, 9]` - i.e., cardinality of 9 (but the test's expectation is 7).
- The existing logic for `n(b1' ∪ b2)` is correct however, and the existing unit test combining the inverted bitmap `[0, 5]` with a non-inverted bitmap `[0, 4]` does have an expected cardinality of 9.
- This patch also adds a small integration test with the original generated query that caught this issue in a CI run.