### PR TITLE
Add segment size info to validDocIdsMetadata API call

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -30,17 +30,20 @@ public class ValidDocIdsMetadataInfo {
   private final long _totalDocs;
   private final String _segmentCrc;
   private final ValidDocIdsType _validDocIdsType;
+  private final long _segmentSizeInBytes;
 
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
-      @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType) {
+      @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
+      @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
     _totalDocs = totalDocs;
     _segmentCrc = segmentCrc;
     _validDocIdsType = validDocIdsType;
+    _segmentSizeInBytes = segmentSizeInBytes;
   }
 
   public String getSegmentName() {
@@ -65,5 +68,9 @@ public class ValidDocIdsMetadataInfo {
 
   public ValidDocIdsType getValidDocIdsType() {
     return _validDocIdsType;
+  }
+
+  public long getSegmentSizeInBytes() {
+    return _segmentSizeInBytes;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -714,6 +714,10 @@ public class TablesResource {
         validDocIdsMetadata.put("totalInvalidDocs", totalInvalidDocs);
         validDocIdsMetadata.put("segmentCrc", indexSegment.getSegmentMetadata().getCrc());
         validDocIdsMetadata.put("validDocIdsType", finalValidDocIdsType);
+        if (segmentDataManager instanceof ImmutableSegmentDataManager) {
+          validDocIdsMetadata.put("segmentSizeInBytes",
+              ((ImmutableSegment) segmentDataManager.getSegment()).getSegmentSizeBytes());
+        }
         allValidDocIdsMetadata.add(validDocIdsMetadata);
       }
       if (nonImmutableSegmentCount > 0) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -347,6 +347,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdsMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdsMetadata.get("segmentCrc").asText(), "1894900283");
     Assert.assertEquals(validDocIdsMetadata.get("validDocIdsType").asText(), "SNAPSHOT");
+    Assert.assertEquals(validDocIdsMetadata.get("segmentSizeInBytes").asLong(), 1877636);
   }
 
   // Verify metadata file from segments.


### PR DESCRIPTION
First step for addressing #14634 

This is a very small change to get segment size info along with other metadata in `/validDocIdsMetadata` API call.
In next PR, we will use this info in UpsertCompactMerge task to form new segments of desired sizes. Keeping this change separate to have the follow-up PR specific to generation and execution logic for UpsertCompactMerge task.