### PR TITLE
[timeseries] Part-1: Misc. Refactor to Enable Broker Reduce

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -20,6 +20,8 @@ package org.apache.pinot.common.datablock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -167,6 +169,21 @@ public final class DataBlockUtils {
     ArrayList<ByteBuffer> result = new ArrayList<>();
     dataBuffer.appendAsByteBuffers(result);
     return result;
+  }
+
+  public static ByteString toByteString(DataBlock dataBlock)
+      throws IOException {
+    List<ByteBuffer> bytes = dataBlock.serialize();
+    ByteString byteString;
+    if (bytes.isEmpty()) {
+      byteString = ByteString.EMPTY;
+    } else {
+      byteString = UnsafeByteOperations.unsafeWrap(bytes.get(0));
+      for (int i = 1; i < bytes.size(); i++) {
+        byteString = byteString.concat(UnsafeByteOperations.unsafeWrap(bytes.get(i)));
+      }
+    }
+    return byteString;
   }
 
   /**

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/M3TimeSeriesPlanner.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/M3TimeSeriesPlanner.java
@@ -108,7 +108,7 @@ public class M3TimeSeriesPlanner implements TimeSeriesLogicalPlanner {
           rootNode = currentNode;
         }
         if (lastNode != null) {
-          lastNode.addChildNode(currentNode);
+          lastNode.addInputNode(currentNode);
         }
         lastNode = currentNode;
       }

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/KeepLastValuePlanNode.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/KeepLastValuePlanNode.java
@@ -29,8 +29,13 @@ import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
 public class KeepLastValuePlanNode extends BaseTimeSeriesPlanNode {
   @JsonCreator
   public KeepLastValuePlanNode(@JsonProperty("id") String id,
-      @JsonProperty("children") List<BaseTimeSeriesPlanNode> children) {
-    super(id, children);
+      @JsonProperty("inputs") List<BaseTimeSeriesPlanNode> inputs) {
+    super(id, inputs);
+  }
+
+  @Override
+  public BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs) {
+    return new KeepLastValuePlanNode(_id, newInputs);
   }
 
   @Override
@@ -45,7 +50,7 @@ public class KeepLastValuePlanNode extends BaseTimeSeriesPlanNode {
 
   @Override
   public BaseTimeSeriesOperator run() {
-    BaseTimeSeriesOperator childOperator = _children.get(0).run();
+    BaseTimeSeriesOperator childOperator = _inputs.get(0).run();
     return new KeepLastValueOperator(List.of(childOperator));
   }
 }

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
@@ -34,13 +34,18 @@ public class TransformNullPlanNode extends BaseTimeSeriesPlanNode {
 
   @JsonCreator
   public TransformNullPlanNode(@JsonProperty("id") String id, @JsonProperty("defaultValue") Double defaultValue,
-      @JsonProperty("children") List<BaseTimeSeriesPlanNode> children) {
-    super(id, children);
+      @JsonProperty("inputs") List<BaseTimeSeriesPlanNode> inputs) {
+    super(id, inputs);
     _defaultValue = defaultValue;
   }
 
   public Double getDefaultValue() {
     return _defaultValue;
+  }
+
+  @Override
+  public BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs) {
+    return new TransformNullPlanNode(_id, _defaultValue, newInputs);
   }
 
   @Override
@@ -55,9 +60,9 @@ public class TransformNullPlanNode extends BaseTimeSeriesPlanNode {
 
   @Override
   public BaseTimeSeriesOperator run() {
-    Preconditions.checkState(_children.size() == 1,
-        "TransformNullPlanNode should have only 1 child, got: %s", _children.size());
-    BaseTimeSeriesOperator childOperator = _children.get(0).run();
+    Preconditions.checkState(_inputs.size() == 1,
+        "TransformNullPlanNode should have only 1 child, got: %s", _inputs.size());
+    BaseTimeSeriesOperator childOperator = _inputs.get(0).run();
     return new TransformNullOperator(_defaultValue, ImmutableList.of(childOperator));
   }
 }

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/TimeBucketComputer.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/time/TimeBucketComputer.java
@@ -48,7 +48,7 @@ public class TimeBucketComputer {
       return constraints;
     }
     QueryTimeBoundaryConstraints constraints = new QueryTimeBoundaryConstraints();
-    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
       QueryTimeBoundaryConstraints childConstraints = process(childNode, request);
       constraints = QueryTimeBoundaryConstraints.merge(constraints, childConstraints);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.proto.Mailbox.MailboxContent;
 import org.apache.pinot.common.proto.PinotMailboxGrpc;
@@ -135,17 +136,7 @@ public class GrpcSendingMailbox implements SendingMailbox {
     long start = System.currentTimeMillis();
     try {
       DataBlock dataBlock = block.getDataBlock();
-      List<ByteBuffer> bytes = dataBlock.serialize();
-
-      ByteString byteString;
-      if (bytes.isEmpty()) {
-        byteString = ByteString.EMPTY;
-      } else {
-        byteString = UnsafeByteOperations.unsafeWrap(bytes.get(0));
-        for (int i = 1; i < bytes.size(); i++) {
-          byteString = byteString.concat(UnsafeByteOperations.unsafeWrap(bytes.get(i)));
-        }
-      }
+      ByteString byteString = DataBlockUtils.toByteString(dataBlock);
       int sizeInBytes = byteString.size();
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Serialized block: {} to {} bytes", block, sizeInBytes);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -19,11 +19,8 @@
 package org.apache.pinot.query.mailbox;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesPlanVisitor.java
@@ -66,15 +66,15 @@ public class PhysicalTimeSeriesPlanVisitor {
   }
 
   public void initLeafPlanNode(BaseTimeSeriesPlanNode planNode, TimeSeriesExecutionContext context) {
-    for (int index = 0; index < planNode.getChildren().size(); index++) {
-      BaseTimeSeriesPlanNode childNode = planNode.getChildren().get(index);
+    for (int index = 0; index < planNode.getInputs().size(); index++) {
+      BaseTimeSeriesPlanNode childNode = planNode.getInputs().get(index);
       if (childNode instanceof LeafTimeSeriesPlanNode) {
         LeafTimeSeriesPlanNode leafNode = (LeafTimeSeriesPlanNode) childNode;
         List<String> segments = context.getPlanIdToSegmentsMap().get(leafNode.getId());
         ServerQueryRequest serverQueryRequest = compileLeafServerQueryRequest(leafNode, segments, context);
         TimeSeriesPhysicalTableScan physicalTableScan = new TimeSeriesPhysicalTableScan(childNode.getId(),
             serverQueryRequest, _queryExecutor, _executorService);
-        planNode.getChildren().set(index, physicalTableScan);
+        planNode.getInputs().set(index, physicalTableScan);
       } else {
         initLeafPlanNode(childNode, context);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.timeseries;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
@@ -52,6 +53,11 @@ public class TimeSeriesPhysicalTableScan extends BaseTimeSeriesPlanNode {
 
   public ExecutorService getExecutorService() {
     return _executorService;
+  }
+
+  @Override
+  public BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs) {
+    throw new UnsupportedOperationException("withInputs not supported for TimeSeriesPhysicalTableScan");
   }
 
   public String getKlass() {

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
@@ -126,7 +126,7 @@ public class TimeSeriesQueryEnvironment {
       tableNameConsumer.accept(scanNode.getTableName());
       return;
     }
-    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
       findTableNames(childNode, tableNameConsumer);
     }
   }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
@@ -61,7 +61,7 @@ public class TableScanVisitor {
       List<String> segments = entry.getValue().getLeft();
       context.getPlanIdToSegmentMap().put(sfpNode.getId(), segments);
     }
-    for (BaseTimeSeriesPlanNode childNode : planNode.getChildren()) {
+    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
       assignSegmentsToPlan(childNode, timeBuckets, context);
     }
   }

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/BaseTimeSeriesPlanNode.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/BaseTimeSeriesPlanNode.java
@@ -28,24 +28,26 @@ import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
  */
 public abstract class BaseTimeSeriesPlanNode {
   protected final String _id;
-  protected final List<BaseTimeSeriesPlanNode> _children;
+  protected final List<BaseTimeSeriesPlanNode> _inputs;
 
-  public BaseTimeSeriesPlanNode(String id, List<BaseTimeSeriesPlanNode> children) {
+  public BaseTimeSeriesPlanNode(String id, List<BaseTimeSeriesPlanNode> inputs) {
     _id = id;
-    _children = children;
+    _inputs = inputs;
   }
 
   public String getId() {
     return _id;
   }
 
-  public List<BaseTimeSeriesPlanNode> getChildren() {
-    return _children;
+  public List<BaseTimeSeriesPlanNode> getInputs() {
+    return _inputs;
   }
 
-  public void addChildNode(BaseTimeSeriesPlanNode planNode) {
-    _children.add(planNode);
+  public void addInputNode(BaseTimeSeriesPlanNode planNode) {
+    _inputs.add(planNode);
   }
+
+  public abstract BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs);
 
   public abstract String getKlass();
 

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
@@ -21,7 +21,6 @@ package org.apache.pinot.tsdb.spi.plan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.tsdb.spi.AggInfo;

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/LeafTimeSeriesPlanNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tsdb.spi.plan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.tsdb.spi.AggInfo;
@@ -47,13 +48,13 @@ public class LeafTimeSeriesPlanNode extends BaseTimeSeriesPlanNode {
 
   @JsonCreator
   public LeafTimeSeriesPlanNode(
-      @JsonProperty("id") String id, @JsonProperty("children") List<BaseTimeSeriesPlanNode> children,
+      @JsonProperty("id") String id, @JsonProperty("inputs") List<BaseTimeSeriesPlanNode> inputs,
       @JsonProperty("tableName") String tableName, @JsonProperty("timeColumn") String timeColumn,
       @JsonProperty("timeUnit") TimeUnit timeUnit, @JsonProperty("offsetSeconds") Long offsetSeconds,
       @JsonProperty("filterExpression") String filterExpression,
       @JsonProperty("valueExpression") String valueExpression, @JsonProperty("aggInfo") AggInfo aggInfo,
       @JsonProperty("groupByExpressions") List<String> groupByExpressions) {
-    super(id, children);
+    super(id, inputs);
     _tableName = tableName;
     _timeColumn = timeColumn;
     _timeUnit = timeUnit;
@@ -62,6 +63,12 @@ public class LeafTimeSeriesPlanNode extends BaseTimeSeriesPlanNode {
     _valueExpression = valueExpression;
     _aggInfo = aggInfo;
     _groupByExpressions = groupByExpressions;
+  }
+
+  @Override
+  public BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs) {
+    return new LeafTimeSeriesPlanNode(_id, newInputs, _tableName, _timeColumn, _timeUnit, _offsetSeconds,
+        _filterExpression, _valueExpression, _aggInfo, _groupByExpressions);
   }
 
   @Override

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/serde/TimeSeriesPlanSerde.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/plan/serde/TimeSeriesPlanSerde.java
@@ -67,15 +67,15 @@ public class TimeSeriesPlanSerde {
 
   public static BaseTimeSeriesPlanNode create(JsonNode jsonNode)
       throws JsonProcessingException, ClassNotFoundException {
-    JsonNode children = null;
+    JsonNode inputs = null;
     if (jsonNode instanceof ObjectNode) {
-      // Remove children field to prevent Jackson from deserializing it. We will handle it manually.
+      // Remove inputs field to prevent Jackson from deserializing it. We will handle it manually.
       ObjectNode objectNode = (ObjectNode) jsonNode;
-      if (objectNode.has("children")) {
-        children = objectNode.get("children");
-        objectNode.remove("children");
+      if (objectNode.has("inputs")) {
+        inputs = objectNode.get("inputs");
+        objectNode.remove("inputs");
       }
-      objectNode.putIfAbsent("children", OBJECT_MAPPER.createArrayNode());
+      objectNode.putIfAbsent("inputs", OBJECT_MAPPER.createArrayNode());
     }
     BaseTimeSeriesPlanNode planNode = null;
     try {
@@ -83,10 +83,10 @@ public class TimeSeriesPlanSerde {
       Class<BaseTimeSeriesPlanNode> klass = (Class<BaseTimeSeriesPlanNode>) Class.forName(klassName);
       planNode = OBJECT_MAPPER.readValue(jsonNode.toString(), klass);
     } finally {
-      if (planNode != null && children instanceof ArrayNode) {
-        ArrayNode childArray = (ArrayNode) children;
+      if (planNode != null && inputs instanceof ArrayNode) {
+        ArrayNode childArray = (ArrayNode) inputs;
         for (JsonNode childJsonNode : childArray) {
-          planNode.addChildNode(create(childJsonNode));
+          planNode.addInputNode(create(childJsonNode));
         }
       }
     }


### PR DESCRIPTION
### Summary

First of the multi-part PRs to enable Broker Reduce for the Time Series Engine.

This PR does the following:

* Renames `child` references to `inputs` to be consistent with pinot-query-planner PlanNode.
* Add `withInputs` to allow sub-plan cloning in the future.
* Moves some of the logic from `GrpcSendingMailbox` to `DataBlockUtils`. For Broker Reduce, we will send a row based `TransferableBlock` from the servers to the brokers.

**Note:** This is a breaking change for the `pinot-timeseries-spi`, but that should be okay since that spi is marked Unstable and is evolving rapidly.

### Test Plan

Ran the Quickstart on local. After the 3-part PRs we will be testing the build out in one of our clusters for scale/perf testing.