### PR TITLE
Configure cross region access in s3 client

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -71,12 +71,15 @@ public class S3Config {
   public static final String DEFAULT_IAM_ROLE_BASED_ACCESS_ENABLED = "false";
   public static final String DEFAULT_SESSION_DURATION_SECONDS = "900";
   public static final String DEFAULT_ASYNC_SESSION_UPDATED_ENABLED = "true";
+  public static final String DEFAULT_CROSS_REGION_ACCESS_ENABLED = "true";
   public static final String HTTP_CLIENT_CONFIG_PREFIX = "httpclient";
   public static final String HTTP_CLIENT_CONFIG_MAX_CONNECTIONS = "maxConnections";
   private static final String HTTP_CLIENT_CONFIG_SOCKET_TIMEOUT = "socketTimeout";
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_TIMEOUT = "connectionTimeout";
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_TIME_TO_LIVE = "connectionTimeToLive";
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_ACQUISITION_TIMEOUT = "connectionAcquisitionTimeout";
+  private static final String CROSS_REGION_ACCESS_ENABLED = "crossRegionAccessEnabled";
+
   private final String _accessKey;
   private final String _secretKey;
   private final String _region;
@@ -97,6 +100,7 @@ public class S3Config {
   private final long _minObjectSizeForMultiPartUpload;
   private final long _multiPartUploadPartSize;
   private final ApacheHttpClient.Builder _httpClientBuilder;
+  private final boolean _enableCrossRegionAccess;
 
   public S3Config(PinotConfiguration pinotConfig) {
     _disableAcl = pinotConfig.getProperty(DISABLE_ACL_CONFIG_KEY, DEFAULT_DISABLE_ACL);
@@ -140,6 +144,8 @@ public class S3Config {
     }
     PinotConfiguration httpConfig = pinotConfig.subset(HTTP_CLIENT_CONFIG_PREFIX);
     _httpClientBuilder = httpConfig.isEmpty() ? null : createHttpClientBuilder(httpConfig);
+    _enableCrossRegionAccess =
+        Boolean.parseBoolean(pinotConfig.getProperty(CROSS_REGION_ACCESS_ENABLED, DEFAULT_CROSS_REGION_ACCESS_ENABLED));
   }
 
   private static ApacheHttpClient.Builder createHttpClientBuilder(PinotConfiguration config) {
@@ -264,5 +270,9 @@ public class S3Config {
   @Nullable
   public String getStorageClass() {
     return _storageClass;
+  }
+
+  public boolean isCrossRegionAccessEnabled() {
+    return _enableCrossRegionAccess;
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -144,7 +144,7 @@ public class S3PinotFS extends BasePinotFS {
       }
 
       S3ClientBuilder s3ClientBuilder = S3Client.builder().forcePathStyle(true).region(Region.of(s3Config.getRegion()))
-          .credentialsProvider(awsCredentialsProvider);
+          .credentialsProvider(awsCredentialsProvider).crossRegionAccessEnabled(s3Config.isCrossRegionAccessEnabled());
       if (StringUtils.isNotEmpty(s3Config.getEndpoint())) {
         try {
           s3ClientBuilder.endpointOverride(new URI(s3Config.getEndpoint()));
@@ -160,8 +160,6 @@ public class S3PinotFS extends BasePinotFS {
         _storageClass = StorageClass.fromValue(s3Config.getStorageClass());
         assert (_storageClass != StorageClass.UNKNOWN_TO_SDK_VERSION);
       }
-
-      s3ClientBuilder.crossRegionAccessEnabled(s3Config.isCrossRegionAccessEnabled());
 
       _s3Client = s3ClientBuilder.build();
       setMultiPartUploadConfigs(s3Config);

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -161,6 +161,8 @@ public class S3PinotFS extends BasePinotFS {
         assert (_storageClass != StorageClass.UNKNOWN_TO_SDK_VERSION);
       }
 
+      s3ClientBuilder.crossRegionAccessEnabled(s3Config.isCrossRegionAccessEnabled());
+
       _s3Client = s3ClientBuilder.build();
       setMultiPartUploadConfigs(s3Config);
     } catch (S3Exception e) {


### PR DESCRIPTION
There have been certain use-cases in which we want to copy objects b/w two buckets that lie in different regions. Currently, this is not supported as the client needs to be in the same region as the bucket. Due to this, we see these exceptions:

```
software.amazon.awssdk.services.s3.model.S3Exception: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint. (Service: S3, Status Code: 301, Request ID: 7CCXVJ9QGQAS3AET, Extended Request ID: X9CQdLj+HPQ2fpty5wLfIxTYkkJWYemNuvh6GHD9qbZ/SxbVwnY5ILdsHXkLXuFqtnOTSdFa5BI=)
```

Ref: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/s3-cross-region.html