### PR TITLE
[Multi-stage] Allow filter for lookup JOIN

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.calcite.rel.hint;
 
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.hint.RelHint;
 
 
@@ -84,6 +85,13 @@ public class PinotHintOptions {
      * Indicates that the join operator(s) within a certain selection scope are colocated
      */
     public static final String IS_COLOCATED_BY_JOIN_KEYS = "is_colocated_by_join_keys";
+
+    // TODO: Consider adding a Join implementation with join strategy.
+    public static boolean useLookupJoinStrategy(Join join) {
+      return LOOKUP_JOIN_STRATEGY.equalsIgnoreCase(
+          PinotHintStrategyTable.getHintOption(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
+              PinotHintOptions.JoinHintOptions.JOIN_STRATEGY));
+    }
   }
 
   public static class TableHintOptions {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
@@ -1,0 +1,262 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.rules.FilterJoinRule;
+import org.apache.calcite.rel.rules.FilterJoinRule.FilterIntoJoinRule.FilterIntoJoinRuleConfig;
+import org.apache.calcite.rel.rules.FilterJoinRule.JoinConditionPushRule.JoinConditionPushRuleConfig;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * Similar to {@link FilterJoinRule} but do not push down filter into right side of lookup join.
+ */
+public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> extends FilterJoinRule<C> {
+
+  private PinotFilterJoinRule(C config) {
+    super(config);
+  }
+
+  // Following code are copy-pasted from Calcite, and modified to not push down filter into right side of lookup join.
+  //@formatter:off
+  @Override
+  protected void perform(RelOptRuleCall call, @Nullable Filter filter, Join join) {
+    List<RexNode> joinFilters =
+        RelOptUtil.conjunctions(join.getCondition());
+    final List<RexNode> origJoinFilters = ImmutableList.copyOf(joinFilters);
+
+    // If there is only the joinRel,
+    // make sure it does not match a cartesian product joinRel
+    // (with "true" condition), otherwise this rule will be applied
+    // again on the new cartesian product joinRel.
+    if (filter == null && joinFilters.isEmpty()) {
+      return;
+    }
+
+    final List<RexNode> aboveFilters =
+        filter != null
+            ? getConjunctions(filter)
+            : new ArrayList<>();
+    final ImmutableList<RexNode> origAboveFilters =
+        ImmutableList.copyOf(aboveFilters);
+
+    // Simplify Outer Joins
+    JoinRelType joinType = join.getJoinType();
+    if (config.isSmart()
+        && !origAboveFilters.isEmpty()
+        && join.getJoinType() != JoinRelType.INNER) {
+      joinType = RelOptUtil.simplifyJoin(join, origAboveFilters, joinType);
+    }
+
+    final List<RexNode> leftFilters = new ArrayList<>();
+    final List<RexNode> rightFilters = new ArrayList<>();
+
+    // TODO - add logic to derive additional filters.  E.g., from
+    // (t1.a = 1 AND t2.a = 2) OR (t1.b = 3 AND t2.b = 4), you can
+    // derive table filters:
+    // (t1.a = 1 OR t1.b = 3)
+    // (t2.a = 2 OR t2.b = 4)
+
+    // PINOT MODIFICATION to not push down filter into right side of lookup join.
+    boolean canPushRight = !PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join);
+
+    // Try to push down above filters. These are typically where clause
+    // filters. They can be pushed down if they are not on the NULL
+    // generating side.
+    boolean filterPushed =
+        RelOptUtil.classifyFilters(join,
+            aboveFilters,
+            joinType.canPushIntoFromAbove(),
+            joinType.canPushLeftFromAbove(),
+            canPushRight && joinType.canPushRightFromAbove(),
+            joinFilters,
+            leftFilters,
+            rightFilters);
+
+    // Move join filters up if needed
+    validateJoinFilters(aboveFilters, joinFilters, join, joinType);
+
+    // If no filter got pushed after validate, reset filterPushed flag
+    if (leftFilters.isEmpty()
+        && rightFilters.isEmpty()
+        && joinFilters.size() == origJoinFilters.size()
+        && aboveFilters.size() == origAboveFilters.size()) {
+      if (Sets.newHashSet(joinFilters)
+          .equals(Sets.newHashSet(origJoinFilters))) {
+        filterPushed = false;
+      }
+    }
+
+    if (joinType != JoinRelType.FULL) {
+      joinFilters = inferJoinEqualConditions(joinFilters, join);
+    }
+
+    // Try to push down filters in ON clause. A ON clause filter can only be
+    // pushed down if it does not affect the non-matching set, i.e. it is
+    // not on the side which is preserved.
+
+    // Anti-join on conditions can not be pushed into left or right, e.g. for plan:
+    //
+    //     Join(condition=[AND(cond1, $2)], joinType=[anti])
+    //     :  - prj(f0=[$0], f1=[$1], f2=[$2])
+    //     :  - prj(f0=[$0])
+    //
+    // The semantic would change if join condition $2 is pushed into left,
+    // that is, the result set may be smaller. The right can not be pushed
+    // into for the same reason.
+    if (RelOptUtil.classifyFilters(
+        join,
+        joinFilters,
+        false,
+        joinType.canPushLeftFromWithin(),
+        canPushRight && joinType.canPushRightFromWithin(),
+        joinFilters,
+        leftFilters,
+        rightFilters)) {
+      filterPushed = true;
+    }
+
+    // if nothing actually got pushed and there is nothing leftover,
+    // then this rule is a no-op
+    if ((!filterPushed
+        && joinType == join.getJoinType())
+        || (joinFilters.isEmpty()
+        && leftFilters.isEmpty()
+        && rightFilters.isEmpty())) {
+      return;
+    }
+
+    // create Filters on top of the children if any filters were
+    // pushed to them
+    final RexBuilder rexBuilder = join.getCluster().getRexBuilder();
+    final RelBuilder relBuilder = call.builder();
+    final RelNode leftRel =
+        relBuilder.push(join.getLeft()).filter(leftFilters).build();
+    final RelNode rightRel =
+        relBuilder.push(join.getRight()).filter(rightFilters).build();
+
+    // create the new join node referencing the new children and
+    // containing its new join filters (if there are any)
+    final ImmutableList<RelDataType> fieldTypes =
+        ImmutableList.<RelDataType>builder()
+            .addAll(RelOptUtil.getFieldTypeList(leftRel.getRowType()))
+            .addAll(RelOptUtil.getFieldTypeList(rightRel.getRowType())).build();
+    final RexNode joinFilter =
+        RexUtil.composeConjunction(rexBuilder,
+            RexUtil.fixUp(rexBuilder, joinFilters, fieldTypes));
+
+    // If nothing actually got pushed and there is nothing leftover,
+    // then this rule is a no-op
+    if (joinFilter.isAlwaysTrue()
+        && leftFilters.isEmpty()
+        && rightFilters.isEmpty()
+        && joinType == join.getJoinType()) {
+      return;
+    }
+
+    RelNode newJoinRel =
+        join.copy(
+            join.getTraitSet(),
+            joinFilter,
+            leftRel,
+            rightRel,
+            joinType,
+            join.isSemiJoinDone());
+    call.getPlanner().onCopy(join, newJoinRel);
+    if (!leftFilters.isEmpty() && filter != null) {
+      call.getPlanner().onCopy(filter, leftRel);
+    }
+    if (!rightFilters.isEmpty() && filter != null) {
+      call.getPlanner().onCopy(filter, rightRel);
+    }
+
+    relBuilder.push(newJoinRel);
+
+    // Create a project on top of the join if some of the columns have become
+    // NOT NULL due to the join-type getting stricter.
+    relBuilder.convert(join.getRowType(), false);
+
+    // create a FilterRel on top of the join if needed
+    relBuilder.filter(
+        RexUtil.fixUp(rexBuilder, aboveFilters,
+            RelOptUtil.getFieldTypeList(relBuilder.peek().getRowType())));
+    call.transformTo(relBuilder.build());
+  }
+
+  private static List<RexNode> getConjunctions(Filter filter) {
+    List<RexNode> conjunctions = RelOptUtil.conjunctions(filter.getCondition());
+    RexBuilder rexBuilder = filter.getCluster().getRexBuilder();
+    for (int i = 0; i < conjunctions.size(); i++) {
+      RexNode node = conjunctions.get(i);
+      if (node instanceof RexCall) {
+        conjunctions.set(i,
+            RelOptUtil.collapseExpandedIsNotDistinctFromExpr((RexCall) node, rexBuilder));
+      }
+    }
+    return conjunctions;
+  }
+  //@formatter:on
+
+  public static class PinotJoinConditionPushRule extends PinotFilterJoinRule<JoinConditionPushRule.Config> {
+    public static final PinotJoinConditionPushRule INSTANCE =
+        new PinotJoinConditionPushRule(JoinConditionPushRuleConfig.DEFAULT);
+
+    private PinotJoinConditionPushRule(JoinConditionPushRuleConfig config) {
+      super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      perform(call, null, call.rel(0));
+    }
+  }
+
+  public static class PinotFilterIntoJoinRule extends PinotFilterJoinRule<FilterIntoJoinRuleConfig> {
+    public static final PinotFilterIntoJoinRule INSTANCE =
+        new PinotFilterIntoJoinRule(FilterIntoJoinRuleConfig.DEFAULT);
+
+    private PinotFilterIntoJoinRule(FilterIntoJoinRuleConfig config) {
+      super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      Filter filter = call.rel(0);
+      Join join = call.rel(1);
+      perform(call, filter, join);
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -26,7 +26,6 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
-import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 
 
@@ -53,11 +52,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
     RelNode left = PinotRuleUtils.unboxRel(join.getInput(0));
     RelNode right = PinotRuleUtils.unboxRel(join.getInput(1));
     JoinInfo joinInfo = join.analyzeCondition();
-    String joinStrategy = PinotHintStrategyTable.getHintOption(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
-        PinotHintOptions.JoinHintOptions.JOIN_STRATEGY);
     RelNode newLeft;
     RelNode newRight;
-    if (PinotHintOptions.JoinHintOptions.LOOKUP_JOIN_STRATEGY.equals(joinStrategy)) {
+    if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
       // Lookup join - add local exchange on the left side
       newLeft = PinotLogicalExchange.create(left, RelDistributions.SINGLETON);
       newRight = right;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectJoinTransposeRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectJoinTransposeRule.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.rules.ProjectJoinTransposeRule;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+
+
+/**
+ * Similar to {@link ProjectJoinTransposeRule} but do not transpose project into right side of lookup join.
+ *
+ * TODO: Allow transposing project into left side of lookup join.
+ */
+public class PinotProjectJoinTransposeRule extends ProjectJoinTransposeRule {
+  public static final PinotProjectJoinTransposeRule INSTANCE = new PinotProjectJoinTransposeRule(Config.DEFAULT);
+
+  private PinotProjectJoinTransposeRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    Join join = call.rel(1);
+    return !PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -22,6 +22,8 @@ import java.util.List;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
+import org.apache.pinot.calcite.rel.rules.PinotFilterJoinRule.PinotFilterIntoJoinRule;
+import org.apache.pinot.calcite.rel.rules.PinotFilterJoinRule.PinotJoinConditionPushRule;
 
 
 /**
@@ -34,20 +36,20 @@ public class PinotQueryRuleSets {
   //@formatter:off
   public static final List<RelOptRule> BASIC_RULES = List.of(
       // push a filter into a join
-      CoreRules.FILTER_INTO_JOIN,
+      PinotFilterIntoJoinRule.INSTANCE,
       // push filter through an aggregation
       CoreRules.FILTER_AGGREGATE_TRANSPOSE,
       // push filter through set operation
       CoreRules.FILTER_SET_OP_TRANSPOSE,
       // push project through join,
-      CoreRules.PROJECT_JOIN_TRANSPOSE,
+      PinotProjectJoinTransposeRule.INSTANCE,
       // push project through set operation
       CoreRules.PROJECT_SET_OP_TRANSPOSE,
 
       // push a filter past a project
       CoreRules.FILTER_PROJECT_TRANSPOSE,
       // push parts of the join condition to its inputs
-      CoreRules.JOIN_CONDITION_PUSH,
+      PinotJoinConditionPushRule.INSTANCE,
       // remove identity project
       CoreRules.PROJECT_REMOVE,
 
@@ -105,7 +107,7 @@ public class PinotQueryRuleSets {
   // single HepInstruction.
   public static final List<RelOptRule> PROJECT_PUSHDOWN_RULES = List.of(
       CoreRules.PROJECT_FILTER_TRANSPOSE,
-      CoreRules.PROJECT_JOIN_TRANSPOSE,
+      PinotProjectJoinTransposeRule.INSTANCE,
       CoreRules.PROJECT_MERGE
   );
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.planner.logical;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Window;
-import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -55,7 +53,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
-import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalAggregate;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalSortExchange;
@@ -315,10 +312,7 @@ public final class RelToPlanNodeConverter {
 
     // Check if the join hint specifies the join strategy
     JoinNode.JoinStrategy joinStrategy;
-    ImmutableList<RelHint> relHints = join.getHints();
-    String joinStrategyHint = PinotHintStrategyTable.getHintOption(relHints, PinotHintOptions.JOIN_HINT_OPTIONS,
-        PinotHintOptions.JoinHintOptions.JOIN_STRATEGY);
-    if (PinotHintOptions.JoinHintOptions.LOOKUP_JOIN_STRATEGY.equals(joinStrategyHint)) {
+    if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
       joinStrategy = JoinNode.JoinStrategy.LOOKUP;
 
       // Run some validations for lookup join
@@ -343,7 +337,7 @@ public final class RelToPlanNodeConverter {
       joinStrategy = JoinNode.JoinStrategy.HASH;
     }
 
-    return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(relHints), inputs, joinType,
+    return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(join.getHints()), inputs, joinType,
         joinInfo.leftKeys, joinInfo.rightKeys, RexExpressionUtils.fromRexNodes(joinInfo.nonEquiConditions),
         joinStrategy);
   }

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -222,7 +222,7 @@
       },
       {
         "description": "Semi join with IN clause",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'hash_table') */ col1, col2 FROM a WHERE col3 IN (SELECT col3 FROM b)",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'hash') */ col1, col2 FROM a WHERE col3 IN (SELECT col3 FROM b)",
         "output": [
           "Execution Plan",
           "\nLogicalProject(col1=[$0], col2=[$1])",
@@ -238,7 +238,7 @@
       },
       {
         "description": "Semi join with multiple IN clause",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'hash_table') */ col1, col2 FROM a WHERE col2 = 'test' AND col3 IN (SELECT col3 FROM b WHERE col1='foo') AND col3 IN (SELECT col3 FROM b WHERE col1='bar') AND col3 IN (SELECT col3 FROM b WHERE col1='foobar')",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'hash') */ col1, col2 FROM a WHERE col2 = 'test' AND col3 IN (SELECT col3 FROM b WHERE col1='foo') AND col3 IN (SELECT col3 FROM b WHERE col1='bar') AND col3 IN (SELECT col3 FROM b WHERE col1='foobar')",
         "output": [
           "Execution Plan",
           "\nLogicalProject(col1=[$0], col2=[$1])",
@@ -578,12 +578,112 @@
       }
     ]
   },
+  "lookup_join_planning_tests": {
+    "queries": [
+      {
+        "description": "Simple lookup join",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with filter on left table",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col2 = 'foo'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$3])",
+          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
+          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with filter on right table",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE b.col2 = 'foo'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[AND(=($0, $1), =($2, _UTF-8'foo'))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with filter on right table in join condition",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 AND b.col2 = 'foo'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[AND(=($0, $1), =($2, _UTF-8'foo'))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with filter on right table joined key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE b.col1 = 'foo'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[AND(=($0, $1), =($1, _UTF-8'foo'))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with transformation on left table joined key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON upper(a.col1) = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$3])",
+          "\n  LogicalJoin(condition=[=($1, $2)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      }
+    ]
+  },
   "exception_throwing_join_planning_tests": {
     "queries": [
       {
         "description": "Incorrect table",
         "sql": "EXPLAIN PLAN FOR SELECT b.col1 - a.col3 FROM a JOIN c ON a.col1 = c.col3",
         "expectedException": ".*Table 'b' not found.*"
+      },
+      {
+        "description": "Lookup join with transformation on right table joined key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = upper(b.col1)",
+        "expectedException": "Right input for lookup join must be an identifier.*"
       }
     ]
   }


### PR DESCRIPTION
Customize the following 2 rules to not push down filters/transforms for lookup JOIN:
- `CoreRules.FILTER_INTO_JOIN` and `CoreRules.JOIN_CONDITION_PUSH`: Do not push down filter to right table, but allow pushing down to left table
- `CoreRules.PROJECT_JOIN_TRANSPOSE`: Disable the rule for lookup JOIN

TODO: Allow transpose to left table in `CoreRules.PROJECT_JOIN_TRANSPOSE`