### PR TITLE
Batch reload api to specify what segments to be reloaded on what servers to be more flexible

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -89,6 +89,7 @@ import org.apache.pinot.controller.util.TableTierReader;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.segment.spi.creator.name.SegmentNameUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -555,7 +556,8 @@ public class PinotSegmentRestletResource {
               + controllerJobZKMetadata.get(CommonConstants.ControllerJob.SUBMISSION_TIME_MS);
       if (segmentNames != null) {
         List<String> targetSegments = serverToSegments.get(server);
-        reloadTaskStatusEndpoint = reloadTaskStatusEndpoint + "&segmentName=" + StringUtils.join(targetSegments, ',');
+        reloadTaskStatusEndpoint = reloadTaskStatusEndpoint + "&segmentName=" + StringUtils.join(targetSegments,
+            SegmentNameUtils.SEGMENT_NAME_SEPARATOR);
       }
       serverUrls.add(reloadTaskStatusEndpoint);
     }
@@ -619,7 +621,7 @@ public class PinotSegmentRestletResource {
     }
     // Skip servers and segments not involved in the segment reloading job.
     List<String> segmnetNameList = new ArrayList<>();
-    Collections.addAll(segmnetNameList, StringUtils.split(segmentNames, ','));
+    Collections.addAll(segmnetNameList, StringUtils.split(segmentNames, SegmentNameUtils.SEGMENT_NAME_SEPARATOR));
     if (instanceName != null) {
       return Map.of(instanceName, segmnetNameList);
     }
@@ -735,7 +737,8 @@ public class PinotSegmentRestletResource {
         instanceMsgData.put(instance, tableReloadMeta);
         // Store in ZK
         try {
-          String segmentNames = StringUtils.join(instanceToSegmentsMap.get(instance), ',');
+          String segmentNames =
+              StringUtils.join(instanceToSegmentsMap.get(instance), SegmentNameUtils.SEGMENT_NAME_SEPARATOR);
           if (_pinotHelixResourceManager.addNewReloadSegmentJob(tableNameWithType, segmentNames, instance,
               msgInfo.getRight(), startTimeMs, numReloadMsgSent)) {
             tableReloadMeta.put("reloadJobMetaZKStorageStatus", "SUCCESS");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2209,7 +2209,9 @@ public class PinotHelixResourceManager {
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(jobSubmissionTimeMs));
     jobMetadata.put(CommonConstants.ControllerJob.MESSAGE_COUNT, Integer.toString(numMessagesSent));
     jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME, segmentNames);
-    jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_INSTANCE_NAME, instanceName);
+    if (instanceName != null) {
+      jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_INSTANCE_NAME, instanceName);
+    }
     return addControllerJobToZK(jobId, jobMetadata, ControllerJobType.RELOAD_SEGMENT);
   }
 
@@ -2230,7 +2232,9 @@ public class PinotHelixResourceManager {
     jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.RELOAD_SEGMENT);
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(jobSubmissionTimeMs));
     jobMetadata.put(CommonConstants.ControllerJob.MESSAGE_COUNT, Integer.toString(numberOfMessagesSent));
-    jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_INSTANCE_NAME, instanceName);
+    if (instanceName != null) {
+      jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_INSTANCE_NAME, instanceName);
+    }
     return addControllerJobToZK(jobId, jobMetadata, ControllerJobType.RELOAD_SEGMENT);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2193,13 +2193,14 @@ public class PinotHelixResourceManager {
   /**
    * Adds a new reload segment job metadata into ZK
    * @param tableNameWithType Table for which job is to be added
-   * @param segmentName Name of the segment being reloaded
+   * @param segmentNames Name of the segments being reloaded, separated by comma
+   * @param instanceName Name of the instance done the segment reloading, optional.
    * @param jobId job's UUID
    * @param jobSubmissionTimeMs time at which the job was submitted
    * @param numMessagesSent number of messages that were sent to servers. Saved as metadata
    * @return boolean representing success / failure of the ZK write step
    */
-  public boolean addNewReloadSegmentJob(String tableNameWithType, String segmentName, @Nullable String instanceName,
+  public boolean addNewReloadSegmentJob(String tableNameWithType, String segmentNames, @Nullable String instanceName,
       String jobId, long jobSubmissionTimeMs, int numMessagesSent) {
     Map<String, String> jobMetadata = new HashMap<>();
     jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
@@ -2207,7 +2208,7 @@ public class PinotHelixResourceManager {
     jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.RELOAD_SEGMENT);
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(jobSubmissionTimeMs));
     jobMetadata.put(CommonConstants.ControllerJob.MESSAGE_COUNT, Integer.toString(numMessagesSent));
-    jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME, segmentName);
+    jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME, segmentNames);
     jobMetadata.put(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_INSTANCE_NAME, instanceName);
     return addControllerJobToZK(jobId, jobMetadata, ControllerJobType.RELOAD_SEGMENT);
   }
@@ -2215,6 +2216,7 @@ public class PinotHelixResourceManager {
   /**
    * Adds a new reload segment job metadata into ZK
    * @param tableNameWithType Table for which job is to be added
+   * @param instanceName Name of the instance done the segment reloading, optional.
    * @param jobId job's UUID
    * @param jobSubmissionTimeMs time at which the job was submitted
    * @param numberOfMessagesSent number of messages that were sent to servers. Saved as metadata

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2611,9 +2611,9 @@ public class PinotHelixResourceManager {
   }
 
   public Map<String, Pair<Integer, String>> reloadSegments(String tableNameWithType, boolean forceDownload,
-      Map<String, List<String>> reloadMap) {
-    LOGGER.info("Sending reload messages for table: {} with forceDownload: {}, and reloadMap: {}", tableNameWithType,
-        forceDownload, reloadMap);
+      Map<String, List<String>> instanceToSegmentsMap) {
+    LOGGER.info("Sending reload messages for table: {} with forceDownload: {}, and instanceToSegmentsMap: {}",
+        tableNameWithType, forceDownload, instanceToSegmentsMap);
 
     if (forceDownload) {
       TableType tt = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
@@ -2624,7 +2624,7 @@ public class PinotHelixResourceManager {
     // Infinite timeout on the recipient
     int timeoutMs = -1;
     Map<String, Pair<Integer, String>> instanceMsgInfoMap = new HashMap<>();
-    for (Map.Entry<String, List<String>> entry : reloadMap.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : instanceToSegmentsMap.entrySet()) {
       String targetInstance = entry.getKey();
       List<String> segments = entry.getValue();
       Criteria recipientCriteria = new Criteria();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotSegmentRestletResourceTest {
+  @Mock
+  PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @InjectMocks
+  PinotSegmentRestletResource _pinotSegmentRestletResource;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testGetServerToSegments() {
+    String tableName = "testTable";
+    Map<String, List<String>> fullServerToSegmentsMap = new HashMap<>();
+    fullServerToSegmentsMap.put("svr01", new ArrayList<>(List.of("seg01", "seg02")));
+    fullServerToSegmentsMap.put("svr02", new ArrayList<>(List.of("seg02", "seg03")));
+    fullServerToSegmentsMap.put("svr03", new ArrayList<>(List.of("seg03", "seg01")));
+    when(_pinotHelixResourceManager.getServerToSegmentsMap(tableName, null)).thenReturn(fullServerToSegmentsMap);
+    when(_pinotHelixResourceManager.getServerToSegmentsMap(tableName, "svr02")).thenReturn(
+        Map.of("svr02", new ArrayList<>(List.of("seg02", "seg03"))));
+    when(_pinotHelixResourceManager.getServers(tableName, "seg01")).thenReturn(Set.of("svr01", "svr03"));
+
+    // Get all servers and all their segments.
+    Map<String, List<String>> serverToSegmentsMap =
+        _pinotSegmentRestletResource.getServerToSegments(tableName, null, null);
+    assertEquals(serverToSegmentsMap, fullServerToSegmentsMap);
+
+    // Get all segments on svr02.
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, null, "svr02");
+    assertEquals(serverToSegmentsMap, Map.of("svr02", List.of("seg02", "seg03")));
+
+    // Get all servers with seg01.
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01", null);
+    assertEquals(serverToSegmentsMap, Map.of("svr01", List.of("seg01"), "svr03", List.of("seg01")));
+
+    // Simply map the provided server to the provided segments.
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01", "svr01");
+    assertEquals(serverToSegmentsMap, Map.of("svr01", List.of("seg01")));
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "anySegment", "anyServer");
+    assertEquals(serverToSegmentsMap, Map.of("anyServer", List.of("anySegment")));
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01,seg02", "svr02");
+    assertEquals(serverToSegmentsMap, Map.of("svr02", List.of("seg01", "seg02")));
+    try {
+      _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01,seg02", null);
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Only one segment is expected but got: [seg01, seg02]"));
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -77,7 +77,7 @@ public class PinotSegmentRestletResourceTest {
     assertEquals(serverToSegmentsMap, Map.of("svr01", List.of("seg01")));
     serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "anySegment", "anyServer");
     assertEquals(serverToSegmentsMap, Map.of("anyServer", List.of("anySegment")));
-    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01,seg02", "svr02");
+    serverToSegmentsMap = _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01|seg02", "svr02");
     assertEquals(serverToSegmentsMap, Map.of("svr02", List.of("seg01", "seg02")));
     try {
       _pinotSegmentRestletResource.getServerToSegments(tableName, "seg01,seg02", null);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
  * Utils for segment names.
  */
 public class SegmentNameUtils {
+  // According to the invalid name pattern below, `|` is safer than `,` as the segment name separator.
+  public static final char SEGMENT_NAME_SEPARATOR = '|';
   private static final Pattern INVALID_SEGMENT_NAME_REGEX = Pattern.compile(".*[\\\\/:\\*?\"<>|].*");
 
   private SegmentNameUtils() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
@@ -54,19 +54,19 @@ public class ControllerJobStatusResource {
   @ApiOperation(value = "Task status", notes = "Return the status of a given reload job")
   public String reloadJobStatus(@PathParam("tableNameWithType") String tableNameWithType,
       @QueryParam("reloadJobTimestamp") long reloadJobSubmissionTimestamp,
-      @QueryParam("segmentNames") String segmentNames, @Context HttpHeaders headers)
+      @QueryParam("segmentName") String segmentName, @Context HttpHeaders headers)
       throws Exception {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     TableDataManager tableDataManager =
         ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
     List<SegmentDataManager> segmentDataManagers;
     long totalSegmentCount;
-    if (segmentNames == null) {
+    if (segmentName == null) {
       segmentDataManagers = tableDataManager.acquireAllSegments();
       totalSegmentCount = segmentDataManagers.size();
     } else {
       List<String> targetSegments = new ArrayList<>();
-      Collections.addAll(targetSegments, StringUtils.split(segmentNames, ','));
+      Collections.addAll(targetSegments, StringUtils.split(segmentName, ','));
       segmentDataManagers = tableDataManager.acquireSegments(targetSegments, new ArrayList<>());
       totalSegmentCount = targetSegments.size();
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
@@ -20,6 +20,8 @@ package org.apache.pinot.server.api.resources;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -30,6 +32,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -51,45 +54,32 @@ public class ControllerJobStatusResource {
   @ApiOperation(value = "Task status", notes = "Return the status of a given reload job")
   public String reloadJobStatus(@PathParam("tableNameWithType") String tableNameWithType,
       @QueryParam("reloadJobTimestamp") long reloadJobSubmissionTimestamp,
-      @QueryParam("segmentName") String segmentName,
-      @Context HttpHeaders headers)
+      @QueryParam("segmentName") String segmentName, @Context HttpHeaders headers)
       throws Exception {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     TableDataManager tableDataManager =
         ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
-
+    List<SegmentDataManager> segmentDataManagers;
     if (segmentName == null) {
-      // All segments
-      List<SegmentDataManager> allSegments = tableDataManager.acquireAllSegments();
-      try {
-        long successCount = 0;
-        for (SegmentDataManager segmentDataManager : allSegments) {
-          if (segmentDataManager.getLoadTimeMs() >= reloadJobSubmissionTimestamp) {
-            successCount++;
-          }
-        }
-        SegmentReloadStatusValue segmentReloadStatusValue =
-            new SegmentReloadStatusValue(allSegments.size(), successCount);
-        return JsonUtils.objectToString(segmentReloadStatusValue);
-      } finally {
-        for (SegmentDataManager segmentDataManager : allSegments) {
-          tableDataManager.releaseSegment(segmentDataManager);
-        }
-      }
+      segmentDataManagers = tableDataManager.acquireAllSegments();
     } else {
-      SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
-      if (segmentDataManager == null) {
-        return JsonUtils.objectToString(new SegmentReloadStatusValue(0, 0));
-      }
-      try {
-        int successCount = 0;
+      List<String> targetSegments = new ArrayList<>();
+      Collections.addAll(targetSegments, StringUtils.split(segmentName, ','));
+      List<String> missingSegments = new ArrayList<>();
+      segmentDataManagers = tableDataManager.acquireSegments(targetSegments, missingSegments);
+    }
+    try {
+      long successCount = 0;
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         if (segmentDataManager.getLoadTimeMs() >= reloadJobSubmissionTimestamp) {
-          successCount = 1;
+          successCount++;
         }
-        SegmentReloadStatusValue segmentReloadStatusValue =
-            new SegmentReloadStatusValue(1, successCount);
-        return JsonUtils.objectToString(segmentReloadStatusValue);
-      } finally {
+      }
+      SegmentReloadStatusValue segmentReloadStatusValue =
+          new SegmentReloadStatusValue(segmentDataManagers.size(), successCount);
+      return JsonUtils.objectToString(segmentReloadStatusValue);
+    } finally {
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         tableDataManager.releaseSegment(segmentDataManager);
       }
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.creator.name.SegmentNameUtils;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.helix.SegmentReloadStatusValue;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -66,7 +67,7 @@ public class ControllerJobStatusResource {
       totalSegmentCount = segmentDataManagers.size();
     } else {
       List<String> targetSegments = new ArrayList<>();
-      Collections.addAll(targetSegments, StringUtils.split(segmentName, ','));
+      Collections.addAll(targetSegments, StringUtils.split(segmentName, SegmentNameUtils.SEGMENT_NAME_SEPARATOR));
       segmentDataManagers = tableDataManager.acquireSegments(targetSegments, new ArrayList<>());
       totalSegmentCount = targetSegments.size();
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -978,6 +978,7 @@ public class CommonConstants {
      * Segment reload job ZK props
      */
     public static final String SEGMENT_RELOAD_JOB_SEGMENT_NAME = "segmentName";
+    public static final String SEGMENT_RELOAD_JOB_INSTANCE_NAME = "instanceName";
     // Force commit job ZK props
     public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentsForceCommitted";
   }


### PR DESCRIPTION
This PR added a new segment reload API to allow more flexible control on segment reloading. The API takes a reloadMap from servers to segments, to specify what segments to be reloaded on what servers. In comparison, the current two APIs either reload a single segment or reload all segments and are not very flexible for scripting. 

e.g. with this new API, one can write a script to reload segments replica group by replica group and do that in small batches to control the reloading workload on servers.

Also extended reload job tracking logic for reloading selected segments on instances.