### PR TITLE
Expose QueryScheduler from ServerInstance & Custom interface

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3802,7 +3802,7 @@ public class PinotHelixResourceManager {
           return false;
         }
         // Could be used to perform operation before segments replacement
-        preSegmentReplaceOperation(tableNameWithType, segmentsTo);
+        preSegmentReplaceUpdateRouting(tableNameWithType, segmentsTo, lineageEntry.getSegmentsFrom());
         // Update lineage entry
         LineageEntry lineageEntryToUpdate =
             new LineageEntry(lineageEntry.getSegmentsFrom(), segmentsTo, LineageEntryState.COMPLETED,
@@ -3839,20 +3839,27 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Internal method to initiate pageCache warmup for a table before the new refresh segments are available
-   * for querying.
-   * This method triggers a pageCache warmup operation on the server for the specified table and segments.
-   * For refresh tables, the `segmentsTo` list is particularly important as it contains the segments
-   * that need to be warmed up.
+   * This method can be overridden to perform custom operations before updating the routing table
+   * to switch routing from the old segments (`segmentsFrom`) to the new segments (`segmentsTo`).
+   * One example usage of this method could be triggering a pageCache warmup operation on the server
+   * for the specified table and segments. For refresh tables, this ensures that the new segments
+   * are warmed up and ready for query availability before the routing table is updated.
+   *
    * Example:
    * To warm up specific segments of the "salesData_OFFLINE" table:
    *   - tableNameWithType: "salesData_OFFLINE"
-   *   - segmentsTo: ["segment1", "segment2", "segment3"]
+   *   - segmentsTo: ["newSegment1", "newSegment2", "newSegment3"]
+   *   - segmentsFrom: ["oldSegment1", "oldSegment2", "oldSegment3"]
    *
-   * @param tableNameWithType The name and type of the table for which the pageCache warmup is triggered
-   * @param segmentsTo A list of segments that need to be warmed up before query availability
+   * @param tableNameWithType The name and type of the table for which operations need to be performed
+   *                          before switching routing from `segmentsFrom` to `segmentsTo`.
+   * @param segmentsTo A list of new segments that need to be prepared (e.g., warmed up) before
+   *                   they are made available for querying.
+   * @param segmentsFrom A list of old segments that are currently routed for queries, in case some operation is needed
+   *                     on it.
    */
-  protected void preSegmentReplaceOperation(String tableNameWithType, List<String> segmentsTo) {
+  protected void preSegmentReplaceUpdateRouting(String tableNameWithType, List<String> segmentsTo,
+      List<String> segmentsFrom) {
     // No-op by default
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3839,9 +3839,11 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Internal method to initiate pageCache warmup for a table before the new refresh segments are available for querying.
+   * Internal method to initiate pageCache warmup for a table before the new refresh segments are available
+   * for querying.
    * This method triggers a pageCache warmup operation on the server for the specified table and segments.
-   * For refresh tables, the `segmentsTo` list is particularly important as it contains the segments that need to be warmed up.
+   * For refresh tables, the `segmentsTo` list is particularly important as it contains the segments
+   * that need to be warmed up.
    * Example:
    * To warm up specific segments of the "salesData_OFFLINE" table:
    *   - tableNameWithType: "salesData_OFFLINE"

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3801,8 +3801,8 @@ public class PinotHelixResourceManager {
         if (!waitForSegmentsBecomeOnline(tableNameWithType, segmentsTo)) {
           return false;
         }
-        // Could be used to perform operation before enabling refresh segments
-        preRefreshOperation(tableNameWithType, segmentsTo);
+        // Could be used to perform operation before segments replacement
+        preSegmentReplaceOperation(tableNameWithType, segmentsTo);
         // Update lineage entry
         LineageEntry lineageEntryToUpdate =
             new LineageEntry(lineageEntry.getSegmentsFrom(), segmentsTo, LineageEntryState.COMPLETED,
@@ -3838,8 +3838,19 @@ public class PinotHelixResourceManager {
         tableNameWithType, segmentLineageEntryId);
   }
 
-  // Can be overridden to provide custom logic
-  protected void preRefreshOperation(String tableNameWithType, List<String> segmentsTo) {
+  /**
+   * Internal method to initiate pageCache warmup for a table before the new refresh segments are available for querying.
+   * This method triggers a pageCache warmup operation on the server for the specified table and segments.
+   * For refresh tables, the `segmentsTo` list is particularly important as it contains the segments that need to be warmed up.
+   * Example:
+   * To warm up specific segments of the "salesData_OFFLINE" table:
+   *   - tableNameWithType: "salesData_OFFLINE"
+   *   - segmentsTo: ["segment1", "segment2", "segment3"]
+   *
+   * @param tableNameWithType The name and type of the table for which the pageCache warmup is triggered
+   * @param segmentsTo A list of segments that need to be warmed up before query availability
+   */
+  protected void preSegmentReplaceOperation(String tableNameWithType, List<String> segmentsTo) {
     // No-op by default
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3801,7 +3801,8 @@ public class PinotHelixResourceManager {
         if (!waitForSegmentsBecomeOnline(tableNameWithType, segmentsTo)) {
           return false;
         }
-
+        // Could be used to perform operation before enabling refresh segments
+        preRefreshOperation(tableNameWithType, segmentsTo);
         // Update lineage entry
         LineageEntry lineageEntryToUpdate =
             new LineageEntry(lineageEntry.getSegmentsFrom(), segmentsTo, LineageEntryState.COMPLETED,
@@ -3835,6 +3836,11 @@ public class PinotHelixResourceManager {
     LOGGER.info("endReplaceSegments is successfully processed in {} ms on attempt: {}. (tableNameWithType = {}, "
             + "segmentLineageEntryId = {})", System.currentTimeMillis() - endReplaceSegmentsTs, attemptCount + 1,
         tableNameWithType, segmentLineageEntryId);
+  }
+
+  // Can be overridden to provide custom logic
+  protected void preRefreshOperation(String tableNameWithType, List<String> segmentsTo) {
+    // No-op by default
   }
 
   /**

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -292,4 +292,8 @@ public class ServerInstance {
   public HelixManager getHelixManager() {
     return _helixManager;
   }
+
+  public QueryScheduler getQueryScheduler() {
+    return _queryScheduler;
+  }
 }


### PR DESCRIPTION
1. Expose QueryScheduler from ServerInstance 
2. Add an interface during endReplaceSegment -> This would be No-op and use to explore pageCache warmup during segment replace 