### PR TITLE
Include column name for v4 raw fwd index build failure

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV4.java
@@ -136,7 +136,8 @@ public class VarByteChunkForwardIndexWriterV4 implements VarByteChunkWriter {
 
   @Override
   public void putBytes(byte[] bytes) {
-    Preconditions.checkState(_chunkOffset < (1L << 32), "exceeded 4GB of compressed chunks");
+    Preconditions.checkState(_chunkOffset < (1L << 32),
+        "exceeded 4GB of compressed chunks for: " + _dataBuffer.getName());
     int sizeRequired = Integer.BYTES + bytes.length;
     if (_chunkBuffer.position() > _chunkBuffer.capacity() - sizeRequired) {
       flushChunk();


### PR DESCRIPTION
It's useful to know which column caused the build failure so it may be addressed more quickly by operators. Currently users are left to guess which column caused the exception. 

_dataBuffer.getFile() output is in the format: `column_name.sv.raw.fwd`