### PR TITLE
[timeseries] Part-4: Complete Support for Multi-Server Queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -117,6 +117,10 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
       if (timeSeriesResponse == null
           || timeSeriesResponse.getStatus().equals(PinotBrokerTimeSeriesResponse.ERROR_STATUS)) {
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.TIME_SERIES_GLOBAL_QUERIES_FAILED, 1);
+        final String errorMessage = timeSeriesResponse == null ? "null time-series response"
+            : timeSeriesResponse.getError();
+        // TODO(timeseries): Remove logging for failed queries.
+        LOGGER.warn("time-series query failed with error: {}", errorMessage);
       }
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -53,6 +53,7 @@ import org.apache.pinot.tsdb.planner.TimeSeriesQueryEnvironment;
 import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
 import org.apache.pinot.tsdb.spi.RangeTimeSeriesRequest;
 import org.apache.pinot.tsdb.spi.TimeSeriesLogicalPlanResult;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactoryProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +71,7 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
     _queryEnvironment = new TimeSeriesQueryEnvironment(config, routingManager, tableCache);
     _queryEnvironment.init(config);
     _queryDispatcher = queryDispatcher;
+    TimeSeriesBuilderFactoryProvider.init(config);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -279,6 +279,10 @@ public class QueryRunner {
         LOGGER.warn("Unable to send error to broker. Original error: {}", t.getMessage(), t2);
       }
     };
+    if (serializedPlanFragments.isEmpty()) {
+      handleErrors.accept(Pair.of(new IllegalStateException("No plan fragments received in server"), ""));
+      return;
+    }
     try {
       final long deadlineMs = extractDeadlineMs(metadata);
       Preconditions.checkState(System.currentTimeMillis() < deadlineMs,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesBrokerPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesBrokerPlanVisitor.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.timeseries;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import org.apache.pinot.tsdb.planner.TimeSeriesExchangeNode;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.plan.LeafTimeSeriesPlanNode;
+
+
+public class PhysicalTimeSeriesBrokerPlanVisitor {
+  // Warning: Don't use singleton access pattern, since Quickstarts run in a single JVM and spawn multiple broker/server
+  public PhysicalTimeSeriesBrokerPlanVisitor() {
+  }
+
+  public void init() {
+  }
+
+  public BaseTimeSeriesOperator compile(BaseTimeSeriesPlanNode rootNode, TimeSeriesExecutionContext context,
+      Map<String, Integer> numInputServersByExchangeNode) {
+    // Step-1: Replace time series exchange node with its Physical Plan Node.
+    rootNode = initExchangeReceivePlanNode(rootNode, context, numInputServersByExchangeNode);
+    // Step-2: Trigger recursive operator generation
+    return rootNode.run();
+  }
+
+  public BaseTimeSeriesPlanNode initExchangeReceivePlanNode(BaseTimeSeriesPlanNode planNode,
+      TimeSeriesExecutionContext context, Map<String, Integer> numInputServersByExchangeNode) {
+    if (planNode instanceof LeafTimeSeriesPlanNode) {
+      throw new IllegalStateException("Found leaf time series plan node in broker");
+    } else if (planNode instanceof TimeSeriesExchangeNode) {
+      int numInputServers = numInputServersByExchangeNode.get(planNode.getId());
+      return compileToPhysicalReceiveNode((TimeSeriesExchangeNode) planNode, context, numInputServers);
+    }
+    List<BaseTimeSeriesPlanNode> newInputs = new ArrayList<>();
+    for (int index = 0; index < planNode.getInputs().size(); index++) {
+      BaseTimeSeriesPlanNode inputNode = planNode.getInputs().get(index);
+      if (inputNode instanceof TimeSeriesExchangeNode) {
+        int numInputServers = numInputServersByExchangeNode.get(inputNode.getId());
+        TimeSeriesExchangeReceivePlanNode exchangeReceivePlanNode = compileToPhysicalReceiveNode(
+            (TimeSeriesExchangeNode) inputNode, context, numInputServers);
+        newInputs.add(exchangeReceivePlanNode);
+      } else {
+        newInputs.add(initExchangeReceivePlanNode(inputNode, context, numInputServersByExchangeNode));
+      }
+    }
+    return planNode.withInputs(newInputs);
+  }
+
+  TimeSeriesExchangeReceivePlanNode compileToPhysicalReceiveNode(TimeSeriesExchangeNode exchangeNode,
+      TimeSeriesExecutionContext context, int numServersQueried) {
+    TimeSeriesExchangeReceivePlanNode exchangeReceivePlanNode = new TimeSeriesExchangeReceivePlanNode(
+        exchangeNode.getId(), context.getDeadlineMs(), exchangeNode.getAggInfo(), context.getSeriesBuilderFactory());
+    BlockingQueue<Object> receiver = context.getExchangeReceiverByPlanId().get(exchangeNode.getId());
+    exchangeReceivePlanNode.init(Objects.requireNonNull(receiver, "No receiver for node"), numServersQueried);
+    return exchangeReceivePlanNode;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitor.java
@@ -82,7 +82,7 @@ public class PhysicalTimeSeriesServerPlanVisitor {
 
   private TimeSeriesPhysicalTableScan convertLeafToPhysicalTableScan(LeafTimeSeriesPlanNode leafNode,
       TimeSeriesExecutionContext context) {
-    List<String> segments = context.getPlanIdToSegmentsMap().get(leafNode.getId());
+    List<String> segments = context.getPlanIdToSegmentsMap().getOrDefault(leafNode.getId(), Collections.emptyList());
     ServerQueryRequest serverQueryRequest = compileLeafServerQueryRequest(leafNode, segments, context);
     return new TimeSeriesPhysicalTableScan(leafNode.getId(), serverQueryRequest, _queryExecutor, _executorService);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/timeseries/TimeSeriesExecutionContext.java
@@ -20,23 +20,31 @@ package org.apache.pinot.query.runtime.timeseries;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactory;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactoryProvider;
 
 
 public class TimeSeriesExecutionContext {
   private final String _language;
   private final TimeBuckets _initialTimeBuckets;
   private final Map<String, List<String>> _planIdToSegmentsMap;
+  private final Map<String, BlockingQueue<Object>> _exchangeReceiverByPlanId;
   private final long _deadlineMs;
   private final Map<String, String> _metadataMap;
+  private final TimeSeriesBuilderFactory _seriesBuilderFactory;
 
-  public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets,
-      Map<String, List<String>> planIdToSegmentsMap, long deadlineMs, Map<String, String> metadataMap) {
+  public TimeSeriesExecutionContext(String language, TimeBuckets initialTimeBuckets, long deadlineMs,
+      Map<String, String> metadataMap, Map<String, List<String>> planIdToSegmentsMap,
+      Map<String, BlockingQueue<Object>> exchangeReceiverByPlanId) {
     _language = language;
     _initialTimeBuckets = initialTimeBuckets;
-    _planIdToSegmentsMap = planIdToSegmentsMap;
     _deadlineMs = deadlineMs;
     _metadataMap = metadataMap;
+    _planIdToSegmentsMap = planIdToSegmentsMap;
+    _exchangeReceiverByPlanId = exchangeReceiverByPlanId;
+    _seriesBuilderFactory = TimeSeriesBuilderFactoryProvider.getSeriesBuilderFactory(language);
   }
 
   public String getLanguage() {
@@ -47,8 +55,8 @@ public class TimeSeriesExecutionContext {
     return _initialTimeBuckets;
   }
 
-  public Map<String, List<String>> getPlanIdToSegmentsMap() {
-    return _planIdToSegmentsMap;
+  public long getDeadlineMs() {
+    return _deadlineMs;
   }
 
   public long getRemainingTimeMs() {
@@ -57,5 +65,17 @@ public class TimeSeriesExecutionContext {
 
   public Map<String, String> getMetadataMap() {
     return _metadataMap;
+  }
+
+  public Map<String, List<String>> getPlanIdToSegmentsMap() {
+    return _planIdToSegmentsMap;
+  }
+
+  public Map<String, BlockingQueue<Object>> getExchangeReceiverByPlanId() {
+    return _exchangeReceiverByPlanId;
+  }
+
+  public TimeSeriesBuilderFactory getSeriesBuilderFactory() {
+    return _seriesBuilderFactory;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -71,17 +72,22 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.service.dispatch.timeseries.AsyncQueryTimeSeriesDispatchResponse;
+import org.apache.pinot.query.runtime.timeseries.PhysicalTimeSeriesBrokerPlanVisitor;
+import org.apache.pinot.query.runtime.timeseries.TimeSeriesExecutionContext;
 import org.apache.pinot.query.service.dispatch.timeseries.TimeSeriesDispatchClient;
+import org.apache.pinot.query.service.dispatch.timeseries.TimeSeriesDispatchObserver;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.tsdb.planner.TimeSeriesExchangeNode;
 import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerRequestMetadataKeys;
-import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerResponseMetadataKeys;
 import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
 import org.apache.pinot.tsdb.planner.physical.TimeSeriesQueryServerInstance;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +106,8 @@ public class QueryDispatcher {
   private final Map<String, TimeSeriesDispatchClient> _timeSeriesDispatchClientMap = new ConcurrentHashMap<>();
   @Nullable
   private final TlsConfig _tlsConfig;
+  private final PhysicalTimeSeriesBrokerPlanVisitor _timeSeriesBrokerPlanVisitor
+      = new PhysicalTimeSeriesBrokerPlanVisitor();
 
   public QueryDispatcher(MailboxService mailboxService) {
     this(mailboxService, null);
@@ -167,41 +175,6 @@ public class QueryDispatcher {
       throw e;
     }
     return planNodes;
-  }
-
-  public PinotBrokerTimeSeriesResponse submitAndGet(RequestContext context, TimeSeriesDispatchablePlan plan,
-      long timeoutMs, Map<String, String> queryOptions) {
-    long requestId = context.getRequestId();
-    BlockingQueue<AsyncQueryTimeSeriesDispatchResponse> receiver = new ArrayBlockingQueue<>(10);
-    try {
-      submit(requestId, plan, timeoutMs, queryOptions, context, receiver::offer);
-      AsyncQueryTimeSeriesDispatchResponse received = receiver.poll(timeoutMs, TimeUnit.MILLISECONDS);
-      if (received == null) {
-        return PinotBrokerTimeSeriesResponse.newErrorResponse(
-            "TimeoutException", "Timed out waiting for response");
-      }
-      if (received.getThrowable() != null) {
-        Throwable t = received.getThrowable();
-        return PinotBrokerTimeSeriesResponse.newErrorResponse(t.getClass().getSimpleName(), t.getMessage());
-      }
-      if (received.getQueryResponse() == null) {
-        return PinotBrokerTimeSeriesResponse.newErrorResponse("NullResponse", "Received null response from server");
-      }
-      if (received.getQueryResponse().containsMetadata(
-          WorkerResponseMetadataKeys.ERROR_MESSAGE)) {
-        return PinotBrokerTimeSeriesResponse.newErrorResponse(
-            received.getQueryResponse().getMetadataOrDefault(
-                WorkerResponseMetadataKeys.ERROR_TYPE, "unknown error-type"),
-            received.getQueryResponse().getMetadataOrDefault(
-                WorkerResponseMetadataKeys.ERROR_MESSAGE, "unknown error"));
-      }
-      Worker.TimeSeriesResponse timeSeriesResponse = received.getQueryResponse();
-      Preconditions.checkNotNull(timeSeriesResponse, "time series response is null");
-      return OBJECT_MAPPER.readValue(
-          timeSeriesResponse.getPayload().toStringUtf8(), PinotBrokerTimeSeriesResponse.class);
-    } catch (Throwable t) {
-      return PinotBrokerTimeSeriesResponse.newErrorResponse(t.getClass().getSimpleName(), t.getMessage());
-    }
   }
 
   @VisibleForTesting
@@ -283,25 +256,8 @@ public class QueryDispatcher {
     }
   }
 
-  void submit(long requestId, TimeSeriesDispatchablePlan plan, long timeoutMs, Map<String, String> queryOptions,
-      RequestContext requestContext, Consumer<AsyncQueryTimeSeriesDispatchResponse> receiver)
-      throws Exception {
-    Deadline deadline = Deadline.after(timeoutMs, TimeUnit.MILLISECONDS);
-    long deadlineMs = System.currentTimeMillis() + timeoutMs;
-    String serializedPlan = plan.getSerializedPlan();
-    Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
-        .addDispatchPlan(serializedPlan)
-        .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext))
-        .putMetadata(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestId))
-        .build();
-    getOrCreateTimeSeriesDispatchClient(plan.getQueryServerInstance()).submit(request,
-        new QueryServerInstance(plan.getQueryServerInstance().getHostname(),
-            plan.getQueryServerInstance().getQueryServicePort(), plan.getQueryServerInstance().getQueryMailboxPort()),
-        deadline, receiver::accept);
-  };
-
   Map<String, String> initializeTimeSeriesMetadataMap(TimeSeriesDispatchablePlan dispatchablePlan, long deadlineMs,
-      RequestContext requestContext) {
+      RequestContext requestContext, String instanceId) {
     Map<String, String> result = new HashMap<>();
     TimeBuckets timeBuckets = dispatchablePlan.getTimeBuckets();
     result.put(WorkerRequestMetadataKeys.LANGUAGE, dispatchablePlan.getLanguage());
@@ -309,7 +265,8 @@ public class QueryDispatcher {
     result.put(WorkerRequestMetadataKeys.WINDOW_SECONDS, Long.toString(timeBuckets.getBucketSize().getSeconds()));
     result.put(WorkerRequestMetadataKeys.NUM_ELEMENTS, Long.toString(timeBuckets.getTimeBuckets().length));
     result.put(WorkerRequestMetadataKeys.DEADLINE_MS, Long.toString(deadlineMs));
-    for (Map.Entry<String, List<String>> entry : dispatchablePlan.getPlanIdToSegments().entrySet()) {
+    Map<String, List<String>> planIdToSegments = dispatchablePlan.getPlanIdToSegmentsByServer().get(instanceId);
+    for (Map.Entry<String, List<String>> entry : planIdToSegments.entrySet()) {
       result.put(WorkerRequestMetadataKeys.encodeSegmentListKey(entry.getKey()), String.join(",", entry.getValue()));
     }
     result.put(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestContext.getRequestId()));
@@ -511,6 +468,58 @@ public class QueryDispatcher {
     _dispatchClientMap.clear();
     _mailboxService.shutdown();
     _executorService.shutdown();
+  }
+
+  public PinotBrokerTimeSeriesResponse submitAndGet(RequestContext context, TimeSeriesDispatchablePlan plan,
+      long timeoutMs, Map<String, String> queryOptions) {
+    long requestId = context.getRequestId();
+    try {
+      TimeSeriesBlock result = submitAndGet(requestId, plan, timeoutMs, queryOptions, context);
+      return PinotBrokerTimeSeriesResponse.fromTimeSeriesBlock(result);
+    } catch (Throwable t) {
+      return PinotBrokerTimeSeriesResponse.newErrorResponse(t.getClass().getSimpleName(), t.getMessage());
+    }
+  }
+
+  TimeSeriesBlock submitAndGet(long requestId, TimeSeriesDispatchablePlan plan, long timeoutMs,
+      Map<String, String> queryOptions, RequestContext requestContext)
+      throws Exception {
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    BaseTimeSeriesPlanNode brokerFragment = plan.getBrokerFragment();
+    // Get consumers for leafs
+    Map<String, BlockingQueue<Object>> receiversByPlanId = new HashMap<>();
+    populateConsumers(brokerFragment, receiversByPlanId);
+    // Compile brokerFragment to get operators
+    TimeSeriesExecutionContext brokerExecutionContext = new TimeSeriesExecutionContext(plan.getLanguage(),
+        plan.getTimeBuckets(), deadlineMs, Collections.emptyMap(), Collections.emptyMap(), receiversByPlanId);
+    BaseTimeSeriesOperator brokerOperator = _timeSeriesBrokerPlanVisitor.compile(brokerFragment,
+        brokerExecutionContext, plan.getNumInputServersForExchangePlanNode());
+    // Create dispatch observer for each query server
+    for (TimeSeriesQueryServerInstance serverInstance : plan.getQueryServerInstances()) {
+      String serverId = serverInstance.getInstanceId();
+      Deadline deadline = Deadline.after(deadlineMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      Preconditions.checkState(!deadline.isExpired(), "Deadline expired before query could be sent to servers");
+      // Send server fragment to every server
+      Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
+          .addAllDispatchPlan(plan.getSerializedPlanFragments(serverId))
+          .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext, serverId))
+          .putMetadata(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestId))
+          .build();
+      TimeSeriesDispatchObserver
+          dispatchObserver = new TimeSeriesDispatchObserver(receiversByPlanId);
+      getOrCreateTimeSeriesDispatchClient(serverInstance).submit(request, deadline, dispatchObserver);
+    }
+    // Execute broker fragment
+    return brokerOperator.nextBlock();
+  }
+
+  private void populateConsumers(BaseTimeSeriesPlanNode planNode, Map<String, BlockingQueue<Object>> receiverMap) {
+    if (planNode instanceof TimeSeriesExchangeNode) {
+      receiverMap.put(planNode.getId(), new LinkedBlockingQueue<>(TimeSeriesDispatchObserver.MAX_QUEUE_CAPACITY));
+    }
+    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
+      populateConsumers(childNode, receiverMap);
+    }
   }
 
   public static class QueryResult {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -515,7 +514,7 @@ public class QueryDispatcher {
 
   private void populateConsumers(BaseTimeSeriesPlanNode planNode, Map<String, BlockingQueue<Object>> receiverMap) {
     if (planNode instanceof TimeSeriesExchangeNode) {
-      receiverMap.put(planNode.getId(), new LinkedBlockingQueue<>(TimeSeriesDispatchObserver.MAX_QUEUE_CAPACITY));
+      receiverMap.put(planNode.getId(), new ArrayBlockingQueue<>(TimeSeriesDispatchObserver.MAX_QUEUE_CAPACITY));
     }
     for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
       populateConsumers(childNode, receiverMap);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -264,8 +264,8 @@ public class QueryDispatcher {
     result.put(WorkerRequestMetadataKeys.WINDOW_SECONDS, Long.toString(timeBuckets.getBucketSize().getSeconds()));
     result.put(WorkerRequestMetadataKeys.NUM_ELEMENTS, Long.toString(timeBuckets.getTimeBuckets().length));
     result.put(WorkerRequestMetadataKeys.DEADLINE_MS, Long.toString(deadlineMs));
-    Map<String, List<String>> planIdToSegments = dispatchablePlan.getPlanIdToSegmentsByServer().get(instanceId);
-    for (Map.Entry<String, List<String>> entry : planIdToSegments.entrySet()) {
+    Map<String, List<String>> leafIdToSegments = dispatchablePlan.getLeafIdToSegmentsByInstanceId().get(instanceId);
+    for (Map.Entry<String, List<String>> entry : leafIdToSegments.entrySet()) {
       result.put(WorkerRequestMetadataKeys.encodeSegmentListKey(entry.getKey()), String.join(",", entry.getValue()));
     }
     result.put(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestContext.getRequestId()));
@@ -500,7 +500,7 @@ public class QueryDispatcher {
       Preconditions.checkState(!deadline.isExpired(), "Deadline expired before query could be sent to servers");
       // Send server fragment to every server
       Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
-          .addAllDispatchPlan(plan.getSerializedPlanFragments(serverId))
+          .addAllDispatchPlan(plan.getSerializedServerFragments())
           .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext, serverId))
           .putMetadata(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, Long.toString(requestId))
           .build();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchClient.java
@@ -21,10 +21,9 @@ package org.apache.pinot.query.service.dispatch.timeseries;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import java.util.function.Consumer;
+import io.grpc.stub.StreamObserver;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
-import org.apache.pinot.query.routing.QueryServerInstance;
 
 
 /**
@@ -48,9 +47,8 @@ public class TimeSeriesDispatchClient {
     return _channel;
   }
 
-  public void submit(Worker.TimeSeriesQueryRequest request, QueryServerInstance virtualServer, Deadline deadline,
-      Consumer<AsyncQueryTimeSeriesDispatchResponse> callback) {
-    _dispatchStub.withDeadline(deadline).submitTimeSeries(
-        request, new TimeSeriesDispatchObserver(virtualServer, callback));
+  public void submit(Worker.TimeSeriesQueryRequest request, Deadline deadline,
+      StreamObserver<Worker.TimeSeriesResponse> responseStreamObserver) {
+    _dispatchStub.withDeadline(deadline).submitTimeSeries(request, responseStreamObserver);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesDispatchObserver.java
@@ -19,9 +19,14 @@
 package org.apache.pinot.query.service.dispatch.timeseries;
 
 import io.grpc.stub.StreamObserver;
-import java.util.function.Consumer;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import org.apache.pinot.common.proto.Worker;
-import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.runtime.timeseries.serde.TimeSeriesBlockSerde;
+import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerResponseMetadataKeys;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,37 +35,57 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  *   engine integration.
  */
 public class TimeSeriesDispatchObserver implements StreamObserver<Worker.TimeSeriesResponse> {
-  private final QueryServerInstance _serverInstance;
-  private final Consumer<AsyncQueryTimeSeriesDispatchResponse> _callback;
+  /**
+   * Each server should send data for each leaf node once. This capacity controls the size of the queue we use to
+   * buffer the data sent by the sender. This is set large enough that we should never hit this for any practical
+   * use-case, while guarding us against bugs.
+   */
+  public static final int MAX_QUEUE_CAPACITY = 4096;
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesDispatchObserver.class);
+  private final Map<String, BlockingQueue<Object>> _exchangeReceiversByPlanId;
 
-  private Worker.TimeSeriesResponse _timeSeriesResponse;
-
-  public TimeSeriesDispatchObserver(QueryServerInstance serverInstance,
-      Consumer<AsyncQueryTimeSeriesDispatchResponse> callback) {
-    _serverInstance = serverInstance;
-    _callback = callback;
+  public TimeSeriesDispatchObserver(Map<String, BlockingQueue<Object>> exchangeReceiversByPlanId) {
+    _exchangeReceiversByPlanId = exchangeReceiversByPlanId;
   }
 
   @Override
   public void onNext(Worker.TimeSeriesResponse timeSeriesResponse) {
-    _timeSeriesResponse = timeSeriesResponse;
+    if (timeSeriesResponse.containsMetadata(WorkerResponseMetadataKeys.ERROR_TYPE)) {
+      String errorType = timeSeriesResponse.getMetadataOrDefault(WorkerResponseMetadataKeys.ERROR_TYPE, "");
+      String errorMessage = timeSeriesResponse.getMetadataOrDefault(WorkerResponseMetadataKeys.ERROR_MESSAGE, "");
+      onError(new Throwable(String.format("Error in server (type: %s): %s", errorType, errorMessage)));
+      return;
+    }
+    String planId = timeSeriesResponse.getMetadataMap().get(WorkerResponseMetadataKeys.PLAN_ID);
+    TimeSeriesBlock block = null;
+    Throwable error = null;
+    try {
+      block = TimeSeriesBlockSerde.deserializeTimeSeriesBlock(timeSeriesResponse.getPayload().asReadOnlyByteBuffer());
+    } catch (Throwable t) {
+      error = t;
+    }
+    BlockingQueue<Object> receiverForPlanId = _exchangeReceiversByPlanId.get(planId);
+    if (receiverForPlanId == null) {
+      String message = String.format("Receiver is not initialized for planId: %s. Receivers exist only for planIds: %s",
+          planId, _exchangeReceiversByPlanId.keySet());
+      LOGGER.warn(message);
+      onError(new IllegalStateException(message));
+    } else {
+      if (!receiverForPlanId.offer(error != null ? error : block)) {
+        onError(new RuntimeException(String.format("Offer to receiver queue (capacity=%s) for planId: %s failed",
+            receiverForPlanId.remainingCapacity(), planId)));
+      }
+    }
   }
 
   @Override
   public void onError(Throwable throwable) {
-    _callback.accept(
-        new AsyncQueryTimeSeriesDispatchResponse(
-            _serverInstance,
-            Worker.TimeSeriesResponse.getDefaultInstance(),
-            throwable));
+    for (BlockingQueue q : _exchangeReceiversByPlanId.values()) {
+      q.offer(throwable);
+    }
   }
 
   @Override
   public void onCompleted() {
-    _callback.accept(
-        new AsyncQueryTimeSeriesDispatchResponse(
-            _serverInstance,
-            _timeSeriesResponse,
-            null));
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -222,8 +222,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   @Override
   public void submitTimeSeries(Worker.TimeSeriesQueryRequest request,
       StreamObserver<Worker.TimeSeriesResponse> responseObserver) {
-    String dispatchPlan = request.getDispatchPlan(0);
-    _queryRunner.processTimeSeriesQuery(dispatchPlan, request.getMetadataMap(), responseObserver);
+    _queryRunner.processTimeSeriesQuery(request.getDispatchPlanList(), request.getMetadataMap(), responseObserver);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
@@ -53,7 +53,7 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap(), DUMMY_DEADLINE_MS, Collections.emptyMap());
+              DUMMY_DEADLINE_MS, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 0L,
               filterExpr, "orderCount", aggInfo, Collections.singletonList("cityName"));
@@ -71,7 +71,7 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
     {
       TimeSeriesExecutionContext context =
           new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
-              Collections.emptyMap(), DUMMY_DEADLINE_MS, Collections.emptyMap());
+              DUMMY_DEADLINE_MS, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 10L,
               filterExpr, "orderCount*2", aggInfo, Collections.singletonList("concat(cityName, stateName, '-')"));

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/timeseries/PhysicalTimeSeriesServerPlanVisitorTest.java
@@ -29,6 +29,9 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.tsdb.spi.AggInfo;
 import org.apache.pinot.tsdb.spi.TimeBuckets;
 import org.apache.pinot.tsdb.spi.plan.LeafTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.series.SimpleTimeSeriesBuilderFactory;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBuilderFactoryProvider;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -38,7 +41,13 @@ import static org.testng.Assert.assertTrue;
 
 
 public class PhysicalTimeSeriesServerPlanVisitorTest {
+  private static final String LANGUAGE = "m3ql";
   private static final int DUMMY_DEADLINE_MS = 10_000;
+
+  @BeforeClass
+  public void setUp() {
+    TimeSeriesBuilderFactoryProvider.registerSeriesBuilderFactory(LANGUAGE, new SimpleTimeSeriesBuilderFactory());
+  }
 
   @Test
   public void testCompileQueryContext() {
@@ -52,14 +61,14 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
     // Case-1: Without offset, simple column based group-by expression, simple column based value, and non-empty filter.
     {
       TimeSeriesExecutionContext context =
-          new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
+          new TimeSeriesExecutionContext(LANGUAGE, TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
               DUMMY_DEADLINE_MS, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 0L,
               filterExpr, "orderCount", aggInfo, Collections.singletonList("cityName"));
       QueryContext queryContext = serverPlanVisitor.compileQueryContext(leafNode, context);
       assertNotNull(queryContext.getTimeSeriesContext());
-      assertEquals(queryContext.getTimeSeriesContext().getLanguage(), "m3ql");
+      assertEquals(queryContext.getTimeSeriesContext().getLanguage(), LANGUAGE);
       assertEquals(queryContext.getTimeSeriesContext().getOffsetSeconds(), 0L);
       assertEquals(queryContext.getTimeSeriesContext().getTimeColumn(), timeColumn);
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().getIdentifier(), "orderCount");
@@ -70,7 +79,7 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
     // Case-2: With offset, complex group-by expression, complex value, and non-empty filter
     {
       TimeSeriesExecutionContext context =
-          new TimeSeriesExecutionContext("m3ql", TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
+          new TimeSeriesExecutionContext(LANGUAGE, TimeBuckets.ofSeconds(1000L, Duration.ofSeconds(10), 100),
               DUMMY_DEADLINE_MS, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
       LeafTimeSeriesPlanNode leafNode =
           new LeafTimeSeriesPlanNode(planId, Collections.emptyList(), tableName, timeColumn, TimeUnit.SECONDS, 10L,
@@ -80,7 +89,7 @@ public class PhysicalTimeSeriesServerPlanVisitorTest {
       assertNotNull(queryContext.getGroupByExpressions());
       assertEquals("concat(cityName,stateName,'-')", queryContext.getGroupByExpressions().get(0).toString());
       assertNotNull(queryContext.getTimeSeriesContext());
-      assertEquals(queryContext.getTimeSeriesContext().getLanguage(), "m3ql");
+      assertEquals(queryContext.getTimeSeriesContext().getLanguage(), LANGUAGE);
       assertEquals(queryContext.getTimeSeriesContext().getOffsetSeconds(), 10L);
       assertEquals(queryContext.getTimeSeriesContext().getTimeColumn(), timeColumn);
       assertEquals(queryContext.getTimeSeriesContext().getValueExpression().toString(), "times(orderCount,'2')");

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactoryProvider.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/series/TimeSeriesBuilderFactoryProvider.java
@@ -51,7 +51,7 @@ public class TimeSeriesBuilderFactoryProvider {
         TimeSeriesBuilderFactory seriesBuilderFactory = (TimeSeriesBuilderFactory) untypedSeriesBuilderFactory;
         seriesBuilderFactory.init(pinotConfiguration.subset(
             PinotTimeSeriesConfiguration.CONFIG_PREFIX + "." + language));
-        FACTORY_MAP.put(language, seriesBuilderFactory);
+        FACTORY_MAP.putIfAbsent(language, seriesBuilderFactory);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -77,7 +77,7 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);
     final QuickstartRunner runner =
-        new QuickstartRunner(quickstartTableRequests, 1, 1, 1, 1, quickstartRunnerDir, getConfigOverrides());
+        new QuickstartRunner(quickstartTableRequests, 1, 1, 2, 1, quickstartRunnerDir, getConfigOverrides());
 
     startKafka();
     startAllDataStreams(_kafkaStarter, quickstartTmpDir);


### PR DESCRIPTION
Finishes the ongoing work to support Time Series queries on tables that can have `numInstancesPerReplicaGroup > 1`.

The Timeseries Quickstart also now starts with 2 servers.

Also tested in one of our smaller clusters and we are able to get 50-100 QPS consistently.