### PR TITLE
Minion task progress tracking improvements

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -63,7 +63,7 @@ public class SegmentProcessorFramework {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentProcessorFramework.class);
   public static final String MAP_STAGE = "MAP";
   public static final String REDUCE_STAGE = "REDUCE";
-  public static final String GENERATE_STAGE = "GENERATE";
+  public static final String GENERATE_STAGE = "GENERATE_SEGMENT";
 
   private final List<RecordReaderFileConfig> _recordReaderFileConfigs;
   private final List<RecordTransformer> _customRecordTransformers;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -190,10 +190,10 @@ public class SegmentMapper {
           writeRecord(transformedRow);
         }
       } catch (Exception e) {
-        String logMessage = "Caught exception while reading data";
+        String logMessage = "Caught exception while reading data.";
         observer.accept(new StatusEntry.Builder()
             .level(StatusEntry.LogLevel.ERROR)
-            .status(logMessage)
+            .status(logMessage + " Reason : " + e.getMessage())
             .build());
         if (!continueOnError) {
           throw new RuntimeException(logMessage, e);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestEventObserverFactory.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestEventObserverFactory.java
@@ -53,6 +53,10 @@ public class TestEventObserverFactory implements MinionEventObserverFactory {
   public MinionEventObserver create() {
     return new MinionEventObserver() {
       @Override
+      public void init(MinionTaskProgressManager progressManager) {
+      }
+
+      @Override
       public void notifyTaskStart(PinotTaskConfig pinotTaskConfig) {
         SimpleMinionClusterIntegrationTest.TASK_START_NOTIFIED.set(true);
       }
@@ -72,6 +76,10 @@ public class TestEventObserverFactory implements MinionEventObserverFactory {
       @Override
       public void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception exception) {
         SimpleMinionClusterIntegrationTest.TASK_ERROR_NOTIFIED.set(true);
+      }
+
+      @Override
+      public void cleanup() {
       }
     };
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestEventObserverFactory.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestEventObserverFactory.java
@@ -25,6 +25,7 @@ import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObserverFactory;
 import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.spi.annotations.minion.EventObserverFactory;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 import static org.testng.Assert.assertTrue;
 
@@ -37,6 +38,10 @@ public class TestEventObserverFactory implements MinionEventObserverFactory {
 
   @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager) {
+  }
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionTaskProgressManager taskProgressManager) {
   }
 
   @Override

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -68,6 +68,7 @@ import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.InstanceTypeUtils;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
@@ -123,7 +124,8 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     _helixManager = new ZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkAddress);
     MinionTaskZkMetadataManager minionTaskZkMetadataManager = new MinionTaskZkMetadataManager(_helixManager);
     _taskExecutorFactoryRegistry = new TaskExecutorFactoryRegistry(minionTaskZkMetadataManager, _config);
-    _eventObserverFactoryRegistry = new EventObserverFactoryRegistry(minionTaskZkMetadataManager);
+    _eventObserverFactoryRegistry = new EventObserverFactoryRegistry(minionTaskZkMetadataManager,
+        getMinionTaskProgressManager());
     _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
     MinionEventObservers.init(_config, _executorService);
@@ -166,6 +168,10 @@ public abstract class BaseMinionStarter implements ServiceStartable {
    */
   public void registerEventObserverFactory(MinionEventObserverFactory eventObserverFactory) {
     _eventObserverFactoryRegistry.registerEventObserverFactory(eventObserverFactory);
+  }
+
+  public MinionTaskProgressManager getMinionTaskProgressManager() {
+    return null;
   }
 
   @Override

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -54,6 +54,7 @@ import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
 import org.apache.pinot.minion.event.MinionEventObserverFactory;
 import org.apache.pinot.minion.event.MinionEventObservers;
@@ -171,7 +172,9 @@ public abstract class BaseMinionStarter implements ServiceStartable {
   }
 
   public MinionTaskProgressManager getMinionTaskProgressManager() {
-    return null;
+    MinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager();
+    progressManager.init(_config);
+    return progressManager;
   }
 
   @Override

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.utils.NetUtils;
 
 public class MinionConf extends PinotConfiguration {
   public static final String END_REPLACE_SEGMENTS_TIMEOUT_MS_KEY = "pinot.minion.endReplaceSegments.timeoutMs";
+  public static final String MINION_TASK_PROGRESS_MANAGER_CLASS = "pinot.minion.taskProgressManager.class";
   public static final int DEFAULT_END_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS = 10 * 60 * 1000; // 10 mins
 
   public MinionConf() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.minion;
 
-import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -45,16 +43,6 @@ public class MinionStarter extends BaseMinionStarter {
     minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
     minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkServers);
     return minionConfig;
-  }
-
-  @Override
-  public MinionTaskProgressManager getMinionTaskProgressManager() {
-    String maxNumStatusToTrackValue = _config.getProperty(DefaultMinionTaskProgressManager.MAX_NUM_STATUS_TO_TRACK);
-    if (maxNumStatusToTrackValue == null) {
-      return new DefaultMinionTaskProgressManager(DefaultMinionTaskProgressManager.DEFAULT_MAX_NUM_STATUS_TO_TRACK);
-    } else {
-      return new DefaultMinionTaskProgressManager(Integer.parseInt(maxNumStatusToTrackValue));
-    }
   }
 
   @Deprecated

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.minion;
 
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -43,6 +45,16 @@ public class MinionStarter extends BaseMinionStarter {
     minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
     minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkServers);
     return minionConfig;
+  }
+
+  @Override
+  public MinionTaskProgressManager getMinionTaskProgressManager() {
+    String maxNumStatusToTrackValue = _config.getProperty(DefaultMinionTaskProgressManager.MAX_NUM_STATUS_TO_TRACK);
+    if (maxNumStatusToTrackValue == null) {
+      return new DefaultMinionTaskProgressManager(DefaultMinionTaskProgressManager.DEFAULT_MAX_NUM_STATUS_TO_TRACK);
+    } else {
+      return new DefaultMinionTaskProgressManager(Integer.parseInt(maxNumStatusToTrackValue));
+    }
   }
 
   @Deprecated

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
@@ -27,6 +27,8 @@ import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
  */
 public abstract class BaseMinionProgressObserverFactory implements MinionEventObserverFactory {
 
+  protected MinionTaskProgressManager _taskProgressManager;
+
   /**
    * Initializes the task executor factory.
    */
@@ -35,6 +37,7 @@ public abstract class BaseMinionProgressObserverFactory implements MinionEventOb
 
   @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionTaskProgressManager taskProgressManager) {
+    _taskProgressManager = taskProgressManager;
   }
 
   /**
@@ -46,6 +49,6 @@ public abstract class BaseMinionProgressObserverFactory implements MinionEventOb
    * Creates a new task event observer.
    */
   public MinionEventObserver create() {
-    return new MinionProgressObserver();
+    return new MinionProgressObserver(_taskProgressManager);
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.minion.event;
 
 import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 
 /**
@@ -30,6 +31,10 @@ public abstract class BaseMinionProgressObserverFactory implements MinionEventOb
    * Initializes the task executor factory.
    */
   public void init(MinionTaskZkMetadataManager zkMetadataManager) {
+  }
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionTaskProgressManager taskProgressManager) {
   }
 
   /**

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/BaseMinionProgressObserverFactory.java
@@ -49,6 +49,8 @@ public abstract class BaseMinionProgressObserverFactory implements MinionEventOb
    * Creates a new task event observer.
    */
   public MinionEventObserver create() {
-    return new MinionProgressObserver(_taskProgressManager);
+    MinionProgressObserver observer = new MinionProgressObserver();
+    observer.init(_taskProgressManager);
+    return observer;
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserver.java
@@ -20,12 +20,20 @@ package org.apache.pinot.minion.event;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 
 /**
  * Default no-op minion event observer which can be extended.
  */
 public class DefaultMinionEventObserver implements MinionEventObserver {
+
+  protected MinionTaskProgressManager _progressManager;
+
+  @Override
+  public void init(MinionTaskProgressManager progressManager) {
+    _progressManager = progressManager;
+  }
 
   @Override
   public void notifyTaskStart(PinotTaskConfig pinotTaskConfig) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserver.java
@@ -50,4 +50,8 @@ public class DefaultMinionEventObserver implements MinionEventObserver {
   @Override
   public void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception exception) {
   }
+
+  @Override
+  public void cleanup() {
+  }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserverFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionEventObserverFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.minion.event;
 
 import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 
 public class DefaultMinionEventObserverFactory implements MinionEventObserverFactory {
@@ -34,6 +35,10 @@ public class DefaultMinionEventObserverFactory implements MinionEventObserverFac
 
   @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager) {
+  }
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionTaskProgressManager taskProgressManager) {
   }
 
   @Override

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionTaskProgressManager.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/DefaultMinionTaskProgressManager.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.event;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
+import org.apache.pinot.spi.tasks.MinionTaskProgressStats;
+
+
+public class DefaultMinionTaskProgressManager implements MinionTaskProgressManager {
+  public static final String MAX_NUM_STATUS_TO_TRACK = "pinot.minion.task.maxNumStatusToTrack";
+  public static final int DEFAULT_MAX_NUM_STATUS_TO_TRACK = 128;
+
+  private final int _maxNumStatusToTrack;
+  private final Map<String, MinionTaskProgressStats> _minionTaskProgressStatsMap = new HashMap<>();
+
+  public DefaultMinionTaskProgressManager(int maxNumStatusToTrack) {
+    _maxNumStatusToTrack = maxNumStatusToTrack;
+  }
+
+  @Override
+  public MinionTaskProgressStats getTaskProgress(String taskId) {
+    return _minionTaskProgressStatsMap.get(taskId);
+  }
+
+  @Override
+  public synchronized void setTaskProgress(String taskId, MinionTaskProgressStats progress) {
+    _minionTaskProgressStatsMap.put(taskId, progress);
+    List<MinionTaskProgressStats.StatusEntry> progressLogs = progress.getProgressLogs();
+    int logSize = progressLogs.size();
+    int startIndex = Math.max(logSize - _maxNumStatusToTrack, 0);
+    _minionTaskProgressStatsMap.get(taskId).setProgressLogs(progressLogs.subList(startIndex, logSize));
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/EventObserverFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/EventObserverFactoryRegistry.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.spi.annotations.minion.EventObserverFactory;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,11 @@ public class EventObserverFactoryRegistry {
    *       convention can significantly reduce the time of class scanning.
    */
   public EventObserverFactoryRegistry(MinionTaskZkMetadataManager zkMetadataManager) {
+    this(zkMetadataManager, null);
+  }
+
+  public EventObserverFactoryRegistry(MinionTaskZkMetadataManager zkMetadataManager,
+      MinionTaskProgressManager taskProgressManager) {
     long startTimeMs = System.currentTimeMillis();
     Set<Class<?>> classes = PinotReflectionUtils
         .getClassesThroughReflection(EVENT_OBSERVER_FACTORY_PACKAGE_REGEX_PATTERN, EventObserverFactory.class);
@@ -55,7 +61,7 @@ public class EventObserverFactoryRegistry {
       if (annotation.enabled()) {
         try {
           MinionEventObserverFactory eventObserverFactory = (MinionEventObserverFactory) clazz.newInstance();
-          eventObserverFactory.init(zkMetadataManager);
+          eventObserverFactory.init(zkMetadataManager, taskProgressManager);
           registerEventObserverFactory(eventObserverFactory);
         } catch (Exception e) {
           LOGGER.error("Caught exception while initializing and registering event observer factory: {}, skipping it",

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/EventObserverFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/EventObserverFactoryRegistry.java
@@ -48,7 +48,7 @@ public class EventObserverFactoryRegistry {
    *       convention can significantly reduce the time of class scanning.
    */
   public EventObserverFactoryRegistry(MinionTaskZkMetadataManager zkMetadataManager) {
-    this(zkMetadataManager, null);
+    this(zkMetadataManager, DefaultMinionTaskProgressManager.getDefaultInstance());
   }
 
   public EventObserverFactoryRegistry(MinionTaskZkMetadataManager zkMetadataManager,

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
@@ -20,12 +20,15 @@ package org.apache.pinot.minion.event;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 
 /**
  * The <code>MinionEventObserver</code> interface provides call backs for Minion events.
  */
 public interface MinionEventObserver {
+
+  void init(MinionTaskProgressManager progressManager);
 
   /**
    * Invoked when a minion task starts.

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
@@ -21,6 +21,7 @@ package org.apache.pinot.minion.event;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
+import org.apache.pinot.spi.tasks.MinionTaskProgressStats;
 
 
 /**
@@ -48,6 +49,11 @@ public interface MinionEventObserver {
 
   @Nullable
   default Object getProgress() {
+    return null;
+  }
+
+  @Nullable
+  default MinionTaskProgressStats getProgressStats() {
     return null;
   }
 
@@ -89,4 +95,6 @@ public interface MinionEventObserver {
   default long getStartTs() {
     return -1;
   }
+
+  void cleanup();
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
@@ -77,7 +77,7 @@ public class MinionEventObservers {
             if (task._endTs + _eventObserverCleanupDelayMs <= nowMs) {
               LOGGER.info("Cleaning up event observer for task: {} that ended at: {}, now at: {} after delay: {}",
                   task._taskId, task._endTs, nowMs, _eventObserverCleanupDelayMs);
-              _taskEventObservers.remove(task._taskId);
+              _taskEventObservers.remove(task._taskId).cleanup();
               _endedTaskQueue.poll();
             } else {
               _availableToClean.await(task._endTs + _eventObserverCleanupDelayMs - nowMs, TimeUnit.MILLISECONDS);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
@@ -28,18 +28,12 @@ import org.apache.pinot.minion.event.MinionProgressObserver;
 
 public class MinionTestUtils {
 
-  private static final DefaultMinionTaskProgressManager PROGRESS_MANAGER;
-  static {
-    PROGRESS_MANAGER = new DefaultMinionTaskProgressManager();
-    PROGRESS_MANAGER.init(new MinionConf());
-  }
-
   private MinionTestUtils() {
   }
 
   public static MinionProgressObserver getMinionProgressObserver() {
     MinionProgressObserver progressObserver = new MinionProgressObserver();
-    progressObserver.init(PROGRESS_MANAGER);
+    progressObserver.init(DefaultMinionTaskProgressManager.getDefaultInstance());
     return progressObserver;
   }
 

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
 
 
 public class MinionTestUtils {
@@ -34,6 +35,16 @@ public class MinionTestUtils {
   public static MinionProgressObserver getMinionProgressObserver() {
     MinionProgressObserver progressObserver = new MinionProgressObserver();
     progressObserver.init(DefaultMinionTaskProgressManager.getDefaultInstance());
+    return progressObserver;
+  }
+
+  public static MinionProgressObserver getMinionProgressObserver(int progressLimit) {
+    MinionProgressObserver progressObserver = new MinionProgressObserver();
+    MinionConf conf = new MinionConf();
+    conf.setProperty(DefaultMinionTaskProgressManager.MAX_NUM_STATUS_TO_TRACK, progressLimit);
+    MinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager();
+    progressManager.init(conf);
+    progressObserver.init(progressManager);
     return progressObserver;
   }
 

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionTestUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
+import org.apache.pinot.minion.event.MinionProgressObserver;
+
+
+public class MinionTestUtils {
+
+  private static final DefaultMinionTaskProgressManager PROGRESS_MANAGER;
+  static {
+    PROGRESS_MANAGER = new DefaultMinionTaskProgressManager();
+    PROGRESS_MANAGER.init(new MinionConf());
+  }
+
+  private MinionTestUtils() {
+  }
+
+  public static MinionProgressObserver getMinionProgressObserver() {
+    MinionProgressObserver progressObserver = new MinionProgressObserver();
+    progressObserver.init(PROGRESS_MANAGER);
+    return progressObserver;
+  }
+
+  public static PinotTaskConfig getPinotTaskConfig(String taskId) {
+    Map<String, String> taskConfigs = new HashMap<>();
+    taskConfigs.put("TASK_ID", taskId != null ? taskId : UUID.randomUUID().toString());
+    return new PinotTaskConfig("DUMMY_TASK", taskConfigs);
+  }
+}

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
@@ -21,10 +21,9 @@ package org.apache.pinot.minion.api.resources;
 import java.io.IOException;
 import java.util.Map;
 import javax.ws.rs.WebApplicationException;
-import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
+import org.apache.pinot.minion.MinionTestUtils;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
-import org.apache.pinot.minion.event.MinionProgressObserver;
 import org.apache.pinot.minion.event.MinionTaskState;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
@@ -38,17 +37,16 @@ public class PinotTaskProgressResourceTest {
   @Test
   public void testGetGivenSubtaskOrStateProgress()
       throws IOException {
-    DefaultMinionTaskProgressManager taskProgressManager = new DefaultMinionTaskProgressManager(128);
-    MinionEventObserver observer1 = new MinionProgressObserver(taskProgressManager);
-    observer1.notifyTaskStart(null);
+    MinionEventObserver observer1 = MinionTestUtils.getMinionProgressObserver();
+    observer1.notifyTaskStart(MinionTestUtils.getPinotTaskConfig("t01"));
     MinionEventObservers.getInstance().addMinionEventObserver("t01", observer1);
 
-    MinionEventObserver observer2 = new MinionProgressObserver(taskProgressManager);
-    observer2.notifyProgress(null, "");
+    MinionEventObserver observer2 = MinionTestUtils.getMinionProgressObserver();
+    observer2.notifyProgress(MinionTestUtils.getPinotTaskConfig("t02"), "");
     MinionEventObservers.getInstance().addMinionEventObserver("t02", observer2);
 
-    MinionEventObserver observer3 = new MinionProgressObserver(taskProgressManager);
-    observer3.notifyTaskSuccess(null, "");
+    MinionEventObserver observer3 = MinionTestUtils.getMinionProgressObserver();
+    observer3.notifyTaskSuccess(MinionTestUtils.getPinotTaskConfig("t03"), "");
     MinionEventObservers.getInstance().addMinionEventObserver("t03", observer3);
 
     PinotTaskProgressResource pinotTaskProgressResource = new PinotTaskProgressResource();

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.minion.api.resources;
 import java.io.IOException;
 import java.util.Map;
 import javax.ws.rs.WebApplicationException;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.event.MinionProgressObserver;
@@ -37,15 +38,16 @@ public class PinotTaskProgressResourceTest {
   @Test
   public void testGetGivenSubtaskOrStateProgress()
       throws IOException {
-    MinionEventObserver observer1 = new MinionProgressObserver();
+    DefaultMinionTaskProgressManager taskProgressManager = new DefaultMinionTaskProgressManager(128);
+    MinionEventObserver observer1 = new MinionProgressObserver(taskProgressManager);
     observer1.notifyTaskStart(null);
     MinionEventObservers.getInstance().addMinionEventObserver("t01", observer1);
 
-    MinionEventObserver observer2 = new MinionProgressObserver();
+    MinionEventObserver observer2 = new MinionProgressObserver(taskProgressManager);
     observer2.notifyProgress(null, "");
     MinionEventObservers.getInstance().addMinionEventObserver("t02", observer2);
 
-    MinionEventObserver observer3 = new MinionProgressObserver();
+    MinionEventObserver observer3 = new MinionProgressObserver(taskProgressManager);
     observer3.notifyTaskSuccess(null, "");
     MinionEventObservers.getInstance().addMinionEventObserver("t03", observer3);
 

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
@@ -38,7 +38,7 @@ public class MinionEventObserversTest {
     MinionConf config = new MinionConf();
     MinionEventObservers.init(config, null);
     for (String taskId : new String[]{"t01", "t02", "t03"}) {
-      MinionEventObserver observer = new MinionProgressObserver();
+      MinionEventObserver observer = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
       MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
       assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
       MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
@@ -54,7 +54,7 @@ public class MinionEventObserversTest {
     MinionEventObservers.init(config, executor);
     String[] taskIds = new String[]{"t01", "t02", "t03"};
     for (String taskId : taskIds) {
-      MinionEventObserver observer = new MinionProgressObserver();
+      MinionEventObserver observer = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
       MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
       assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
       MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
@@ -69,15 +69,15 @@ public class MinionEventObserversTest {
 
   @Test
   public void testGetMinionEventObserverWithGivenState() {
-    MinionEventObserver observer1 = new MinionProgressObserver();
+    MinionEventObserver observer1 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
     observer1.notifyTaskStart(null);
     MinionEventObservers.getInstance().addMinionEventObserver("t01", observer1);
 
-    MinionEventObserver observer2 = new MinionProgressObserver();
+    MinionEventObserver observer2 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
     observer2.notifyProgress(null, "");
     MinionEventObservers.getInstance().addMinionEventObserver("t02", observer2);
 
-    MinionEventObserver observer3 = new MinionProgressObserver();
+    MinionEventObserver observer3 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
     observer3.notifyTaskSuccess(null, "");
     MinionEventObservers.getInstance().addMinionEventObserver("t03", observer3);
 

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.minion.MinionTestUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
@@ -38,7 +39,7 @@ public class MinionEventObserversTest {
     MinionConf config = new MinionConf();
     MinionEventObservers.init(config, null);
     for (String taskId : new String[]{"t01", "t02", "t03"}) {
-      MinionEventObserver observer = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
+      MinionEventObserver observer = MinionTestUtils.getMinionProgressObserver();
       MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
       assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
       MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
@@ -54,7 +55,7 @@ public class MinionEventObserversTest {
     MinionEventObservers.init(config, executor);
     String[] taskIds = new String[]{"t01", "t02", "t03"};
     for (String taskId : taskIds) {
-      MinionEventObserver observer = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
+      MinionEventObserver observer = MinionTestUtils.getMinionProgressObserver();
       MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
       assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
       MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
@@ -69,16 +70,16 @@ public class MinionEventObserversTest {
 
   @Test
   public void testGetMinionEventObserverWithGivenState() {
-    MinionEventObserver observer1 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
-    observer1.notifyTaskStart(null);
+    MinionEventObserver observer1 = MinionTestUtils.getMinionProgressObserver();
+    observer1.notifyTaskStart(MinionTestUtils.getPinotTaskConfig("t01"));
     MinionEventObservers.getInstance().addMinionEventObserver("t01", observer1);
 
-    MinionEventObserver observer2 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
-    observer2.notifyProgress(null, "");
+    MinionEventObserver observer2 = MinionTestUtils.getMinionProgressObserver();
+    observer2.notifyProgress(MinionTestUtils.getPinotTaskConfig("t02"), "");
     MinionEventObservers.getInstance().addMinionEventObserver("t02", observer2);
 
-    MinionEventObserver observer3 = new MinionProgressObserver(new DefaultMinionTaskProgressManager(128));
-    observer3.notifyTaskSuccess(null, "");
+    MinionEventObserver observer3 = MinionTestUtils.getMinionProgressObserver();
+    observer3.notifyTaskSuccess(MinionTestUtils.getPinotTaskConfig("t03"), "");
     MinionEventObservers.getInstance().addMinionEventObserver("t03", observer3);
 
     Map<String, MinionEventObserver> minionEventObserverWithGivenState =

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
@@ -21,7 +21,7 @@ package org.apache.pinot.minion.event;
 import java.util.List;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionTestUtils;
-import org.apache.pinot.spi.tasks.MinionTaskProgressStats;
+import org.apache.pinot.spi.tasks.StatusEntry;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -36,7 +36,7 @@ public class MinionProgressObserverTest {
     PinotTaskConfig pinotTaskConfig = MinionTestUtils.getPinotTaskConfig(null);
 
     observer.notifyTaskStart(pinotTaskConfig);
-    List<MinionTaskProgressStats.StatusEntry> progress = observer.getProgress();
+    List<StatusEntry> progress = observer.getProgress();
     assertNotNull(progress);
     assertEquals(progress.size(), 1);
 
@@ -50,7 +50,7 @@ public class MinionProgressObserverTest {
     observer.notifyTaskError(pinotTaskConfig, new Exception("bad bug"));
     progress = observer.getProgress();
     assertEquals(progress.size(), 3);
-    MinionTaskProgressStats.StatusEntry entry = progress.get(0);
+    StatusEntry entry = progress.get(0);
     assertTrue(entry.getStatus().contains("generating"), entry.getStatus());
     entry = progress.get(2);
     assertTrue(entry.getStatus().contains("bad bug"), entry.getStatus());

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.minion.event;
 
 import java.util.List;
+import org.apache.pinot.spi.tasks.MinionTaskProgressStats;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -28,10 +29,11 @@ import static org.testng.Assert.assertTrue;
 public class MinionProgressObserverTest {
   @Test
   public void testNotifyProgressStatus() {
-    MinionProgressObserver observer = new MinionProgressObserver(3);
+    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
+    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
 
     observer.notifyTaskStart(null);
-    List<MinionProgressObserver.StatusEntry> progress = observer.getProgress();
+    List<MinionTaskProgressStats.StatusEntry> progress = observer.getProgress();
     assertEquals(progress.size(), 1);
 
     observer.notifyProgress(null, "preparing input: A");
@@ -44,7 +46,7 @@ public class MinionProgressObserverTest {
     observer.notifyTaskError(null, new Exception("bad bug"));
     progress = observer.getProgress();
     assertEquals(progress.size(), 3);
-    MinionProgressObserver.StatusEntry entry = progress.get(0);
+    MinionTaskProgressStats.StatusEntry entry = progress.get(0);
     assertTrue(entry.getStatus().contains("generating"), entry.getStatus());
     entry = progress.get(2);
     assertTrue(entry.getStatus().contains("bad bug"), entry.getStatus());
@@ -52,7 +54,8 @@ public class MinionProgressObserverTest {
 
   @Test
   public void testGetStartTs() {
-    MinionProgressObserver observer = new MinionProgressObserver(3);
+    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
+    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
     long ts1 = System.currentTimeMillis();
     observer.notifyTaskStart(null);
     long ts = observer.getStartTs();
@@ -63,7 +66,8 @@ public class MinionProgressObserverTest {
 
   @Test
   public void testUpdateAndGetTaskState() {
-    MinionProgressObserver observer = new MinionProgressObserver(3);
+    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
+    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
     assertEquals(observer.getTaskState(), MinionTaskState.UNKNOWN);
     observer.notifyTaskStart(null);
     assertEquals(observer.getTaskState(), MinionTaskState.IN_PROGRESS);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertTrue;
 public class MinionProgressObserverTest {
   @Test
   public void testNotifyProgressStatus() {
-    MinionProgressObserver observer = MinionTestUtils.getMinionProgressObserver();
+    MinionProgressObserver observer = MinionTestUtils.getMinionProgressObserver(3);
     PinotTaskConfig pinotTaskConfig = MinionTestUtils.getPinotTaskConfig(null);
 
     observer.notifyTaskStart(pinotTaskConfig);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
@@ -19,31 +19,35 @@
 package org.apache.pinot.minion.event;
 
 import java.util.List;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.minion.MinionTestUtils;
 import org.apache.pinot.spi.tasks.MinionTaskProgressStats;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
 public class MinionProgressObserverTest {
   @Test
   public void testNotifyProgressStatus() {
-    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
-    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
+    MinionProgressObserver observer = MinionTestUtils.getMinionProgressObserver();
+    PinotTaskConfig pinotTaskConfig = MinionTestUtils.getPinotTaskConfig(null);
 
-    observer.notifyTaskStart(null);
+    observer.notifyTaskStart(pinotTaskConfig);
     List<MinionTaskProgressStats.StatusEntry> progress = observer.getProgress();
+    assertNotNull(progress);
     assertEquals(progress.size(), 1);
 
-    observer.notifyProgress(null, "preparing input: A");
-    observer.notifyProgress(null, "preparing input: B");
-    observer.notifyProgress(null, "generating segment");
+    observer.notifyProgress(pinotTaskConfig, "preparing input: A");
+    observer.notifyProgress(pinotTaskConfig, "preparing input: B");
+    observer.notifyProgress(pinotTaskConfig, "generating segment");
     progress = observer.getProgress();
     assertEquals(progress.size(), 3);
 
-    observer.notifyProgress(null, "uploading segment");
-    observer.notifyTaskError(null, new Exception("bad bug"));
+    observer.notifyProgress(pinotTaskConfig, "uploading segment");
+    observer.notifyTaskError(pinotTaskConfig, new Exception("bad bug"));
     progress = observer.getProgress();
     assertEquals(progress.size(), 3);
     MinionTaskProgressStats.StatusEntry entry = progress.get(0);
@@ -54,10 +58,10 @@ public class MinionProgressObserverTest {
 
   @Test
   public void testGetStartTs() {
-    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
-    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
+    MinionProgressObserver observer = MinionTestUtils.getMinionProgressObserver();
+    PinotTaskConfig pinotTaskConfig = MinionTestUtils.getPinotTaskConfig(null);
     long ts1 = System.currentTimeMillis();
-    observer.notifyTaskStart(null);
+    observer.notifyTaskStart(pinotTaskConfig);
     long ts = observer.getStartTs();
     long ts2 = System.currentTimeMillis();
     assertTrue(ts1 <= ts);
@@ -66,18 +70,18 @@ public class MinionProgressObserverTest {
 
   @Test
   public void testUpdateAndGetTaskState() {
-    DefaultMinionTaskProgressManager progressManager = new DefaultMinionTaskProgressManager(128);
-    MinionProgressObserver observer = new MinionProgressObserver(progressManager);
+    MinionProgressObserver observer = MinionTestUtils.getMinionProgressObserver();
+    PinotTaskConfig pinotTaskConfig = MinionTestUtils.getPinotTaskConfig(null);
     assertEquals(observer.getTaskState(), MinionTaskState.UNKNOWN);
-    observer.notifyTaskStart(null);
+    observer.notifyTaskStart(pinotTaskConfig);
     assertEquals(observer.getTaskState(), MinionTaskState.IN_PROGRESS);
-    observer.notifyProgress(null, "");
+    observer.notifyProgress(pinotTaskConfig, "");
     assertEquals(observer.getTaskState(), MinionTaskState.IN_PROGRESS);
-    observer.notifyTaskSuccess(null, "");
+    observer.notifyTaskSuccess(pinotTaskConfig, "");
     assertEquals(observer.getTaskState(), MinionTaskState.SUCCEEDED);
-    observer.notifyTaskCancelled(null);
+    observer.notifyTaskCancelled(pinotTaskConfig);
     assertEquals(observer.getTaskState(), MinionTaskState.CANCELLED);
-    observer.notifyTaskError(null, new Exception());
+    observer.notifyTaskError(pinotTaskConfig, new Exception());
     assertEquals(observer.getTaskState(), MinionTaskState.ERROR);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskTestUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskTestUtils.java
@@ -18,25 +18,18 @@
  */
 package org.apache.pinot.plugin.minion.tasks;
 
-import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionProgressObserver;
 
 
 public class MinionTaskTestUtils {
 
-  private static final DefaultMinionTaskProgressManager PROGRESS_MANAGER;
-  static {
-    PROGRESS_MANAGER = new DefaultMinionTaskProgressManager();
-    PROGRESS_MANAGER.init(new MinionConf());
-  }
-
   private MinionTaskTestUtils() {
   }
 
   public static MinionProgressObserver getMinionProgressObserver() {
     MinionProgressObserver progressObserver = new MinionProgressObserver();
-    progressObserver.init(PROGRESS_MANAGER);
+    progressObserver.init(DefaultMinionTaskProgressManager.getDefaultInstance());
     return progressObserver;
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskTestUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskTestUtils.java
@@ -16,20 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.tasks;
+package org.apache.pinot.plugin.minion.tasks;
 
-import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
+import org.apache.pinot.minion.event.MinionProgressObserver;
 
 
-public interface MinionTaskProgressManager {
+public class MinionTaskTestUtils {
 
-  void init(PinotConfiguration configuration);
+  private static final DefaultMinionTaskProgressManager PROGRESS_MANAGER;
+  static {
+    PROGRESS_MANAGER = new DefaultMinionTaskProgressManager();
+    PROGRESS_MANAGER.init(new MinionConf());
+  }
 
-  MinionTaskProgressStats getTaskProgress(String taskId);
+  private MinionTaskTestUtils() {
+  }
 
-  void setTaskProgress(String taskId, MinionTaskProgressStats progress);
-
-  default int getProgressBufferSize() {
-    return 1;
+  public static MinionProgressObserver getMinionProgressObserver() {
+    MinionProgressObserver progressObserver = new MinionProgressObserver();
+    progressObserver.init(PROGRESS_MANAGER);
+    return progressObserver;
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
@@ -33,8 +33,7 @@ import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.MinionContext;
-import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
-import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.plugin.minion.tasks.MinionTaskTestUtils;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -109,8 +108,7 @@ public class MergeRollupTaskExecutorTest {
   public void testConvert()
       throws Exception {
     MergeRollupTaskExecutor mergeRollupTaskExecutor = new MergeRollupTaskExecutor(new MinionConf());
-    mergeRollupTaskExecutor.setMinionEventObserver(
-        new MinionProgressObserver(new DefaultMinionTaskProgressManager(128)));
+    mergeRollupTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.MergeRollupTask.MERGE_LEVEL_KEY, "daily");
@@ -130,7 +128,7 @@ public class MergeRollupTaskExecutorTest {
   public void testDimensionErasure()
       throws Exception {
     MergeRollupTaskExecutor mergeRollupTaskExecutor = new MergeRollupTaskExecutor(new MinionConf());
-    mergeRollupTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    mergeRollupTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.MergeRollupTask.MERGE_LEVEL_KEY, "daily");

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionProgressObserver;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -108,7 +109,8 @@ public class MergeRollupTaskExecutorTest {
   public void testConvert()
       throws Exception {
     MergeRollupTaskExecutor mergeRollupTaskExecutor = new MergeRollupTaskExecutor(new MinionConf());
-    mergeRollupTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    mergeRollupTaskExecutor.setMinionEventObserver(
+        new MinionProgressObserver(new DefaultMinionTaskProgressManager(128)));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.MergeRollupTask.MERGE_LEVEL_KEY, "daily");

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionProgressObserver;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -123,7 +124,7 @@ public class PurgeTaskExecutorTest {
   public void testConvert()
       throws Exception {
     PurgeTaskExecutor purgeTaskExecutor = new PurgeTaskExecutor();
-    purgeTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    purgeTaskExecutor.setMinionEventObserver(new MinionProgressObserver(new DefaultMinionTaskProgressManager(128)));
     PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.PurgeTask.TASK_TYPE, Collections
         .singletonMap(MinionConstants.TABLE_NAME_KEY, TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME)));
     File purgedIndexDir = purgeTaskExecutor.convert(pinotTaskConfig, _originalIndexDir, PURGED_SEGMENT_DIR).getFile();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
@@ -32,8 +32,7 @@ import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
-import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
-import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.plugin.minion.tasks.MinionTaskTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
@@ -124,7 +123,7 @@ public class PurgeTaskExecutorTest {
   public void testConvert()
       throws Exception {
     PurgeTaskExecutor purgeTaskExecutor = new PurgeTaskExecutor();
-    purgeTaskExecutor.setMinionEventObserver(new MinionProgressObserver(new DefaultMinionTaskProgressManager(128)));
+    purgeTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.PurgeTask.TASK_TYPE, Collections
         .singletonMap(MinionConstants.TABLE_NAME_KEY, TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME)));
     File purgedIndexDir = purgeTaskExecutor.convert(pinotTaskConfig, _originalIndexDir, PURGED_SEGMENT_DIR).getFile();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
 import org.apache.pinot.minion.event.MinionProgressObserver;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -85,6 +86,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
   private List<File> _segmentIndexDirList;
   private List<File> _segmentIndexDirListEpochHours;
   private List<File> _segmentIndexDirListSDF;
+  private DefaultMinionTaskProgressManager _progressManager = new DefaultMinionTaskProgressManager(128);
 
   @BeforeClass
   public void setUp()
@@ -221,7 +223,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -249,7 +251,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -278,7 +280,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -308,7 +310,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -342,7 +344,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_PARTITIONING);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600468000000");
@@ -375,7 +377,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_SORTED_COL);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -404,7 +406,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_EPOCH_HOURS);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -434,7 +436,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver());
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_SDF);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
@@ -34,8 +34,7 @@ import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
-import org.apache.pinot.minion.event.DefaultMinionTaskProgressManager;
-import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.plugin.minion.tasks.MinionTaskTestUtils;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -86,7 +85,6 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
   private List<File> _segmentIndexDirList;
   private List<File> _segmentIndexDirListEpochHours;
   private List<File> _segmentIndexDirListSDF;
-  private DefaultMinionTaskProgressManager _progressManager = new DefaultMinionTaskProgressManager(128);
 
   @BeforeClass
   public void setUp()
@@ -223,7 +221,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -251,7 +249,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -280,7 +278,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -310,7 +308,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -344,7 +342,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_PARTITIONING);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600468000000");
@@ -377,7 +375,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_SORTED_COL);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -406,7 +404,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_EPOCH_HOURS);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");
@@ -436,7 +434,7 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
 
     RealtimeToOfflineSegmentsTaskExecutor realtimeToOfflineSegmentsTaskExecutor =
         new RealtimeToOfflineSegmentsTaskExecutor(null, null);
-    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(new MinionProgressObserver(_progressManager));
+    realtimeToOfflineSegmentsTaskExecutor.setMinionEventObserver(MinionTaskTestUtils.getMinionProgressObserver());
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_SDF);
     configs.put(MinionConstants.RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY, "1600473600000");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
@@ -21,6 +21,9 @@ package org.apache.pinot.spi.tasks;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
+/**
+ * Interface to decouple minion task progress storage from task progress tracking
+ */
 public interface MinionTaskProgressManager {
 
   void init(PinotConfiguration configuration);
@@ -29,6 +32,11 @@ public interface MinionTaskProgressManager {
 
   void setTaskProgress(String taskId, MinionTaskProgressStats progress);
 
+  MinionTaskProgressStats deleteTaskProgress(String taskId);
+
+  /**
+   * Use this to achieve batch updates on the progress tracked in the storage
+   */
   default int getProgressBufferSize() {
     return 1;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
@@ -19,7 +19,12 @@
 package org.apache.pinot.spi.tasks;
 
 public interface MinionTaskProgressManager {
-  Object getTaskProgress(String taskId);
+  MinionTaskProgressStats getTaskProgress(String taskId);
 
-  void setTaskProgress(String taskId, Object progress);
+  void setTaskProgress(String taskId, MinionTaskProgressStats progress);
+
+
+  default int getProgressBufferSize() {
+    return 1;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressManager.java
@@ -16,34 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.minion.event;
+package org.apache.pinot.spi.tasks;
 
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
-import org.apache.pinot.spi.tasks.MinionTaskProgressManager;
+public interface MinionTaskProgressManager {
+  Object getTaskProgress(String taskId);
 
-
-/**
- * Factory for {@link MinionEventObserver}.
- */
-public interface MinionEventObserverFactory {
-
-  /**
-   * Initializes the task executor factory.
-   */
-  void init(MinionTaskZkMetadataManager zkMetadataManager);
-
-  /**
-   * Initializes the task executor factory.
-   */
-  void init(MinionTaskZkMetadataManager zkMetadataManager, MinionTaskProgressManager taskProgressManager);
-
-  /**
-   * Returns the task type of the event observer.
-   */
-  String getTaskType();
-
-  /**
-   * Creates a new task event observer.
-   */
-  MinionEventObserver create();
+  void setTaskProgress(String taskId, Object progress);
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressStats.java
@@ -24,14 +24,16 @@ import java.util.Map;
 
 
 public class MinionTaskProgressStats {
-  private String _taskId;
-  private String _currentStage;
-  private String _currentState;
-  private Map<String, Timer> _stageTimes = new HashMap<>();
-  private long _startTimestamp;
-  private long _endTimestamp;
-  private int _segmentsGenerated;
-  private List<StatusEntry> _progressLogs;
+  protected String _taskId;
+  protected String _currentStage;
+  protected String _currentState;
+  protected Map<String, Timer> _stageTimes = new HashMap<>();
+  protected long _startTimestamp;
+  protected long _endTimestamp;
+  protected List<Map<String, String>> _inputUnits;
+  protected int _inputUnitsProcessed;
+  protected int _segmentsGenerated;
+  protected List<StatusEntry> _progressLogs;
 
   public String getTaskId() {
     return _taskId;
@@ -96,6 +98,24 @@ public class MinionTaskProgressStats {
     return this;
   }
 
+  public List<Map<String, String>> getInputUnits() {
+    return _inputUnits;
+  }
+
+  public MinionTaskProgressStats setInputUnits(List<Map<String, String>> inputUnits) {
+    _inputUnits = inputUnits;
+    return this;
+  }
+
+  public int getInputUnitsProcessed() {
+    return _inputUnitsProcessed;
+  }
+
+  public MinionTaskProgressStats setInputUnitsProcessed(int inputUnitsProcessed) {
+    _inputUnitsProcessed = inputUnitsProcessed;
+    return this;
+  }
+
   public List<StatusEntry> getProgressLogs() {
     return _progressLogs;
   }
@@ -103,52 +123,6 @@ public class MinionTaskProgressStats {
   public MinionTaskProgressStats setProgressLogs(List<StatusEntry> progressLogs) {
     _progressLogs = progressLogs;
     return this;
-  }
-
-  public static class StatusEntry {
-    private long _ts;
-    private String _stage;
-    private String _status;
-
-    public StatusEntry() {
-    }
-
-    public StatusEntry(String stage, String status) {
-      this(System.currentTimeMillis(), stage, status);
-    }
-
-    public StatusEntry(long ts, String stage, String status) {
-      _ts = ts;
-      _stage = stage;
-      _status = status;
-    }
-
-    public long getTs() {
-      return _ts;
-    }
-
-    public String getStage() {
-      return _stage;
-    }
-
-    public String getStatus() {
-      return _status;
-    }
-
-    public StatusEntry setTs(long ts) {
-      _ts = ts;
-      return this;
-    }
-
-    public StatusEntry setStage(String stage) {
-      _stage = stage;
-      return this;
-    }
-
-    public StatusEntry setStatus(String status) {
-      _status = status;
-      return this;
-    }
   }
 
   public static class Timer {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskProgressStats.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.tasks;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class MinionTaskProgressStats {
+  private String _taskId;
+  private String _currentStage;
+  private String _currentState;
+  private Map<String, Timer> _stageTimes = new HashMap<>();
+  private long _startTimestamp;
+  private long _endTimestamp;
+  private int _segmentsGenerated;
+  private List<StatusEntry> _progressLogs;
+
+  public String getTaskId() {
+    return _taskId;
+  }
+
+  public MinionTaskProgressStats setTaskId(String taskId) {
+    _taskId = taskId;
+    return this;
+  }
+
+  public long getEndTimestamp() {
+    return _endTimestamp;
+  }
+
+  public MinionTaskProgressStats setEndTimestamp(long endTimestamp) {
+    _endTimestamp = endTimestamp;
+    return this;
+  }
+
+  public long getStartTimestamp() {
+    return _startTimestamp;
+  }
+
+  public MinionTaskProgressStats setStartTimestamp(long startTimestamp) {
+    _startTimestamp = startTimestamp;
+    return this;
+  }
+
+  public Map<String, Timer> getStageTimes() {
+    return _stageTimes;
+  }
+
+  public MinionTaskProgressStats setStageTimes(Map<String, Timer> stageTimes) {
+    _stageTimes = stageTimes;
+    return this;
+  }
+
+  public String getCurrentState() {
+    return _currentState;
+  }
+
+  public MinionTaskProgressStats setCurrentState(String currentState) {
+    _currentState = currentState;
+    return this;
+  }
+
+  public String getCurrentStage() {
+    return _currentStage;
+  }
+
+  public MinionTaskProgressStats setCurrentStage(String currentStage) {
+    _currentStage = currentStage;
+    return this;
+  }
+
+  public int getSegmentsGenerated() {
+    return _segmentsGenerated;
+  }
+
+  public MinionTaskProgressStats setSegmentsGenerated(int segmentsGenerated) {
+    _segmentsGenerated = segmentsGenerated;
+    return this;
+  }
+
+  public List<StatusEntry> getProgressLogs() {
+    return _progressLogs;
+  }
+
+  public MinionTaskProgressStats setProgressLogs(List<StatusEntry> progressLogs) {
+    _progressLogs = progressLogs;
+    return this;
+  }
+
+  public static class StatusEntry {
+    private long _ts;
+    private String _stage;
+    private String _status;
+
+    public StatusEntry() {
+    }
+
+    public StatusEntry(String stage, String status) {
+      this(System.currentTimeMillis(), stage, status);
+    }
+
+    public StatusEntry(long ts, String stage, String status) {
+      _ts = ts;
+      _stage = stage;
+      _status = status;
+    }
+
+    public long getTs() {
+      return _ts;
+    }
+
+    public String getStage() {
+      return _stage;
+    }
+
+    public String getStatus() {
+      return _status;
+    }
+
+    public StatusEntry setTs(long ts) {
+      _ts = ts;
+      return this;
+    }
+
+    public StatusEntry setStage(String stage) {
+      _stage = stage;
+      return this;
+    }
+
+    public StatusEntry setStatus(String status) {
+      _status = status;
+      return this;
+    }
+  }
+
+  public static class Timer {
+    private long _totalTimeMs = 0;
+    private long _startTimeMs = 0;
+
+    public void start() {
+      _startTimeMs = System.currentTimeMillis();
+    }
+
+    public void stop() {
+      if (_startTimeMs != 0) {
+        _totalTimeMs += System.currentTimeMillis() - _startTimeMs;
+        _startTimeMs = 0;
+      }
+    }
+    public long getTotalTimeMs() {
+      return _totalTimeMs;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/StatusEntry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/StatusEntry.java
@@ -47,6 +47,12 @@ public class StatusEntry {
     return _level;
   }
 
+  @Override
+  public String toString() {
+    return "StatusEntry{" + "_ts=" + _ts + ", _level=" + _level + ", _stage='" + _stage + '\''
+        + ", _status='" + _status + '\'' + '}';
+  }
+
   public static class Builder {
     private long _ts;
     private LogLevel _level = LogLevel.INFO;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/StatusEntry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/StatusEntry.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.tasks;
+
+public class StatusEntry {
+  private final long _ts;
+  private final LogLevel _level;
+  private final String _stage;
+  private final String _status;
+
+  public StatusEntry(long ts, String stage, LogLevel level, String status) {
+    _ts = ts;
+    _stage = stage;
+    _level = level != null ? level : LogLevel.INFO;
+    _status = status;
+  }
+
+  public long getTs() {
+    return _ts;
+  }
+
+  public String getStage() {
+    return _stage;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+
+  public LogLevel getLevel() {
+    return _level;
+  }
+
+  public static class Builder {
+    private long _ts;
+    private LogLevel _level = LogLevel.INFO;
+    private String _stage;
+    private String _status;
+
+    public Builder timestamp(long ts) {
+      _ts = ts;
+      return this;
+    }
+
+    public Builder level(LogLevel level) {
+      _level = level;
+      return this;
+    }
+
+    public Builder stage(String stage) {
+      _stage = stage;
+      return this;
+    }
+
+    public Builder status(String status) {
+      _status = status;
+      return this;
+    }
+
+    public org.apache.pinot.spi.tasks.StatusEntry build() {
+      if (_ts == 0) {
+        _ts = System.currentTimeMillis();
+      }
+      return new org.apache.pinot.spi.tasks.StatusEntry(_ts, _stage, _level, _status);
+    }
+  }
+
+  public enum LogLevel {
+    INFO, WARN, ERROR
+  }
+}


### PR DESCRIPTION
# Description

This PR tries to decouple the way how minion task progress is being tracked and stored so that we can reuse the implementations of `MinionEventObserver` and decide the underlying storage to be used based on the requirements.

This PR also adds some extra stats to track as part of the observer so that user can get more granular information about the minion task execution.

## Introduce new `MinionTaskProgressManager` interface

The responsibility of storing the task progress data that's being monitored by `MinionEventObserver` will be delegated to this new interface `MinionTaskProgressManager`. It will expose the below methods to manage the `MinionTaskProgressStats` for each task run.

- `init(PinotConfiguration configuration)`
- `getTaskProgress(String taskId)`
- `setTaskProgress(String taskId, MinionTaskProgressStats progress)`
- `deleteTaskProgress(String taskId)`

### Configuration

In order to plug the desired implementation of `MinionTaskProgressManager` there is a new config introduced 
```
pinot.minion.taskProgressManager.class
```
If the config is not provided or minion is unable to load the instance of that class, the default implementation `DefaultMinionTaskProgressManager` will be used.
This is the same logic of how the existing progress is being maintained in minion memory.

## Track more stats with `MinionTaskProgressStats`

The info maintained by MinionEventObserver in current implementation is not enough to get the granular view on a task's progress. A new wrapper class `MinionTaskProgressStats` is introduced to track and manage more stats.

### Stats tracked right now

- Task start time
- Current task state (from `MinionTaskState`)
- Progress logs (timestamp, plain string log)

### New stats added

- Stage (in addition to the MinionTaskState, track task type specific stages/states )
- Time spent on each stage
- startTime
- endTime
- progress log (timestamp, stage, log level, plain string log )
- input units (segments, files etc)
- #input units processed
- #generated segments


## New interface methods on `MinionEventObserver`

Few new interface methods are added to `MinionEventObserver` along with the above improvements 

- `MinionTaskProgressStats getProgressStats()` : to get all the stats for the task being tracked
- `cleanup()` : cleanup code which will be called when the observer is purged upon reaching the ttl threshold

## Onboard MergeRollupTask

To try out the improvements, the MergeRollupTaskExecutor flow has been updated to enable tracking all the new stats. As the flow spans over `SegmentProcessorFramework` and `SegmentMapper` as well the tracking has been updated there as well
