### PR TITLE
Force cert reload on a daily basis.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -293,12 +293,14 @@ public class RenewableTlsUtils {
                       trustStorePassword, sslContextProtocol, secureRandom, false, insecureModeSupplier.get());
               SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory);
               LOGGER.info("reloadSslFactory :: Successfully renewed SSLFactory {} "
-                      + "(built from key store {} and truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
+                  + "(built from key store {} and "
+                  + "truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
               LOGGER.info(
                   "reloadSslFactory :: Encountered issues when renewing SSLFactory "
-                      + "{} (built from key store {} and truststore {}) on ", baseSslFactory, keyStorePath, trustStorePath, e);
+                  + "{} (built from key store {} and "
+                  + "truststore {}) on ", baseSslFactory, keyStorePath, trustStorePath, e);
               return false;
             }
           });

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -265,15 +265,15 @@ public class RenewableTlsUtils {
                   + "(built from key store {} and truststore {})",
               changedFile, baseSslFactory, keyStorePath, trustStorePath);
 
-          reloadSslFactory(baseSslFactory, keyStoreType, keyStorePath, keyStorePassword, trustStoreType, trustStorePath, trustStorePassword, sslContextProtocol, secureRandom, insecureModeSupplier);
+          reloadSslFactory(baseSslFactory, keyStoreType, keyStorePath, keyStorePassword, trustStoreType,
+              trustStorePath, trustStorePassword, sslContextProtocol, secureRandom, insecureModeSupplier);
         }
       }
       key.reset();
     }
   }
 
-  @VisibleForTesting
-  static synchronized void reloadSslFactory(SSLFactory baseSslFactory,
+  private static synchronized void reloadSslFactory(SSLFactory baseSslFactory,
       String keyStoreType, String keyStorePath, String keyStorePassword,
       String trustStoreType, String trustStorePath, String trustStorePassword,
       String sslContextProtocol, SecureRandom secureRandom, Supplier<Boolean> insecureModeSupplier) {
@@ -292,13 +292,13 @@ public class RenewableTlsUtils {
                   createSSLFactory(keyStoreType, keyStorePath, keyStorePassword, trustStoreType, trustStorePath,
                       trustStorePassword, sslContextProtocol, secureRandom, false, insecureModeSupplier.get());
               SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory);
-              LOGGER.info("reloadSslFactory :: Successfully renewed SSLFactory {} (built from key store {} and truststore {}) on file"
-                  , baseSslFactory, keyStorePath, trustStorePath);
+              LOGGER.info("reloadSslFactory :: Successfully renewed SSLFactory {} "
+                      + "(built from key store {} and truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
               LOGGER.info(
-                  "reloadSslFactory :: Encountered issues when renewing SSLFactory {} (built from key store {} and truststore {}) on "
-                  , baseSslFactory, keyStorePath, trustStorePath, e);
+                  "reloadSslFactory :: Encountered issues when renewing SSLFactory "
+                      + "{} (built from key store {} and truststore {}) on ", baseSslFactory, keyStorePath, trustStorePath, e);
               return false;
             }
           });

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -229,7 +229,7 @@ public class RenewableTlsUtils {
       // thread which will run once a day and reload the certs.
 
       Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-        log.info("Creating a scheduled thread to reloadSsl once a day");
+        LOGGER.info("Creating a scheduled thread to reloadSsl once a day");
         try {
           reloadSslFactory(sslFactory,
               keyStoreType, keyStorePath, keyStorePassword,


### PR DESCRIPTION
Forcing SSL reload once a day using a scheduled thread. This is to prevent any discrepancy due to FileWatcher in reloading the certs.

There has been scenarios where the FileWatcher is not reliable in detecting changes and reloading the certs as expected when changed. The certs were reloaded successfully in few components but it was never detected and run in others. This will result in few components with stale certificates. In order to prevent this issue, we are adding a new scheduled thread which will run once a day and reload the certs.