### PR TITLE
Adds Support of maxNumRowsPerTask in RealtimeToOfflineSegmentsTasksGe…

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -41,6 +41,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
 
   private static final String WATERMARK_KEY = "watermarkMs";
+  private static final String SUBTASKS_KEY = "numSubtasks";
 
   private final String _tableNameWithType;
   private long _watermarkMs;
@@ -49,6 +50,12 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
   public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs) {
     _tableNameWithType = tableNameWithType;
     _watermarkMs = watermarkMs;
+  }
+
+  public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs, int numSubtasks) {
+    _tableNameWithType = tableNameWithType;
+    _watermarkMs = watermarkMs;
+    _numSubtasks = numSubtasks;
   }
 
   public String getTableNameWithType() {
@@ -76,12 +83,14 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
 
   public static RealtimeToOfflineSegmentsTaskMetadata fromZNRecord(ZNRecord znRecord) {
     long watermark = znRecord.getLongField(WATERMARK_KEY, 0);
-    return new RealtimeToOfflineSegmentsTaskMetadata(znRecord.getId(), watermark);
+    int subtasksLeft = znRecord.getIntField(SUBTASKS_KEY, 0);
+    return new RealtimeToOfflineSegmentsTaskMetadata(znRecord.getId(), watermark, subtasksLeft);
   }
 
   public ZNRecord toZNRecord() {
     ZNRecord znRecord = new ZNRecord(_tableNameWithType);
     znRecord.setLongField(WATERMARK_KEY, _watermarkMs);
+    znRecord.setIntField(SUBTASKS_KEY, _numSubtasks);
     return znRecord;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -45,29 +45,29 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
 
   private final String _tableNameWithType;
   private long _watermarkMs;
-  private int _numSubtasks;
+  private int _numSubtasksPending;
 
   public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs) {
     _tableNameWithType = tableNameWithType;
     _watermarkMs = watermarkMs;
   }
 
-  public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs, int numSubtasks) {
+  public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs, int numSubtasksPending) {
     _tableNameWithType = tableNameWithType;
     _watermarkMs = watermarkMs;
-    _numSubtasks = numSubtasks;
+    _numSubtasksPending = numSubtasksPending;
   }
 
   public String getTableNameWithType() {
     return _tableNameWithType;
   }
 
-  public int getNumSubtasks() {
-    return _numSubtasks;
+  public int getNumSubtasksPending() {
+    return _numSubtasksPending;
   }
 
-  public void setNumSubtasks(int numSubtasks) {
-    _numSubtasks = numSubtasks;
+  public void setNumSubtasksPending(int numSubtasksPending) {
+    _numSubtasksPending = numSubtasksPending;
   }
 
   public void setWatermarkMs(long watermarkMs) {
@@ -90,7 +90,7 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
   public ZNRecord toZNRecord() {
     ZNRecord znRecord = new ZNRecord(_tableNameWithType);
     znRecord.setLongField(WATERMARK_KEY, _watermarkMs);
-    znRecord.setIntField(SUBTASKS_KEY, _numSubtasks);
+    znRecord.setIntField(SUBTASKS_KEY, _numSubtasksPending);
     return znRecord;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -43,7 +43,8 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
   private static final String WATERMARK_KEY = "watermarkMs";
 
   private final String _tableNameWithType;
-  private final long _watermarkMs;
+  private long _watermarkMs;
+  private int _numSubtasks;
 
   public RealtimeToOfflineSegmentsTaskMetadata(String tableNameWithType, long watermarkMs) {
     _tableNameWithType = tableNameWithType;
@@ -52,6 +53,18 @@ public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
 
   public String getTableNameWithType() {
     return _tableNameWithType;
+  }
+
+  public int getNumSubtasks() {
+    return _numSubtasks;
+  }
+
+  public void setNumSubtasks(int numSubtasks) {
+    _numSubtasks = numSubtasks;
+  }
+
+  public void setWatermarkMs(long watermarkMs) {
+    _watermarkMs = watermarkMs;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -150,7 +150,6 @@ public class MinionConstants {
     public static final String ROUND_BUCKET_TIME_PERIOD_KEY = "roundBucketTimePeriod";
     public static final String MERGE_TYPE_KEY = "mergeType";
     public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";
-    public static final String SEGMENT_ZK_METADATA_TIME_KEY = TASK_TYPE + TASK_TIME_SUFFIX;
 
     public final static EnumSet<AggregationFunctionType> AVAILABLE_CORE_VALUE_AGGREGATORS =
         EnumSet.of(MIN, MAX, SUM, DISTINCTCOUNTHLL, DISTINCTCOUNTRAWHLL, DISTINCTCOUNTTHETASKETCH,

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -150,6 +150,7 @@ public class MinionConstants {
     public static final String ROUND_BUCKET_TIME_PERIOD_KEY = "roundBucketTimePeriod";
     public static final String MERGE_TYPE_KEY = "mergeType";
     public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";
+    public static final String SEGMENT_ZK_METADATA_TIME_KEY = TASK_TYPE + TASK_TIME_SUFFIX;
 
     public final static EnumSet<AggregationFunctionType> AVAILABLE_CORE_VALUE_AGGREGATORS =
         EnumSet.of(MIN, MAX, SUM, DISTINCTCOUNTHLL, DISTINCTCOUNTRAWHLL, DISTINCTCOUNTTHETASKETCH,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
@@ -211,6 +210,9 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
           RealtimeToOfflineSegmentsTaskMetadata.fromZNRecord(realtimeToOfflineSegmentsTaskZNRecord);
 
       int numSubtasksLeft = realtimeToOfflineSegmentsTaskMetadata.getNumSubtasks() - 1;
+      Preconditions.checkState(numSubtasksLeft >= 0,
+          "num of minion subtasks pending for table: %s should be greater than equal to zero.",
+          realtimeTableName);
       realtimeToOfflineSegmentsTaskMetadata.setNumSubtasks(numSubtasksLeft);
 
       try {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.minion.RealtimeToOfflineSegmentsTaskMetadata;
@@ -84,28 +85,28 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
    * Checks that the <code>watermarkMs</code> from the ZNode matches the windowStartMs in the task configs.
    * If yes, caches the ZNode version to check during update.
    */
-  @Override
-  public void preProcess(PinotTaskConfig pinotTaskConfig) {
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
-
-    ZNRecord realtimeToOfflineSegmentsTaskZNRecord =
-        _minionTaskZkMetadataManager.getTaskMetadataZNRecord(realtimeTableName,
-            RealtimeToOfflineSegmentsTask.TASK_TYPE);
-    Preconditions.checkState(realtimeToOfflineSegmentsTaskZNRecord != null,
-        "RealtimeToOfflineSegmentsTaskMetadata ZNRecord for table: %s should not be null. Exiting task.",
-        realtimeTableName);
-
-    RealtimeToOfflineSegmentsTaskMetadata realtimeToOfflineSegmentsTaskMetadata =
-        RealtimeToOfflineSegmentsTaskMetadata.fromZNRecord(realtimeToOfflineSegmentsTaskZNRecord);
-    long windowStartMs = Long.parseLong(configs.get(RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY));
-    Preconditions.checkState(realtimeToOfflineSegmentsTaskMetadata.getWatermarkMs() <= windowStartMs,
-        "watermarkMs in RealtimeToOfflineSegmentsTask metadata: %s shouldn't be larger than windowStartMs: %d in task"
-            + " configs for table: %s. ZNode may have been modified by another task",
-        realtimeToOfflineSegmentsTaskMetadata.getWatermarkMs(), windowStartMs, realtimeTableName);
-
-    _expectedVersion = realtimeToOfflineSegmentsTaskZNRecord.getVersion();
-  }
+//  @Override
+//  public void preProcess(PinotTaskConfig pinotTaskConfig) {
+//    Map<String, String> configs = pinotTaskConfig.getConfigs();
+//    String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
+//
+//    ZNRecord realtimeToOfflineSegmentsTaskZNRecord =
+//        _minionTaskZkMetadataManager.getTaskMetadataZNRecord(realtimeTableName,
+//            RealtimeToOfflineSegmentsTask.TASK_TYPE);
+//    Preconditions.checkState(realtimeToOfflineSegmentsTaskZNRecord != null,
+//        "RealtimeToOfflineSegmentsTaskMetadata ZNRecord for table: %s should not be null. Exiting task.",
+//        realtimeTableName);
+//
+//    RealtimeToOfflineSegmentsTaskMetadata realtimeToOfflineSegmentsTaskMetadata =
+//        RealtimeToOfflineSegmentsTaskMetadata.fromZNRecord(realtimeToOfflineSegmentsTaskZNRecord);
+//    long windowStartMs = Long.parseLong(configs.get(RealtimeToOfflineSegmentsTask.WINDOW_START_MS_KEY));
+//    Preconditions.checkState(realtimeToOfflineSegmentsTaskMetadata.getWatermarkMs() <= windowStartMs,
+//        "watermarkMs in RealtimeToOfflineSegmentsTask metadata: %s shouldn't be larger than windowStartMs: %d in task"
+//            + " configs for table: %s. ZNode may have been modified by another task",
+//        realtimeToOfflineSegmentsTaskMetadata.getWatermarkMs(), windowStartMs, realtimeTableName);
+//
+//    _expectedVersion = realtimeToOfflineSegmentsTaskZNRecord.getVersion();
+//  }
 
   @Override
   protected List<SegmentConversionResult> convert(PinotTaskConfig pinotTaskConfig, List<File> segmentDirs,
@@ -194,21 +195,24 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
    * watermark in the ZNode
    * TODO: Making the minion task update the ZK metadata is an anti-pattern, however cannot see another way to do it
    */
-  @Override
-  public void postProcess(PinotTaskConfig pinotTaskConfig) {
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
-    long waterMarkMs = Long.parseLong(configs.get(RealtimeToOfflineSegmentsTask.WINDOW_END_MS_KEY));
-    RealtimeToOfflineSegmentsTaskMetadata newMinionMetadata =
-        new RealtimeToOfflineSegmentsTaskMetadata(realtimeTableName, waterMarkMs);
-    _minionTaskZkMetadataManager.setTaskMetadataZNRecord(newMinionMetadata, RealtimeToOfflineSegmentsTask.TASK_TYPE,
-        _expectedVersion);
-  }
+//  @Override
+//  public void postProcess(PinotTaskConfig pinotTaskConfig) {
+//    Map<String, String> configs = pinotTaskConfig.getConfigs();
+//    String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
+//    long waterMarkMs = Long.parseLong(configs.get(RealtimeToOfflineSegmentsTask.WINDOW_END_MS_KEY));
+//    RealtimeToOfflineSegmentsTaskMetadata newMinionMetadata =
+//        new RealtimeToOfflineSegmentsTaskMetadata(realtimeTableName, waterMarkMs);
+//    _minionTaskZkMetadataManager.setTaskMetadataZNRecord(newMinionMetadata, RealtimeToOfflineSegmentsTask.TASK_TYPE,
+//        _expectedVersion);
+//  }
 
   @Override
   protected SegmentZKMetadataCustomMapModifier getSegmentZKMetadataCustomMapModifier(PinotTaskConfig pinotTaskConfig,
       SegmentConversionResult segmentConversionResult) {
+    Map<String, String> updateMap = new TreeMap<>();
+    updateMap.put(MinionConstants.RealtimeToOfflineSegmentsTask.SEGMENT_ZK_METADATA_TIME_KEY,
+        String.valueOf(System.currentTimeMillis()));
     return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE,
-        Collections.emptyMap());
+        updateMap);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -53,8 +53,6 @@ import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.common.metadata.ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata;
-
 
 /**
  * A {@link PinotTaskGenerator} implementation for generating tasks of type {@link RealtimeToOfflineSegmentsTask}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -346,11 +346,6 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
     // [20200813, 20200814)
     watermarkMs = (minStartTimeMs / bucketMs) * bucketMs;
 
-    // Create RealtimeToOfflineSegmentsTaskMetadata ZNode using watermark calculated above
-//    realtimeToOfflineSegmentsTaskMetadata = new RealtimeToOfflineSegmentsTaskMetadata(realtimeTableName, watermarkMs);
-//      _clusterInfoAccessor.setMinionTaskMetadata(realtimeToOfflineSegmentsTaskMetadata,
-//          MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, -1);
-
     return new RealtimeToOfflineSegmentsTaskMetadata(realtimeTableName, watermarkMs);
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -157,7 +157,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
           getRTOTaskMetadata(realtimeTableName, completedSegmentsZKMetadata, bucketMs, realtimeToOfflineZNRecord);
 
       if (realtimeToOfflineSegmentsTaskMetadata.getNumSubtasksPending() == 0) {
-        // this might happen in-case of any failure.
+        // this might happen in some edge cases - (like minion server instance went offline, etc).
         LOGGER.warn(
             "No incomplete minion tasks exists in taskQueue, however num of pending subtasks are non zero for table: "
                 + "{}, taskType: {}. Overriding num of subtasks pending to zero.", realtimeTableName, taskType);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -204,8 +204,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
 
             numRecordsPerTask += segmentZKMetadata.getTotalDocs();
 
-            if ((numRecordsPerTask >= maxNumRecordsPerTask)
-                || (segmentZkMetadataIndex == (completedSegmentsZKMetadata.size() - 1))) {
+            if (numRecordsPerTask >= maxNumRecordsPerTask) {
               segmentNamesGroupList.add(segmentNames);
               downloadURLsGroupList.add(downloadURLs);
               numRecordsPerTask = 0;
@@ -213,8 +212,14 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
               downloadURLs = new ArrayList<>();
             }
           }
+
+          if ((!segmentNames.isEmpty())
+              && (segmentZkMetadataIndex == (completedSegmentsZKMetadata.size() - 1))) {
+            segmentNamesGroupList.add(segmentNames);
+            downloadURLsGroupList.add(downloadURLs);
+          }
         }
-        if (skipGenerate || !segmentNames.isEmpty()) {
+        if (skipGenerate || !segmentNamesGroupList.isEmpty()) {
           break;
         }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -177,7 +177,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
         int maxNumRecordsPerTask =
             taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY) != null
                 ? Integer.parseInt(
-                taskConfigs.get(MinionConstants.MergeRollupTask.MAX_NUM_RECORDS_PER_TASK_KEY))
+                taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY))
                 : DEFAULT_MAX_NUM_RECORDS_PER_TASK;
 
         for (int segmentZkMetadataIndex = 0; segmentZkMetadataIndex < completedSegmentsZKMetadata.size();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -399,5 +399,4 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
 
     return new PinotTaskConfig(taskType, configs);
   }
-
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -176,6 +176,12 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
       List<List<String>> segmentNamesGroupList = new ArrayList<>();
       List<List<String>> downloadURLsGroupList = new ArrayList<>();
 
+      int maxNumRecordsPerTask =
+          taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY) != null
+              ? Integer.parseInt(
+              taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY))
+              : DEFAULT_MAX_NUM_RECORDS_PER_TASK;
+
       while (true) {
         // Check that execution window is older than bufferTime
         if (windowEndMs > System.currentTimeMillis() - bufferMs) {
@@ -185,12 +191,6 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
           skipGenerate = true;
           break;
         }
-
-        int maxNumRecordsPerTask =
-            taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY) != null
-                ? Integer.parseInt(
-                taskConfigs.get(MinionConstants.RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_TASK_KEY))
-                : DEFAULT_MAX_NUM_RECORDS_PER_TASK;
 
         for (int segmentZkMetadataIndex = 0; segmentZkMetadataIndex < completedSegmentsZKMetadata.size();
             segmentZkMetadataIndex++) {
@@ -211,7 +211,6 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
               skipGenerate = true;
               break;
             }
-
             segmentNames.add(segmentName);
             downloadURLs.add(segmentZKMetadata.getDownloadUrl());
 


### PR DESCRIPTION
Fixes: [https://github.com/apache/pinot/issues/12857](https://github.com/apache/pinot/issues/12857
)

(**Issue description**: Currently [RealtimeToOfflineSegmentsTask that is used to move real time segments to offline segments](https://docs.pinot.apache.org/operators/operating-pinot/pinot-managed-offline-flows), does not have the ability to tune maxNumRowsPerTask. This is the parameter that determines the input to a task. Without this configuration, we end up creating one minion task, which takes in all the input (i.e all segments that meet the criteria to be converted to offline segments) which prevents us from using other minions.
There's no parallelism for this task.)

Propose Solution (Rejected, check [Alternate solution](https://github.com/apache/pinot/pull/14623)):

1. Divide a task into multiple subtasks based on max num of rows per subtask. Once subtasks are generated, during the execution of subtasks, each subtasks atomically updates zookeeper state after it's execution is finished. The last subtask pending will updates the watermark after checking zookeeper if any subtasks is pending.

Update: [Alternate solution](https://github.com/apache/pinot/pull/14623)

