### PR TITLE
Increase timeout for kafka client connection for metadata fetch

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1762,7 +1762,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           //  a single partition
           //  Fix this before opening support for partitioning in Kinesis
           int numPartitionGroups = _partitionMetadataProvider.computePartitionGroupMetadata(_clientId, _streamConfig,
-              Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
+              Collections.emptyList(), /*maxWaitTimeMs=*/15000).size();
 
           if (numPartitionGroups != numPartitions) {
             _segmentLogger.info(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -68,7 +68,7 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
     try (
         StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createStreamMetadataProvider(clientId)) {
       _newPartitionGroupMetadataList = streamMetadataProvider.computePartitionGroupMetadata(clientId, _streamConfig,
-          _partitionGroupConsumptionStatusList, /*maxWaitTimeMs=*/5000);
+          _partitionGroupConsumptionStatusList, /*maxWaitTimeMs=*/15000);
       if (_exception != null) {
         // We had at least one failure, but succeeded now. Log an info
         LOGGER.info("Successfully retrieved PartitionGroupMetadata for topic {}", _topicName);


### PR DESCRIPTION
### Issue

During the `segmentCommitEndWithMetadata` call from the server to the controller at commit time, the controller persists information about the committing segment in Zookeeper (ZK). It then attempts to push ZK metadata for the new segments by fetching the `List<PartitionInfo>` of the Kafka topic. If this Kafka call fails due to network issues, the new segment is not created, and consumption halts. While the system has an auto-recover periodic task in the controller that runs every hour to restore consumption, this delay impacts the real-time processing pipeline.

### Root cause

Upon investigation, the issue was traced back to the following:

- **Kafka Broker Unavailability**: The Kafka broker being queried was down due to issues on its end. Metadata-fetch operations in Kafka are designed to try alternative brokers in a round-robin fashion if the queried broker is unavailable.

- **Timeout Mismatch**: Kafka’s `socket.connection.setup.timeout.ms` (default: 10 seconds) specifies the wait time before switching to another broker. Pinot’s timeout for the metadata-fetch call was set to 5 seconds, which is shorter than Kafka's round-robin timeout, leading to Pinot prematurely failing the request.

### Solution 

#### Immediate Hotfix
**Increase Pinot’s Timeout**: The default timeout for the metadata-fetch call in Pinot is increased from 5 seconds to 15 seconds. This ensures Kafka has sufficient time to try to connect with at least one more broker in round-robin cycle through the broker list, improving the chances of a successful metadata-fetch.

#### Follow-Up Actions:
- **Make Timeout Configurable**: Introduce a configurable property for Pinot’s timeout, allowing adjustments based on deployment scenarios and Kafka configurations.

- **Adjust Kafka Consumer Configuration**: Investigate setting a lower value for `Kafka’s socket.connection.setup.timeout.ms` to align it with Pinot’s requirements. However, this must be carefully evaluated since the same consumer configuration is used in servers for real-time consumption.

