### PR TITLE
Retain boolean type from CLPLogRecordExtractor decoder.

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -130,6 +130,17 @@ public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Objec
   }
 
   /**
+   * In addition to the basic conversion, we also needs to retain the type info of Boolean input.
+   */
+  @Override
+  protected Object convertSingleValue(Object value) {
+    if (value instanceof Boolean) {
+      return value;
+    }
+    return super.convertSingleValue(value);
+  }
+
+  /**
    * Encodes a field with CLP
    * <p></p>
    * Given a field "x", this will output three fields: "x_logtype", "x_dictionaryVars", "x_encodedVars"

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -43,6 +43,8 @@ public class CLPLogRecordExtractorTest {
   private static final int _TIMESTAMP_FIELD_VALUE = 10;
   private static final String _LEVEL_FIELD_NAME = "level";
   private static final String _LEVEL_FIELD_VALUE = "INFO";
+  private static final String _BOOLEAN_FIELD_NAME = "booleanField";
+  private static final boolean _BOOLEAN_FIELD_VALUE = true;
   private static final String _MESSAGE_1_FIELD_NAME = "message1";
   private static final String _MESSAGE_1_FIELD_VALUE = "Started job_123 on node-987: 4 cores, 8 threads and "
       + "51.4% memory used.";
@@ -105,6 +107,7 @@ public class CLPLogRecordExtractorTest {
     row = extract(props, null);
     assertEquals(row.getValue(_TIMESTAMP_FIELD_NAME), _TIMESTAMP_FIELD_VALUE);
     assertEquals(row.getValue(_LEVEL_FIELD_NAME), _LEVEL_FIELD_VALUE);
+    assertEquals(row.getValue(_BOOLEAN_FIELD_NAME), _BOOLEAN_FIELD_VALUE);
     validateClpEncodedField(row, _MESSAGE_1_FIELD_NAME, _MESSAGE_1_FIELD_VALUE);
     validateClpEncodedField(row, _MESSAGE_2_FIELD_NAME, _MESSAGE_2_FIELD_VALUE);
   }
@@ -153,6 +156,7 @@ public class CLPLogRecordExtractorTest {
     record.put(_MESSAGE_1_FIELD_NAME, _MESSAGE_1_FIELD_VALUE);
     record.put(_MESSAGE_2_FIELD_NAME, _MESSAGE_2_FIELD_VALUE);
     record.put(_LEVEL_FIELD_NAME, _LEVEL_FIELD_VALUE);
+    record.put(_BOOLEAN_FIELD_NAME, _BOOLEAN_FIELD_VALUE);
 
     GenericRow row = new GenericRow();
     extractor.extract(record, row);


### PR DESCRIPTION
This PR updates the behavior of CLPLogRecordExtractor to prevent Boolean fields from being cast to the string type. Searching for Boolean values in a string column can be confusing, particularly for users accustomed to different programming languages. For instance, Python uses True, while Java uses true, leading to potential inconsistencies.