### PR TITLE
[timeseries] Part-2: Enable Streaming Response for Time Series

### DIFF
--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -25,7 +25,7 @@ service PinotQueryWorker {
   // Dispatch a QueryRequest to a PinotQueryWorker
   rpc Submit(QueryRequest) returns (QueryResponse);
 
-  rpc SubmitTimeSeries(TimeSeriesQueryRequest) returns (TimeSeriesResponse);
+  rpc SubmitTimeSeries(TimeSeriesQueryRequest) returns (stream TimeSeriesResponse);
 
   rpc Cancel(CancelRequest) returns (CancelResponse);
 
@@ -54,7 +54,8 @@ message QueryResponse {
 }
 
 message TimeSeriesQueryRequest {
-  bytes dispatchPlan = 1;
+  // List of plan sub-trees which will be executed in order on the server
+  repeated string dispatchPlan = 1;
   map<string, string> metadata = 2;
 }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -160,7 +160,8 @@ public class QueryRunner {
       throw new RuntimeException(e);
     }
     if (StringUtils.isNotBlank(config.getProperty(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey()))) {
-      _timeSeriesPhysicalPlanVisitor = new PhysicalTimeSeriesServerPlanVisitor(_leafQueryExecutor, _executorService, serverMetrics);
+      _timeSeriesPhysicalPlanVisitor = new PhysicalTimeSeriesServerPlanVisitor(_leafQueryExecutor, _executorService,
+          serverMetrics);
       TimeSeriesBuilderFactoryProvider.init(config);
     }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -265,7 +265,7 @@ public class QueryRunner {
     };
     try {
       final long deadlineMs = extractDeadlineMs(metadata);
-      Preconditions.checkState(deadlineMs > 0,
+      Preconditions.checkState(System.currentTimeMillis() < deadlineMs,
           "Query timed out before getting processed in server. Remaining time: %s", deadlineMs);
       // Deserialize plan, and compile to create a tree of operators.
       BaseTimeSeriesPlanNode rootNode = TimeSeriesPlanSerde.deserialize(serializedPlan);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
@@ -42,17 +42,13 @@ import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
 import org.apache.pinot.tsdb.spi.plan.LeafTimeSeriesPlanNode;
 
 
-public class PhysicalTimeSeriesPlanVisitor {
-  public static final PhysicalTimeSeriesPlanVisitor INSTANCE = new PhysicalTimeSeriesPlanVisitor();
-
+public class PhysicalTimeSeriesServerPlanVisitor {
   private QueryExecutor _queryExecutor;
   private ExecutorService _executorService;
   private ServerMetrics _serverMetrics;
 
-  private PhysicalTimeSeriesPlanVisitor() {
-  }
-
-  public void init(QueryExecutor queryExecutor, ExecutorService executorService, ServerMetrics serverMetrics) {
+  // Warning: Don't use singleton access pattern, since Quickstarts run in a single JVM and spawn multiple broker/server
+  public PhysicalTimeSeriesServerPlanVisitor(QueryExecutor queryExecutor, ExecutorService executorService, ServerMetrics serverMetrics) {
     _queryExecutor = queryExecutor;
     _executorService = executorService;
     _serverMetrics = serverMetrics;
@@ -103,7 +99,7 @@ public class PhysicalTimeSeriesPlanVisitor {
         .setFilter(filterContext)
         .setGroupByExpressions(groupByExpressions)
         .setSelectExpressions(Collections.emptyList())
-        .setQueryOptions(ImmutableMap.of(QueryOptionKey.TIMEOUT_MS, Long.toString(context.getTimeoutMs())))
+        .setQueryOptions(ImmutableMap.of(QueryOptionKey.TIMEOUT_MS, Long.toString(context.getRemainingTimeMs())))
         .setAliasList(Collections.emptyList())
         .setTimeSeriesContext(timeSeriesContext)
         .setLimit(Integer.MAX_VALUE)

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
@@ -48,7 +48,8 @@ public class PhysicalTimeSeriesServerPlanVisitor {
   private ServerMetrics _serverMetrics;
 
   // Warning: Don't use singleton access pattern, since Quickstarts run in a single JVM and spawn multiple broker/server
-  public PhysicalTimeSeriesServerPlanVisitor(QueryExecutor queryExecutor, ExecutorService executorService, ServerMetrics serverMetrics) {
+  public PhysicalTimeSeriesServerPlanVisitor(QueryExecutor queryExecutor, ExecutorService executorService,
+      ServerMetrics serverMetrics) {
     _queryExecutor = queryExecutor;
     _executorService = executorService;
     _serverMetrics = serverMetrics;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
@@ -27,15 +27,15 @@ public class TimeSeriesExecutionContext {
   private final String _language;
   private final TimeBuckets _initialTimeBuckets;
   private final Map<String, List<String>> _planIdToSegmentsMap;
-  private final long _timeoutMs;
+  private final long _deadlineMs;
   private final Map<String, String> _metadataMap;
 
   public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets,
-      Map<String, List<String>> planIdToSegmentsMap, long timeoutMs, Map<String, String> metadataMap) {
+      Map<String, List<String>> planIdToSegmentsMap, long deadlineMs, Map<String, String> metadataMap) {
     _language = language;
     _initialTimeBuckets = initialTimeBuckets;
     _planIdToSegmentsMap = planIdToSegmentsMap;
-    _timeoutMs = timeoutMs;
+    _deadlineMs = deadlineMs;
     _metadataMap = metadataMap;
   }
 
@@ -51,8 +51,8 @@ public class TimeSeriesExecutionContext {
     return _planIdToSegmentsMap;
   }
 
-  public long getTimeoutMs() {
-    return _timeoutMs;
+  public long getRemainingTimeMs() {
+    return _deadlineMs - System.currentTimeMillis();
   }
 
   public Map<String, String> getMetadataMap() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesPhysicalTableScan.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.timeseries;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -57,7 +58,8 @@ public class TimeSeriesPhysicalTableScan extends BaseTimeSeriesPlanNode {
 
   @Override
   public BaseTimeSeriesPlanNode withInputs(List<BaseTimeSeriesPlanNode> newInputs) {
-    throw new UnsupportedOperationException("withInputs not supported for TimeSeriesPhysicalTableScan");
+    Preconditions.checkState(newInputs.isEmpty(), "Attempted to add inputs to physical table scan");
+    return new TimeSeriesPhysicalTableScan(_id, _request, _queryExecutor, _executorService);
   }
 
   public String getKlass() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Deadline;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -291,7 +290,7 @@ public class QueryDispatcher {
     long deadlineMs = System.currentTimeMillis() + timeoutMs;
     String serializedPlan = plan.getSerializedPlan();
     Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
-        .setDispatchPlan(ByteString.copyFrom(serializedPlan, StandardCharsets.UTF_8))
+        .addDispatchPlan(serializedPlan)
         .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext))
         .putMetadata(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestId))
         .build();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -222,8 +222,8 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   @Override
   public void submitTimeSeries(Worker.TimeSeriesQueryRequest request,
       StreamObserver<Worker.TimeSeriesResponse> responseObserver) {
-    ByteString bytes = request.getDispatchPlan();
-    _queryRunner.processTimeSeriesQuery(bytes.toStringUtf8(), request.getMetadataMap(), responseObserver);
+    String dispatchPlan = request.getDispatchPlan(0);
+    _queryRunner.processTimeSeriesQuery(dispatchPlan, request.getMetadataMap(), responseObserver);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -66,7 +65,7 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().getIdentifier(), "orderCount");
       assertEquals(queryContext.getFilter().toString(),
           "(cityName = 'Chicago' AND orderTime > '990' AND orderTime <= '1990')");
-      assertTrue(StringUtils.isNumeric(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)));
+      assertTrue(isNumber(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)));
     }
     // Case-2: With offset, complex group-by expression, complex value, and non-empty filter
     {
@@ -88,7 +87,16 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
       assertNotNull(queryContext.getFilter());
       assertEquals(queryContext.getFilter().toString(),
           "(cityName = 'Chicago' AND orderTime > '980' AND orderTime <= '1980')");
-      assertTrue(StringUtils.isNumeric(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)));
+      assertTrue(isNumber(queryContext.getQueryOptions().get(QueryOptionKey.TIMEOUT_MS)));
+    }
+  }
+
+  private boolean isNumber(String s) {
+    try {
+      Long.parseLong(s);
+      return true;
+    } catch (NumberFormatException ignored) {
+      return false;
     }
   }
 }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesPlanConstants.java
@@ -51,6 +51,7 @@ public class TimeSeriesPlanConstants {
   }
 
   public static class WorkerResponseMetadataKeys {
+    public static final String PLAN_ID = "planId";
     public static final String ERROR_TYPE = "errorType";
     public static final String ERROR_MESSAGE = "error";
   }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesQueryServerInstance.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesQueryServerInstance.java
@@ -22,18 +22,25 @@ import org.apache.pinot.core.transport.ServerInstance;
 
 
 public class TimeSeriesQueryServerInstance {
+  private final String _instanceId;
   private final String _hostname;
   private final int _queryServicePort;
   private final int _queryMailboxPort;
 
   public TimeSeriesQueryServerInstance(ServerInstance serverInstance) {
-    this(serverInstance.getHostname(), serverInstance.getQueryServicePort(), serverInstance.getQueryMailboxPort());
+    this(serverInstance.getInstanceId(), serverInstance.getHostname(), serverInstance.getQueryServicePort(),
+        serverInstance.getQueryMailboxPort());
   }
 
-  public TimeSeriesQueryServerInstance(String hostname, int queryServicePort, int queryMailboxPort) {
+  public TimeSeriesQueryServerInstance(String instanceId, String hostname, int queryServicePort, int queryMailboxPort) {
+    _instanceId = instanceId;
     _hostname = hostname;
     _queryServicePort = queryServicePort;
     _queryMailboxPort = queryMailboxPort;
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
   }
 
   public String getHostname() {


### PR DESCRIPTION
Building on top of #14582, this PR enables support for sending multiple plan fragments from the broker to the server, and enables the server to return multiple responses back to the broker.

Additionally, I have also added the following minor refactoring:

* Remove singleton logic from Physical time series plan visitor since it doesn't work in Quickstarts.
* Change timeout to deadline.

**Note:** This changes the contract between broker/server for time-series requests, so running time-series queries on a cluster would fail as this patch is rolling out.

**Test Plan:** Ran a Quickstart on local and confirmed E2E integrations work fine. Once the remaining 2-3 PRs for broker reduce are merged, we'll re-run tests on our internal cluster for perf comparisons