### PR TITLE
Fix JDBC date time parsing issue

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DateTimeUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DateTimeUtils.java
@@ -34,8 +34,8 @@ public class DateTimeUtils {
   private DateTimeUtils() {
   }
 
-  private static final String TIMESTAMP_FORMAT_STR = "yyyy-MM-dd HH:mm:ss";
-  private static final String DATE_FORMAT_STR = "yyyy-MM-dd";
+  private static final String TIMESTAMP_FORMAT_STR = "yyyy-MM-dd HH:mm:ss[.SSS]";
+  private static final String DATE_FORMAT_STR = "yyyy-MM-dd[ HH:mm:ss[.SSS]]";
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_STR);
   private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(TIMESTAMP_FORMAT_STR);
 

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotResultSetTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotResultSetTest.java
@@ -26,10 +26,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.client.utils.DateTimeUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -209,79 +205,6 @@ public class PinotResultSetTest {
 
     calculatedResult = pinotResultSet.getCalculatedScale("-1.234");
     Assert.assertEquals(calculatedResult, 3);
-  }
-
-  @Test
-  public void testDateFromStringConcurrent()
-      throws Throwable {
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    AtomicReference<Throwable> throwable = new AtomicReference<>();
-    for (int i = 0; i < 10; i++) {
-      executorService.submit(() -> {
-        try {
-          Assert.assertEquals(DateTimeUtils.getDateFromString("2020-01-01", Calendar.getInstance()).toString(),
-              "2020-01-01");
-        } catch (Throwable t) {
-          throwable.set(t);
-        }
-      });
-    }
-
-    executorService.shutdown();
-    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
-
-    if (throwable.get() != null) {
-      throw throwable.get();
-    }
-  }
-
-  @Test
-  public void testTimeFromStringConcurrent()
-      throws Throwable {
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    AtomicReference<Throwable> throwable = new AtomicReference<>();
-    for (int i = 0; i < 10; i++) {
-      executorService.submit(() -> {
-        try {
-          Assert.assertEquals(DateTimeUtils.getTimeFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
-              "12:00:00");
-        } catch (Throwable t) {
-          throwable.set(t);
-        }
-      });
-    }
-
-    executorService.shutdown();
-    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
-
-    if (throwable.get() != null) {
-      throw throwable.get();
-    }
-  }
-
-  @Test
-  public void testTimestampFromStringConcurrent()
-      throws Throwable {
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    AtomicReference<Throwable> throwable = new AtomicReference<>();
-    for (int i = 0; i < 10; i++) {
-      executorService.submit(() -> {
-        try {
-          Assert.assertEquals(
-              DateTimeUtils.getTimestampFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
-              "2020-01-01 12:00:00.0");
-        } catch (Throwable t) {
-          throwable.set(t);
-        }
-      });
-    }
-
-    executorService.shutdown();
-    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
-
-    if (throwable.get() != null) {
-      throw throwable.get();
-    }
   }
 
   private ResultSetGroup getResultSet(String resourceName) {

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/utils/DateTimeUtilsTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/utils/DateTimeUtilsTest.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.utils;
+
+import java.util.Calendar;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DateTimeUtilsTest {
+
+  @Test
+  public void testDateFromStringConcurrent()
+      throws Throwable {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    AtomicReference<Throwable> throwable = new AtomicReference<>();
+    for (int i = 0; i < 10; i++) {
+      executorService.submit(() -> {
+        try {
+          Assert.assertEquals(DateTimeUtils.getDateFromString("2020-01-01", Calendar.getInstance()).toString(),
+              "2020-01-01");
+        } catch (Throwable t) {
+          throwable.set(t);
+        }
+      });
+    }
+
+    executorService.shutdown();
+    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+    if (throwable.get() != null) {
+      throw throwable.get();
+    }
+  }
+
+  @Test
+  public void testTimeFromStringConcurrent()
+      throws Throwable {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    AtomicReference<Throwable> throwable = new AtomicReference<>();
+    for (int i = 0; i < 10; i++) {
+      executorService.submit(() -> {
+        try {
+          Assert.assertEquals(DateTimeUtils.getTimeFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
+              "12:00:00");
+        } catch (Throwable t) {
+          throwable.set(t);
+        }
+      });
+    }
+
+    executorService.shutdown();
+    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+    if (throwable.get() != null) {
+      throw throwable.get();
+    }
+  }
+
+  @Test
+  public void testTimestampFromStringConcurrent()
+      throws Throwable {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    AtomicReference<Throwable> throwable = new AtomicReference<>();
+    for (int i = 0; i < 10; i++) {
+      executorService.submit(() -> {
+        try {
+          Assert.assertEquals(
+              DateTimeUtils.getTimestampFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
+              "2020-01-01 12:00:00.0");
+        } catch (Throwable t) {
+          throwable.set(t);
+        }
+      });
+    }
+
+    executorService.shutdown();
+    executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+    if (throwable.get() != null) {
+      throw throwable.get();
+    }
+  }
+
+  @Test
+  public void testDateFromString() {
+    Assert.assertEquals(DateTimeUtils.getDateFromString("2020-01-01", Calendar.getInstance()).toString(), "2020-01-01");
+    Assert.assertEquals(
+        DateTimeUtils.getDateFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
+        "2020-01-01");
+    Assert.assertEquals(
+        DateTimeUtils.getDateFromString("2020-01-01 12:00:00.000", Calendar.getInstance()).toString(),
+        "2020-01-01");
+    Assert.assertThrows(() -> DateTimeUtils.getDateFromString("2020-01", Calendar.getInstance()));
+  }
+
+  @Test
+  public void testTimeFromString() {
+    Assert.assertEquals(DateTimeUtils.getTimeFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
+        "12:00:00");
+    Assert.assertEquals(DateTimeUtils.getTimeFromString("2020-01-01 12:00:00.000", Calendar.getInstance()).toString(),
+        "12:00:00");
+    Assert.assertThrows(() -> DateTimeUtils.getTimeFromString("2020-01-01", Calendar.getInstance()));
+  }
+
+  @Test
+  public void testTimestampFromString() {
+    Assert.assertEquals(
+        DateTimeUtils.getTimestampFromString("2020-01-01 12:00:00", Calendar.getInstance()).toString(),
+        "2020-01-01 12:00:00.0");
+    Assert.assertEquals(
+        DateTimeUtils.getTimestampFromString("2020-01-01 12:00:00.000", Calendar.getInstance()).toString(),
+        "2020-01-01 12:00:00.0");
+    Assert.assertThrows(() -> DateTimeUtils.getTimestampFromString("2020-01-01", Calendar.getInstance()));
+  }
+}


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/14723 replaced `SimpleDateFormat` with `DateTimeFormatter` to resolve thread safety / concurrency issues.
- However, this causes a bug where a string like `'2024-12-31 12:18:42.375'` that was parseable with `DateTimeUtils.getDateFromString` now fails with `java.time.format.DateTimeParseException: Text '2024-12-31 12:18:42.375' could not be parsed, unparsed text found at index 10 `.
- `SimpleDateFormat` is lenient in its parsing and can tolerate extra text in the input if the pattern doesn't fully cover the string. It will basically successfully parse as much as it can and ignore the rest.
- The newer `DateTimeFormatter` is stricter than SimpleDateFormat and expects the input string to match the pattern exactly. This can be resolved by adding an optional section in the pattern to tolerate inputs like the above (even though we won't actually use the time portion for date parsing).