### PR TITLE
Modify test log4j2.xml to hint how to debug calcite rules

### DIFF
--- a/pinot-query-runtime/src/test/resources/log4j2.xml
+++ b/pinot-query-runtime/src/test/resources/log4j2.xml
@@ -32,6 +32,12 @@
 <!--    <Logger name="org.apache.pinot.query" level="trace" additivity="false">-->
 <!--      <AppenderRef ref="console"/>-->
 <!--    </Logger>-->
+
+    <!-- Change level to DEBUG in order to log the optimization process -->
+    <logger name="org.apache.calcite.plan.RelOptPlanner" level="ERROR" additivity="false">
+      <!--    Change onMatch to ACCEPT, to see the produced plan after every rule invocation using the EXPLAIN format-->
+      <MarkerFilter marker="FULL_PLAN" onMatch="DENY" onMismatch="NEUTRAL"/>
+    </logger>
     <Root level="error">
       <AppenderRef ref="console"/>
     </Root>


### PR DESCRIPTION
A small PR that adds a commented section indicating how to modify log4j2.xml to log calcite rules being applied. The logs are disabled by default, but are stored here so we don't need to google again how to enable it each time we need it.