### PR TITLE
add option to delete table and schema immediately

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Confirm.tsx
+++ b/pinot-controller/src/main/resources/app/components/Confirm.tsx
@@ -60,10 +60,11 @@ type Props = {
   successCallback: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   closeDialog: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   dialogYesLabel?: string,
-  dialogNoLabel?: string
+  dialogNoLabel?: string,
+  children?: React.ReactNode
 };
 
-const Confirm = ({openDialog, dialogTitle, dialogContent, successCallback, closeDialog, dialogYesLabel = 'Yes', dialogNoLabel = 'No'}: Props) => {
+const Confirm = ({openDialog, dialogTitle, dialogContent, successCallback, closeDialog, dialogYesLabel = 'Yes', dialogNoLabel = 'No', children}: Props) => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(openDialog);
 
@@ -89,6 +90,7 @@ const Confirm = ({openDialog, dialogTitle, dialogContent, successCallback, close
               {dialogContent}
             </DialogContentText>
             : dialogContent}
+          {children}
         </DialogContent>
         <DialogActions style={{paddingBottom: 20}} className={`${isStringDialog ? classes.dialogActions : ''}`}>
           <Button variant="outlined" onClick={closeDialog} color="secondary" className={classes.red}>

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Button, FormControlLabel, Grid, Switch, Tooltip, Typography } from '@material-ui/core';
+import { Box, Button, Checkbox, FormControlLabel, Grid, Switch, Tooltip, Typography } from '@material-ui/core';
 import { RouteComponentProps, useHistory, useLocation } from 'react-router-dom';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { DISPLAY_SEGMENT_STATUS, InstanceState, TableData, TableSegmentJobs, TableType } from 'Models';
@@ -151,6 +151,18 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   const [tableJobsData, setTableJobsData] = useState<TableSegmentJobs | null>(null);
   const [showRebalanceServerModal, setShowRebalanceServerModal] = useState(false);
   const [schemaJSONFormat, setSchemaJSONFormat] = useState(false);
+
+  // This is quite hacky, but it's the only way to get this to work with the dialog.
+  // The useState variables are simply for the dialog box to know what to render in
+  // the checkbox fields. The actual state of the checkboxes is stored in the refs.
+  // The refs are then used to determine how we delete the table. If you try to use
+  // the state variables in this class, you will not be able to get their latest values.
+  const [dialogCheckboxes, setDialogCheckboxes] = useState({
+    deleteImmediately: false,
+    deleteSchema: false
+  });
+  const deleteImmediatelyRef = useRef(false);
+  const deleteSchemaRef = useRef(false);
 
   const fetchTableData = async () => {
     // We keep all the fetching inside this component since we need to be able
@@ -299,45 +311,66 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   };
 
   const handleDeleteTableAction = () => {
+    // Set checkboxes to the last state when opening dialog
+    setDialogCheckboxes({
+      deleteImmediately: deleteImmediatelyRef.current,
+      deleteSchema: deleteSchemaRef.current
+    });
+
     setDialogDetails({
       title: 'Delete Table',
-      content: 'Are you sure want to delete this table? All data and configs will be deleted.',
-      successCb: () => deleteTable()
+      content:
+        'Are you sure want to delete this table? All data and configs will be deleted.',
+      successCb: () => {
+        deleteTable();
+      },
+      renderChildren: true,
     });
     setConfirmDialog(true);
   };
 
   const deleteTable = async () => {
-    const result = await PinotMethodUtils.deleteTableOp(tableName);
-    if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
-    } else {
-      dispatch({type: 'error', message: result.error, show: true});
-    }
-    closeDialog();
-    if(result.status){
-      setTimeout(()=>{
-        if(tenantName){
-          history.push(Utils.navigateToPreviousPage(location, true));  
-        } else {
-          history.push('/tables');
+    let message = '';
+    let tableDeleted = false;
+    let schemaDeleted = false;
+
+    try {
+      const tableRes = await PinotMethodUtils.deleteTableOp(tableName, deleteImmediatelyRef.current ? '0d' : undefined);
+
+      if (tableRes.status) {
+        message = tableRes.status;
+        tableDeleted = true;
+
+        if (deleteSchemaRef.current) {
+          const schemaRes = await PinotMethodUtils.deleteSchemaOp(schemaJSON.schemaName);
+          if (schemaRes.status) {
+            message += ". " + schemaRes.status;
+            schemaDeleted = true;
+          } else {
+            message += ". " + schemaRes.error || "Unknown error deleting schema";
+          }
         }
-      }, 1000);
+      } else {
+        message = tableRes.error || "Unknown error deleting table";
+      }
+
+      const isSuccess = tableDeleted && (!deleteSchemaRef.current || schemaDeleted);
+      dispatch({ type: isSuccess ? 'success' : 'error', message, show: true });
+      closeDialog();
+
+      if (tableDeleted) {
+        setTimeout(() => {
+          if (tenantName) {
+            history.push(Utils.navigateToPreviousPage(location, true));
+          } else {
+            history.push('/tables');
+          }
+        }, 1000);
+      }
+    } catch (error) {
+      dispatch({ type: 'error', message: error.toString(), show: true });
+      closeDialog();
     }
-  };
-
-  const handleDeleteSchemaAction = () => {
-    setDialogDetails({
-      title: 'Delete Schema',
-      content: 'Are you sure want to delete this schema? Any tables using this schema might not function correctly.',
-      successCb: () => deleteSchema()
-    });
-    setConfirmDialog(true);
-  };
-
-  const deleteSchema = async () => {
-    const result = await PinotMethodUtils.deleteSchemaOp(schemaJSON.schemaName);
-    syncResponse(result);
   };
 
   const handleReloadSegments = () => {
@@ -478,20 +511,6 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
                 enableTooltip={true}
               >
                 Edit Schema
-              </CustomButton>
-              <CustomButton
-                isDisabled={!schemaJSON} onClick={handleDeleteSchemaAction}
-                tooltipTitle="Delete Schema"
-                enableTooltip={true}
-              >
-                Delete Schema
-              </CustomButton>
-              <CustomButton
-                isDisabled={true} onClick={()=>{}}
-                tooltipTitle="Truncate Table"
-                enableTooltip={true}
-              >
-                Truncate Table
               </CustomButton>
               <CustomButton
                 onClick={handleReloadSegments}
@@ -647,35 +666,91 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
         </Grid>
         <EditConfigOp
           showModal={showEditConfig}
-          hideModal={()=>{setShowEditConfig(false);}}
+          hideModal={() => {
+            setShowEditConfig(false);
+          }}
           saveConfig={saveConfigAction}
           config={config}
           handleConfigChange={handleConfigChange}
         />
-        {
-          showReloadStatusModal &&
+        {showReloadStatusModal && (
           <ReloadStatusOp
-            hideModal={()=>{setShowReloadStatusModal(false); setReloadStatusData(null)}}
+            hideModal={() => {
+              setShowReloadStatusModal(false);
+              setReloadStatusData(null);
+            }}
             reloadStatusData={reloadStatusData}
             tableJobsData={tableJobsData}
           />
-        }
-        {showRebalanceServerModal &&
+        )}
+        {showRebalanceServerModal && (
           <RebalanceServerTableOp
-            hideModal={()=>{setShowRebalanceServerModal(false)}}
+            hideModal={() => {
+              setShowRebalanceServerModal(false);
+            }}
             tableType={tableType.toUpperCase()}
             tableName={tableName}
           />
-        }
-        {confirmDialog && dialogDetails && <Confirm
-          openDialog={confirmDialog}
-          dialogTitle={dialogDetails.title}
-          dialogContent={dialogDetails.content}
-          successCallback={dialogDetails.successCb}
-          closeDialog={closeDialog}
-          dialogYesLabel='Yes'
-          dialogNoLabel='No'
-        />}
+        )}
+        {confirmDialog && dialogDetails && (
+          <Confirm
+            openDialog={confirmDialog}
+            dialogTitle={dialogDetails.title}
+            dialogContent={dialogDetails.content}
+            successCallback={dialogDetails.successCb}
+            children={
+              dialogDetails.renderChildren && <>
+                <Tooltip
+                  title="Delete table and all segments immediately.
+                         If not checked, all segments will be copied over to a separate path
+                         and kept until the cluster default retention period is met."
+                  arrow
+                  placement="right"
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={dialogCheckboxes.deleteImmediately}
+                        onChange={(e) => {
+                          const { checked } = e.target;
+                          setDialogCheckboxes(prev => ({
+                            ...prev,
+                            deleteImmediately: checked
+                          }));
+                          deleteImmediatelyRef.current = checked
+                        }}
+                        color="primary"
+                      />
+                    }
+                    label="Delete Immediately"
+                  />
+                </Tooltip>
+                <Tooltip title="If the table is successfully deleted, also delete the schema associated with this table." arrow placement="right">
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={dialogCheckboxes.deleteSchema}
+                        onChange={(e) => {
+                          const { checked } = e.target;
+                          setDialogCheckboxes(prev => ({
+                            ...prev,
+                            deleteSchema: checked
+                          }));
+                          deleteSchemaRef.current = checked;
+                        }}
+                        color="primary"
+                      />
+                    }
+                    label="Delete Schema"
+                  />
+                </Tooltip>
+              </>
+            }
+            closeDialog={closeDialog}
+            dialogYesLabel="Yes"
+            dialogNoLabel="No"
+          />
+        )}
       </Grid>
     );
   }

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -255,8 +255,8 @@ export const getTableJobs = (tableName: string, jobTypes?: string): Promise<Axio
 export const getSegmentReloadStatus = (jobId: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/segments/segmentReloadStatus/${jobId}`, {headers});
 
-export const deleteTable = (tableName: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.delete(`/tables/${tableName}`, {headers});
+export const deleteTable = (tableName: string, retention?: string): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.delete(`/tables/${tableName}${retention ? `?retention=${retention}` : ''}`, {headers});
 
 export const deleteSchema = (schemaName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/schemas/${schemaName}`, {headers});

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -970,8 +970,8 @@ const updateSchema = (schemaName: string, schema: string, reload?: boolean) => {
   })
 };
 
-const deleteTableOp = (tableName) => {
-  return deleteTable(tableName).then((response)=>{
+const deleteTableOp = (tableName: string, retention?: string) => {
+  return deleteTable(tableName, retention).then((response)=>{
     return response.data;
   });
 };


### PR DESCRIPTION
This is a small `UI` quality of life `feature`

- remove the "delete schema" button. You can't delete the schema while the table exists. So there's no way a "delete schema" button works on the table page
- remove the "truncate table" button. It's been >2 years since it's been pending, so I'm removing it to reclaim the UI space.
- update the "delete table" modal with 2 options: delete immediately and delete schema
  - "delete immediately" bypasses retention which is really useful for large tables that cause this API to time out
  - "delete schema" is a replacement for the dedicated button that will only delete the schema after deleting the table 

I tested this locally with a quickstart:
- deleting a table with neither option
- deleting a table immediately
- deleting the offline table and schema of a hybrid table deletes the tables but fails to delete the schema still in use
- deleting a table with both options

how the modal looks
<img width="668" alt="image" src="https://github.com/user-attachments/assets/653752ab-e3ae-4fac-ae98-946757ae95e6" />

deleting both the table and schema
<img width="590" alt="image" src="https://github.com/user-attachments/assets/e3b7b1d4-3f05-4e0f-a92a-6be8623d364c" />
