### PR TITLE
[flaky-test] Increase Timeouts for TPCHQueryIntegrationTest and MultiStageEngineIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -27,6 +27,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +108,16 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     waitForAllDocsLoaded(600_000L);
 
     setupTableWithNonDefaultDatabase(avroFiles);
+  }
+
+  @Override
+  protected Map<String, String> getExtraQueryProperties() {
+    // Increase timeout for this test since it keeps failing in CI.
+    Map<String, String> timeoutProperties = new HashMap<>();
+    timeoutProperties.put("brokerReadTimeoutMs", "120000");
+    timeoutProperties.put("brokerConnectTimeoutMs", "60000");
+    timeoutProperties.put("brokerHandshakeTimeoutMs", "60000");
+    return timeoutProperties;
   }
 
   private void setupTableWithNonDefaultDatabase(List<File> avroFiles)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/TPCHQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/TPCHQueryIntegrationTest.java
@@ -171,9 +171,9 @@ public class TPCHQueryIntegrationTest extends BaseClusterIntegrationTest {
   protected Map<String, String> getExtraQueryProperties() {
     // Increase timeout for this test since it keeps failing in CI.
     Map<String, String> timeoutProperties = new HashMap<>();
-    timeoutProperties.put("brokerReadTimeoutMs", "120_000");
-    timeoutProperties.put("brokerConnectTimeoutMs", "60_000");
-    timeoutProperties.put("brokerHandshakeTimeoutMs", "60_000");
+    timeoutProperties.put("brokerReadTimeoutMs", "120000");
+    timeoutProperties.put("brokerConnectTimeoutMs", "60000");
+    timeoutProperties.put("brokerHandshakeTimeoutMs", "60000");
     return timeoutProperties;
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/TPCHQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/TPCHQueryIntegrationTest.java
@@ -27,6 +27,8 @@ import java.nio.charset.Charset;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
@@ -163,6 +165,16 @@ public class TPCHQueryIntegrationTest extends BaseClusterIntegrationTest {
   @Override
   protected boolean useMultiStageQueryEngine() {
     return true;
+  }
+
+  @Override
+  protected Map<String, String> getExtraQueryProperties() {
+    // Increase timeout for this test since it keeps failing in CI.
+    Map<String, String> timeoutProperties = new HashMap<>();
+    timeoutProperties.put("brokerReadTimeoutMs", "120_000");
+    timeoutProperties.put("brokerConnectTimeoutMs", "60_000");
+    timeoutProperties.put("brokerHandshakeTimeoutMs", "60_000");
+    return timeoutProperties;
   }
 
   @AfterClass


### PR DESCRIPTION
fixes #14099

Default timeout for broker-read is 60s, and the other two timeouts are 2s. This increases the broker-read timeout to 120s, and the others to 60 seconds.

The queries for TPCH can be expensive so that may be one reason for timeouts.