### PR TITLE
Clean up and enhance functions in SchemaConformingTransformer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerV2.java
@@ -28,6 +28,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -49,13 +50,13 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * This transformer evolves from {@link SchemaConformingTransformer} and is designed to support extra cases for
  * better text searching:
  *   - Support over-lapping schema fields, in which case it could support schema column "a" and "a.b" at the same time.
  *     And it only allows primitive type fields to be the value.
  *   - Extract flattened key-value pairs as mergedTextIndex for better text searching.
- *   - Add shingle index tokenization functionality for extremely large text fields.
  * <p>
  * For example, consider this record:
  * <pre>
@@ -129,8 +130,8 @@ import org.slf4j.LoggerFactory;
 public class SchemaConformingTransformerV2 implements RecordTransformer {
   private static final Logger _logger = LoggerFactory.getLogger(SchemaConformingTransformerV2.class);
   private static final int MAXIMUM_LUCENE_DOCUMENT_SIZE = 32766;
-  private static final String MIN_DOCUMENT_LENGTH_DESCRIPTION =
-      "key length + `:` + shingle index overlap length + one non-overlap char";
+  private static final List<String> MERGED_TEXT_INDEX_SUFFIX_TO_EXCLUDE = Arrays.asList("_logtype", "_dictionaryVars",
+      "_encodedVars");
 
   private final boolean _continueOnError;
   private final SchemaConformingTransformerV2Config _transformerConfig;
@@ -143,6 +144,7 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
   @Nullable
   private PinotMeter _realtimeMergedTextIndexTruncatedDocumentSizeMeter = null;
   private String _tableName;
+  private int _jsonKeyValueSeparatorByteCount;
   private long _mergedTextIndexDocumentBytesCount = 0L;
   private long _mergedTextIndexDocumentCount = 0L;
 
@@ -171,6 +173,8 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
     _tableName = tableConfig.getTableName();
     _schemaTree = validateSchemaAndCreateTree(schema, _transformerConfig);
     _serverMetrics = ServerMetrics.get();
+    _jsonKeyValueSeparatorByteCount = _transformerConfig.getJsonKeyValueSeparator()
+        .getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
   }
 
   /**
@@ -187,6 +191,20 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
     String unindexableExtrasFieldName = transformerConfig.getUnindexableExtrasField();
     if (null != unindexableExtrasFieldName) {
       SchemaConformingTransformer.getAndValidateExtrasFieldType(schema, indexableExtrasFieldName);
+    }
+
+    Map<String, String> columnNameToJsonKeyPathMap = transformerConfig.getColumnNameToJsonKeyPathMap();
+    for (Map.Entry<String, String> entry : columnNameToJsonKeyPathMap.entrySet()) {
+      String columnName = entry.getKey();
+      FieldSpec fieldSpec = schema.getFieldSpecFor(entry.getKey());
+      Preconditions.checkState(null != fieldSpec, "Field '%s' doesn't exist in schema", columnName);
+    }
+    Set<String> preserveFieldNames = transformerConfig.getFieldPathsToPreserveInput();
+    for (String preserveFieldName : preserveFieldNames) {
+      Preconditions.checkState(
+          columnNameToJsonKeyPathMap.containsValue(preserveFieldName)
+              || schema.getFieldSpecFor(preserveFieldName) != null,
+          "Preserved path '%s' doesn't exist in columnNameToJsonKeyPathMap or schema", preserveFieldName);
     }
 
     validateSchemaAndCreateTree(schema, transformerConfig);
@@ -264,7 +282,7 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
           currentNode = childNode;
         }
       }
-      currentNode.setColumn(jsonKeyPathToColumnNameMap.get(field));
+      currentNode.setColumn(jsonKeyPathToColumnNameMap.get(field), schema);
     }
 
     return rootNode;
@@ -303,9 +321,9 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
       if (null != _mergedTextIndexFieldSpec && !mergedTextIndexMap.isEmpty()) {
         List<String> luceneDocuments = getLuceneDocumentsFromMergedTextIndexMap(mergedTextIndexMap);
         if (_mergedTextIndexFieldSpec.isSingleValueField()) {
-          outputRecord.putValue(_transformerConfig.getMergedTextIndexField(), String.join(" ", luceneDocuments));
+          outputRecord.putValue(_mergedTextIndexFieldSpec.getName(), String.join(" ", luceneDocuments));
         } else {
-          outputRecord.putValue(_transformerConfig.getMergedTextIndexField(), luceneDocuments);
+          outputRecord.putValue(_mergedTextIndexFieldSpec.getName(), luceneDocuments);
         }
       }
     } catch (Exception e) {
@@ -382,23 +400,33 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
 
     String keyJsonPath = String.join(".", jsonPath);
 
-    if (_transformerConfig.getFieldPathsToPreserveInput().contains(keyJsonPath)
-        || _transformerConfig.getFieldPathsToPreserveInputWithIndex().contains(keyJsonPath)) {
-      outputRecord.putValue(keyJsonPath, value);
-      if (_transformerConfig.getFieldPathsToPreserveInputWithIndex().contains(keyJsonPath)) {
-        flattenAndAddToMergedTextIndexMap(mergedTextIndexMap, keyJsonPath, value);
-      }
-      return extraFieldsContainer;
-    }
-
     Set<String> fieldPathsToDrop = _transformerConfig.getFieldPathsToDrop();
     if (null != fieldPathsToDrop && fieldPathsToDrop.contains(keyJsonPath)) {
       return extraFieldsContainer;
     }
 
-    SchemaTreeNode currentNode = parentNode == null ? null : parentNode.getChild(key);
+    SchemaTreeNode currentNode =
+        parentNode == null ? null : parentNode.getChild(key, _transformerConfig.isUseAnonymousDotInFieldNames());
+    if (_transformerConfig.getFieldPathsToPreserveInput().contains(keyJsonPath)
+        || _transformerConfig.getFieldPathsToPreserveInputWithIndex().contains(keyJsonPath)) {
+      if (currentNode != null) {
+        outputRecord.putValue(currentNode.getColumnName(), currentNode.getValue(value));
+      } else {
+        outputRecord.putValue(keyJsonPath, value);
+      }
+      if (_transformerConfig.getFieldPathsToPreserveInputWithIndex().contains(keyJsonPath)) {
+        flattenAndAddToMergedTextIndexMap(mergedTextIndexMap, keyJsonPath, value);
+      }
+      return extraFieldsContainer;
+    }
     String unindexableFieldSuffix = _transformerConfig.getUnindexableFieldSuffix();
     isIndexable = isIndexable && (null == unindexableFieldSuffix || !key.endsWith(unindexableFieldSuffix));
+
+    // return in advance to truncate the subtree if nothing left to be added
+    if (currentNode == null && !storeIndexableExtras && !storeUnindexableExtras) {
+      return extraFieldsContainer;
+    }
+
     if (value == null) {
       return extraFieldsContainer;
     }
@@ -413,12 +441,14 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
           if (_transformerConfig.getFieldsToDoubleIngest().contains(keyJsonPath)) {
             extraFieldsContainer.addIndexableEntry(key, value);
           }
-          mergedTextIndexMap.put(keyJsonPath, value);
+          mergedTextIndexMap.put(currentNode.getColumnName(), value);
         } else {
           // The field is not mapped to one of the dedicated columns in the Pinot table schema. Thus it will be put
           // into the extraField column of the table.
           if (storeIndexableExtras) {
-            extraFieldsContainer.addIndexableEntry(key, value);
+            if (!_transformerConfig.getFieldPathsToSkipStorage().contains(keyJsonPath)) {
+              extraFieldsContainer.addIndexableEntry(key, value);
+            }
             mergedTextIndexMap.put(keyJsonPath, value);
           }
         }
@@ -439,7 +469,7 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
 
   /**
    * Generate a Lucene document based on the provided key-value pair.
-   * The index document follows this format: "val:key".
+   * The index document follows this format: "val" + jsonKeyValueSeparator + "key".
    * @param kv                               used to generate text index documents
    * @param indexDocuments                   a list to store the generated index documents
    * @param mergedTextIndexDocumentMaxLength which we enforce via truncation during document generation
@@ -475,129 +505,30 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
 
   private void addLuceneDoc(List<String> indexDocuments, Integer mergedTextIndexDocumentMaxLength, String key,
       String val) {
-    // TODO: theoretically, the key length + 1 could cause integer overflow. But in reality, upstream message size
-    //  limit usually could not reach that high. We should revisit this if we see any issue.
-    if (key.length() + 1 > MAXIMUM_LUCENE_DOCUMENT_SIZE) {
+    if (key.length() + _jsonKeyValueSeparatorByteCount > MAXIMUM_LUCENE_DOCUMENT_SIZE) {
       _logger.error("The provided key's length is too long, text index document cannot be truncated");
       return;
     }
 
     // Truncate the value to ensure the generated index document is less or equal to mergedTextIndexDocumentMaxLength
-    // The value length should be the mergedTextIndexDocumentMaxLength minus ":" character (length 1) minus key length
-    int valueTruncationLength = mergedTextIndexDocumentMaxLength - 1 - key.length();
+    // The value length should be the mergedTextIndexDocumentMaxLength minus key length, and then minus the byte length
+    // of ":" or the specified Json key value separator character
+    int valueTruncationLength = mergedTextIndexDocumentMaxLength - _jsonKeyValueSeparatorByteCount - key.length();
     if (val.length() > valueTruncationLength) {
       _realtimeMergedTextIndexTruncatedDocumentSizeMeter = _serverMetrics
           .addMeteredTableValue(_tableName, ServerMeter.REALTIME_MERGED_TEXT_IDX_TRUNCATED_DOCUMENT_SIZE,
-              key.length() + 1 + val.length(), _realtimeMergedTextIndexTruncatedDocumentSizeMeter);
+              key.length() + _jsonKeyValueSeparatorByteCount + val.length(),
+              _realtimeMergedTextIndexTruncatedDocumentSizeMeter);
       val = val.substring(0, valueTruncationLength);
     }
 
-    _mergedTextIndexDocumentBytesCount += key.length() + 1 + val.length();
+    _mergedTextIndexDocumentBytesCount += key.length() + _jsonKeyValueSeparatorByteCount + val.length();
     _mergedTextIndexDocumentCount += 1;
     _serverMetrics.setValueOfTableGauge(_tableName, ServerGauge.REALTIME_MERGED_TEXT_IDX_DOCUMENT_AVG_LEN,
         _mergedTextIndexDocumentBytesCount / _mergedTextIndexDocumentCount);
 
-    indexDocuments.add(val + ":" + key);
-  }
-
-  /**
-   * Implement shingling for the merged text index based on the provided key-value pair.
-   * Each shingled index document retains the format of a standard index document: "val:key". However, "val" now
-   * denotes a sliding window of characters on the value. The total length of each shingled index document
-   * (key length + shingled value length + 1）must be less than or equal to shingleIndexMaxLength. The starting index
-   * of the sliding window for the value is increased by shinglingOverlapLength for every new shingled document.
-   * All shingle index documents, except for the last one, should have the maximum possible length. If the minimum
-   * document length (shingling overlap length + key length + 1) exceeds the maximum Lucene document size
-   * (MAXIMUM_LUCENE_DOCUMENT_SIZE), shingling is disabled, and the value is truncated to match the maximum Lucene
-   * document size. If shingleIndexMaxLength is lower than the required minimum document length and also lower than
-   * the maximum
-   * Lucene document size, shingleIndexMaxLength is adjusted to match the maximum Lucene document size.
-   *
-   * Note that the most important parameter, the shingleIndexOverlapLength, is the maximum search length that will yield
-   * results with 100% accuracy.
-   *
-   * Example: key-> "key", value-> "0123456789ABCDEF", max length: 10, shingling overlap length: 3
-   * Generated documents:
-   * 012345:key
-   *    345678:key
-   *       6789AB:key
-   *          9ABCDE:key
-   *             CDEF:key
-   * Any query with a length of 7 will yield no results, such as "0123456" or "6789ABC".
-   * Any query with a length of 3 will yield results with 100% accuracy (i.e. is always guaranteed to be searchable).
-   * Any query with a length between 4 and 6 (inclusive) has indeterminate accuracy.
-   * E.g. for queries with length 5, "12345", "789AB" will hit, while "23456" will miss.
-   *
-   * @param kv                        used to generate shingle text index documents
-   * @param shingleIndexDocuments        a list to store the generated shingle index documents
-   * @param shingleIndexMaxLength     the maximum length of each shingle index document. Needs to be greater than the
-   *                                  length of the key and shingleIndexOverlapLength + 1, and must be lower or equal
-   *                                  to MAXIMUM_LUCENE_DOCUMENT_SIZE.
-   * @param shingleIndexOverlapLength the number of characters in the kv-pair's value shared by two adjacent shingle
-   *                                  index documents. If null, the overlap length will be defaulted to half of the max
-   *                                  document length.
-   */
-  public void generateShingleTextIndexDocument(Map.Entry<String, Object> kv, List<String> shingleIndexDocuments,
-      int shingleIndexMaxLength, int shingleIndexOverlapLength) {
-    String key = kv.getKey();
-    String val;
-    // To avoid redundant leading and tailing '"', only convert to JSON string if the value is a list or an array
-    if (kv.getValue() instanceof Collection || kv.getValue() instanceof Object[]) {
-      try {
-        val = JsonUtils.objectToString(kv.getValue());
-      } catch (JsonProcessingException e) {
-        val = kv.getValue().toString();
-      }
-    } else {
-      val = kv.getValue().toString();
-    }
-    final int valLength = val.length();
-    final int documentSuffixLength = key.length() + 1;
-    final int minDocumentLength = documentSuffixLength + shingleIndexOverlapLength + 1;
-
-    if (shingleIndexOverlapLength >= valLength) {
-      if (_logger.isDebugEnabled()) {
-        _logger.warn(
-            "The shingleIndexOverlapLength {} is longer than the value length {}. Shingling will not be applied since "
-                + "only one document will be generated.", shingleIndexOverlapLength, valLength);
-      }
-      generateTextIndexLuceneDocument(kv, shingleIndexDocuments, shingleIndexMaxLength);
-      return;
-    }
-
-    if (minDocumentLength > MAXIMUM_LUCENE_DOCUMENT_SIZE) {
-      _logger.debug("The minimum document length {} (" + MIN_DOCUMENT_LENGTH_DESCRIPTION
-          + ")  exceeds the limit of maximum Lucene document size " + MAXIMUM_LUCENE_DOCUMENT_SIZE
-          + ". Value will be truncated and shingling will not be applied.", minDocumentLength);
-      generateTextIndexLuceneDocument(kv, shingleIndexDocuments, shingleIndexMaxLength);
-      return;
-    }
-
-    // This logging becomes expensive if user accidentally sets a very low shingleIndexMaxLength
-    if (shingleIndexMaxLength < minDocumentLength) {
-      _logger.debug("The shingleIndexMaxLength {} is smaller than the minimum document length {} ("
-          + MIN_DOCUMENT_LENGTH_DESCRIPTION + "). Increasing the shingleIndexMaxLength to maximum Lucene document size "
-          + MAXIMUM_LUCENE_DOCUMENT_SIZE + ".", shingleIndexMaxLength, minDocumentLength);
-      shingleIndexMaxLength = MAXIMUM_LUCENE_DOCUMENT_SIZE;
-    }
-
-    // Shingle window slide length is the index position on the value which we shall advance on every iteration.
-    // We ensure shingleIndexMaxLength >= minDocumentLength so that shingleWindowSlideLength >= 1.
-    int shingleWindowSlideLength = shingleIndexMaxLength - shingleIndexOverlapLength - documentSuffixLength;
-
-    // Generate shingle index documents
-    // When starting_idx + shingleIndexOverlapLength >= valLength, there are no new characters to capture, then we stop
-    // the shingle document generation loop.
-    // We ensure that shingleIndexOverlapLength < valLength so that this loop will be entered at lease once.
-    for (int i = 0; i + shingleIndexOverlapLength < valLength; i += shingleWindowSlideLength) {
-      String documentValStr = val.substring(i, Math.min(i + shingleIndexMaxLength - documentSuffixLength, valLength));
-      String shingleIndexDocument = documentValStr + ":" + key;
-      shingleIndexDocuments.add(shingleIndexDocument);
-      _mergedTextIndexDocumentBytesCount += shingleIndexDocument.length();
-      ++_mergedTextIndexDocumentCount;
-    }
-    _serverMetrics.setValueOfTableGauge(_tableName, ServerGauge.REALTIME_MERGED_TEXT_IDX_DOCUMENT_AVG_LEN,
-        _mergedTextIndexDocumentBytesCount / _mergedTextIndexDocumentCount);
+    addKeyValueToDocuments(indexDocuments, key, val, _transformerConfig.isReverseTextIndexKeyValueOrder(),
+        _transformerConfig.isOptimizeCaseInsensitiveSearch());
   }
 
   private void flattenAndAddToMergedTextIndexMap(Map<String, Object> mergedTextIndexMap, String key, Object value) {
@@ -643,22 +574,41 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
   private List<String> getLuceneDocumentsFromMergedTextIndexMap(Map<String, Object> mergedTextIndexMap) {
     final Integer mergedTextIndexDocumentMaxLength = _transformerConfig.getMergedTextIndexDocumentMaxLength();
     final @Nullable
-    Integer mergedTextIndexShinglingOverlapLength = _transformerConfig.getMergedTextIndexShinglingOverlapLength();
     List<String> luceneDocuments = new ArrayList<>();
     mergedTextIndexMap.entrySet().stream().filter(kv -> null != kv.getKey() && null != kv.getValue())
         .filter(kv -> !_transformerConfig.getMergedTextIndexPathToExclude().contains(kv.getKey())).filter(
         kv -> !base64ValueFilter(kv.getValue().toString().getBytes(),
             _transformerConfig.getMergedTextIndexBinaryDocumentDetectionMinLength())).filter(
-        kv -> _transformerConfig.getMergedTextIndexSuffixToExclude().stream()
-            .anyMatch(suffix -> !kv.getKey().endsWith(suffix))).forEach(kv -> {
-      if (null == mergedTextIndexShinglingOverlapLength) {
-        generateTextIndexLuceneDocument(kv, luceneDocuments, mergedTextIndexDocumentMaxLength);
-      } else {
-        generateShingleTextIndexDocument(kv, luceneDocuments, mergedTextIndexDocumentMaxLength,
-            mergedTextIndexShinglingOverlapLength);
-      }
+        kv -> !MERGED_TEXT_INDEX_SUFFIX_TO_EXCLUDE.stream()
+            .anyMatch(suffix -> kv.getKey().endsWith(suffix))).forEach(kv -> {
+      generateTextIndexLuceneDocument(kv, luceneDocuments, mergedTextIndexDocumentMaxLength);
     });
     return luceneDocuments;
+  }
+
+  private void addKeyValueToDocuments(List<String> documents, String key, String value, boolean addInReverseOrder,
+      boolean addCaseInsensitiveVersion) {
+    addKeyValueToDocumentWithOrder(documents, key, value, addInReverseOrder);
+
+    // To optimize the case insensitive search, add the lower case version if applicable
+    // Note that we only check the value as Key is always case-sensitive search
+    if (addCaseInsensitiveVersion && value.chars().anyMatch(Character::isUpperCase)) {
+      addKeyValueToDocumentWithOrder(documents, key, value.toLowerCase(Locale.ENGLISH), addInReverseOrder);
+    }
+  }
+
+  private void addKeyValueToDocumentWithOrder(List<String> documents, String key, String value,
+      boolean addInReverseOrder) {
+    // Not doing refactor here to avoid allocating new intermediate string
+    if (addInReverseOrder) {
+      documents.add(_transformerConfig.getMergedTextIndexBeginOfDocAnchor() + value
+          + _transformerConfig.getJsonKeyValueSeparator() + key
+          + _transformerConfig.getMergedTextIndexEndOfDocAnchor());
+    } else {
+      documents.add(_transformerConfig.getMergedTextIndexBeginOfDocAnchor() + key
+          + _transformerConfig.getJsonKeyValueSeparator() + value
+          + _transformerConfig.getMergedTextIndexEndOfDocAnchor());
+    }
   }
 }
 
@@ -677,16 +627,16 @@ public class SchemaConformingTransformerV2 implements RecordTransformer {
  */
 class SchemaTreeNode {
   private boolean _isColumn;
-  private Map<String, SchemaTreeNode> _children;
+  private final Map<String, SchemaTreeNode> _children;
   // Taking the example of key "x.y.z", the keyName will be "z" and the parentPath will be "x.y"
   // Root node would have keyName as "" and parentPath as null
   // Root node's children will have keyName as the first level key and parentPath as ""
   @Nonnull
-  private String _keyName;
+  private final String _keyName;
   @Nullable
   private String _columnName;
   @Nullable
-  private String _parentPath;
+  private final String _parentPath;
   private FieldSpec _fieldSpec;
 
   public SchemaTreeNode(String keyName, String parentPath, Schema schema) {
@@ -700,11 +650,12 @@ class SchemaTreeNode {
     return _isColumn;
   }
 
-  public void setColumn(String columnName) {
+  public void setColumn(String columnName, Schema schema) {
     if (columnName == null) {
       _columnName = getJsonKeyPath();
     } else {
       _columnName = columnName;
+      _fieldSpec = schema.getFieldSpecFor(columnName);
     }
     _isColumn = true;
   }
@@ -728,8 +679,24 @@ class SchemaTreeNode {
     return child;
   }
 
-  public SchemaTreeNode getChild(String key) {
+  private SchemaTreeNode getChild(String key) {
     return _children.get(key);
+  }
+
+  public SchemaTreeNode getChild(String key, boolean useAnonymousDot) {
+    if (useAnonymousDot && key.contains(".")) {
+      SchemaTreeNode node = this;
+      for (String subKey : key.split("\\.")) {
+        if (node != null) {
+          node = node.getChild(subKey);
+        } else {
+          return null;
+        }
+      }
+      return node;
+    } else {
+      return getChild(key);
+    }
   }
 
   public String getKeyName() {
@@ -750,6 +717,9 @@ class SchemaTreeNode {
         }
         if (value instanceof Object[]) {
           return JsonUtils.objectToString(Arrays.asList((Object[]) value));
+        }
+        if (value instanceof Map) {
+          return JsonUtils.objectToString(value);
         }
       } catch (JsonProcessingException e) {
         return value.toString();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/SchemaConformingTransformerV2Config.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/SchemaConformingTransformerV2Config.java
@@ -16,19 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pinot.spi.config.table.ingestion;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+
 
 public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   @JsonPropertyDescription("Enable indexable extras")
@@ -58,24 +58,31 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
       + "input. This will NOT skip building mergedTextIndex for the field.")
   private Set<String> _fieldPathsToPreserveInputWithIndex = new HashSet<>();
 
+  @JsonPropertyDescription("Array of flattened (dot-delimited) object paths not to store but only build "
+      + "mergedTextIndex for the field.")
+  private Set<String> _fieldPathsToSkipStorage = Set.of("message");
+
   @JsonPropertyDescription("Map from customized meaningful column name to json key path")
   private Map<String, String> _columnNameToJsonKeyPathMap = new HashMap<>();
 
   @JsonPropertyDescription("mergedTextIndex field")
   private String _mergedTextIndexField = "__mergedTextIndex";
 
+  @JsonPropertyDescription(
+      "If set to true {'a.b': 'c'} will be indexed in the same way as {'a': {'b': 'c}}. Otherwise, "
+          + "the former one will be ignored.")
+  private Boolean _useAnonymousDotInFieldNames = true;
+
+  @JsonPropertyDescription("Whether to store extra lower cases value:key pairs in __mergedTextIndex to optimize case "
+      + "insensitive queries")
+  private Boolean _optimizeCaseInsensitiveSearch = false;
+
+  @JsonPropertyDescription("Whether to store key and value in reverse order, if true store as value:key, else store"
+      + " as key:value")
+  private Boolean _reverseTextIndexKeyValueOrder = true;
+
   @JsonPropertyDescription("mergedTextIndex document max length")
   private int _mergedTextIndexDocumentMaxLength = 32766;
-
-  @JsonPropertyDescription(
-      "Recall that merged text index document is in the format of <value:key>. "
-          + "The mergedTextIndex shingling overlap length refers to the "
-          + "maximum search length of the value that will yield results with "
-          + "100% accuracy. If the value is null, shingle index will be turned off "
-          + "and the value will be truncated such that the document is equal to "
-          + "_mergedTextIndexDocumentMaxLength"
-  )
-  private @Nullable Integer _mergedTextIndexShinglingOverlapLength = null;
 
   @JsonPropertyDescription("mergedTextIndex binary document detection minimum length")
   private Integer _mergedTextIndexBinaryDocumentDetectionMinLength = 512;
@@ -83,30 +90,44 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   @JsonPropertyDescription("Array of paths to exclude from merged text index.")
   private Set<String> _mergedTextIndexPathToExclude = new HashSet<>();
 
-  // TODO: set default value from CLPRewriter once it open sourced
-  @JsonPropertyDescription("Array of suffix to exclude from merged text index.")
-  private List<String> _mergedTextIndexSuffixToExclude = Arrays.asList("_logtype", "_dictionaryVars", "_encodedVars");
+  @JsonPropertyDescription("Anchor before merged text index value. Default is empty String")
+  private String _mergedTextIndexBeginOfDocAnchor = "";
+
+  @JsonPropertyDescription("Anchor after merged text index value. Default is empty String")
+  private String _mergedTextIndexEndOfDocAnchor = "";
 
   @JsonPropertyDescription("Dedicated fields to double ingest into json_data column")
   private Set<String> _fieldsToDoubleIngest = new HashSet<>();
 
+  @JsonPropertyDescription("Separator between key and value in json used in the Lucene index. Default is ':'.")
+  private String _jsonKeyValueSeparator = ":";
+
   @JsonCreator
   public SchemaConformingTransformerV2Config(
       @JsonProperty("enableIndexableExtras") @Nullable Boolean enableIndexableExtras,
-      @JsonProperty("indexableExtrasField") String indexableExtrasField,
+      @JsonProperty("indexableExtrasField") @Nullable String indexableExtrasField,
       @JsonProperty("enableUnindexableExtras") @Nullable Boolean enableUnindexableExtras,
       @JsonProperty("unindexableExtrasField") @Nullable String unindexableExtrasField,
       @JsonProperty("unindexableFieldSuffix") @Nullable String unindexableFieldSuffix,
       @JsonProperty("fieldPathsToDrop") @Nullable Set<String> fieldPathsToDrop,
       @JsonProperty("fieldPathsToKeepSameAsInput") @Nullable Set<String> fieldPathsToPreserveInput,
       @JsonProperty("fieldPathsToKeepSameAsInputWithIndex") @Nullable Set<String> fieldPathsToPreserveInputWithIndex,
-      @JsonProperty("mergedTextIndexField") @Nullable String mergedTextIndexField,
+      @JsonProperty("fieldPathsToSkipStorage") @Nullable Set<String> fieldPathsToSkipStorage,
+      @JsonProperty("columnNameToJsonKeyPathMap") @Nullable Map<String, String> columnNameToJsonKeyPathMap,
+      @JsonProperty("mergedTextIndexField") @Nullable String mergedTextIndexFields,
+      @JsonProperty("useAnonymousDotInFieldNames") @Nullable Boolean useAnonymousDotInFieldNames,
+      @JsonProperty("optimizeCaseInsensitiveSearch") @Nullable Boolean optimizeCaseInsensitiveSearch,
+      @JsonProperty("reverseTextIndexKeyValueOrder") @Nullable Boolean reverseTextIndexKeyValueOrder,
       @JsonProperty("mergedTextIndexDocumentMaxLength") @Nullable Integer mergedTextIndexDocumentMaxLength,
-      @JsonProperty("mergedTextIndexShinglingOverlapLength") @Nullable Integer mergedTextIndexShinglingOverlapLength,
+      @JsonProperty("mergedTextIndexBinaryTokenDetectionMinLength")
+      @Nullable Integer mergedTextIndexBinaryTokenDetectionMinLength, // Deprecated, add it to be backward compatible
       @JsonProperty("mergedTextIndexBinaryDocumentDetectionMinLength")
       @Nullable Integer mergedTextIndexBinaryDocumentDetectionMinLength,
       @JsonProperty("mergedTextIndexPathToExclude") @Nullable Set<String> mergedTextIndexPathToExclude,
-      @JsonProperty("fieldsToDoubleIngest") @Nullable Set<String> fieldsToDoubleIngest
+      @JsonProperty("fieldsToDoubleIngest") @Nullable Set<String> fieldsToDoubleIngest,
+      @JsonProperty("jsonKeyValueSeparator") @Nullable String jsonKeyValueSeparator,
+      @JsonProperty("mergedTextIndexBeginOfDocAnchor") @Nullable String mergedTextIndexBeginOfDocAnchor,
+      @JsonProperty("mergedTextIndexEndOfDocAnchor") @Nullable String mergedTextIndexEndOfDocAnchor
   ) {
     setEnableIndexableExtras(enableIndexableExtras);
     setIndexableExtrasField(indexableExtrasField);
@@ -116,17 +137,30 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
     setFieldPathsToDrop(fieldPathsToDrop);
     setFieldPathsToPreserveInput(fieldPathsToPreserveInput);
     setFieldPathsToPreserveInputWithIndex(fieldPathsToPreserveInputWithIndex);
+    setFieldPathsToSkipStorage(fieldPathsToSkipStorage);
+    setColumnNameToJsonKeyPathMap(columnNameToJsonKeyPathMap);
 
-    setMergedTextIndexField(mergedTextIndexField);
+    setMergedTextIndexField(mergedTextIndexFields);
+    setUseAnonymousDotInFieldNames(useAnonymousDotInFieldNames);
+    setOptimizeCaseInsensitiveSearch(optimizeCaseInsensitiveSearch);
+    setReverseTextIndexKeyValueOrder(reverseTextIndexKeyValueOrder);
     setMergedTextIndexDocumentMaxLength(mergedTextIndexDocumentMaxLength);
-    setMergedTextIndexShinglingDocumentOverlapLength(mergedTextIndexShinglingOverlapLength);
+    mergedTextIndexBinaryDocumentDetectionMinLength = mergedTextIndexBinaryDocumentDetectionMinLength == null
+        ? mergedTextIndexBinaryTokenDetectionMinLength : mergedTextIndexBinaryDocumentDetectionMinLength;
     setMergedTextIndexBinaryDocumentDetectionMinLength(mergedTextIndexBinaryDocumentDetectionMinLength);
     setMergedTextIndexPathToExclude(mergedTextIndexPathToExclude);
     setFieldsToDoubleIngest(fieldsToDoubleIngest);
+    setJsonKeyValueSeparator(jsonKeyValueSeparator);
+    setMergedTextIndexBeginOfDocAnchor(mergedTextIndexBeginOfDocAnchor);
+    setMergedTextIndexEndOfDocAnchor(mergedTextIndexEndOfDocAnchor);
+  }
+
+  public Boolean isEnableIndexableExtras() {
+    return _enableIndexableExtras;
   }
 
   public SchemaConformingTransformerV2Config setEnableIndexableExtras(Boolean enableIndexableExtras) {
-    _enableIndexableExtras = enableIndexableExtras == null ? _enableUnindexableExtras : enableIndexableExtras;
+    _enableIndexableExtras = enableIndexableExtras == null ? _enableIndexableExtras : enableIndexableExtras;
     return this;
   }
 
@@ -137,6 +171,10 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   public SchemaConformingTransformerV2Config setIndexableExtrasField(String indexableExtrasField) {
     _indexableExtrasField = indexableExtrasField == null ? _indexableExtrasField : indexableExtrasField;
     return this;
+  }
+
+  public Boolean isEnableUnindexableExtras() {
+    return _enableUnindexableExtras;
   }
 
   public SchemaConformingTransformerV2Config setEnableUnindexableExtras(Boolean enableUnindexableExtras) {
@@ -181,6 +219,15 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
     return this;
   }
 
+  public Set<String> getFieldPathsToSkipStorage() {
+    return _fieldPathsToSkipStorage;
+  }
+
+  public SchemaConformingTransformerV2Config setFieldPathsToSkipStorage(Set<String> fieldPathsToSkipStorage) {
+    _fieldPathsToSkipStorage = fieldPathsToSkipStorage == null ? _fieldPathsToSkipStorage : fieldPathsToSkipStorage;
+    return this;
+  }
+
   public Set<String> getFieldPathsToPreserveInputWithIndex() {
     return _fieldPathsToPreserveInputWithIndex;
   }
@@ -189,7 +236,7 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
       Set<String> fieldPathsToPreserveInputWithIndex) {
     _fieldPathsToPreserveInputWithIndex =
         fieldPathsToPreserveInputWithIndex == null ? _fieldPathsToPreserveInputWithIndex
-        : fieldPathsToPreserveInputWithIndex;
+            : fieldPathsToPreserveInputWithIndex;
     return this;
   }
 
@@ -213,6 +260,36 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
     return this;
   }
 
+  public Boolean isUseAnonymousDotInFieldNames() {
+    return _useAnonymousDotInFieldNames;
+  }
+
+  public SchemaConformingTransformerV2Config setUseAnonymousDotInFieldNames(Boolean useAnonymousDotInFieldNames) {
+    _useAnonymousDotInFieldNames = useAnonymousDotInFieldNames == null ? _useAnonymousDotInFieldNames
+        : useAnonymousDotInFieldNames;
+    return this;
+  }
+
+  public Boolean isOptimizeCaseInsensitiveSearch() {
+    return _optimizeCaseInsensitiveSearch;
+  }
+
+  public SchemaConformingTransformerV2Config setOptimizeCaseInsensitiveSearch(Boolean optimizeCaseInsensitiveSearch) {
+    _optimizeCaseInsensitiveSearch = optimizeCaseInsensitiveSearch == null ? _optimizeCaseInsensitiveSearch
+        : optimizeCaseInsensitiveSearch;
+    return this;
+  }
+
+  public Boolean isReverseTextIndexKeyValueOrder() {
+    return _reverseTextIndexKeyValueOrder;
+  }
+
+  public SchemaConformingTransformerV2Config setReverseTextIndexKeyValueOrder(Boolean reverseTextIndexKeyValueOrder) {
+    _reverseTextIndexKeyValueOrder = reverseTextIndexKeyValueOrder == null ? _reverseTextIndexKeyValueOrder
+        : reverseTextIndexKeyValueOrder;
+    return this;
+  }
+
   public Integer getMergedTextIndexDocumentMaxLength() {
     return _mergedTextIndexDocumentMaxLength;
   }
@@ -222,16 +299,6 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
   ) {
     _mergedTextIndexDocumentMaxLength = mergedTextIndexDocumentMaxLength == null
         ? _mergedTextIndexDocumentMaxLength : mergedTextIndexDocumentMaxLength;
-    return this;
-  }
-
-  public Integer getMergedTextIndexShinglingOverlapLength() {
-    return _mergedTextIndexShinglingOverlapLength;
-  }
-
-  public SchemaConformingTransformerV2Config setMergedTextIndexShinglingDocumentOverlapLength(
-      Integer mergedTextIndexShinglingOverlapLength) {
-    _mergedTextIndexShinglingOverlapLength = mergedTextIndexShinglingOverlapLength;
     return this;
   }
 
@@ -250,10 +317,6 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
     return _mergedTextIndexPathToExclude;
   }
 
-  public List<String> getMergedTextIndexSuffixToExclude() {
-    return _mergedTextIndexSuffixToExclude;
-  }
-
   public SchemaConformingTransformerV2Config setMergedTextIndexPathToExclude(Set<String> mergedTextIndexPathToExclude) {
     _mergedTextIndexPathToExclude = mergedTextIndexPathToExclude == null
         ? _mergedTextIndexPathToExclude : mergedTextIndexPathToExclude;
@@ -266,6 +329,35 @@ public class SchemaConformingTransformerV2Config extends BaseJsonConfig {
 
   public SchemaConformingTransformerV2Config setFieldsToDoubleIngest(Set<String> fieldsToDoubleIngest) {
     _fieldsToDoubleIngest = fieldsToDoubleIngest == null ? _fieldsToDoubleIngest : fieldsToDoubleIngest;
+    return this;
+  }
+
+  public String getJsonKeyValueSeparator() {
+    return _jsonKeyValueSeparator;
+  }
+
+  public void setJsonKeyValueSeparator(@Nullable String jsonKeyValueSeparator) {
+    _jsonKeyValueSeparator = jsonKeyValueSeparator == null ? ":" : jsonKeyValueSeparator;
+  }
+
+  public String getMergedTextIndexBeginOfDocAnchor() {
+    return _mergedTextIndexBeginOfDocAnchor;
+  }
+
+  public SchemaConformingTransformerV2Config setMergedTextIndexBeginOfDocAnchor(
+      String mergedTextIndexBeginOfDocAnchor) {
+    _mergedTextIndexBeginOfDocAnchor = mergedTextIndexBeginOfDocAnchor == null
+        ? _mergedTextIndexBeginOfDocAnchor : mergedTextIndexBeginOfDocAnchor;
+    return this;
+  }
+
+  public String getMergedTextIndexEndOfDocAnchor() {
+    return _mergedTextIndexEndOfDocAnchor;
+  }
+
+  public SchemaConformingTransformerV2Config setMergedTextIndexEndOfDocAnchor(String mergedTextIndexEndOfDocAnchor) {
+    _mergedTextIndexEndOfDocAnchor = mergedTextIndexEndOfDocAnchor == null
+        ? _mergedTextIndexEndOfDocAnchor : mergedTextIndexEndOfDocAnchor;
     return this;
   }
 }


### PR DESCRIPTION
`feature``bugfix` `backward-incompat`
This PR will converge the open source SchemaConformingTransformerV2 with Uber internal's version. The later one has been running in real production environment for a long time with large scale of data. The convergence would clean up some function that we found not useful and also added some function that we found required.
There would also be a complete user manual/instruction to be release to expose to broader public usages.

Clean up:

- Shingling merged text index generation

New functionalities:

- Enhance case insensitive search by adding extra values to merged text index by `optimizeCaseInsensitiveSearch = true`.
- Customize merged text index to do search by either key:value order or value:key order by `reverseTextIndexKeyValueOrder`.
- Customize the document begin anchor, end anchor and key/value separator. This could optimize the prefix match, suffix match and avoid the confusions when searching ":". Use `mergedTextIndexBeginOfDocAnchor` `mergedTextIndexEndOfDocAnchor` and `jsonKeyValueSeparator`.
- Add functionality to skip indexing some special fields by `fieldPathsToSkipStorage`.
- Add functionality to index document keys with ".". For example, {"a.b": 1} could only be put to json_data even though there is dedicated column "a.b" because "a.b" was always translated to {"a": {"b": 1}}. With the config `useAnonymousDotInFieldNames` enabled, both would end in the same "a.b" column.
