### PR TITLE
add icons and shortcuts for query submit and format

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -233,6 +233,10 @@ const QueryPage = () => {
     if (modifiedEnabled && event.keyCode == 191) {
       handleComment(editor);
     }
+    // Map (Cmd/Ctrl) + \ KeyPress to toggle formatting the query
+    if (modifiedEnabled && event.keyCode == 220) {
+      handleFormatSQL(editor.getValue());
+    }
   }
 
   const handleComment = (cm: NativeCodeMirror.Editor) => {
@@ -539,6 +543,7 @@ const QueryPage = () => {
                     variant="contained"
                     color="primary"
                     onClick={() => handleFormatSQL(inputQuery)}
+                    endIcon={<span style={{fontSize: '0.8em', lineHeight: 1}}>{navigator.platform.includes('Mac') ? '⌘\\' : 'Ctrl+\\'}</span>}
                 >
                   Format SQL
                 </Button>
@@ -549,6 +554,7 @@ const QueryPage = () => {
                     variant="contained"
                     color="primary"
                     onClick={() => handleRunNow()}
+                    endIcon={<span style={{fontSize: '0.8em', lineHeight: 1}}>{navigator.platform.includes('Mac') ? '⌘↵' : 'Ctrl+↵'}</span>}
                 >
                   Run Query
                 </Button>


### PR DESCRIPTION
this is a small `ui` `feature` to put shortcuts for UI buttons with the buttons. It should be different for mac vs non-mac.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/a6bde23e-dc60-4b1c-82fb-b87d296e377f" />
