### PR TITLE
restrict UploadedRealtimeSegmentName upload to realtime table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -82,6 +82,7 @@ import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.FileUploadDownloadClient.FileUploadType;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
+import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
@@ -350,6 +351,12 @@ public class PinotSegmentUploadDownloadRestletResource {
       String tableNameWithType = tableType == TableType.OFFLINE
           ? TableNameBuilder.OFFLINE.tableNameWithType(rawTableName)
           : TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+
+      if (UploadedRealtimeSegmentName.isUploadedRealtimeSegmentName(segmentName) && tableType != TableType.REALTIME) {
+        throw new ControllerApplicationException(LOGGER, "Cannot upload segment: " + segmentName
+            + " to OFFLINE table as this format is reserved for uploaded real-time segment",
+            Response.Status.BAD_REQUEST);
+      }
 
       String clientAddress = InetAddress.getByName(request.getRemoteAddr()).getHostName();
       LOGGER.info("Processing upload request for segment: {} of table: {} with upload type: {} from client: {}, "


### PR DESCRIPTION
`backward-incompat`

Adds a validation to not allow UploadedRealtimeSegmentName segments to offline tables. Though a backward incompatible change but the documentations in UploadedRealtimeSegmentName calls out its usage to only realtime tables.

This address some edge cases where segment name is used to derive table types. see #14494