### PR TITLE
Include exception when no server is found

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -703,7 +703,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
       if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {
         if (!exceptions.isEmpty()) {
-          LOGGER.info("No server found for request {}: {}", requestId, query);
+          ProcessingException firstException = exceptions.get(0);
+          String logTail = exceptions.size() > 1 ? (exceptions.size()) + " exceptions found. Logging only the first one"
+              : "1 exception found";
+          LOGGER.info("No server found for request {}: {}. {}", requestId, query, logTail, firstException);
           _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.NO_SERVER_FOUND_EXCEPTIONS, 1);
           return new BrokerResponseNative(exceptions);
         } else {


### PR DESCRIPTION
Recently we found an issue when the log `No server found for request` was printed. This log implies there is an exception that don't let us find servers to query, but the exception is not printed.

This PR modifies the log to include a the first exception found. In case more than exception is affecting the system, we only log the first one, but we include the total number of exceptions in the log.