### PR TITLE
Adjust RequestUtils#getTableNames to get table names from both left and right sides of join

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -614,7 +614,7 @@ public class RequestUtils {
       return getTableNames(dataSource.getSubquery());
     } else if (dataSource.isSetJoin()) {
       return ImmutableSet.<String>builder().addAll(getTableNames(dataSource.getJoin().getLeft()))
-          .addAll(getTableNames(dataSource.getJoin().getLeft())).build();
+          .addAll(getTableNames(dataSource.getJoin().getRight())).build();
     }
     return ImmutableSet.of(dataSource.getTableName());
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -65,7 +65,9 @@ public class RequestUtilsTest {
   public Object[][] queryProvider() {
     return new Object[][] {
       {"select foo from countries where bar > 1", Set.of("countries")},
-      {"select 1", null}
+      {"select 1", null},
+      {"SET useMultiStageEngine=true; SELECT table1.foo, table2.bar FROM "
+              + "table1 JOIN table2 ON table1.id = table2.id LIMIT 10;", Set.of("table1", "table2")}
     };
   }
 


### PR DESCRIPTION
Currently when using a join query, the RequestUtils#getTableNames method will only return the table name from the left side of the query. So in this example, even when we join `table1` and `table2`, the output of table names is only `<table1>`.

```sql
SELECT 
  table1.foo,
  table2.bar 
FROM 
  table1 
JOIN table2 ON table1.id = table2.id 
LIMIT 10;
```

This PR fixes this to output both the correct table names `<table1, table2>`

https://github.com/apache/pinot/issues/14555