### PR TITLE
make updating segment.tier and rebalancing table consistent on segment's tier

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -68,8 +69,8 @@ public final class TierConfigUtils {
    * @return InstancePartitions if the one can be derived from the given sorted tiers, null otherwise
    */
   @Nullable
-  public static InstancePartitions getTieredInstancePartitionsForSegment(String tableNameWithType,
-      String segmentName, @Nullable List<Tier> sortedTiers, HelixManager helixManager) {
+  public static InstancePartitions getTieredInstancePartitionsForSegment(String tableNameWithType, String segmentName,
+      @Nullable List<Tier> sortedTiers, HelixManager helixManager) {
     if (CollectionUtils.isEmpty(sortedTiers)) {
       return null;
     }
@@ -139,10 +140,18 @@ public final class TierConfigUtils {
    */
   public static List<Tier> getSortedTiersForStorageType(List<TierConfig> tierConfigList, String storageType,
       HelixManager helixManager) {
+    return getSortedTiersForStorageType(tierConfigList, storageType, helixManager, null);
+  }
+
+  public static List<Tier> getSortedTiersForStorageType(List<TierConfig> tierConfigList, String storageType,
+      HelixManager helixManager, @Nullable Map<String, Set<String>> providedTierToSegmentsMap) {
     List<Tier> sortedTiers = new ArrayList<>();
     for (TierConfig tierConfig : tierConfigList) {
       if (storageType.equalsIgnoreCase(tierConfig.getStorageType())) {
-        sortedTiers.add(TierFactory.getTier(tierConfig, helixManager));
+        String tierName = tierConfig.getName();
+        Set<String> providedSegmentsForTier =
+            providedTierToSegmentsMap == null ? null : providedTierToSegmentsMap.get(tierName);
+        sortedTiers.add(TierFactory.getTier(tierConfig, helixManager, providedSegmentsForTier));
       }
     }
     sortedTiers.sort(TierConfigUtils.getTierComparator());


### PR DESCRIPTION
Currently, updating segment's tier (a field in segment ZK metadata) and rebalancing table call TierSegmentSelectors to decide if a segment belongs to a specific tier separately. But tier selectors like TimeBasedTierSegmentSelector may return different tiers for a segment between the two steps, as the tier assignment is decided by comparing segment data time vs. current time, which keeps changing. This caused segment to be relocated and loaded on new servers, but with wrong segment tier.  

This PR takes the segment tier assignments as calculated when updating segment's tier, and pass it to table rebalancer to use to make segment tier decision consistent. 