### PR TITLE
Add config for ignoreCrcMismatch for upsert-compaction task

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -220,6 +220,16 @@ public class MinionConstants {
     public static final String SNAPSHOT = "snapshot";
 
     /**
+     * key representing if upsert compaction task executor should ignore crc mismatch or not during task execution
+     */
+    public static final String IGNORE_CRC_MISMATCH_KEY = "ignoreCrcMismatch";
+
+    /**
+     * default value for the key IGNORE_CRC_MISMATCH_KEY: false
+     */
+    public static final boolean DEFAULT_IGNORE_CRC_MISMATCH = false;
+
+    /**
      * number of segments to query in one batch to fetch valid doc id metadata, by default 500
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -185,6 +185,9 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoAccessor.getVipUrl() + "/segments");
         configs.put(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY, String.valueOf(segment.getCrc()));
         configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType.toString());
+        configs.put(UpsertCompactionTask.IGNORE_CRC_MISMATCH_KEY,
+            taskConfigs.getOrDefault(UpsertCompactionTask.IGNORE_CRC_MISMATCH_KEY,
+            String.valueOf(UpsertCompactionTask.DEFAULT_IGNORE_CRC_MISMATCH)));
         pinotTaskConfigs.add(new PinotTaskConfig(UpsertCompactionTask.TASK_TYPE, configs));
         numTasks++;
       }


### PR DESCRIPTION
Related to issue: https://github.com/apache/pinot/issues/13491#issuecomment-2225868886

A fix has already been implemented to address potential segment CRC mismatches between Zookeeper (ZK) and Deepstore: https://github.com/apache/pinot/pull/14506

Despite the fix, many tables in Uber's Pinot production environment still exhibit CRC mismatches that were introduced earlier (before the fix). As a result, the compaction task consistently fails for these segments, effectively halting compaction for affected tables.

Task failure is almost consistent for these tables:
<img width="1712" alt="Screenshot 2024-12-16 at 11 52 23 PM" src="https://github.com/user-attachments/assets/1cd34ab9-484b-46be-ad63-9e426e9c143c" />

Default Setting: The option is disabled (false) by default and should only be manually enabled when necessary.

To unblock these tables compaction, **we are introducing an `ignoreCrcMismatch` task config for upsert compaction**. When enabled, the task will proceed with compaction even if a CRC mismatch is detected. Default value = false.


As another follow-up, adding a Controller API will allow manual correction of segment CRC mismatches. However, given the scale of the current issue (with hundreds of affected segments), triggering fixes manually via the API might not be practical.
