### PR TITLE
Fix timestamp literal handling in the multi-stage query engine

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -255,7 +255,15 @@ public class RexExpressionUtils {
         value = Boolean.TRUE.equals(value) ? BooleanUtils.INTERNAL_TRUE : BooleanUtils.INTERNAL_FALSE;
         break;
       case TIMESTAMP:
-        value = ((Calendar) value).getTimeInMillis();
+        if (value instanceof Calendar) {
+          value = ((Calendar) value).getTimeInMillis();
+        } else if (value instanceof TimestampString) {
+          value = ((TimestampString) value).getMillisSinceEpoch();
+        } else if (value instanceof Long) {
+          // Already in millis
+        } else {
+          throw new IllegalStateException("Unsupported value type for TIMESTAMP: " + value.getClass().getName());
+        }
         break;
       case STRING:
         value = ((NlsString) value).getValue();

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -250,6 +250,9 @@ public class QueryEnvironmentTestBase {
         new Object[]{"SELECT JSON_EXTRACT_SCALAR(col1, '$.foo', 'FLOAT_ARRAY') FROM a"},
         new Object[]{"SELECT JSON_EXTRACT_SCALAR(col1, '$.foo', 'DOUBLE_ARRAY') FROM a"},
         new Object[]{"SELECT JSON_EXTRACT_SCALAR(col1, '$.foo', 'STRING_ARRAY') FROM a"},
+        new Object[]{"SELECT ts_timestamp FROM a WHERE ts_timestamp BETWEEN TIMESTAMP '2016-01-01 00:00:00' AND "
+            + "TIMESTAMP '2016-01-01 10:00:00'"},
+        new Object[]{"SELECT ts_timestamp FROM a WHERE ts_timestamp >= CAST(1454284798000 AS TIMESTAMP)"}
     };
   }
 


### PR DESCRIPTION
- There are some gaps in timestamp literal handling in the multi-stage query engine - particularly, when converting from Calcite's internal representation to a long value representing milliseconds since epoch (which is what Pinot uses internally).
- The existing logic only handles the case where the representation is an instance of `java.util.Calendar`. However, the internal representation used by Calcite for timestamp types is `org.apache.calcite.util.TimestampString` (see [here](https://github.com/apache/calcite/blob/f2ec11fe7e23ecf2db903bc02c40609242993aad/core/src/main/java/org/apache/calcite/rex/RexLiteral.java#L344-L346)). External callers usually convert this to `Calendar` or `Long` (see [here](https://github.com/apache/calcite/blob/f2ec11fe7e23ecf2db903bc02c40609242993aad/core/src/main/java/org/apache/calcite/rex/RexLiteral.java#L951-L990)), but this doesn't always appear to be the case.
- One example is range sets in a `Sarg` (search argument) - this issue was detected by a query with a filter predicate like `WHERE ts BETWEEN '2016-01-01 00:00:00' AND '2016-01-01 10:00:00'` where the class cast exception `class org.apache.calcite.util.TimestampString cannot be cast to class java.util.Calendar` was thrown when converting the bounds of a range [here](https://github.com/apache/pinot/blob/89622c0ff657392048e90f3cd6acd124026800cb/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java#L381) during conversion of `SEARCH` to an `OR` of ranges. This wasn't a major issue until recently because search nodes were usually reduced before the final query plan was generated (which changed in https://github.com/apache/pinot/pull/14448).
- Simply replacing the `Calendar` based cast logic to `TimestampString` based cast logic is also incorrect and a query with a filter predicate like `WHERE ts >= CAST(1454284798000 AS TIMESTAMP)` will fail with a class cast exception `class java.util.GregorianCalendar cannot be cast to class org.apache.calcite.util.TimestampString`.
- This patch fixes the timestamp literal handling logic to cover all the cases. A couple of query compilation tests based on the above two filter predicates have also been added.