### PR TITLE
Fix false data loss alerts in case of read_committed Kafka isolation

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaMessageBatch;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamMessageMetadata;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.BytesStreamMessage;
@@ -88,8 +89,14 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
       }
     }
 
+    // In case read_committed is enabled, the messages consumed are not guaranteed to have consecutive offsets.
+    // TODO: A better solution would be to fetch earliest offset from topic and see if it is greater than startOffset.
+    // However, this would require and additional call to Kafka which we want to avoid.
+    boolean hasDataLoss = !_config.getKafkaIsolationLevel()
+        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED)
+        && firstOffset > startOffset;
     return new KafkaMessageBatch(filteredRecords, records.size(), offsetOfNextBatch, firstOffset, lastMessageMetadata,
-        firstOffset > startOffset);
+        hasDataLoss);
   }
 
   private StreamMessageMetadata extractMessageMetadata(ConsumerRecord<String, Bytes> record) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -92,9 +92,11 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     // In case read_committed is enabled, the messages consumed are not guaranteed to have consecutive offsets.
     // TODO: A better solution would be to fetch earliest offset from topic and see if it is greater than startOffset.
     // However, this would require and additional call to Kafka which we want to avoid.
-    boolean hasDataLoss = !_config.getKafkaIsolationLevel()
-        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED)
-        && firstOffset > startOffset;
+    boolean hasDataLoss = false;
+    if (_config.getKafkaIsolationLevel() == null || _config.getKafkaIsolationLevel()
+        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_UNCOMMITTED)) {
+      hasDataLoss = firstOffset > startOffset;
+    }
     return new KafkaMessageBatch(filteredRecords, records.size(), offsetOfNextBatch, firstOffset, lastMessageMetadata,
         hasDataLoss);
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaMessageBatch;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamMessageMetadata;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.BytesStreamMessage;
@@ -88,8 +89,14 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
       }
     }
 
+    // In case read_committed is enabled, the messages consumed are not guaranteed to have consecutive offsets.
+    // TODO: A better solution would be to fetch earliest offset from topic and see if it is greater than startOffset.
+    // However, this would require and additional call to Kafka which we want to avoid.
+    boolean hasDataLoss = !_config.getKafkaIsolationLevel()
+        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED)
+        && firstOffset > startOffset;
     return new KafkaMessageBatch(filteredRecords, records.size(), offsetOfNextBatch, firstOffset, lastMessageMetadata,
-        firstOffset > startOffset);
+        hasDataLoss);
   }
 
   private StreamMessageMetadata extractMessageMetadata(ConsumerRecord<String, Bytes> record) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
@@ -92,9 +92,11 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     // In case read_committed is enabled, the messages consumed are not guaranteed to have consecutive offsets.
     // TODO: A better solution would be to fetch earliest offset from topic and see if it is greater than startOffset.
     // However, this would require and additional call to Kafka which we want to avoid.
-    boolean hasDataLoss = !_config.getKafkaIsolationLevel()
-        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED)
-        && firstOffset > startOffset;
+    boolean hasDataLoss = false;
+    if (_config.getKafkaIsolationLevel() == null || _config.getKafkaIsolationLevel()
+        .equals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_UNCOMMITTED)) {
+      hasDataLoss = firstOffset > startOffset;
+    }
     return new KafkaMessageBatch(filteredRecords, records.size(), offsetOfNextBatch, firstOffset, lastMessageMetadata,
         hasDataLoss);
   }


### PR DESCRIPTION
We recently ran into an issue where a lot of data loss warnings were being logged in pinot logs

However on investigation it was found out that we had read_committed enabled in Kafka consumer.

So we don't read records from some of the offset cause the transaction was aborted for them. 

This PR removes data loss check for read_committed. A better solution can be to check for earliest offset in kafka topic and see if startOffset is earlier than that. However this would lead to additional delay in consumer which I don't want