### PR TITLE
Cleanup non split commit code

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.realtime;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Field;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -125,8 +126,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testStoppedConsumeDuringCompletion()
-      throws Exception {
+  public void testStoppedConsumeDuringCompletion() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     final String reason = "IAmLazy";
@@ -149,8 +149,8 @@ public class SegmentCompletionTest {
         .withSegmentName(_segmentNameStr).withReason(reason);
     response = _segmentCompletionMgr.segmentStoppedConsuming(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
-    Assert.assertEquals(new LLCSegmentName(_segmentNameStr), _segmentManager._stoppedSegmentName);
-    Assert.assertEquals(S_3, _segmentManager._stoppedInstance);
+    Assert.assertEquals(_segmentManager._stoppedSegmentName, new LLCSegmentName(_segmentNameStr));
+    Assert.assertEquals(_segmentManager._stoppedInstance, S_3);
     _segmentManager._stoppedSegmentName = null;
     _segmentManager._stoppedInstance = null;
 
@@ -182,8 +182,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
 
     // Now the FSM should have disappeared from the map
@@ -201,8 +201,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testStoppedConsumeBeforeHold()
-      throws Exception {
+  public void testStoppedConsumeBeforeHold() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     final String reason = "IAmLazy";
@@ -212,8 +211,8 @@ public class SegmentCompletionTest {
         .withSegmentName(_segmentNameStr).withReason(reason);
     response = _segmentCompletionMgr.segmentStoppedConsuming(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
-    Assert.assertEquals(new LLCSegmentName(_segmentNameStr), _segmentManager._stoppedSegmentName);
-    Assert.assertEquals(S_1, _segmentManager._stoppedInstance);
+    Assert.assertEquals(_segmentManager._stoppedSegmentName, new LLCSegmentName(_segmentNameStr));
+    Assert.assertEquals(_segmentManager._stoppedInstance, S_1);
     _segmentManager._stoppedSegmentName = null;
     _segmentManager._stoppedInstance = null;
 
@@ -259,8 +258,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
 
     // Now the FSM should have disappeared from the map
@@ -279,8 +278,7 @@ public class SegmentCompletionTest {
 
   // s2 sends stoppedConsuming message, but then may have gotten restarted, so eventually we complete the segment.
   @Test
-  public void testHappyPathAfterStoppedConsuming()
-      throws Exception {
+  public void testHappyPathAfterStoppedConsuming() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     _segmentCompletionMgr._seconds = 5;
@@ -290,7 +288,7 @@ public class SegmentCompletionTest {
     response = _segmentCompletionMgr.segmentStoppedConsuming(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
     Assert.assertEquals(new LLCSegmentName(_segmentNameStr), _segmentManager._stoppedSegmentName);
-    Assert.assertEquals(S_2, _segmentManager._stoppedInstance);
+    Assert.assertEquals(_segmentManager._stoppedInstance, S_2);
     _segmentManager._stoppedSegmentName = null;
     _segmentManager._stoppedInstance = null;
 
@@ -298,28 +296,23 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testHappyPath()
-      throws Exception {
+  public void testHappyPath() {
     testHappyPath(5L);
   }
 
-  // Tests happy path with split commit protocol
   @Test
-  public void testHappyPathSplitCommitWithLocalFS()
-      throws Exception {
-    testHappyPathSplitCommit(5L, "/local/file", "http://null:null/segments/" + _tableName + "/" + _segmentNameStr);
+  public void testHappyPathWithLocalFS() {
+    testHappyPath(5L, "/local/file", "http://null:null/segments/" + _tableName + "/" + _segmentNameStr);
   }
 
   @Test
-  public void testHappyPathSplitCommitWithDeepstore()
-      throws Exception {
-    testHappyPathSplitCommit(5L, "fakefs:///segment1", "fakefs:///segment1");
+  public void testHappyPathWithDeepStore() {
+    testHappyPath(5L, "fakefs:///segment1", "fakefs:///segment1");
   }
 
   @Test
-  public void testHappyPathSplitCommitWithPeerDownloadScheme()
-      throws Exception {
-    testHappyPathSplitCommit(5L, CommonConstants.Segment.PEER_SEGMENT_DOWNLOAD_SCHEME + "/segment1",
+  public void testHappyPathWithPeerDownloadScheme() {
+    testHappyPath(5L, CommonConstants.Segment.PEER_SEGMENT_DOWNLOAD_SCHEME + "/segment1",
         CommonConstants.Segment.PEER_SEGMENT_DOWNLOAD_SCHEME + "/segment1");
   }
 
@@ -393,8 +386,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("doNotCommitMe");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.FAILED);
 
     // Now the FSM should have aborted
@@ -431,15 +424,14 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_3).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), ControllerResponseStatus.COMMIT_SUCCESS);
     // And the FSM should be removed.
     Assert.assertFalse(_fsmMap.containsKey(_segmentNameStr));
   }
 
-  private void testHappyPathSplitCommit(long startTime, String segmentLocation, String downloadURL)
-      throws Exception {
+  private void testHappyPath(long startTime, String segmentLocation, @Nullable String downloadURL) {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
@@ -473,7 +465,6 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentConsumed(params);
-    // TODO: Verify controller asked to do a split commit
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
     // s3 comes back with new caught up offset, it should get a HOLD, since commit is not done yet.
     _segmentCompletionMgr._seconds += 1;
@@ -491,10 +482,12 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation(segmentLocation);
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
-    Assert.assertEquals(_segmentManager.getSegmentZKMetadata(null, null, null).getDownloadUrl(), downloadURL);
+    if (downloadURL != null) {
+      Assert.assertEquals(_segmentManager.getSegmentZKMetadata(null, null, null).getDownloadUrl(), downloadURL);
+    }
 
     // Now the FSM should have disappeared from the map
     Assert.assertFalse(_fsmMap.containsKey(_segmentNameStr));
@@ -510,10 +503,13 @@ public class SegmentCompletionTest {
     Assert.assertFalse(_fsmMap.containsKey(_segmentNameStr));
   }
 
+  private void testHappyPath(long startTime) {
+    testHappyPath(startTime, "location", null);
+  }
+
   // Tests that we abort when the server instance comes back with a different offset than it is told to commit with
   @Test
-  public void testCommitDifferentOffsetSplitCommit()
-      throws Exception {
+  public void testCommitDifferentOffset() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
@@ -547,8 +543,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_3).withStreamPartitionMsgOffset(_s3Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, true, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.FAILED);
 
     // Now the FSM should have disappeared from the map
@@ -563,75 +559,6 @@ public class SegmentCompletionTest {
 
     // FSM should still be there for that segment
     Assert.assertTrue(_fsmMap.containsKey(_segmentNameStr));
-  }
-
-  public void testHappyPath(long startTime)
-      throws Exception {
-    SegmentCompletionProtocol.Response response;
-    Request.Params params;
-    // s1 sends offset of 20, gets HOLD at t = 5s;
-    _segmentCompletionMgr._seconds = startTime;
-    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
-    // s2 sends offset of 40, gets HOLD
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
-    // s3 sends offset of 30, gets catchup to 40
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_3).withStreamPartitionMsgOffset(_s3Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
-    verifyOffset(response, _s2Offset);
-    // Now s1 comes back, and is asked to catchup.
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
-    // s2 is asked to commit.
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
-    // s3 comes back with new caught up offset, it should get a HOLD, since commit is not done yet.
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_3).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
-    // s2 executes a successful commit
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentCommitStart(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_CONTINUE);
-
-    _segmentCompletionMgr._seconds += 5;
-    params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
-
-    // Now the FSM should have disappeared from the map
-    Assert.assertFalse(_fsmMap.containsKey(_segmentNameStr));
-
-    // Now if s3 or s1 come back, they are asked to keep the segment they have.
-    _segmentCompletionMgr._seconds += 1;
-    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s2Offset.toString())
-        .withSegmentName(_segmentNameStr);
-    response = _segmentCompletionMgr.segmentConsumed(params);
-    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
-
-    // And the FSM should be removed.
-    Assert.assertFalse(_fsmMap.containsKey(_segmentNameStr));
   }
 
   @Test
@@ -649,8 +576,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testWinnerOnTimeLimit()
-      throws Exception {
+  public void testWinnerOnTimeLimit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     _segmentCompletionMgr._seconds = 10L;
@@ -661,8 +587,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testWinnerOnForceCommit()
-      throws Exception {
+  public void testWinnerOnForceCommit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // S1 comes to force commit
@@ -714,8 +639,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
 
     // S3 comes back at the latest offset
@@ -736,8 +661,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testWinnerOnRowLimit()
-      throws Exception {
+  public void testWinnerOnRowLimit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     _segmentCompletionMgr._seconds = 10L;
@@ -767,8 +691,8 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
     // We ask S2 to keep the segment
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s1Offset.toString())
@@ -782,26 +706,12 @@ public class SegmentCompletionTest {
     Assert.assertEquals(response.getStatus(), ControllerResponseStatus.DISCARD);
   }
 
-  // Tests that when server is delayed(Stalls for a hour), when server comes back, we commit successfully.
   @Test
-  public void testDelayedServerSplitCommit()
-      throws Exception {
-    testDelayedServer(true);
-  }
-
-  @Test
-  public void testDelayedServer()
-      throws Exception {
-    testDelayedServer(false);
-  }
-
-  public void testDelayedServer(boolean isSplitCommit)
-      throws Exception {
+  public void testDelayedServer() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
-    final int startTimeSecs = 5;
-    _segmentCompletionMgr._seconds = startTimeSecs;
+    _segmentCompletionMgr._seconds = 5;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentConsumed(params);
@@ -840,7 +750,7 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds += 5;
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr).withSegmentLocation("location");
-    response = _segmentCompletionMgr.segmentCommitEnd(params, true, isSplitCommit,
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
         CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
     // Now the FSM should have disappeared from the map
@@ -858,13 +768,11 @@ public class SegmentCompletionTest {
 
   // We test the case where all servers go silent after controller asks one of them commit
   @Test
-  public void testDeadServers()
-      throws Exception {
+  public void testDeadServers() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
-    final int startTimeSecs = 5;
-    _segmentCompletionMgr._seconds = startTimeSecs;
+    _segmentCompletionMgr._seconds = 5;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentConsumed(params);
@@ -914,13 +822,11 @@ public class SegmentCompletionTest {
 
   // We test the case when the committer is asked to commit, but they never come back.
   @Test
-  public void testCommitterFailure()
-      throws Exception {
+  public void testCommitterFailure() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
-    final int startTimeSecs = 5;
-    _segmentCompletionMgr._seconds = startTimeSecs;
+    _segmentCompletionMgr._seconds = 5;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentConsumed(params);
@@ -993,8 +899,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testHappyPathSlowCommit()
-      throws Exception {
+  public void testHappyPathSlowCommit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 1509242466s;
@@ -1059,16 +964,15 @@ public class SegmentCompletionTest {
     long commitTimeMs = (_segmentCompletionMgr._seconds - startTime) * 1000;
     Assert.assertEquals(_commitTimeMap.get(tableName).longValue(), commitTimeMs);
     _segmentCompletionMgr._seconds += 55;
-    response = _segmentCompletionMgr
-        .segmentCommitEnd(params, true, false, CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
+    response = _segmentCompletionMgr.segmentCommitEnd(params,
+        CommittingSegmentDescriptor.fromSegmentCompletionReqParams(params));
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
     // now FSM should be out of the map.
     Assert.assertFalse((_fsmMap.containsKey(_segmentNameStr)));
   }
 
   @Test
-  public void testFailedSlowCommit()
-      throws Exception {
+  public void testFailedSlowCommit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     final String tableName = new LLCSegmentName(_segmentNameStr).getTableName();
@@ -1127,8 +1031,7 @@ public class SegmentCompletionTest {
   }
 
   @Test
-  public void testLeaseTooLong()
-      throws Exception {
+  public void testLeaseTooLong() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
     // s1 sends offset of 20, gets HOLD at t = 5s;
@@ -1176,8 +1079,8 @@ public class SegmentCompletionTest {
 
     final int leaseTimeSec = 20;
     // Lease will not be granted if the time taken so far plus lease time exceeds the max allowabale.
-    while (_segmentCompletionMgr._seconds + leaseTimeSec <= startTime + SegmentCompletionManager
-        .getMaxCommitTimeForAllSegmentsSeconds()) {
+    while (_segmentCompletionMgr._seconds + leaseTimeSec
+        <= startTime + SegmentCompletionManager.getMaxCommitTimeForAllSegmentsSeconds()) {
       params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
           .withSegmentName(_segmentNameStr).withExtraTimeSec(leaseTimeSec);
       response = _segmentCompletionMgr.extendBuildTime(params);
@@ -1252,7 +1155,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentCommitStart(params);
-    Assert.assertTrue(response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
+    Assert.assertEquals(response.getStatus(), ControllerResponseStatus.HOLD);
 
     // So s2 goes back into HOLDING state. s1 and s3 are already holding, so now it will get COMMIT back.
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
@@ -1322,7 +1225,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
         .withSegmentName(_segmentNameStr);
     response = _segmentCompletionMgr.segmentCommitStart(params);
-    Assert.assertTrue(response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
+    Assert.assertEquals(response.getStatus(), ControllerResponseStatus.HOLD);
 
     // So s2 goes back into HOLDING state. s1 and s3 are already holding, so now it will get COMMIT back.
     params = new Request.Params().withInstanceId(S_2).withStreamPartitionMsgOffset(_s2Offset.toString())
@@ -1404,8 +1307,8 @@ public class SegmentCompletionTest {
   }
 
   public static class MockSegmentCompletionManager extends SegmentCompletionManager {
+    private final boolean _isLeader;
     public long _seconds;
-    private boolean _isLeader;
 
     protected MockSegmentCompletionManager(PinotLLCRealtimeSegmentManager segmentManager, boolean isLeader,
         boolean isConnected) {


### PR DESCRIPTION
On top of #14557, please review the second commit

After releasing `1.1`, split commit becomes the only commit mechanism. Clean up the deprecated code for non-split commit