### PR TITLE
Populating segment size in bytes in the ZK metadata during the COMMIT_END_METADATA call of the segment commit protocol.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -660,6 +660,7 @@ public class PinotLLCRealtimeSegmentManager {
       committingSegmentZKMetadata.setIndexVersion(segmentVersion.name());
     }
     committingSegmentZKMetadata.setTotalDocs(segmentMetadata.getTotalDocs());
+    committingSegmentZKMetadata.setSizeInBytes(committingSegmentDescriptor.getSegmentSizeBytes());
 
     // Update the partition group metadata based on the segment metadata
     // NOTE: When the stream partition changes, or the records are not properly partitioned from the stream, the


### PR DESCRIPTION
1. COMMIT_END_METADATA call during the segment commit protocol aims to update the segment zk metadata for the committing segment.
2. Metadata is currently updated with endOffset, startTime etc during the commit protocol. 
3. This PR populates the segmentSizeInBytes as well that is passed during the segment commit protocol.
4. Will help in segment size calculation when size based segment thresholds are used in the stream config. 

**ZK metadata before changes**

![Screenshot 2024-12-18 at 2 15 01 PM](https://github.com/user-attachments/assets/f850cf2f-14f6-4bb1-9a30-b74d14073b2e)

**ZK metadata post changes**

![Screenshot 2024-12-18 at 2 13 10 PM](https://github.com/user-attachments/assets/5eb6a045-eddf-4037-a7ea-0cd0c3ac05f1)
