### PR TITLE
[timeseries] Response Size Limit, Metrics and Series Limit

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -108,13 +108,14 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
       TimeSeriesLogicalPlanResult logicalPlanResult = _queryEnvironment.buildLogicalPlan(timeSeriesRequest);
       TimeSeriesDispatchablePlan dispatchablePlan =
           _queryEnvironment.buildPhysicalPlan(timeSeriesRequest, requestContext, logicalPlanResult);
-      timeSeriesResponse = _queryDispatcher.submitAndGet(requestContext, dispatchablePlan, timeSeriesRequest.getTimeout().toMillis(),
-          new HashMap<>());
+      timeSeriesResponse = _queryDispatcher.submitAndGet(requestContext, dispatchablePlan,
+          timeSeriesRequest.getTimeout().toMillis(), new HashMap<>());
       return timeSeriesResponse;
     } finally {
       _brokerMetrics.addTimedValue(BrokerTimer.QUERY_TOTAL_TIME_MS, System.currentTimeMillis() - queryStartTime,
           TimeUnit.MILLISECONDS);
-      if (timeSeriesResponse == null || timeSeriesResponse.getStatus().equals(PinotBrokerTimeSeriesResponse.ERROR_STATUS)) {
+      if (timeSeriesResponse == null
+          || timeSeriesResponse.getStatus().equals(PinotBrokerTimeSeriesResponse.ERROR_STATUS)) {
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.TIME_SERIES_GLOBAL_QUERIES_FAILED, 1);
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -61,11 +61,7 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
    */
   SINGLE_STAGE_QUERIES_INVALID_MULTI_STAGE("queries", true),
   /**
-   * Number of time-series queries submitted.
-   */
-  TIME_SERIES_QUERIES("queries", false),
-  /**
-   * Number of time-series queries. Unlike {@link #TIME_SERIES_QUERIES}, this metric is not grouped on the table name.
+   * Number of time-series queries. This metric is not grouped on the table name.
    */
   TIME_SERIES_GLOBAL_QUERIES("queries", true),
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -60,6 +60,18 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
    * Number of single-stage queries executed that would not have successfully run on the multi-stage query engine as is.
    */
   SINGLE_STAGE_QUERIES_INVALID_MULTI_STAGE("queries", true),
+  /**
+   * Number of time-series queries submitted.
+   */
+  TIME_SERIES_QUERIES("queries", false),
+  /**
+   * Number of time-series queries. Unlike {@link #TIME_SERIES_QUERIES}, this metric is not grouped on the table name.
+   */
+  TIME_SERIES_GLOBAL_QUERIES("queries", true),
+  /**
+   * Number of time-series queries that failed. This metric is not grouped on the table name.
+   */
+  TIME_SERIES_GLOBAL_QUERIES_FAILED("queries", true),
   // These metrics track the exceptions caught during query execution in broker side.
   // Query rejected by Jersey thread pool executor
   QUERY_REJECTED_EXCEPTIONS("exceptions", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/TimeSeriesResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/TimeSeriesResultsBlock.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.operator.blocks.TimeSeriesBuilderBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
+// TODO(timeseries): Implement unsupported functions when merging with MSE.
 public class TimeSeriesResultsBlock extends BaseResultsBlock {
   private final TimeSeriesBuilderBlock _timeSeriesBuilderBlock;
 
@@ -42,14 +43,12 @@ public class TimeSeriesResultsBlock extends BaseResultsBlock {
   @Nullable
   @Override
   public QueryContext getQueryContext() {
-    // TODO(timeseries): Implement this when merging with MSE. Only LeafStageTransferableBlockOperator uses this so far.
     throw new UnsupportedOperationException("Time series results block does not support getting QueryContext yet");
   }
 
   @Nullable
   @Override
   public DataSchema getDataSchema() {
-    // TODO(timeseries): Define this when merging with MSE.
     throw new UnsupportedOperationException("Time series results block does not support getting DataSchema yet");
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/TimeSeriesResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/TimeSeriesResultsBlock.java
@@ -36,34 +36,33 @@ public class TimeSeriesResultsBlock extends BaseResultsBlock {
 
   @Override
   public int getNumRows() {
-    // TODO: Unused right now.
-    return 0;
+    return _timeSeriesBuilderBlock.getSeriesBuilderMap().size();
   }
 
   @Nullable
   @Override
   public QueryContext getQueryContext() {
-    // TODO: Unused right now.
-    return null;
+    // TODO(timeseries): Implement this when merging with MSE. Only LeafStageTransferableBlockOperator uses this so far.
+    throw new UnsupportedOperationException("Time series results block does not support getting QueryContext yet");
   }
 
   @Nullable
   @Override
   public DataSchema getDataSchema() {
-    // TODO: Unused right now.
-    return null;
+    // TODO(timeseries): Define this when merging with MSE.
+    throw new UnsupportedOperationException("Time series results block does not support getting DataSchema yet");
   }
 
   @Nullable
   @Override
   public List<Object[]> getRows() {
-    return null;
+    throw new UnsupportedOperationException("Time series results block does not support getRows yet");
   }
 
   @Override
   public DataTable getDataTable()
       throws IOException {
-    return null;
+    throw new UnsupportedOperationException("Time series results block does not support returning DataTable");
   }
 
   public TimeSeriesBuilderBlock getTimeSeriesBuilderBlock() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/TimeSeriesAggResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/TimeSeriesAggResultsBlockMerger.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.combine.merger;
 
+import com.google.common.base.Preconditions;
 import org.apache.pinot.core.operator.blocks.TimeSeriesBuilderBlock;
 import org.apache.pinot.core.operator.blocks.results.TimeSeriesResultsBlock;
 import org.apache.pinot.tsdb.spi.AggInfo;
@@ -28,10 +29,12 @@ import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactory;
 public class TimeSeriesAggResultsBlockMerger implements ResultsBlockMerger<TimeSeriesResultsBlock> {
   private final TimeSeriesBuilderFactory _seriesBuilderFactory;
   private final AggInfo _aggInfo;
+  private final int _maxSeriesLimit;
 
   public TimeSeriesAggResultsBlockMerger(TimeSeriesBuilderFactory seriesBuilderFactory, AggInfo aggInfo) {
     _seriesBuilderFactory = seriesBuilderFactory;
     _aggInfo = aggInfo;
+    _maxSeriesLimit = _seriesBuilderFactory.getMaxUniqueSeriesPerServerLimit();
   }
 
   @Override
@@ -44,6 +47,9 @@ public class TimeSeriesAggResultsBlockMerger implements ResultsBlockMerger<TimeS
       BaseTimeSeriesBuilder newTimeSeriesToMerge = entry.getValue();
       if (currentTimeSeriesBuilder == null) {
         currentTimeSeriesBlock.getSeriesBuilderMap().put(seriesHash, newTimeSeriesToMerge);
+        Preconditions.checkState(currentTimeSeriesBlock.getSeriesBuilderMap().size() <= _maxSeriesLimit,
+            "Max series limit reached in combine operator. Limit: %s. Current Size: %s",
+            _maxSeriesLimit, currentTimeSeriesBlock.getSeriesBuilderMap().size());
       } else {
         currentTimeSeriesBuilder.mergeAlignedSeriesBuilder(newTimeSeriesToMerge);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -62,6 +62,7 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
   private final TimeBuckets _timeBuckets;
   private final TimeSeriesBuilderFactory _seriesBuilderFactory;
   private final int _maxSeriesLimit;
+  private final long _maxDataPointsLimit;
   private final long _numTotalDocs;
   private long _numDocsScanned = 0;
 
@@ -86,6 +87,7 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
     _timeBuckets = timeBuckets;
     _seriesBuilderFactory = seriesBuilderFactory;
     _maxSeriesLimit = _seriesBuilderFactory.getMaxUniqueSeriesPerServerLimit();
+    _maxDataPointsLimit = _seriesBuilderFactory.getMaxDataPointsPerServerLimit();
     _numTotalDocs = segmentMetadata.getTotalDocs();
   }
 
@@ -138,6 +140,9 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
           throw new IllegalStateException(
               "Don't yet support value expression of type: " + valueExpressionBlockValSet.getValueType());
       }
+      Preconditions.checkState(seriesBuilderMap.size() * (long) _timeBuckets.getNumBuckets() <= _maxDataPointsLimit,
+          "Query exceed max data point limit per server. Limit: %s. Data points in current segment so far: %s",
+          _maxDataPointsLimit, seriesBuilderMap.size() * _timeBuckets.getNumBuckets());
       Preconditions.checkState(seriesBuilderMap.size() <= _maxSeriesLimit,
           "Query exceeded max unique series limit per server. Limit: %s. Series in current segment so far: %s",
           _maxSeriesLimit, seriesBuilderMap.size());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -141,10 +141,10 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
               "Don't yet support value expression of type: " + valueExpressionBlockValSet.getValueType());
       }
       Preconditions.checkState(seriesBuilderMap.size() * (long) _timeBuckets.getNumBuckets() <= _maxDataPointsLimit,
-          "Query exceed max data point limit per server. Limit: %s. Data points in current segment so far: %s",
+          "Exceeded max data point limit per server. Limit: %s. Data points in current segment so far: %s",
           _maxDataPointsLimit, seriesBuilderMap.size() * _timeBuckets.getNumBuckets());
       Preconditions.checkState(seriesBuilderMap.size() <= _maxSeriesLimit,
-          "Query exceeded max unique series limit per server. Limit: %s. Series in current segment so far: %s",
+          "Exceeded max unique series limit per server. Limit: %s. Series in current segment so far: %s",
           _maxSeriesLimit, seriesBuilderMap.size());
     }
     return new TimeSeriesResultsBlock(new TimeSeriesBuilderBlock(_timeBuckets, seriesBuilderMap));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperator.java
@@ -161,7 +161,8 @@ public class TimeSeriesAggregationOperator extends BaseOperator<TimeSeriesResult
   public ExecutionStatistics getExecutionStatistics() {
     long numEntriesScannedInFilter = _projectOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = _numDocsScanned * _projectOperator.getNumColumnsProjected();
-    return new ExecutionStatistics(_numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, _numTotalDocs);
+    return new ExecutionStatistics(_numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
+        _numTotalDocs);
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TimeSeriesPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TimeSeriesPlanNode.java
@@ -66,7 +66,8 @@ public class TimeSeriesPlanNode implements PlanNode {
         getGroupByColumns(),
         _timeSeriesContext.getTimeBuckets(),
         projectionOperator,
-        _seriesBuilderFactory);
+        _seriesBuilderFactory,
+        _segmentContext.getIndexSegment().getSegmentMetadata());
   }
 
   private List<ExpressionContext> getProjectPlanNodeExpressions() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/timeseries/TimeSeriesAggregationOperatorTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.BaseProjectOperator;
+import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.tsdb.spi.AggInfo;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactory;
@@ -91,6 +92,7 @@ public class TimeSeriesAggregationOperatorTest {
   private TimeSeriesAggregationOperator buildOperator(TimeUnit storedTimeUnit, TimeBuckets timeBuckets) {
     return new TimeSeriesAggregationOperator(
         DUMMY_TIME_COLUMN, storedTimeUnit, 0L, AGG_INFO, VALUE_EXPRESSION, Collections.emptyList(),
-        timeBuckets, mock(BaseProjectOperator.class), mock(TimeSeriesBuilderFactory.class));
+        timeBuckets, mock(BaseProjectOperator.class), mock(TimeSeriesBuilderFactory.class),
+        mock(SegmentMetadata.class));
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/LeafTimeSeriesOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/LeafTimeSeriesOperator.java
@@ -25,6 +25,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.results.TimeSeriesResultsBlock;
 import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.logger.ServerQueryLogger;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
@@ -34,6 +35,7 @@ public class LeafTimeSeriesOperator extends BaseTimeSeriesOperator {
   private final ServerQueryRequest _request;
   private final QueryExecutor _queryExecutor;
   private final ExecutorService _executorService;
+  private final ServerQueryLogger _queryLogger;
 
   public LeafTimeSeriesOperator(ServerQueryRequest serverQueryRequest, QueryExecutor queryExecutor,
       ExecutorService executorService) {
@@ -41,6 +43,7 @@ public class LeafTimeSeriesOperator extends BaseTimeSeriesOperator {
     _request = serverQueryRequest;
     _queryExecutor = queryExecutor;
     _executorService = executorService;
+    _queryLogger = ServerQueryLogger.getInstance();
   }
 
   @Override
@@ -48,6 +51,7 @@ public class LeafTimeSeriesOperator extends BaseTimeSeriesOperator {
     Preconditions.checkNotNull(_queryExecutor, "Leaf time series operator has not been initialized");
     InstanceResponseBlock instanceResponseBlock = _queryExecutor.execute(_request, _executorService);
     assert instanceResponseBlock.getResultsBlock() instanceof TimeSeriesResultsBlock;
+    _queryLogger.logQuery(_request, instanceResponseBlock, "TimeSeries");
     if (MapUtils.isNotEmpty(instanceResponseBlock.getExceptions())) {
       // TODO: Return error in the TimeSeriesBlock instead?
       String oneException = instanceResponseBlock.getExceptions().values().iterator().next();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
@@ -33,12 +33,15 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  *   engine integration.
  */
 public class TimeSeriesDispatchClient {
+  // TODO: Note that time-series engine at present uses QueryServer for data transfer from server to broker. This will
+  //   be fixed as we integrate with MSE.
+  private static final int INBOUND_SIZE_LIMIT = 256 * 1024 * 1024;
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
   public TimeSeriesDispatchClient(String host, int port) {
     _channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
-    _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);
+    _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel).withMaxInboundMessageSize(INBOUND_SIZE_LIMIT);
   }
 
   public ManagedChannel getChannel() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
@@ -29,12 +29,12 @@ import org.apache.pinot.query.routing.QueryServerInstance;
 
 /**
  * Dispatch client used to dispatch a runnable plan to the server.
- * TODO: This shouldn't exist and we should re-use DispatchClient. TBD as part of multi-stage
+ * TODO(timeseries): This shouldn't exist and we should re-use DispatchClient. TBD as part of multi-stage
  *   engine integration.
  */
 public class TimeSeriesDispatchClient {
-  // TODO: Note that time-series engine at present uses QueryServer for data transfer from server to broker. This will
-  //   be fixed as we integrate with MSE.
+  // TODO(timeseries): Note that time-series engine at present uses QueryServer for data transfer from server to broker.
+  //   This will be fixed as we integrate with MSE.
   private static final int INBOUND_SIZE_LIMIT = 256 * 1024 * 1024;
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/SimpleTimeSeriesBuilderFactory.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/SimpleTimeSeriesBuilderFactory.java
@@ -28,8 +28,17 @@ import org.apache.pinot.tsdb.spi.series.builders.SummingTimeSeriesBuilder;
 
 
 public class SimpleTimeSeriesBuilderFactory extends TimeSeriesBuilderFactory {
+  private final int _maxSeriesLimit;
+  private final long _maxDataPointsLimit;
+
   public SimpleTimeSeriesBuilderFactory() {
+    this(DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT, DEFAULT_MAX_DATA_POINTS_PER_SERVER_LIMIT);
+  }
+
+  public SimpleTimeSeriesBuilderFactory(int maxSeriesLimit, long maxDataPointsLimit) {
     super();
+    _maxSeriesLimit = maxSeriesLimit;
+    _maxDataPointsLimit = maxDataPointsLimit;
   }
 
   @Override
@@ -49,5 +58,15 @@ public class SimpleTimeSeriesBuilderFactory extends TimeSeriesBuilderFactory {
 
   @Override
   public void init(PinotConfiguration pinotConfiguration) {
+  }
+
+  @Override
+  public int getMaxUniqueSeriesPerServerLimit() {
+    return _maxSeriesLimit;
+  }
+
+  @Override
+  public long getMaxDataPointsPerServerLimit() {
+    return _maxDataPointsLimit;
   }
 }

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
@@ -26,6 +26,10 @@ import org.apache.pinot.tsdb.spi.TimeBuckets;
 
 public abstract class TimeSeriesBuilderFactory {
   private static final int DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT = 100_000;
+  /**
+   * Default limit for the total number of values across all series.
+   */
+  private static final long DEFAULT_MAX_DATA_POINTS_PER_SERVER_LIMIT = 100_000_000;
 
   public abstract BaseTimeSeriesBuilder newTimeSeriesBuilder(
       AggInfo aggInfo,
@@ -36,6 +40,10 @@ public abstract class TimeSeriesBuilderFactory {
 
   public int getMaxUniqueSeriesPerServerLimit() {
     return DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT;
+  }
+
+  public long getMaxDataPointsPerServerLimit() {
+    return DEFAULT_MAX_DATA_POINTS_PER_SERVER_LIMIT;
   }
 
   public abstract void init(PinotConfiguration pinotConfiguration);

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
@@ -25,11 +25,11 @@ import org.apache.pinot.tsdb.spi.TimeBuckets;
 
 
 public abstract class TimeSeriesBuilderFactory {
-  private static final int DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT = 100_000;
+  protected static final int DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT = 100_000;
   /**
    * Default limit for the total number of values across all series.
    */
-  private static final long DEFAULT_MAX_DATA_POINTS_PER_SERVER_LIMIT = 100_000_000;
+  protected static final long DEFAULT_MAX_DATA_POINTS_PER_SERVER_LIMIT = 100_000_000;
 
   public abstract BaseTimeSeriesBuilder newTimeSeriesBuilder(
       AggInfo aggInfo,

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactory.java
@@ -25,12 +25,18 @@ import org.apache.pinot.tsdb.spi.TimeBuckets;
 
 
 public abstract class TimeSeriesBuilderFactory {
+  private static final int DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT = 100_000;
+
   public abstract BaseTimeSeriesBuilder newTimeSeriesBuilder(
       AggInfo aggInfo,
       String id,
       TimeBuckets timeBuckets,
       List<String> tagNames,
       Object[] tagValues);
+
+  public int getMaxUniqueSeriesPerServerLimit() {
+    return DEFAULT_MAX_UNIQUE_SERIES_PER_SERVER_LIMIT;
+  }
 
   public abstract void init(PinotConfiguration pinotConfiguration);
 }


### PR DESCRIPTION
### Description

##### Series and Data Points Limits

Adds basic series and data points limits, which can be overridden using `TimeSeriesBuilderFactory`.

##### Response Size Limit

`TimeSeriesDispatchClient` didn't have the inbound size limit set, which would have meant that we can only do 4MB of response from the servers. This PR increases it to a liberal 256MB. I am not making it configurable yet since we plan to merge this with the Multistage DispatchClient.

##### Metrics

Enables some basic metrics like:

* broker level global query count and query failure count
* broker level latency metric
* server level docs scanned, filter entries scanned (in/post).

Additionally server query logger now logs the query, which has some basic metrics populated. Some metrics are not available either because many of the timers are initialized in instance request handler, which only works for V1 Engine queries.

```
➜  logs git:(ts-limits) tail -f pinot-all.log | grep "TimeSeries"
2024/11/20 19:55:54.524 INFO [ServerQueryLogger] [query-runner-on-44513-1-thread-1] Processed requestId=993728721000000000,table=meetupRsvp_REALTIME,segments(queried/processed/matched/consumingQueried/consumingProcessed/consumingMatched/invalid/limit/value)=10/10/10/10/0/0/0/0/0,schedulerWaitMs=-1,reqDeserMs=-1,totalExecMs=33,resSerMs=-1,totalTimeMs=-1,minConsumingFreshnessMs=1732132549533,broker=Broker_10.24.24.52_8000,numDocsScanned=3552,scanInFilter=4788,scanPostFilter=7104,sched=TimeSeries,threadCpuTimeNs(total/thread/sysActivity/resSer)=0/0/0/0
2024/11/20 19:55:57.205 INFO [ServerQueryLogger] [query-runner-on-44513-1-thread-1] Processed requestId=993728721000000001,table=meetupRsvp_REALTIME,segments(queried/processed/matched/consumingQueried/consumingProcessed/consumingMatched/invalid/limit/value)=10/10/10/10/0/0/0/0/0,schedulerWaitMs=-1,reqDeserMs=-1,totalExecMs=8,resSerMs=-1,totalTimeMs=-1,minConsumingFreshnessMs=1732132553141,broker=Broker_10.24.24.52_8000,numDocsScanned=3555,scanInFilter=4792,scanPostFilter=7110,sched=TimeSeries,threadCpuTimeNs(total/thread/sysActivity/resSer)=0/0/0/0
```

### Test Plan

Added a unit test to verify the series limits are working properly. Also ran Quickstart to confirm E2E things are working.

Also used jmxterm to verify that the metrics like numDocsScanned in the server are getting updated:

```
$>info
#mbean = "org.apache.pinot.common.metrics":name="pinot.server.meetupRsvp_REALTIME.numDocsScanned",type="ServerMetrics"
#class name = com.yammer.metrics.reporting.JmxReporter$Meter
# attributes
  %0   - Count (long, r)
  %1   - EventType (java.lang.String, r)
  %2   - FifteenMinuteRate (double, r)
  %3   - FiveMinuteRate (double, r)
  %4   - MeanRate (double, r)
  %5   - OneMinuteRate (double, r)
  %6   - RateUnit (java.util.concurrent.TimeUnit, r)
# operations
  %0   - javax.management.ObjectName objectName()
#there's no notifications
$>get Count
#mbean = "org.apache.pinot.common.metrics":name="pinot.server.meetupRsvp_REALTIME.numDocsScanned",type="ServerMetrics":
Count = 1397;
# ==> ran a time-series query here
$>get Count
#mbean = "org.apache.pinot.common.metrics":name="pinot.server.meetupRsvp_REALTIME.numDocsScanned",type="ServerMetrics":
Count = 2081;
```

Also tested on our cluster and you can see a screenshot showing metrics which are being populated and metrics which are not.
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/cb87d91b-f352-4600-ba55-a2f3ce84f753">
