### PR TITLE
Make RecordExtractor preserve empty array/map and map entries with empty value

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,13 +46,12 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
     AvroRecordExtractorConfig config = (AvroRecordExtractorConfig) recordExtractorConfig;
     if (config != null) {
       _applyLogicalTypes = config.isEnableLogicalTypes();
-      _differentiateNullAndEmptyForMV = config.isDifferentiateNullAndEmptyForMV();
     }
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
-      _fields = Collections.emptySet();
+      _fields = Set.of();
     } else {
-      _fields = ImmutableSet.copyOf(fields);
+      _fields = Set.copyOf(fields);
     }
   }
 
@@ -108,22 +105,15 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
    *              without checking
    */
   @Override
-  @Nullable
-  protected Object convertRecord(Object value) {
+  protected Map<Object, Object> convertRecord(Object value) {
     GenericRecord record = (GenericRecord) value;
     List<Schema.Field> fields = record.getSchema().getFields();
-    if (fields.isEmpty()) {
-      return null;
-    }
-
-    Map<Object, Object> convertedMap = new HashMap<>();
+    Map<Object, Object> convertedMap = Maps.newHashMapWithExpectedSize(fields.size());
     for (Schema.Field field : fields) {
       String fieldName = field.name();
       Object fieldValue = record.get(fieldName);
-      if (fieldValue != null) {
-        fieldValue = transformValue(fieldValue, field);
-      }
-      convertedMap.put(fieldName, fieldValue);
+      Object convertedValue = fieldValue != null ? transformValue(fieldValue, field) : null;
+      convertedMap.put(fieldName, convertedValue);
     }
     return convertedMap;
   }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
@@ -27,12 +27,10 @@ import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
  */
 public class AvroRecordExtractorConfig implements RecordExtractorConfig {
   private boolean _enableLogicalTypes = false;
-  private boolean _differentiateNullAndEmptyForMV = false;
 
   @Override
   public void init(Map<String, String> props) {
     _enableLogicalTypes = Boolean.parseBoolean(props.get("enableLogicalTypes"));
-    _differentiateNullAndEmptyForMV = Boolean.parseBoolean(props.get("differentiateNullAndEmptyForMV"));
   }
 
   public boolean isEnableLogicalTypes() {
@@ -41,13 +39,5 @@ public class AvroRecordExtractorConfig implements RecordExtractorConfig {
 
   public void setEnableLogicalTypes(boolean enableLogicalTypes) {
     _enableLogicalTypes = enableLogicalTypes;
-  }
-
-  public boolean isDifferentiateNullAndEmptyForMV() {
-    return _differentiateNullAndEmptyForMV;
-  }
-
-  public void setDifferentiateNullAndEmptyForMV(boolean differentiateNullAndEmptyForMV) {
-    _differentiateNullAndEmptyForMV = differentiateNullAndEmptyForMV;
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -23,7 +23,6 @@ import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
 import com.yscope.clp.compressorfrontend.EncodedMessage;
 import com.yscope.clp.compressorfrontend.MessageEncoder;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -103,7 +102,7 @@ public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Objec
     _config = (CLPLogRecordExtractorConfig) recordExtractorConfig;
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
-      _fields = Collections.emptySet();
+      _fields = Set.of();
     } else {
       _fields = new HashSet<>(fields);
       // Remove the fields to be CLP-encoded to make it easier to work with them

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.csv;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.csv.CSVRecord;
@@ -42,7 +41,7 @@ public class CSVRecordExtractor extends BaseRecordExtractor<CSVRecord> {
     if (fields == null || fields.isEmpty()) {
       _fields = csvRecordExtractorConfig.getColumnNames();
     } else {
-      _fields = ImmutableSet.copyOf(fields);
+      _fields = Set.copyOf(fields);
     }
     _multiValueDelimiter = csvRecordExtractorConfig.getMultiValueDelimiter();
   }
@@ -56,11 +55,8 @@ public class CSVRecordExtractor extends BaseRecordExtractor<CSVRecord> {
     return to;
   }
 
-  @Override
-  @Nullable
-  public Object convert(@Nullable Object value) {
-    String stringValue = (String) value;
-    if (stringValue == null || StringUtils.isEmpty(stringValue)) {
+  private Object convert(@Nullable String value) {
+    if (value == null || StringUtils.isEmpty(value)) {
       return null;
       // NOTE about CSV behavior for empty string e.g. foo,bar,,zoo or foo,bar,"",zoo. These both are equivalent to a
       // CSVParser
@@ -70,11 +66,11 @@ public class CSVRecordExtractor extends BaseRecordExtractor<CSVRecord> {
 
     // If the delimiter is not set, then return the value as is
     if (_multiValueDelimiter == null) {
-      return stringValue;
+      return value;
     }
 
-    final String[] stringValues = StringUtils.split(stringValue, _multiValueDelimiter);
-    final int numValues = stringValues.length;
+    String[] stringValues = StringUtils.split(value, _multiValueDelimiter);
+    int numValues = stringValues.length;
 
     // NOTE about CSV behavior for multi value column - cannot distinguish between multi value column with just 1
     // entry vs single value
@@ -88,7 +84,7 @@ public class CSVRecordExtractor extends BaseRecordExtractor<CSVRecord> {
       }
       return array;
     } else {
-      return stringValue;
+      return value;
     }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.json;
 
-import com.google.common.collect.ImmutableSet;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -40,9 +38,9 @@ public class JSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
   public void init(Set<String> fields, @Nullable RecordExtractorConfig recordExtractorConfig) {
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
-      _fields = Collections.emptySet();
+      _fields = Set.of();
     } else {
-      _fields = ImmutableSet.copyOf(fields);
+      _fields = Set.copyOf(fields);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -165,10 +165,9 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     int recordsRead = 0;
     while (avroRecordReader.hasNext()) {
       Assert.assertTrue(nativeRecordReader.hasNext());
-      final GenericRow avroReaderRow = avroRecordReader.next(avroReuse);
-      final GenericRow nativeReaderRow = nativeRecordReader.next(nativeReuse);
-      Assert.assertEquals(nativeReaderRow.toString(), avroReaderRow.toString());
-      Assert.assertTrue(avroReaderRow.equals(nativeReaderRow));
+      avroReuse.clear();
+      nativeReuse.clear();
+      Assert.assertEquals(avroRecordReader.next(avroReuse), nativeRecordReader.next(nativeReuse));
       recordsRead++;
     }
     Assert.assertFalse(nativeRecordReader.hasNext());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.spi.data.readers;
 
+import com.google.common.collect.Maps;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.apache.commons.lang3.ArrayUtils;
 
 
 /**
@@ -31,18 +30,12 @@ import javax.annotation.Nullable;
  *
  * @param <T> the format of the input record
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
-
-  protected boolean _differentiateNullAndEmptyForMV = false;
 
   /**
    * Converts the field value to either a single value (string, number, byte[]), multi value (Object[]) or a Map.
-   * Returns {@code null} if the value is an empty array/collection/map.
-   *
-   * Natively Pinot only understands single values and multi values.
-   * Map is useful only if some ingestion transform functions operates on it in the transformation layer.
    */
-  @Nullable
   public Object convert(Object value) {
     Object convertedValue;
     if (isMultiValue(value)) {
@@ -70,7 +63,7 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
    * multi-value objects differently.
    */
   protected boolean isMultiValue(Object value) {
-    return value instanceof Collection;
+    return value instanceof Collection || (value.getClass().isArray() && !(value instanceof byte[]));
   }
 
   /**
@@ -85,90 +78,83 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
    * Handles the conversion of every field of the object for the particular data format. Override this method if the
    * extractor can convert nested record types.
    *
-   * @param value should be verified to be a record type prior to calling this method as it will be handled with this
-   *              assumption
+   * @param value should be verified to be a record type prior to calling this method
    */
-  @Nullable
-  protected Object convertRecord(Object value) {
+  protected Map<Object, Object> convertRecord(Object value) {
     throw new UnsupportedOperationException("Extractor cannot convert record type structures for this data format.");
   }
 
   /**
-   * Handles the conversion of each element of a multi-value object. Returns {@code null} if the field value is
-   * {@code null}.
+   * Handles the conversion of each element of a multi-value object, and returns an Object array. Override this method
+   * if the data format requires a different conversion for its multi-value objects.
    *
-   * This implementation converts the Collection to an Object array. Any elements of the Collection that are
-   * {@code null} will be excluded from the returned multi-value object.
-   *
-   * Override this method if the data format requires a different conversion for its multi-value objects.
-   *
-   * @param value should be verified to be a Collection type prior to calling this method as it will be casted
-   *              to a Collection without checking
+   * @param value should be verified to be a multi-value type prior to calling this method
    */
-  @Nullable
-  protected Object convertMultiValue(Object value) {
-    Collection collection = (Collection) value;
-    if (collection.isEmpty()) {
-      return _differentiateNullAndEmptyForMV ? new Object[0] : null;
+  protected Object[] convertMultiValue(Object value) {
+    if (value instanceof Collection) {
+      return convertCollection((Collection) value);
     }
+    if (value instanceof Object[]) {
+      return convertArray((Object[]) value);
+    }
+    return convertPrimitiveArray(value);
+  }
 
+  protected Object[] convertCollection(Collection collection) {
     int numValues = collection.size();
-    Object[] array = new Object[numValues];
+    Object[] convertedValues = new Object[numValues];
     int index = 0;
-    for (Object element : collection) {
-      Object convertedValue = null;
-      if (element != null) {
-        convertedValue = convert(element);
-      }
-      if (convertedValue != null) {
-        array[index++] = convertedValue;
-      }
+    for (Object value : collection) {
+      Object convertedValue = value != null ? convert(value) : null;
+      convertedValues[index++] = convertedValue;
     }
+    return convertedValues;
+  }
 
-    if (index == numValues) {
-      return array;
-    } else if (index == 0) {
-      return null;
-    } else {
-      return Arrays.copyOf(array, index);
+  protected Object[] convertArray(Object[] array) {
+    int numValues = array.length;
+    Object[] convertedValues = new Object[numValues];
+    for (int i = 0; i < numValues; i++) {
+      Object value = array[i];
+      Object convertedValue = value != null ? convert(value) : null;
+      convertedValues[i] = convertedValue;
     }
+    return convertedValues;
+  }
+
+  protected Object[] convertPrimitiveArray(Object array) {
+    if (array instanceof int[]) {
+      return ArrayUtils.toObject((int[]) array);
+    }
+    if (array instanceof long[]) {
+      return ArrayUtils.toObject((long[]) array);
+    }
+    if (array instanceof float[]) {
+      return ArrayUtils.toObject((float[]) array);
+    }
+    if (array instanceof double[]) {
+      return ArrayUtils.toObject((double[]) array);
+    }
+    throw new IllegalArgumentException("Unsupported primitive array type: " + array.getClass().getName());
   }
 
   /**
-   * Handles the conversion of every value of the map. Note that map keys will be handled as a single-value type.
-   * Returns {@code null} if the field value is {@code null}. This should be overridden if the data format requires
-   * a different conversion for map values.
+   * Handles the conversion of every value of the map. Note that map keys will be handled as a single-value type. This
+   * should be overridden if the data format requires a different conversion for map values.
    *
-   * @param value should be verified to be a Map type prior to calling this method as it will be casted to a Map
-   *              without checking
+   * @param value should be verified to be a Map type prior to calling this method
    */
-  @Nullable
-  protected Object convertMap(Object value) {
+  protected Map<Object, Object> convertMap(Object value) {
     Map<Object, Object> map = (Map) value;
-    if (map.isEmpty()) {
-      return null;
-    }
-
-    Map<Object, Object> convertedMap = new HashMap<>();
+    Map<Object, Object> convertedMap = Maps.newHashMapWithExpectedSize(map.size());
     for (Map.Entry<Object, Object> entry : map.entrySet()) {
       Object mapKey = entry.getKey();
-      Object mapValue = entry.getValue();
       if (mapKey != null) {
-        Object convertedMapValue = null;
-        if (mapValue != null) {
-          convertedMapValue = convert(mapValue);
-        }
-
-        if (convertedMapValue != null) {
-          convertedMap.put(convertSingleValue(entry.getKey()), convertedMapValue);
-        }
+        Object mapValue = entry.getValue();
+        Object convertedMapValue = mapValue != null ? convert(mapValue) : null;
+        convertedMap.put(convertSingleValue(entry.getKey()), convertedMapValue);
       }
     }
-
-    if (convertedMap.isEmpty()) {
-      return null;
-    }
-
     return convertedMap;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordExtractor.java
@@ -25,8 +25,8 @@ import javax.annotation.Nullable;
 
 /**
  * Extracts fields from input records
- * 1) Number/String/ByteBuffer become single-value column
- * 2) Collections become Object[] i.e. multi-value column
+ * 1) Number/String/ByteBuffer/byte[] become single-value column
+ * 2) Collections/Arrays (except for byte[]) become Object[] i.e. multi-value column
  * 3) Nested/Complex fields (e.g. json maps, avro maps, avro records) become Map<Object, Object>
  * @param <T> The format of the input record
  */
@@ -53,12 +53,12 @@ public interface RecordExtractor<T> extends Serializable {
    * Converts a field of the given input record. The field value will be converted to either a single value
    * (string, number, byte[]), multi value (Object[]) or a Map.
    *
-   * Natively Pinot only understands single values and multi values.
-   * Map is useful only if some ingestion transform functions operates on it in the transformation layer.
+   * The converted values can be used in ingestion transforms, so it should preserve the original values as much as
+   * possible (e.g. empty Object[], empty Map, Map entries with null value, etc.). Data type transformer (applied in the
+   * transform pipeline) is able to transform these values into proper value according to the data type.
    *
    * @param value the field value to be converted
-   * @return The converted field value. Returns null for empty array/collection/map.
+   * @return The converted field value
    */
-  @Nullable
   Object convert(Object value);
 }


### PR DESCRIPTION
The concept is similar to #13572, which added a config to differentiate empty array and `null`.
This PR makes this the default behavior (reverted the added config), and extend the behavior to all record extractors and preserve more values.

`RecordExtractor` should preserve the values as much as possible because the extracted values are fed into ingestion transforms.
This PR changes `RecordExtractor` to preserve the following values:
- Empty array
- Empty map
- Map entries with null value

`DataTypeTransformer` is able to handle these values properly.

# Backward Incompatible
1. Some protected method signature is changed in `BaseRecordExtractor` (not interface)
2. Behavior change for record extractor (should be desired)