### PR TITLE
include reason why TableSegmentValidationInfo is invalid

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfo.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.restlet.resources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 
 
 public class TableSegmentValidationInfo {
@@ -30,7 +31,7 @@ public class TableSegmentValidationInfo {
 
   @JsonCreator
   public TableSegmentValidationInfo(@JsonProperty("valid") boolean valid,
-      @JsonProperty("invalidReason") String invalidReason,
+      @JsonProperty("invalidReason") @Nullable String invalidReason,
       @JsonProperty("maxEndTimeMs") long maxEndTimeMs) {
     _valid = valid;
     _invalidReason = invalidReason;
@@ -45,6 +46,7 @@ public class TableSegmentValidationInfo {
     return _maxEndTimeMs;
   }
 
+  @Nullable
   public String getInvalidReason() {
     return _invalidReason;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfo.java
@@ -25,12 +25,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TableSegmentValidationInfo {
   private final boolean _valid;
+  private final String _invalidReason;
   private final long _maxEndTimeMs;
 
   @JsonCreator
   public TableSegmentValidationInfo(@JsonProperty("valid") boolean valid,
+      @JsonProperty("invalidReason") String invalidReason,
       @JsonProperty("maxEndTimeMs") long maxEndTimeMs) {
     _valid = valid;
+    _invalidReason = invalidReason;
     _maxEndTimeMs = maxEndTimeMs;
   }
 
@@ -40,5 +43,9 @@ public class TableSegmentValidationInfo {
 
   public long getMaxEndTimeMs() {
     return _maxEndTimeMs;
+  }
+
+  public String getInvalidReason() {
+    return _invalidReason;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfoTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/TableSegmentValidationInfoTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TableSegmentValidationInfoTest {
+
+  @Test
+  public void testParsingFromJsonStringAllFields()
+      throws JsonProcessingException {
+    String tableSegmentValidationInfoString = "{\"valid\":false,\"invalidReason\":\"invalid\",\"maxEndTimeMs\":0}";
+    TableSegmentValidationInfo tableSegmentValidationInfo =
+        JsonUtils.stringToObject(tableSegmentValidationInfoString, TableSegmentValidationInfo.class);
+    Assert.assertFalse(tableSegmentValidationInfo.isValid());
+    Assert.assertEquals(tableSegmentValidationInfo.getInvalidReason(), "invalid");
+    Assert.assertEquals(tableSegmentValidationInfo.getMaxEndTimeMs(), 0);
+  }
+
+  @Test
+  public void testParsingFromJsonStringNoInvalidReason()
+      throws JsonProcessingException {
+    String tableSegmentValidationInfoString = "{\"valid\":true,\"maxEndTimeMs\":0}";
+    TableSegmentValidationInfo tableSegmentValidationInfo =
+        JsonUtils.stringToObject(tableSegmentValidationInfoString, TableSegmentValidationInfo.class);
+    Assert.assertTrue(tableSegmentValidationInfo.isValid());
+    Assert.assertNull(tableSegmentValidationInfo.getInvalidReason());
+    Assert.assertEquals(tableSegmentValidationInfo.getMaxEndTimeMs(), 0);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -1256,8 +1256,7 @@ public class PinotTableRestletResource {
       TableSegmentValidationInfo tableSegmentValidationInfo =
           JsonUtils.stringToObject(response, TableSegmentValidationInfo.class);
       if (!tableSegmentValidationInfo.isValid()) {
-        String error = String.format("Table segment validation failed. error=%s",
-            tableSegmentValidationInfo.getInvalidReason());
+        String error = "Table segment validation failed. error=" + tableSegmentValidationInfo.getInvalidReason();
         throw new ControllerApplicationException(LOGGER, error, Response.Status.PRECONDITION_FAILED);
       }
       timeBoundaryMs = Math.max(timeBoundaryMs, tableSegmentValidationInfo.getMaxEndTimeMs());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -1256,8 +1256,9 @@ public class PinotTableRestletResource {
       TableSegmentValidationInfo tableSegmentValidationInfo =
           JsonUtils.stringToObject(response, TableSegmentValidationInfo.class);
       if (!tableSegmentValidationInfo.isValid()) {
-        throw new ControllerApplicationException(LOGGER, "Table segment validation failed",
-            Response.Status.PRECONDITION_FAILED);
+        String error = String.format("Table segment validation failed. error=%s",
+            tableSegmentValidationInfo.getInvalidReason());
+        throw new ControllerApplicationException(LOGGER, error, Response.Status.PRECONDITION_FAILED);
       }
       timeBoundaryMs = Math.max(timeBoundaryMs, tableSegmentValidationInfo.getMaxEndTimeMs());
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -1035,7 +1035,6 @@ public class TablesResource {
               if (segmentDataManager == null) {
                 String invalidReason = String.format(
                     "Segment %s is in CONSUMING state, but segmentDataManager is null", segmentName);
-                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               }
               break;
@@ -1049,7 +1048,6 @@ public class TablesResource {
               if (segmentDataManager == null) {
                 String invalidReason = String.format(
                     "Segment %s is in ONLINE state, but segmentDataManager is null", segmentName);
-                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               } else if (!segmentDataManager.getSegment().getSegmentMetadata().getCrc()
                   .equals(String.valueOf(zkMetadata.getCrc()))) {
@@ -1057,7 +1055,6 @@ public class TablesResource {
                     "Segment %s is in ONLINE state, but has CRC mismatch. "
                         + "zk_metadata_crc=%s, segment_data_manager_crc=%s",
                     segmentName, zkMetadata.getCrc(), segmentDataManager.getSegment().getSegmentMetadata().getCrc());
-                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               }
               maxEndTimeMs = Math.max(maxEndTimeMs, zkMetadata.getEndTimeMs());

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -1035,6 +1035,7 @@ public class TablesResource {
               if (segmentDataManager == null) {
                 String invalidReason = String.format(
                     "Segment %s is in CONSUMING state, but segmentDataManager is null", segmentName);
+                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               }
               break;
@@ -1048,6 +1049,7 @@ public class TablesResource {
               if (segmentDataManager == null) {
                 String invalidReason = String.format(
                     "Segment %s is in ONLINE state, but segmentDataManager is null", segmentName);
+                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               } else if (!segmentDataManager.getSegment().getSegmentMetadata().getCrc()
                   .equals(String.valueOf(zkMetadata.getCrc()))) {
@@ -1055,6 +1057,7 @@ public class TablesResource {
                     "Segment %s is in ONLINE state, but has CRC mismatch. "
                         + "zk_metadata_crc=%s, segment_data_manager_crc=%s",
                     segmentName, zkMetadata.getCrc(), segmentDataManager.getSegment().getSegmentMetadata().getCrc());
+                LOGGER.error(invalidReason);
                 return new TableSegmentValidationInfo(false, invalidReason, -1);
               }
               maxEndTimeMs = Math.max(maxEndTimeMs, zkMetadata.getEndTimeMs());


### PR DESCRIPTION
This is an API enhancement so servers give a reason for why time boundary advance failing. We've found with tables wtih 10k+ segments, this API will repeatedly fail, but there's no way to debug what segment failed or why.

I added a unit test to ensure parsing still works without "invalidReason".

I also tested this on a cluster by manually changing the segment CRC in the zk metadata.

Calling the API when the controller was upgraded but the server wasn't gave back "null" as the error.
```
{
  "code": 412,
  "error": "Table segment validation failed. error=null"
}
```
Calling the API with bot components upgraded gave back the actual error.

```
{
  "code": 412,
  "error": "Table segment validation failed. error=Segment <table_name>_1732579200000_1733356800000_1733450209949 is in ONLINE state, but has CRC mismatch. zk_metadata_crc=1408182336, segment_data_manager_crc=1408182337"
}
```