### PR TITLE
Fix default value handling in REGEXP_EXTRACT transform function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
@@ -81,10 +81,10 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
     }
 
     if (arguments.size() == 4) {
-      TransformFunction positionFunction = arguments.get(3);
-      Preconditions.checkState(positionFunction instanceof LiteralTransformFunction,
+      TransformFunction defaultValueTransformFunction = arguments.get(3);
+      Preconditions.checkState(defaultValueTransformFunction instanceof LiteralTransformFunction,
           "`default_value` must be a literal expression.");
-      _defaultValue = ((LiteralTransformFunction) regexpFunction).getStringLiteral();
+      _defaultValue = ((LiteralTransformFunction) defaultValueTransformFunction).getStringLiteral();
     } else {
       _defaultValue = "";
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RegexpTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RegexpTransformFunctionTest.java
@@ -41,8 +41,20 @@ public class RegexpTransformFunctionTest extends BaseTransformFunctionTest {
     for (int i = 0; i < NUM_ROWS; i++) {
       Matcher matcher = PATTERN.matcher(_stringSVValues[i]);
       Assert.assertEquals(
-          matcher.find() && matcher.groupCount() >= group ? matcher.group(group) : defaultValue,
-          actualValues[i]);
+          actualValues[i],
+          matcher.find() && matcher.groupCount() >= group ? matcher.group(group) : defaultValue
+      );
+    }
+  }
+
+  @Test
+  public void testDefaultValue() {
+    String expressionStr = String.format("REGEXP_EXTRACT(%s, '%s', 1, 'null')", STRING_SV_COLUMN, "nonMatchingRegex");
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[] actualValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(actualValues[i], "null");
     }
   }
 


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/14488.
- `REGEXP_EXTRACT(stringCol, 'nonMatchingRegex', 0, 'null')` returns `nonMatchingRegex` instead of `null`.
- `REGEXP_EXTRACT('stringLiteral', 'nonMatchingRegex', 0, 'null')` correctly returns `null` however.
- This is because the corresponding transform function has a bug here - https://github.com/apache/pinot/blob/c096c705903b40fa8f951958a2b14bfd524076e9/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java#L83-L88
- The corresponding scalar function is correct though - https://github.com/apache/pinot/blob/c096c705903b40fa8f951958a2b14bfd524076e9/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java#L280-L289
- This patch fixes the transform function bug and adds a small unit test.