### PR TITLE
bugfix: Add null check in query and storage component for optional field UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddQueryComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddQueryComponent.tsx
@@ -68,7 +68,7 @@ export default function AddQueryComponent({
           <Input
             id="timeoutMs"
             key="timeoutMs"
-            value={tableDataObj.query.timeoutMs || ""}
+            value={tableDataObj?.query?.timeoutMs || ""}
             onChange={(e)=> changeHandler('timeoutMs', e.target.value)}
             type="number"
           />
@@ -79,7 +79,7 @@ export default function AddQueryComponent({
           <Input
             id="maxQueriesPerSecond"
             key="maxQueriesPerSecond"
-            value={tableDataObj.quota.maxQueriesPerSecond || ""}
+            value={tableDataObj?.quota?.maxQueriesPerSecond || ""}
             onChange={(e)=> changeHandler('maxQueriesPerSecond', e.target.value)}
             type="number"
           />

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddStorageComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddStorageComponent.tsx
@@ -105,7 +105,7 @@ export default function AddStorageComponent({
           <Input
             id="maxQueriesPerSecond"
             key="maxQueriesPerSecond"
-            value={tableDataObj.quota.storage || ""}
+            value={tableDataObj?.quota?.storage || ""}
             onChange={(e)=>
                 changeHandler('maxQueriesPerSecond', e.target.value)
             }


### PR DESCRIPTION
Fixed a null check error in the 'Table Config' input field when pasting the JSON schema. The issue occurred due to missing null checks for optional fields (query.timeoutMs, quota.storage, quota.maxQueriesPerSecond). Added optional chaining to resolve this.

Error Images 
<img width="845" alt="image" src="https://github.com/user-attachments/assets/06b4c9b1-c972-4d59-9513-254ea31e06a7" />


Success Image (Successfully able to add schema by removing optional field)
<img width="845" alt="image" src="https://github.com/user-attachments/assets/892e699c-0e38-4290-86b3-9e3fa06bbc79" />

