### PR TITLE
Safeguard AbstractBuilder copy constructor from empty TextIndexConfig

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
@@ -20,11 +20,11 @@ package org.apache.pinot.segment.local.segment.store;
 
 import java.io.File;
 import java.util.Arrays;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.text.TextIndexConfigBuilder;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.TextIndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -35,7 +35,7 @@ public class TextIndexUtilsTest {
 
   @Test
   public void testRoundTripProperties()
-      throws ConfigurationException {
+      throws Exception {
     TextIndexConfig config =
         new TextIndexConfigBuilder().withLuceneAnalyzerClass("org.apache.lucene.analysis.core.KeywordAnalyzer")
             .withLuceneAnalyzerClassArgs(
@@ -45,7 +45,8 @@ public class TextIndexUtilsTest {
 
     TextIndexUtils.writeConfigToPropertiesFile(TEMP_DIR, config);
     TextIndexConfig readConfig = TextIndexUtils.getUpdatedConfigFromPropertiesFile(
-        new File(TEMP_DIR, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE), config);
+        new File(TEMP_DIR, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE),
+        JsonUtils.stringToObject("{}", TextIndexConfig.class));
     assertEquals(readConfig, config);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -39,7 +39,7 @@ public class TextIndexConfig extends IndexConfig {
   private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
   private static final boolean LUCENE_INDEX_REUSE_MUTABLE_INDEX = false;
   private static final int LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB = 0;
-  private static final boolean LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES = true;
+  private static final boolean LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES = false;
 
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
@@ -66,7 +66,7 @@ public class TextIndexConfig extends IndexConfig {
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("fst") FSTType fstType,
       @JsonProperty("rawValue") @Nullable Object rawValueForTextIndex,
       @JsonProperty("queryCache") boolean enableQueryCache,
-      @JsonProperty("useANDForMultiTermQueries") Boolean useANDForMultiTermQueries,
+      @JsonProperty("useANDForMultiTermQueries") boolean useANDForMultiTermQueries,
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
@@ -82,8 +82,7 @@ public class TextIndexConfig extends IndexConfig {
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
     _enableQueryCache = enableQueryCache;
-    _useANDForMultiTermQueries = useANDForMultiTermQueries == null
-        ? LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES : useANDForMultiTermQueries;
+    _useANDForMultiTermQueries = useANDForMultiTermQueries;
     _stopWordsInclude = stopWordsInclude;
     _stopWordsExclude = stopWordsExclude;
     _luceneUseCompoundFile =
@@ -344,16 +343,17 @@ public class TextIndexConfig extends IndexConfig {
       return false;
     }
     TextIndexConfig that = (TextIndexConfig) o;
-    return _enableQueryCache == that._enableQueryCache && _useANDForMultiTermQueries == that._useANDForMultiTermQueries
+    return _enableQueryCache == that._enableQueryCache
+        && _useANDForMultiTermQueries == that._useANDForMultiTermQueries
         && _luceneUseCompoundFile == that._luceneUseCompoundFile
         && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB
         && _enablePrefixSuffixMatchingInPhraseQueries == that._enablePrefixSuffixMatchingInPhraseQueries
         && _reuseMutableIndex == that._reuseMutableIndex
         && _luceneNRTCachingDirectoryMaxBufferSizeMB == that._luceneNRTCachingDirectoryMaxBufferSizeMB
-        && _fstType == that._fstType && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
-        && Objects.equals(_stopWordsInclude, that._stopWordsInclude) && Objects.equals(_stopWordsExclude,
-        that._stopWordsExclude) && _luceneUseCompoundFile == that._luceneUseCompoundFile
-        && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB
+        && _fstType == that._fstType
+        && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
+        && Objects.equals(_stopWordsInclude, that._stopWordsInclude)
+        && Objects.equals(_stopWordsExclude, that._stopWordsExclude)
         && Objects.equals(_luceneAnalyzerClass, that._luceneAnalyzerClass)
         && Objects.equals(_luceneAnalyzerClassArgs, that._luceneAnalyzerClassArgs)
         && Objects.equals(_luceneAnalyzerClassArgTypes, that._luceneAnalyzerClassArgTypes)

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -39,6 +39,7 @@ public class TextIndexConfig extends IndexConfig {
   private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
   private static final boolean LUCENE_INDEX_REUSE_MUTABLE_INDEX = false;
   private static final int LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB = 0;
+  private static final boolean LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES = true;
 
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
@@ -65,7 +66,7 @@ public class TextIndexConfig extends IndexConfig {
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("fst") FSTType fstType,
       @JsonProperty("rawValue") @Nullable Object rawValueForTextIndex,
       @JsonProperty("queryCache") boolean enableQueryCache,
-      @JsonProperty("useANDForMultiTermQueries") boolean useANDForMultiTermQueries,
+      @JsonProperty("useANDForMultiTermQueries") Boolean useANDForMultiTermQueries,
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
@@ -81,7 +82,8 @@ public class TextIndexConfig extends IndexConfig {
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
     _enableQueryCache = enableQueryCache;
-    _useANDForMultiTermQueries = useANDForMultiTermQueries;
+    _useANDForMultiTermQueries = useANDForMultiTermQueries == null
+        ? LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES : useANDForMultiTermQueries;
     _stopWordsInclude = stopWordsInclude;
     _stopWordsExclude = stopWordsExclude;
     _luceneUseCompoundFile =
@@ -205,7 +207,7 @@ public class TextIndexConfig extends IndexConfig {
     @Nullable
     protected Object _rawValueForTextIndex;
     protected boolean _enableQueryCache = false;
-    protected boolean _useANDForMultiTermQueries = true;
+    protected boolean _useANDForMultiTermQueries = LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES;
     protected List<String> _stopWordsInclude = new ArrayList<>();
     protected List<String> _stopWordsExclude = new ArrayList<>();
     protected boolean _luceneUseCompoundFile = LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
@@ -227,8 +229,10 @@ public class TextIndexConfig extends IndexConfig {
       _fstType = other._fstType;
       _enableQueryCache = other._enableQueryCache;
       _useANDForMultiTermQueries = other._useANDForMultiTermQueries;
-      _stopWordsInclude = new ArrayList<>(other._stopWordsInclude);
-      _stopWordsExclude = new ArrayList<>(other._stopWordsExclude);
+      _stopWordsInclude =
+          other._stopWordsInclude == null ? new ArrayList<>() : new ArrayList<>(other._stopWordsInclude);
+      _stopWordsExclude =
+          other._stopWordsExclude == null ? new ArrayList<>() : new ArrayList<>(other._stopWordsExclude);
       _luceneUseCompoundFile = other._luceneUseCompoundFile;
       _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
       _luceneAnalyzerClass = other._luceneAnalyzerClass;


### PR DESCRIPTION
Refer https://github.com/apache/pinot/pull/13948#issuecomment-2523157822

The PR also fixes the default value of `useANDForMultiTermQueries` which was being set to `true` via `AbstractBuilder(FSTType fstType)` but false when created through json creator on `TextIndexConfig()` with a json string missing the `useANDForMultiTermQueries` field. Going with false as `LuceneTextIndexReader` also has a false default for  it 