### PR TITLE
Update NUMBER_TASKS_EXECUTED meter only after task execution is done

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -145,11 +145,6 @@ public class TaskFactoryRegistry {
               String tableName = pinotTaskConfig.getTableName();
 
               _eventObserver.notifyTaskStart(pinotTaskConfig);
-              _minionMetrics.addMeteredValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
-              if (tableName != null) {
-                _minionMetrics.addMeteredTableValue(tableName, taskType,
-                    MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
-              }
               LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
                   pinotTaskConfig.getConfigs());
 
@@ -190,6 +185,12 @@ public class TaskFactoryRegistry {
                 }
                 LOGGER.error("Caught exception while executing task: {}", _taskConfig.getId(), e);
                 return new TaskResult(TaskResult.Status.FAILED, extractAndTrimRootCauseMessage(e));
+              } finally {
+                _minionMetrics.addMeteredValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
+                if (tableName != null) {
+                  _minionMetrics.addMeteredTableValue(tableName, taskType,
+                      MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
+                }
               }
             }
 


### PR DESCRIPTION
Right now the meter is incremented at start of task execution hence the sum of other task state metrics does not add up to the executed state metric during an ongoing task execution.