### PR TITLE
[perf] Benchmark for Filter Performance for an Immutable Segment

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -184,6 +184,10 @@
               <mainClass>org.apache.pinot.perf.StringDictionaryPerfTest</mainClass>
               <name>pinot-StringDictionaryPerfTest</name>
             </program>
+            <program>
+              <mainClass>org.apache.pinot.perf.BenchmarkFilterOperator</mainClass>
+              <name>pinot-BenchmarkFilterOperator</name>
+            </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilterOperator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilterOperator.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.plan.FilterPlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 5, time = 50)
+@Fork(1)
+@State(Scope.Benchmark)
+public class BenchmarkFilterOperator {
+  private static final Random RANDOM = new Random();
+  private static final int MAX_DOC_PER_CALL = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+  private static final String TABLE_NAME = "tbl1";
+
+  private ImmutableSegment _immutableSegment;
+  private FilterContext _filterContext;
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    // Load segment
+    String segmentDirStr = System.getenv("PERF_TEST_SEGMENT_DIR");
+    File segmentDir = new File(segmentDirStr);
+    _immutableSegment = ImmutableSegmentLoader.load(segmentDir, ReadMode.mmap);
+    // Load filter
+    String filterExprFile = System.getenv("PERF_TEST_FILTER_EXP_FILE");
+    String filter = FileUtils.readFileToString(new File(filterExprFile), StandardCharsets.UTF_8);
+    _filterContext = RequestContextUtils.getFilter(RequestContextUtils.getExpression(filter));
+  }
+
+  @TearDown
+  public void tearDown()
+      throws Exception {
+  }
+
+  @Benchmark
+  public int testFilterDocIdSetOperator() {
+    SegmentContext segmentContext = new SegmentContext(_immutableSegment);
+    QueryContext queryContext = buildQueryContext(_filterContext);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(segmentContext, queryContext, _filterContext);
+    DocIdSetPlanNode docIdSetPlanNode = new DocIdSetPlanNode(segmentContext, queryContext, MAX_DOC_PER_CALL,
+        filterPlanNode.run());
+    DocIdSetOperator docIdSetOperator = docIdSetPlanNode.run();
+    DocIdSetBlock block = null;
+    int result = 0;
+    while ((block = docIdSetOperator.nextBlock()) != null) {
+      result += block.getLength();
+    }
+    return result;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkFilterOperator.class.getSimpleName());
+    new Runner(opt.build()).run();
+  }
+
+  private QueryContext buildQueryContext(FilterContext filterContext) {
+    return new QueryContext.Builder().setFilter(filterContext).setTableName(TABLE_NAME).setLimit(Integer.MAX_VALUE)
+        .setAliasList(Collections.emptyList()).setGroupByExpressions(Collections.emptyList())
+        .setSelectExpressions(Collections.emptyList()).build();
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Benchmark filter operator: create contexts, build filter and doc ID set plans, run operator, sum block lengths\.

```mermaid
flowchart TD
  N0["Create SegmentContext #40;F2#41;"]:::stAdded
  N1["Build QueryContext #40;F2#41;"]:::stAdded
  N2["Create FilterPlanNode #40;F2#41;"]:::stAdded
  N3["Create DocIdSetPlanNode #40;F2#41;"]:::stAdded
  N4["Run DocIdSetPlanNode #40;F2#41;"]:::stAdded
  N5["Process Blocks #40;F2#41;"]:::stAdded
  N0 -->|"sequential"| N1
  N1 -->|"queryContext used"| N2
  N2 -->|"filterPlanNode#46;run#40;#41; used"| N3
  N3 -->|"sequential"| N4
  N4 -->|"docIdSetOperator used"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilterOperator\.java — [after](https://github.com/apache/pinot/blob/94596ebdbfb59af04992ad685790a07a0f280ffd/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilterOperator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImJlY2I1N2UwNjRmNTdiYTIzMGJiZjM1MjdmZTA4ZTY2YTYwOTc0ZGIiLCJjb250ZXh0X2hhc2giOiJkY2ZhZjM4ZDVlMDJlNmIzNzNlZGQyMTE0OTkxMzA5YTg3MWJmYTA5OWU0YjY3MTJhOTA5Y2IyNDY0OWZjNzMxIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTA0NzU2LCJoZWFkX3NoYSI6Ijk0NTk2ZWJkYmZiNTlhZjA0OTkyYWQ2ODU3OTBhMDdhMGYyODBmZmQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmOGZhMWE4YTU3MmY3NjY4MDU4YmMyOWRlMjNkYTU4NmRjNDBjODU1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature bb971109679e6d4503e1eb747cdd74a852022081fd55a6dd6c28fedb4c93f236 -->
<!-- pinot-pr-flow:end -->

A simple benchmark that can be used to test the performance of a filter expression against a given segment.

The test takes two parameters: the location of the segment and the filter expression.

TODO: Switch to `@Param` instead of env vars.