### PR TITLE
Fix broken BIG_DECIMAL aggregations (MIN / MAX / SUM / AVG) in the multi-stage query engine

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1159,6 +1159,15 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertNoError(jsonNode);
   }
 
+  @Test
+  public void testBigDecimalAggregations()
+      throws Exception {
+    String query =
+        "SELECT MIN(CAST(ArrTime AS DECIMAL)), MAX(CAST(ArrTime AS DECIMAL)), SUM(CAST(ArrTime AS DECIMAL)), AVG(CAST"
+            + "(ArrTime AS DECIMAL)) FROM mytable";
+    testQuery(query);
+  }
+
   @Override
   protected String getTableName() {
     return _tableName;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/TypeUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/TypeUtils.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.floats.FloatArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.math.BigDecimal;
 import org.apache.pinot.common.utils.ArrayListUtils;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
@@ -46,6 +47,8 @@ public class TypeUtils {
         return ((Number) value).floatValue();
       case DOUBLE:
         return ((Number) value).doubleValue();
+      case BIG_DECIMAL:
+        return value instanceof BigDecimal ? value : BigDecimal.valueOf(((Number) value).doubleValue());
       // For AggregationFunctions that return serialized custom object, e.g. DistinctCountRawHLLAggregationFunction
       case STRING:
         return value.toString();

--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -6,16 +6,17 @@
           {"name": "int_col", "type": "INT"},
           {"name": "double_col", "type": "DOUBLE"},
           {"name": "string_col", "type": "STRING"},
-          {"name": "bool_col", "type": "BOOLEAN"}
+          {"name": "bool_col", "type": "BOOLEAN"},
+          {"name": "big_decimal_col", "type": "BIG_DECIMAL"}
         ],
         "inputs": [
-          [2, 300, "a", true],
-          [2, 400, "a", true],
-          [3, 100, "b", false],
-          [100, 1, "b", false],
-          [101, 1.01, "c", false],
-          [150, 1.5, "c", false],
-          [175, 1.75, "c", true]
+          [2, 300, "a", true, 1.23456789],
+          [2, 400, "a", true, 2.3456789],
+          [3, 100, "b", false, 3.456789],
+          [100, 1, "b", false, 4.56789],
+          [101, 1.01, "c", false, 5.6789],
+          [150, 1.5, "c", false, 6.789],
+          [175, 1.75, "c", true, 7.89]
         ]
       }
     },
@@ -44,6 +45,11 @@
         "psql": "4.2.7",
         "description": "aggregations on string column",
         "sql": "SELECT count(string_col), count(distinct(string_col)), count(*) FROM {tbl}"
+      },
+      {
+        "psql": "4.2.7",
+        "description": "aggregations on big_decimal column",
+        "sql": "SELECT min(big_decimal_col), max(big_decimal_col), avg(big_decimal_col), sum(big_decimal_col), count(big_decimal_col), count(*) FROM {tbl}"
       }
     ]
   },


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/12705.
- As discussed in the above issue, the problem is that in final aggregates the actual return type from the aggregation function will be a double value (from `MIN` / `MAX` / `SUM` / `AVG`) and this is attempted to be cast to `BigDecimal` when constructing the data block to be sent over the wire. The cast is attempted because the return type for `MIN` / `MAX` / `SUM` / `AVG` is inferred as `DECIMAL` when the input operand type is `DECIMAL` (or `BIG_DECIMAL` in Pinot) due to the use of the standard operators in Calcite. We don't want to change this type inference logic because it's backward incompatible (the actual return type for users would change if we change this) and also because we want to move towards actual polymorphic aggregation functions (i.e., not just the appearance of polymorphism through casting). Note that this isn't an issue in the leaf aggregation because the return type there is determined as `DOUBLE` through the [AggregationFunctionType](https://github.com/apache/pinot/blob/d15f8c8caf531b29a839801a8afc08dc314c6d8e/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java#L54-L59) (see [here](https://github.com/apache/pinot/blob/d15f8c8caf531b29a839801a8afc08dc314c6d8e/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java#L326-L331)).
- The type conversion logic added to `TypeUtils::convert` (that handles single-stage -> multi-stage type conversion) includes a type check before converting because there are some aggregation functions like `SUMPRECISION` that actually return `BigDecimal` values and we don't want to lose precision there by converting through doubles.
- In the long term, we want to support truly polymorphic aggregation functions in the multi-stage query engine (i.e., where the MAX aggregation function would return a value of the same type as the input operand type - right now it's always `DOUBLE`). However, this has backward compatibility implications and we need to be careful about not breaking the v1 engine. Right now, the output type to end users will still be the same as the input operand type in the MSQE but there can be loss of precision (`MAX(BIG_DECIMAL col) -> DOUBLE output -> cast to BIG_DECIMAL (loss of precision)` for instance).