### PR TITLE
Avoid closing response stream while downloading instance logs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -224,18 +224,16 @@ public class PinotControllerLogger {
       if (authorization != null) {
         requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, authorization);
       }
-      try (CloseableHttpResponse httpResponse = _fileUploadDownloadClient.getHttpClient()
-          .execute(requestBuilder.build())) {
-        if (httpResponse.getCode() >= 400) {
-          throw new WebApplicationException(IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8"),
-              Response.Status.fromStatusCode(httpResponse.getCode()));
-        }
-        Response.ResponseBuilder builder = Response.ok();
-        builder.entity(httpResponse.getEntity().getContent());
-        builder.contentLocation(uri);
-        builder.header(HttpHeaders.CONTENT_LENGTH, httpResponse.getEntity().getContentLength());
-        return builder.build();
+      CloseableHttpResponse httpResponse = _fileUploadDownloadClient.getHttpClient().execute(requestBuilder.build());
+      if (httpResponse.getCode() >= 400) {
+        throw new WebApplicationException(IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8"),
+            Response.Status.fromStatusCode(httpResponse.getCode()));
       }
+      Response.ResponseBuilder builder = Response.ok();
+      builder.entity(httpResponse.getEntity().getContent());
+      builder.contentLocation(uri);
+      builder.header(HttpHeaders.CONTENT_LENGTH, httpResponse.getEntity().getContentLength());
+      return builder.build();
     } catch (IOException e) {
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
## Description

Due the response stream being closed on controller, client is unable to download the logs from other instances and facing 
```
2024/12/24 08:11:46.111 ERROR [WebApplicationExceptionMapper] [grizzly-http-server-0] Server error: 
org.apache.hc.core5.http.StreamClosedException: Stream already closed
```