### PR TITLE
Avoid handling JSON_ARRAY as multi value JSON during transformation

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.common.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -218,6 +220,21 @@ public class PinotDataTypeTest {
         "{\"bytes\":\"AAE=\",\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]},"
             + "\"timestamp\":1620324238610}");
     assertEquals(JSON.convert(new Timestamp(1620324238610L), TIMESTAMP), "1620324238610");
+  }
+
+  @Test
+  public void testJSONArray()
+      throws JsonProcessingException {
+    assertEquals(JSON.convert(new Object[]{false}, BOOLEAN), "[false]");
+    assertEquals(JSON.convert(new Object[]{true}, BOOLEAN), "[true]"); // Base64 encoding.
+    assertEquals(JSON.convert(new Object[]{
+        JsonUtils.stringToObject("{\"bytes\":\"AAE=\"}", Map.class),
+            JsonUtils.stringToObject("{\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]}}", Map.class),
+            JsonUtils.stringToObject("{\"timestamp\":1620324238610}", Map.class)}, JSON),
+        "[{\"bytes\":\"AAE=\"},{\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]}},"
+            + "{\"timestamp\":1620324238610}]");
+    assertEquals(JSON.convert(new Object[]{}, JSON), "[]");
+    assertEquals(JSON.convert(new Object[]{new Timestamp(1620324238610L)}, TIMESTAMP), "[1620324238610]");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -229,7 +229,8 @@ public class PinotDataTypeTest {
     assertEquals(JSON.convert(new Object[]{true}, BOOLEAN), "[true]"); // Base64 encoding.
     assertEquals(JSON.convert(new Object[]{
         JsonUtils.stringToObject("{\"bytes\":\"AAE=\"}", Map.class),
-            JsonUtils.stringToObject("{\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]}}", Map.class),
+            JsonUtils.stringToObject("{\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]}}",
+                Map.class),
             JsonUtils.stringToObject("{\"timestamp\":1620324238610}", Map.class)}, JSON),
         "[{\"bytes\":\"AAE=\"},{\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]}},"
             + "{\"timestamp\":1620324238610}]");

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
@@ -67,4 +67,10 @@ public class JSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
     }
     return to;
   }
+
+  @Override
+  protected boolean isMultiValue(Object value) {
+    // multi value JSON is treated as JSON_ARRAY hence it's never a multi value column
+    return false;
+  }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
@@ -67,10 +67,4 @@ public class JSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
     }
     return to;
   }
-
-  @Override
-  protected boolean isMultiValue(Object value) {
-    // multi value JSON is treated as JSON_ARRAY hence it's never a multi value column
-    return false;
-  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -94,7 +94,12 @@ public class DataTypeTransformer implements RecordTransformer {
         if (value instanceof Object[]) {
           // Multi-value column
           Object[] values = (Object[]) value;
-          source = PinotDataType.getMultiValueType(values[0].getClass());
+          // JSON is not standardised for empty json array
+          if (dest == PinotDataType.JSON && values.length == 0) {
+            source = PinotDataType.JSON;
+          } else {
+            source = PinotDataType.getMultiValueType(values[0].getClass());
+          }
         } else {
           // Single-value column
           source = PinotDataType.getSingleValueType(value.getClass());


### PR DESCRIPTION
The transform pipeline is failing with an `ArrayIndexOutOfBoundsException` when it encounters a JSON column value with empty json array as JSON value is not standardised (empty array -> null) https://github.com/apache/pinot/blob/master/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java#L97

Earlier empty array for json datatype was getting extracted as string, now its getting extracted as Object[] due to the change at https://github.com/apache/pinot/pull/14547/files#diff-7ac5349f9d75e27a62a063dbf81db3ed30c8de052b4ffa7719187e4babaa60baR66
which leads to `isMultiValue` returning true for empty json array

`convertMultiValue`  returns `Object[]` while `convertSingleValue`  returns a `string`
https://github.com/apache/pinot/blob/master/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java#L39
```
  public Object convert(Object value) {
    Object convertedValue;
    if (isMultiValue(value)) {
      convertedValue = convertMultiValue(value);
    } else if (isMap(value)) {
      convertedValue = convertMap(value);
    } else if (isRecord(value)) {
      convertedValue = convertRecord(value);
    } else {
      convertedValue = convertSingleValue(value);
    }
    return convertedValue;
  }
```

Updating the transform logic to handle the empty array for JSON datatype