### PR TITLE
Fix H3 index boundary calculations.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.queries;
 
 import com.google.common.collect.ImmutableList;
+import com.uber.h3core.LengthUnit;
+import com.uber.h3core.util.LatLng;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,9 +38,12 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
+import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -47,9 +52,11 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.locationtech.jts.geom.Coordinate;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.segment.local.utils.H3Utils.H3_CORE;
 
 /**
  * Queries test for H3 index.
@@ -58,26 +65,20 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "H3IndexQueriesTest");
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME = "testSegment";
-  private static final Random RANDOM = new Random();
 
+  // this test is only useful when number of records is high, e.g. 1 mil or higher ( but it's much too slow for CI )
   private static final int NUM_RECORDS = 10000;
 
   private static final String H3_INDEX_COLUMN = "h3Column";
   private static final String H3_INDEX_GEOMETRY_COLUMN = "h3Column_geometry";
   private static final String NON_H3_INDEX_COLUMN = "nonH3Column";
   private static final String NON_H3_INDEX_GEOMETRY_COLUMN = "nonH3Column_geometry";
+
   private static final Schema SCHEMA =
       new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME).addSingleValueDimension(H3_INDEX_COLUMN, DataType.BYTES)
           .addSingleValueDimension(NON_H3_INDEX_COLUMN, DataType.BYTES)
           .addSingleValueDimension(H3_INDEX_GEOMETRY_COLUMN, DataType.BYTES)
           .addSingleValueDimension(NON_H3_INDEX_GEOMETRY_COLUMN, DataType.BYTES).build();
-  private static final Map<String, String> H3_INDEX_PROPERTIES = Collections.singletonMap("resolutions", "5");
-  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
-      .setFieldConfigList(ImmutableList
-          .of(new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.H3, null,
-                  H3_INDEX_PROPERTIES),
-              new FieldConfig(H3_INDEX_GEOMETRY_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.H3,
-                  null, H3_INDEX_PROPERTIES))).build();
 
   private IndexSegment _indexSegment;
 
@@ -98,9 +99,23 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
 
   public void setUp(List<GenericRow> records)
       throws Exception {
+    setUp(records, 5);
+  }
+
+  public void setUp(List<GenericRow> records, int resolution)
+      throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
 
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    Map<String, String> h3IndexProps = Collections.singletonMap("resolutions", String.valueOf(resolution));
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setFieldConfigList(ImmutableList
+            .of(new FieldConfig(H3_INDEX_COLUMN, EncodingType.DICTIONARY, IndexType.H3, null,
+                    h3IndexProps),
+                new FieldConfig(H3_INDEX_GEOMETRY_COLUMN, EncodingType.DICTIONARY, IndexType.H3,
+                    null, h3IndexProps))).build();
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
@@ -109,7 +124,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
     driver.build();
 
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, SCHEMA);
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
   }
 
@@ -126,16 +141,98 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     records.add(record);
   }
 
-  @Test
-  public void testH3Index()
+  @DataProvider
+  public Integer[] getResolutions() {
+    Integer[] result = new Integer[16];
+    for (int i = 0; i < result.length; i++) {
+      result[i] = i;
+    }
+    return result;
+  }
+
+  // no really a test but a calculation of distance stats per level
+  @Test(dataProvider = "getResolutions", enabled = false)
+  public void testH3IndexDistances(int resolution) {
+    double latitude = 37;
+    double longitude = -122.5;
+    double maxDistance = 1000;
+
+    double edgeLength;
+    long h3Id = H3Utils.H3_CORE.geoToH3(latitude, longitude, resolution);
+    LatLng h3Coords = H3Utils.H3_CORE.h3ToGeo(h3Id);
+
+    double coreDist = H3_CORE.pointDist(h3Coords, new LatLng(latitude, longitude), LengthUnit.m);
+
+    double maxLength = 0;
+    List<Long> edges = H3_CORE.getH3UnidirectionalEdgesFromHexagon(h3Id);
+    for (int i = 0, len = edges.size(); i < len; i++) {
+      maxLength = Math.max(maxLength, H3Utils.H3_CORE.exactEdgeLength(edges.get(i), LengthUnit.m));
+    }
+    edgeLength = maxLength;
+
+    System.out.println(" core dist is " + coreDist + ", edge length " + edgeLength);
+
+    int fullN = (int) Math.floor((maxDistance / edgeLength - 2) / 1.7321);
+    int partialN = (int) Math.floor((maxDistance / edgeLength + 2) / 1.44 + 0.001);
+
+    List<List<Long>> rings = H3_CORE.kRingDistances(h3Id, 100);
+    List<double[]> stats = new ArrayList<>();
+
+    for (int i = 0, len = rings.size(); i < len; i++) {
+
+      List<Long> ring = rings.get(i);
+      int jlen = ring.size();
+      int full = 0;
+      int partial = 0;
+      double minDist = Double.MAX_VALUE;
+      double maxDist = 0;
+
+      for (int j = 0; j < jlen; j++) {
+        double dist = H3_CORE.pointDist(h3Coords, H3_CORE.h3ToGeo(ring.get(j)), LengthUnit.m);
+
+        if (dist > maxDistance + edgeLength) {
+          // beyond maxDistance
+        } else if (dist <= maxDistance - edgeLength) {
+          // fully contained
+          full++;
+        } else if (dist < maxDistance) {
+          // partially contained, need additional check
+          partial++;
+        }
+
+        minDist = Math.min(minDist, dist);
+        maxDist = Math.max(maxDist, dist);
+      }
+      if (minDist == Double.MAX_VALUE) {
+        minDist = 0;
+      }
+
+      stats.add(new double[]{
+          i, jlen, full, partial, minDist,
+          minDist / edgeLength, minDist / (edgeLength * i),
+          maxDist, maxDist / edgeLength, maxDist / (edgeLength * i),
+          i <= fullN ? 1.0 : 0.0, i <= partialN ? 1.0 : 0.0
+      });
+    }
+
+    for (int i = 0; i < stats.size(); i++) {
+      System.out.println(Arrays.toString(stats.get(i)));
+    }
+  }
+
+  @Test(dataProvider = "getResolutions")
+  public void testH3Index(int resolution)
       throws Exception {
+    final Random random = new Random(0L);
+
     List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
     for (int i = 0; i < NUM_RECORDS; i++) {
-      double longitude = -122.5 + RANDOM.nextDouble();
-      double latitude = 37 + RANDOM.nextDouble();
+      // one degree amounts to about 100km
+      double longitude = -122.5 + random.nextDouble();
+      double latitude = 37 + random.nextDouble();
       addRecord(records, longitude, latitude);
     }
-    setUp(records);
+    setUp(records, resolution);
 
     // Invalid upper bound
     {
@@ -169,53 +266,34 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     }
 
     // Lower bound only
-    // 1km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 1000");
-    // 5km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 5000");
-    // 10km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 10000");
-    // 20km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 20000");
-    // 50km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 50000");
-    // 100km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > 100000");
+    for (int i = 1; i <= 100; i += 2) {
+      testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) > " + i * 1000);
+    }
 
     // Upper bound only
-    // 1km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 1000");
-    // 5km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 5000");
-    // 10km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 10000");
-    // 20km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 20000");
-    // 50km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 50000");
-    // 100km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < 100000");
+    for (int i = 1; i <= 100; i += 2) {
+      testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) < " + (i * 1000));
+    }
 
     // Both lower and upper bound
-    // 1-5km
     testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN 1000 AND 5000");
-    // 5-10km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN 5000 AND 10000");
-    // 10-20km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN 10000 AND 20000");
-    // 20-50km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN 20000 AND 50000");
-    // 50-100km
-    testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN 50000 AND 100000");
+
+    for (int i = 1; i < 20; i += 2) {
+      for (int j = i + 1; j <= 20; j += 2) {
+        testQuery("SELECT COUNT(*) FROM testTable WHERE ST_Distance(%s, ST_Point(-122, 37.5, 1)) BETWEEN " + (i * 5000)
+            + " AND " + (j * 5000));
+      }
+    }
 
     // Distance is too large, should fall back to scan-based ExpressionFilterOperator
     {
       String query = "SELECT COUNT(*) FROM testTable WHERE ST_Distance(h3Column, ST_Point(-122, 37.5, 1)) < 10000000";
       AggregationOperator aggregationOperator = getOperator(query);
       AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
-      // Expect 10000 entries scanned in filter
       QueriesTestUtils
-          .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS, NUM_RECORDS,
+          .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS,
+              //at coarse-grained resolutions 100 hexagon rings can easily cover 10k km or even whole of earth
+              resolution < 4 ? 0 : NUM_RECORDS,
               0, NUM_RECORDS);
       List<Object> aggregationResult = resultsBlock.getResults();
       Assert.assertNotNull(aggregationResult);
@@ -425,15 +503,22 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     AggregationResultsBlock h3IndexResultsBlock = h3IndexOperator.nextBlock();
     AggregationResultsBlock nonH3IndexResultsBlock = nonH3IndexOperator.nextBlock();
     // Expect less than 10000 entries scanned in filter
-    Assert.assertTrue(h3IndexOperator.getExecutionStatistics().getNumEntriesScannedInFilter() < NUM_RECORDS);
-    Assert.assertEquals(nonH3IndexOperator.getExecutionStatistics().getNumEntriesScannedInFilter(), NUM_RECORDS);
-    Assert.assertEquals(h3IndexResultsBlock.getResults(), nonH3IndexResultsBlock.getResults());
+    try {
+      Assert.assertTrue(h3IndexOperator.getExecutionStatistics().getNumEntriesScannedInFilter() <= NUM_RECORDS);
+      Assert.assertEquals(nonH3IndexOperator.getExecutionStatistics().getNumEntriesScannedInFilter(), NUM_RECORDS);
+      Assert.assertEquals(h3IndexResultsBlock.getResults(), nonH3IndexResultsBlock.getResults());
+    } catch (AssertionError ae) {
+      throw new AssertionError(ae.getMessage() + "\nQuery: " + h3IndexQuery, ae);
+    }
   }
 
-  @AfterClass
+  @AfterMethod
   public void tearDown()
       throws IOException {
-    _indexSegment.destroy();
+    if (_indexSegment != null) {
+      _indexSegment.destroy();
+      _indexSegment = null;
+    }
     FileUtils.deleteDirectory(INDEX_DIR);
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Per\-hexagon max edge length replaces average; used to compute rings for H3 index filtering in ST\_Distance queries\.

```mermaid
flowchart TD
  N0["Constructor #40;H3IndexFilterOperator#46;java#41; #40;F1#41;"]:::stRemoved
  N1["getAlwaysMatchH3Ids #40;H3IndexFilterOperator#46;java#41; #40;F1#41;"]:::stModified
  N2["getPossibleMatchH3Ids #40;H3IndexFilterOperator#46;java#41; #40;F1#41;"]:::stModified
  N3["getH3Ids #40;H3IndexFilterOperator#46;java#41; #40;F1#41;"]:::stModified
  N0 -->|"uses #95;edgeLength"| N1
  N0 -->|"uses #95;edgeLength"| N2
  N2 -->|"calls getH3Ids"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator\.java — [before](https://github.com/apache/pinot/blob/1641a6d4bf4738db082b1fdf832024b5ef90f04c/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java) · [after](https://github.com/apache/pinot/blob/443d7e9b7c8dbaf56ec4fc9ffbf3b391c57cecc3/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjE2NDFhNmQ0YmY0NzM4ZGIwODJiMWZkZjgzMjAyNGI1ZWY5MGYwNGMiLCJjb250ZXh0X2hhc2giOiI1Y2VmYmE4ZTIxY2I1ZmMzMzM0ZmQzZTVhOGE3ODk3NzI3NjRkZDUyMGRlZTU2Y2IwNDcyOTIwM2UwNDA5M2IxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Njk5MDIwLCJoZWFkX3NoYSI6IjQ0M2Q3ZTliN2M4ZGJhZjU2ZWM0ZmM5ZmZiZjNiMzkxYzU3Y2VjYzMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxNjQxYTZkNGJmNDczOGRiMDgyYjFmZGY4MzIwMjRiNWVmOTBmMDRjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature aa9a0ace2ccfb7d9bcbcc8771d2d632c7254daafd29d523803c75341a54a6949 -->
<!-- pinot-pr-flow:end -->

PR fixes H3IndexFilterOperator's accuracy when used with ST_Distance function.

Calculations in master branch are inaccurate because:
- hexagon size in is not constant per level, so using average value could lead to including too many points without verifying actual distances 
- distance between given point (e.g.hexagon center) and center's of n-th ring or hexagons is not uniform and varies greatly for large values of N

Example: 
```sql
SELECT COUNT(*) 
FROM testTable 
WHERE ST_Distance(indexed_point, ST_Point(-122, 37.5, 1)) <  10000
```

Useful links:
https://observablehq.com/@nrabinowitz/h3-area-variation
https://observablehq.com/@nrabinowitz/h3-area-stats
