### PR TITLE
Improve the unit test dataset used by CLPMutableForwardIndexV2Test and CLPForwardIndexCreatorV2Test

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/CLPForwardIndexCreatorV2Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/CLPForwardIndexCreatorV2Test.java
@@ -18,10 +18,15 @@
  */
 package org.apache.pinot.segment.local.segment.index.creator;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.realtime.impl.forward.CLPMutableForwardIndexV2;
@@ -34,6 +39,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -42,39 +48,57 @@ public class CLPForwardIndexCreatorV2Test {
   private static final File TEMP_DIR =
       new File(FileUtils.getTempDirectory(), CLPForwardIndexCreatorV2Test.class.getSimpleName());
   private PinotDataBufferMemoryManager _memoryManager;
+  private List<String> _logMessages = new ArrayList<>();
 
   @BeforeClass
   public void setUp()
       throws Exception {
     TestUtils.ensureDirectoriesExistAndEmpty(TEMP_DIR);
     _memoryManager = new DirectMemoryManager(VarByteSVMutableForwardIndexTest.class.getName());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    try (GzipCompressorInputStream gzipInputStream = new GzipCompressorInputStream(
+        getClass().getClassLoader().getResourceAsStream("data/log.jsonl.gz"));
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(gzipInputStream))) {
+      String line;
+      while ((line = bufferedReader.readLine()) != null) {
+        JsonNode jsonNode = objectMapper.readTree(line);
+        _logMessages.add(jsonNode.get("message").asText());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    TestUtils.ensureDirectoriesExistAndEmpty(TEMP_DIR);
   }
 
   @Test
   public void testCLPWriter()
       throws IOException {
-    List<String> logLines = new ArrayList<>();
-    logLines.add("INFO [PropertyCache] [HelixController-pipeline-default-pinot-(4a02a32c_DEFAULT)] "
-        + "Event pinot::DEFAULT::4a02a32c_DEFAULT : Refreshed 35 property LiveInstance took 5 ms. Selective: true");
-    logLines.add("INFO [PropertyCache] [HelixController-pipeline-default-pinot-(4a02a32d_DEFAULT)] "
-        + "Event pinot::DEFAULT::4a02a32d_DEFAULT : Refreshed 81 property LiveInstance took 4 ms. Selective: true");
-    logLines.add("INFO [ControllerResponseFilter] [grizzly-http-server-2] Handled request from 0.0"
-        + ".0.0 GET https://0.0.0.0:8443/health?checkType=liveness, content-type null status code 200 OK");
-    logLines.add("INFO [ControllerResponseFilter] [grizzly-http-server-6] Handled request from 0.0"
-        + ".0.0 GET https://pinot-pinot-broker-headless.managed.svc.cluster.local:8093/tables, content-type "
-        + "application/json status code 200 OK");
-    logLines.add("null");
-
     // Create and ingest into a clp mutable forward indexes
     CLPMutableForwardIndexV2 clpMutableForwardIndexV2 = new CLPMutableForwardIndexV2("column1", _memoryManager);
-    for (int i = 0; i < logLines.size(); i++) {
-      clpMutableForwardIndexV2.setString(i, logLines.get(i));
+    int raw_size_bytes = 0;
+    for (int i = 0; i < _logMessages.size(); i++) {
+      clpMutableForwardIndexV2.setString(i, _logMessages.get(i));
+      raw_size_bytes += _logMessages.get(i).length();
     }
 
+    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.LZ4, raw_size_bytes, 40);
+    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.ZSTANDARD, raw_size_bytes, 66);
+  }
+
+  private void validateImmutableForwardIndex(CLPMutableForwardIndexV2 clpMutableForwardIndexV2,
+      ChunkCompressionType compressor, int raw_size_bytes, float min_compression_ratio)
+      throws IOException {
     // Create a immutable forward index from mutable forward index
+    TestUtils.ensureDirectoriesExistAndEmpty(TEMP_DIR);
     CLPForwardIndexCreatorV2 clpForwardIndexCreatorV2 =
-        new CLPForwardIndexCreatorV2(TEMP_DIR, clpMutableForwardIndexV2, ChunkCompressionType.ZSTANDARD);
-    for (int i = 0; i < logLines.size(); i++) {
+        new CLPForwardIndexCreatorV2(TEMP_DIR, clpMutableForwardIndexV2, compressor);
+    for (int i = 0; i < _logMessages.size(); i++) {
       clpForwardIndexCreatorV2.putString(clpMutableForwardIndexV2.getString(i));
     }
     clpForwardIndexCreatorV2.seal();
@@ -83,10 +107,14 @@ public class CLPForwardIndexCreatorV2Test {
     // Read from immutable forward index and validate the content
     File indexFile = new File(TEMP_DIR, "column1" + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     PinotDataBuffer pinotDataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
-    CLPForwardIndexReaderV2 clpForwardIndexReaderV2 = new CLPForwardIndexReaderV2(pinotDataBuffer, logLines.size());
+    CLPForwardIndexReaderV2 clpForwardIndexReaderV2 = new CLPForwardIndexReaderV2(pinotDataBuffer, _logMessages.size());
     CLPForwardIndexReaderV2.CLPReaderContext clpForwardIndexReaderV2Context = clpForwardIndexReaderV2.createContext();
-    for (int i = 0; i < logLines.size(); i++) {
-      Assert.assertEquals(clpForwardIndexReaderV2.getString(i, clpForwardIndexReaderV2Context), logLines.get(i));
+    for (int i = 0; i < _logMessages.size(); i++) {
+      Assert.assertEquals(clpForwardIndexReaderV2.getString(i, clpForwardIndexReaderV2Context), _logMessages.get(i));
     }
+
+    // We expect to achieve a compression ratio >=66x with default configuration
+    float compression_ratio = (float) raw_size_bytes / indexFile.length();
+    Assert.assertTrue(compression_ratio >= min_compression_ratio);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/CLPForwardIndexCreatorV2Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/CLPForwardIndexCreatorV2Test.java
@@ -81,18 +81,18 @@ public class CLPForwardIndexCreatorV2Test {
       throws IOException {
     // Create and ingest into a clp mutable forward indexes
     CLPMutableForwardIndexV2 clpMutableForwardIndexV2 = new CLPMutableForwardIndexV2("column1", _memoryManager);
-    int raw_size_bytes = 0;
+    int rawSizeBytes = 0;
     for (int i = 0; i < _logMessages.size(); i++) {
       clpMutableForwardIndexV2.setString(i, _logMessages.get(i));
-      raw_size_bytes += _logMessages.get(i).length();
+      rawSizeBytes += _logMessages.get(i).length();
     }
 
-    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.LZ4, raw_size_bytes, 40);
-    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.ZSTANDARD, raw_size_bytes, 66);
+    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.LZ4, rawSizeBytes, 40);
+    validateImmutableForwardIndex(clpMutableForwardIndexV2, ChunkCompressionType.ZSTANDARD, rawSizeBytes, 66);
   }
 
   private void validateImmutableForwardIndex(CLPMutableForwardIndexV2 clpMutableForwardIndexV2,
-      ChunkCompressionType compressor, int raw_size_bytes, float min_compression_ratio)
+      ChunkCompressionType compressor, int rawSizeBytes, float minCompressionRatio)
       throws IOException {
     // Create a immutable forward index from mutable forward index
     TestUtils.ensureDirectoriesExistAndEmpty(TEMP_DIR);
@@ -114,7 +114,7 @@ public class CLPForwardIndexCreatorV2Test {
     }
 
     // We expect to achieve a compression ratio >=66x with default configuration
-    float compression_ratio = (float) raw_size_bytes / indexFile.length();
-    Assert.assertTrue(compression_ratio >= min_compression_ratio);
+    float compressionRatio = (float) rawSizeBytes / indexFile.length();
+    Assert.assertTrue(compressionRatio >= minCompressionRatio);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexV2Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexV2Test.java
@@ -18,10 +18,15 @@
  */
 package org.apache.pinot.segment.local.segment.index.forward.mutable;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.realtime.impl.forward.CLPMutableForwardIndexV2;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
@@ -33,10 +38,24 @@ import org.testng.annotations.Test;
 
 public class CLPMutableForwardIndexV2Test {
   private PinotDataBufferMemoryManager _memoryManager;
+  private List<String> _logMessages= new ArrayList<>();
 
   @BeforeClass
   public void setUp() {
     _memoryManager = new DirectMemoryManager(VarByteSVMutableForwardIndexTest.class.getName());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    try (GzipCompressorInputStream gzipInputStream = new GzipCompressorInputStream(
+        getClass().getClassLoader().getResourceAsStream("data/log.jsonl.gz"));
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(gzipInputStream))) {
+      String line;
+      while ((line = bufferedReader.readLine()) != null) {
+        JsonNode jsonNode = objectMapper.readTree(line);
+        _logMessages.add(jsonNode.get("message").asText());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @AfterClass
@@ -52,33 +71,17 @@ public class CLPMutableForwardIndexV2Test {
   public void testReadWriteOnLogMessages()
       throws IOException {
     try (CLPMutableForwardIndexV2 readerWriter = new CLPMutableForwardIndexV2("col1", _memoryManager)) {
-      List<String> logLines = new ArrayList<>();
-      for (int i = 0; i < 10000; i++) {
-        logLines.add("INFO [PropertyCache] [HelixController-pipeline-default-pinot-(4a02a32c_DEFAULT)] "
-            + "Event pinot::DEFAULT::4a02a32c_DEFAULT : Refreshed 35 property LiveInstance took 5 ms. Selective:"
-            + " true");
-        logLines.add("INFO [PropertyCache] [HelixController-pipeline-default-pinot-(4a02a32d_DEFAULT)] "
-            + "Event pinot::DEFAULT::4a02a32d_DEFAULT : Refreshed 81 property LiveInstance took 4 ms. Selective:"
-            + " true");
-        logLines.add("INFO [ControllerResponseFilter] [grizzly-http-server-2] Handled request from 0.0"
-            + ".0.0 GET https://0.0.0.0:8443/health?checkType=liveness, content-type null status code 200 OK");
-        logLines.add("INFO [ControllerResponseFilter] [grizzly-http-server-6] Handled request from 0.0"
-            + ".0.0 GET https://pinot-pinot-broker-headless.managed.svc.cluster.local:8093/tables, content-type "
-            + "application/json status code 200 OK");
-        logLines.add("null");
-      }
-
       // Typically, log messages should be clp encoded due to low logtype and dictionary variable cardinality
       Assert.assertTrue(readerWriter.isClpEncoded());
 
       // Write
-      for (int i = 0; i < logLines.size(); i++) {
-        readerWriter.setString(i, logLines.get(i));
+      for (int i = 0; i < _logMessages.size(); i++) {
+        readerWriter.setString(i, _logMessages.get(i));
       }
 
       // Read
-      for (int i = 0; i < logLines.size(); i++) {
-        Assert.assertEquals(readerWriter.getString(i), logLines.get(i));
+      for (int i = 0; i < _logMessages.size(); i++) {
+        Assert.assertEquals(readerWriter.getString(i), _logMessages.get(i));
       }
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexV2Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexV2Test.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 public class CLPMutableForwardIndexV2Test {
   private PinotDataBufferMemoryManager _memoryManager;
-  private List<String> _logMessages= new ArrayList<>();
+  private List<String> _logMessages = new ArrayList<>();
 
   @BeforeClass
   public void setUp() {


### PR DESCRIPTION
This PR enhances the unit tests for `CLPMutableForwardIndexV2Test` and `CLPForwardIndexCreatorV2Test` by replacing the previously trivial input data, inherited from `CLPMutableForwardIndexTest` and `CLPForwardIndexCreatorTest`, with logs from a real-world system (Apache Hadoop). The new input log file is located at `pinot-segment-local/src/test/resources/data/log.jsonl.gz`. It is a JSONL file where each line contains a JSON document with the fields `ts`, `level`, and `message`. When decompressed, the entire dataset size is approximately 268MB, with the message field accounting for 245MB of the total.

Using this dataset in CLPForwardIndexCreatorV2Test, the compression ratio is expected to exceed 40x with the LZ4 compressor and 66x with the ZSTD compressor. Additionally, the CLP-compressed forward index is over 25% smaller with LZ4 and more than 19% smaller with ZSTD compared to the raw forward index generated by the respective compressors.