### PR TITLE
[FEATURE] Add getTopics API to StreamMetadataProvider for Topic Enumeration in Streaming Connectors

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -168,8 +168,8 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public List<TopicMetadata> listTopics(Duration timeout) {
-    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics(timeout);
+  public List<TopicMetadata> listTopics() {
+    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics();
     if (namePartitionsMap == null) {
       return Collections.emptyList();
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -168,15 +168,28 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public List<TopicMetadata> listTopics() {
+  public List<TopicMetadata> getTopics() {
     Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics();
     if (namePartitionsMap == null) {
       return Collections.emptyList();
     }
     return namePartitionsMap.keySet()
         .stream()
-        .map(topic -> new TopicMetadata().setName(topic))
+        .map(topic -> new KafkaTopicMetadata().setName(topic))
         .collect(Collectors.toList());
+  }
+
+  public static class KafkaTopicMetadata implements TopicMetadata {
+    private String _name;
+
+    public String getName() {
+      return _name;
+    }
+
+    public KafkaTopicMetadata setName(String name) {
+      _name = name;
+      return this;
+    }
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
@@ -164,6 +165,18 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(offsetLagString, availabilityLagMs));
     }
     return perPartitionLag;
+  }
+
+  @Override
+  public List<TopicMetadata> listTopics(Duration timeout) {
+    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics(timeout);
+    if (namePartitionsMap == null) {
+      return Collections.emptyList();
+    }
+    return namePartitionsMap.keySet()
+        .stream()
+        .map(topic -> new TopicMetadata().setName(topic))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -168,8 +168,8 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public List<TopicMetadata> listTopics(Duration timeout) {
-    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics(timeout);
+  public List<TopicMetadata> listTopics() {
+    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics();
     if (namePartitionsMap == null) {
       return Collections.emptyList();
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
@@ -164,6 +165,18 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(offsetLagString, availabilityLagMs));
     }
     return perPartitionLag;
+  }
+
+  @Override
+  public List<TopicMetadata> listTopics(Duration timeout) {
+    Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics(timeout);
+    if (namePartitionsMap == null) {
+      return Collections.emptyList();
+    }
+    return namePartitionsMap.keySet()
+        .stream()
+        .map(topic -> new TopicMetadata().setName(topic))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -168,17 +168,29 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public List<TopicMetadata> listTopics() {
+  public List<TopicMetadata> getTopics() {
     Map<String, List<PartitionInfo>> namePartitionsMap = _consumer.listTopics();
     if (namePartitionsMap == null) {
       return Collections.emptyList();
     }
     return namePartitionsMap.keySet()
         .stream()
-        .map(topic -> new TopicMetadata().setName(topic))
+        .map(topic -> new KafkaTopicMetadata().setName(topic))
         .collect(Collectors.toList());
   }
 
+  public static class KafkaTopicMetadata implements TopicMetadata {
+    private String _name;
+
+    public String getName() {
+      return _name;
+    }
+
+    public KafkaTopicMetadata setName(String name) {
+      _name = name;
+      return this;
+    }
+  }
   @Override
   public void close()
       throws IOException {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -424,9 +423,9 @@ public class KafkaPartitionLevelConsumerTest {
 
     KafkaStreamMetadataProvider streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
     List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.listTopics(Duration.ofSeconds(60));
-    Set<String> topicNames = topics.stream()
+    List<String> topicNames = topics.stream()
         .map(StreamMetadataProvider.TopicMetadata::getName)
-        .collect(Collectors.toSet());
-    assertEquals(topicNames, Set.of(TEST_TOPIC_1, TEST_TOPIC_2, TEST_TOPIC_3));
+        .collect(Collectors.toList());
+    assertTrue(topicNames.containsAll(List.of(TEST_TOPIC_1, TEST_TOPIC_2, TEST_TOPIC_3)));
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -423,9 +423,10 @@ public class KafkaPartitionLevelConsumerTest {
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
-    List<StreamMetadataProvider.TopicMetadata> topics =
-        streamMetadataProvider.listTopics(Duration.ofSeconds(60));
-    Set<String> topicNames = topics.stream().map(StreamMetadataProvider.TopicMetadata::getName).collect(Collectors.toSet());
+    List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.listTopics(Duration.ofSeconds(60));
+    Set<String> topicNames = topics.stream()
+        .map(StreamMetadataProvider.TopicMetadata::getName)
+        .collect(Collectors.toSet());
     assertEquals(topicNames, Set.of(TEST_TOPIC_1, TEST_TOPIC_2, TEST_TOPIC_3));
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -421,7 +421,7 @@ public class KafkaPartitionLevelConsumerTest {
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
-    List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.listTopics();
+    List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.getTopics();
     List<String> topicNames = topics.stream()
         .map(StreamMetadataProvider.TopicMetadata::getName)
         .collect(Collectors.toList());

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.stream.kafka30;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -422,7 +421,7 @@ public class KafkaPartitionLevelConsumerTest {
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     KafkaStreamMetadataProvider streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
-    List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.listTopics(Duration.ofSeconds(60));
+    List<StreamMetadataProvider.TopicMetadata> topics = streamMetadataProvider.listTopics();
     List<String> topicNames = topics.stream()
         .map(StreamMetadataProvider.TopicMetadata::getName)
         .collect(Collectors.toList());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -111,24 +111,15 @@ public interface StreamMetadataProvider extends Closeable {
    *
    * @return List of topics
    */
-  default List<TopicMetadata> listTopics() {
+  default List<TopicMetadata> getTopics() {
     throw new UnsupportedOperationException();
   }
 
   /**
    * Represents the metadata of a topic. This can be used to represent the topic name and other metadata in the future.
    */
-  class TopicMetadata {
-    private String _name;
-
-    public String getName() {
-      return _name;
-    }
-
-    public TopicMetadata setName(String name) {
-      _name = name;
-      return this;
-    }
+  interface TopicMetadata {
+    String getName();
   }
 
   class UnknownLagState extends PartitionLagState {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -20,7 +20,6 @@ package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -110,11 +109,9 @@ public interface StreamMetadataProvider extends Closeable {
   /**
    * Fetches the list of available topics/streams
    *
-   * @param timeout Timeout for fetching the list of topics. If this is null, the implementation should use a default
-   *                timeout.
    * @return List of topics
    */
-  default List<TopicMetadata> listTopics(Duration timeout) {
+  default List<TopicMetadata> listTopics() {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -104,6 +105,33 @@ public interface StreamMetadataProvider extends Closeable {
     PartitionLagState unknownLagState = new UnknownLagState();
     currentPartitionStateMap.forEach((k, v) -> result.put(k, unknownLagState));
     return result;
+  }
+
+  /**
+   * Fetches the list of available topics/streams
+   *
+   * @param timeout Timeout for fetching the list of topics. If this is null, the implementation should use a default
+   *                timeout.
+   * @return List of topics
+   */
+  default List<TopicMetadata> listTopics(Duration timeout) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Represents the metadata of a topic. This can be used to represent the topic name and other metadata in the future.
+   */
+  class TopicMetadata {
+    private String _name;
+
+    public String getName() {
+      return _name;
+    }
+
+    public TopicMetadata setName(String name) {
+      _name = name;
+      return this;
+    }
   }
 
   class UnknownLagState extends PartitionLagState {


### PR DESCRIPTION
Introduces a new `getTopics()` API to the `StreamMetadataProvider` interface, enabling the ability to enumerate topics for streaming connectors in Apache Pinot.

Key Changes
1. New API in StreamMetadataProvider:
- Added `getTopics()` method to fetch the list of topics
- Introduced TopicMetadata as a representation of topic metadata, currently including the topic name but extensible for future metadata fields.
2. Implementation for Kafka Connectors (2.0 & 3.0)
- Implemented the listTopics method in KafkaStreamMetadataProvider for both Kafka 2.0 and Kafka 3.0 plugins.
- Utilized Kafka’s Consumer#listTopics() API to retrieve the topic list and mapped the results to the TopicMetadata structure.
3. Unit Test Coverage:
- Added unit test in KafkaPartitionLevelConsumerTest to validate the listTopics functionality.
4. Backward Compatibility:
- Default implementation of listTopics in StreamMetadataProvider throws UnsupportedOperationException to maintain backward compatibility with other connectors that do not override the method.

Future Work:
- Extend TopicMetadata to include additional metadata like partition count, replication factor, or topic configurations.
- Add similar support for other streaming connectors in Apache Pinot.