### PR TITLE
add server status to all instance tables

### DIFF
--- a/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
@@ -25,28 +25,15 @@ import PinotMethodUtils from '../utils/PinotMethodUtils';
 import Utils from '../utils/Utils';
 import Loading from './Loading';
 
-type BaseProps = {
+type Props = {
   instanceType: InstanceType;
   showInstanceDetails?: boolean;
   instanceNames: string[] | null;
   liveInstanceNames?: string[];
 };
 
-type ClusterProps = BaseProps & {
-  cluster: string;
-  tenant?: never;
-};
-
-type TenantProps = BaseProps & {
-  tenant: string;
-  cluster?: never;
-};
-
-type Props = ClusterProps | TenantProps;
-
 export const AsyncInstanceTable = ({
   instanceType,
-  cluster,
   instanceNames,
   liveInstanceNames,
   showInstanceDetails = false,
@@ -70,10 +57,10 @@ export const AsyncInstanceTable = ({
 
   useEffect(() => {
     // async load all the other details
-    if(showInstanceDetails && cluster && instanceNames && liveInstanceNames) {
+    if(showInstanceDetails && instanceNames && liveInstanceNames) {
       fetchAdditionalInstanceDetails();
     }
-  }, [showInstanceDetails, cluster, instanceNames, liveInstanceNames]);
+  }, [showInstanceDetails, instanceNames, liveInstanceNames]);
 
   const fetchAdditionalInstanceDetails = async () => {
     const additionalData = await PinotMethodUtils.getInstanceData(

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
@@ -30,7 +30,7 @@ type Props = {
 };
 
 
-const Instances = ({ clusterName, instanceType, instances, liveInstanceNames }: Props) => {
+const Instances = ({ instanceType, instances, liveInstanceNames }: Props) => {
   const order = [
     InstanceType.CONTROLLER,
     InstanceType.BROKER,
@@ -45,7 +45,6 @@ const Instances = ({ clusterName, instanceType, instances, liveInstanceNames }: 
           return (
             <AsyncInstanceTable
               key={startCase(key)}
-              cluster={clusterName}
               instanceType={key}
               showInstanceDetails
               instanceNames={instances?.[key] || null}

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -130,7 +130,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   const [showEditConfig, setShowEditConfig] = useState(false);
   const [config, setConfig] = useState('{}');
 
-  const instanceColumns = ["Instance Name", "# of segments"];
+  const instanceColumns = ["Instance Name", "# of segments", "Status"];
   const loadingInstanceData = Utils.getLoadingTableData(instanceColumns);
   const [instanceCountData, setInstanceCountData] = useState<TableData>(loadingInstanceData);
 
@@ -187,10 +187,13 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   const fetchSegmentData = async () => {
     const result = await PinotMethodUtils.getSegmentList(tableName);
     const data = await PinotMethodUtils.fetchServerToSegmentsCountData(tableName, tableType);
+    const liveInstanceNames = await PinotMethodUtils.getLiveInstances();
     const {columns, records} = result;
     setInstanceCountData({
       columns: instanceColumns,
-      records: data.records
+      records: data.records.map((record) => {
+        return [...record, liveInstanceNames.data.includes(record[0]) ? 'Alive' : 'Dead'];
+      })
     });
 
     const segmentTableRows = [];

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -46,6 +46,7 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
     [InstanceType.BROKER]: null,
     [InstanceType.SERVER]: null,
   })
+  const [liveInstanceNames, setLiveInstanceNames] = useState<string[]>();
 
   useEffect(() => {
      fetchInstanceData();
@@ -58,6 +59,10 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
       [InstanceType.BROKER]: Array.isArray(brokerNames) ? brokerNames : [],
       [InstanceType.SERVER]: Array.isArray(serverNames) ? serverNames : [],
     });
+
+    const liveInstanceNames = await PinotMethodUtils.getLiveInstances();
+    setLiveInstanceNames(liveInstanceNames.data || []);
+
   }
 
   return (
@@ -76,16 +81,18 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
           <div>
             <CustomButton
               onClick={() => {}}
-              tooltipTitle="Recalculates the segment to server mapping for all tables in this tenant"
-              enableTooltip={true}
+              // Tooltips do not render on disabled buttons. Add this back when we have a working implementation.
+              // tooltipTitle="Recalculates the segment to server mapping for all tables in this tenant"
+              // enableTooltip={true}
               isDisabled={true}
             >
               Rebalance Server Tenant
             </CustomButton>
             <CustomButton
               onClick={() => {}}
-              tooltipTitle="Rebuilds brokerResource mappings for all tables in this tenant"
-              enableTooltip={true}
+              // Tooltips do not render on disabled buttons. Add this back when we have a working implementation.
+              // tooltipTitle="Rebuilds brokerResource mappings for all tables in this tenant"
+              // enableTooltip={true}
               isDisabled={true}
             >
               Rebuild Broker Resource
@@ -99,18 +106,20 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
         baseUrl={`/tenants/${tenantName}/table/`}
       />
       <Grid container spacing={2}>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <AsyncInstanceTable
             instanceNames={instanceNames[InstanceType.BROKER]}
             instanceType={InstanceType.BROKER}
-            tenant={tenantName}
+            liveInstanceNames={liveInstanceNames}
+            showInstanceDetails
           />
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <AsyncInstanceTable
             instanceNames={instanceNames[InstanceType.SERVER]}
             instanceType={InstanceType.SERVER}
-            tenant={tenantName}
+            liveInstanceNames={liveInstanceNames}
+            showInstanceDetails
           />
         </Grid>
       </Grid>

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -199,10 +199,23 @@ const getClusterName = () => {
 // This method is used to fetch array of live instances name
 // API: /zk/ls?path=:ClusterName/LIVEINSTANCES
 // Expected Output: []
-const getLiveInstance = (clusterName) => {
+const getLiveInstance = (clusterName: string) => {
   const params = encodeURIComponent(`/${clusterName}/LIVEINSTANCES`);
   return zookeeperGetList(params).then((data) => {
     return data;
+  });
+};
+
+const getLiveInstances = () => {
+  let localclusterName: string | null = localStorage.getItem('pinot_ui:clusterName');
+  let clusterNameRes: Promise<string>;
+  if(!localclusterName || localclusterName === ''){
+    clusterNameRes = getClusterName();
+  } else {
+    clusterNameRes = Promise.resolve(localclusterName);
+  }
+  return clusterNameRes.then((clusterName) => {
+    return getLiveInstance(clusterName);
   });
 };
 
@@ -1277,6 +1290,7 @@ export default {
   getSegmentCountAndStatus,
   getClusterName,
   getLiveInstance,
+  getLiveInstances,
   getLiveInstanceConfig,
   getInstanceConfig,
   getInstanceDetails,


### PR DESCRIPTION
This is a `ui` `feature` to add server status to all instance tables. The pages where this is important:

The tenants pages is the only page that has servers filtered down to the specified tenant. It's useful to be able to see all the info for those servers.

before
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/323fd2de-f754-46be-bea5-7c3de3cfade2" />

after
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/54dda743-74a5-46d6-a0f5-4790b643f4af" />

The tables page has a table with instance name and count. But this is the only page with exact server assignment for that table. So again, it's useful to know which of the servers are alive.

before
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/a355bbc0-0c1a-4672-8672-a9dcde1033b9" />

after
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/4d6e82c7-daa8-4961-b270-3d7719180d92" />
