### PR TITLE
validate schemaName must not have double underscore

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -392,6 +392,9 @@ public class PinotSchemaRestletResource {
       throw new ControllerApplicationException(LOGGER,
           "Invalid schema. Reason: 'schemaName' should not be null or empty", Response.Status.BAD_REQUEST);
     }
+    if (schema.getSchemaName().contains(TableConfig.TABLE_NAME_FORBIDDEN_SUBSTRING)) {
+      throw new IllegalStateException("'schemaName' cannot contain double underscore ('__')");
+    }
   }
 
   private void validateSchemaInternal(Schema schema) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -60,7 +60,7 @@ public class TableConfig extends BaseJsonConfig {
   public static final String TIER_OVERWRITES_KEY = "tierOverwrites";
 
   // Double underscore is reserved for real-time segment name delimiter
-  private static final String TABLE_NAME_FORBIDDEN_SUBSTRING = "__";
+  public static final String TABLE_NAME_FORBIDDEN_SUBSTRING = "__";
 
   /* MANDATORY FIELDS */
 


### PR DESCRIPTION
`cleanup`

This PR adds the validation for schemaName to not allow double underscores similar to table name validation.

We don't allow table names with double underscores `__` and additionally don't allow tables with schema name different from table name. Schema name validations can help early catching of wrongly named schemas.

https://github.com/apache/pinot/blob/81f16f3056a9957311cc13d4f92ee1b2e7b1761e/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java#L144

https://github.com/apache/pinot/blob/81f16f3056a9957311cc13d4f92ee1b2e7b1761e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java#L260