### PR TITLE
Include the task scheduling errors in schedule response

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -486,18 +486,18 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   /**
    * Schedules tasks (all task types) for all tables.
    * It might be called from the non-leader controller.
-   * Returns a map from the task type to the list of tasks scheduled.
+   * Returns a map from the task type to the {@link TaskSchedulingInfo} of tasks scheduled.
    */
-  public synchronized Map<String, List<String>> scheduleAllTasksForAllTables(@Nullable String minionInstanceTag) {
+  public synchronized Map<String, TaskSchedulingInfo> scheduleAllTasksForAllTables(@Nullable String minionInstanceTag) {
     return scheduleTasks(_pinotHelixResourceManager.getAllTables(), false, minionInstanceTag);
   }
 
   /**
    * Schedules tasks (all task types) for all tables in the given database.
    * It might be called from the non-leader controller.
-   * Returns a map from the task type to the list of tasks scheduled.
+   * Returns a map from the task type to the {@link TaskSchedulingInfo} of tasks scheduled.
    */
-  public synchronized Map<String, List<String>> scheduleAllTasksForDatabase(@Nullable String database,
+  public synchronized Map<String, TaskSchedulingInfo> scheduleAllTasksForDatabase(@Nullable String database,
       @Nullable String minionInstanceTag) {
     return scheduleTasks(_pinotHelixResourceManager.getAllTables(database), false, minionInstanceTag);
   }
@@ -505,9 +505,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   /**
    * Schedules tasks (all task types) for the given table.
    * It might be called from the non-leader controller.
-   * Returns a map from the task type to the list of tasks scheduled.
+   * Returns a map from the task type to the {@link TaskSchedulingInfo} of tasks scheduled.
    */
-  public synchronized Map<String, List<String>> scheduleAllTasksForTable(String tableNameWithType,
+  public synchronized Map<String, TaskSchedulingInfo> scheduleAllTasksForTable(String tableNameWithType,
       @Nullable String minionInstanceTag) {
     return scheduleTasks(List.of(tableNameWithType), false, minionInstanceTag);
   }
@@ -515,20 +515,26 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   /**
    * Schedules task for the given task type for all tables.
    * It might be called from the non-leader controller.
-   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
+   * Returns {@link TaskSchedulingInfo} which consists
+   *  - list of scheduled task names (empty list if nothing to schedule),
+   *    or {@code null} if no task is scheduled due to scheduling errors.
+   *  - list of task generation errors if any
+   *  - list of task scheduling errors if any
    */
-  @Nullable
-  public synchronized List<String> scheduleTaskForAllTables(String taskType, @Nullable String minionInstanceTag) {
+  public synchronized TaskSchedulingInfo scheduleTaskForAllTables(String taskType, @Nullable String minionInstanceTag) {
     return scheduleTask(taskType, _pinotHelixResourceManager.getAllTables(), minionInstanceTag);
   }
 
   /**
    * Schedules task for the given task type for all tables in the given database.
    * It might be called from the non-leader controller.
-   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
+   * Returns {@link TaskSchedulingInfo} which consists
+   *  - list of scheduled task names (empty list if nothing to schedule),
+   *    or {@code null} if no task is scheduled due to scheduling errors.
+   *  - list of task generation errors if any
+   *  - list of task scheduling errors if any
    */
-  @Nullable
-  public synchronized List<String> scheduleTaskForDatabase(String taskType, @Nullable String database,
+  public synchronized TaskSchedulingInfo scheduleTaskForDatabase(String taskType, @Nullable String database,
       @Nullable String minionInstanceTag) {
     return scheduleTask(taskType, _pinotHelixResourceManager.getAllTables(database), minionInstanceTag);
   }
@@ -536,20 +542,23 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   /**
    * Schedules task for the given task type for the give table.
    * It might be called from the non-leader controller.
-   * Returns a list of tasks scheduled, or {@code null} if no task is scheduled.
+   * Returns {@link TaskSchedulingInfo} which consists
+   *  - list of scheduled task names (empty list if nothing to schedule),
+   *    or {@code null} if no task is scheduled due to scheduling errors.
+   *  - list of task generation errors if any
+   *  - list of task scheduling errors if any
    */
-  @Nullable
-  public synchronized List<String> scheduleTaskForTable(String taskType, String tableNameWithType,
+  public synchronized TaskSchedulingInfo scheduleTaskForTable(String taskType, String tableNameWithType,
       @Nullable String minionInstanceTag) {
     return scheduleTask(taskType, List.of(tableNameWithType), minionInstanceTag);
   }
 
   /**
-   * Helper method to schedule tasks (all task types) for the given tables that have the tasks enabled. Returns a map
-   * from the task type to the list of the tasks scheduled.
+   * Helper method to schedule tasks (all task types) for the given tables that have the tasks enabled.
+   * Returns a map from the task type to the {@link TaskSchedulingInfo} of the tasks scheduled.
    */
-  protected synchronized Map<String, List<String>> scheduleTasks(List<String> tableNamesWithType, boolean isLeader,
-      @Nullable String minionInstanceTag) {
+  protected synchronized Map<String, TaskSchedulingInfo> scheduleTasks(List<String> tableNamesWithType,
+      boolean isLeader, @Nullable String minionInstanceTag) {
     _controllerMetrics.addMeteredGlobalValue(ControllerMeter.NUMBER_TIMES_SCHEDULE_TASKS_CALLED, 1L);
 
     // Scan all table configs to get the tables with tasks enabled
@@ -565,7 +574,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     }
 
     // Generate each type of tasks
-    Map<String, List<String>> tasksScheduled = new HashMap<>();
+    Map<String, TaskSchedulingInfo> tasksScheduled = new HashMap<>();
     for (Map.Entry<String, List<TableConfig>> entry : enabledTableConfigMap.entrySet()) {
       String taskType = entry.getKey();
       List<TableConfig> enabledTableConfigs = entry.getValue();
@@ -577,16 +586,18 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         addTaskTypeMetricsUpdaterIfNeeded(taskType);
         tasksScheduled.put(taskType, scheduleTask(taskGenerator, enabledTableConfigs, isLeader, minionInstanceTag));
       } else {
-        LOGGER.warn("Task type: {} is not registered, cannot enable it for tables: {}", taskType, enabledTables);
-        tasksScheduled.put(taskType, null);
+        String message = "Task type: " + taskType + " is not registered, cannot enable it for tables: " + enabledTables;
+        LOGGER.warn(message);
+        TaskSchedulingInfo taskSchedulingInfo = new TaskSchedulingInfo();
+        taskSchedulingInfo.addSchedulingError(message);
+        tasksScheduled.put(taskType, taskSchedulingInfo);
       }
     }
 
     return tasksScheduled;
   }
 
-  @Nullable
-  protected synchronized List<String> scheduleTask(String taskType, List<String> tables,
+  protected synchronized TaskSchedulingInfo scheduleTask(String taskType, List<String> tables,
       @Nullable String minionInstanceTag) {
     PinotTaskGenerator taskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
     Preconditions.checkState(taskGenerator != null, "Task type: %s is not registered", taskType);
@@ -608,17 +619,23 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
 
   /**
    * Helper method to schedule task with the given task generator for the given tables that have the task enabled.
-   * Returns the list of task names, or {@code null} if no task is scheduled.
+   * Returns
+   *  - list of scheduled task names (empty list if nothing to schedule),
+   *    or {@code null} if no task is scheduled due to scheduling errors.
+   *  - list of task generation errors if any
+   *  - list of task scheduling errors if any
    */
-  @Nullable
-  protected List<String> scheduleTask(PinotTaskGenerator taskGenerator, List<TableConfig> enabledTableConfigs,
+  protected TaskSchedulingInfo scheduleTask(PinotTaskGenerator taskGenerator, List<TableConfig> enabledTableConfigs,
       boolean isLeader, @Nullable String minionInstanceTagForTask) {
+    TaskSchedulingInfo response = new TaskSchedulingInfo();
     String taskType = taskGenerator.getTaskType();
     List<String> enabledTables =
         enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
     LOGGER.info("Trying to schedule task type: {}, for tables: {}, isLeader: {}", taskType, enabledTables, isLeader);
     if (!isTaskSchedulable(taskType, enabledTables)) {
-      return null;
+      response.addSchedulingError("Unable to start scheduling for task type " + taskType
+          + " as task queue may be stopped. Please check the task queue status.");
+      return response;
     }
     Map<String, List<PinotTaskConfig>> minionInstanceTagToTaskConfigs = new HashMap<>();
     for (TableConfig tableConfig : enabledTableConfigs) {
@@ -645,6 +662,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         try (PrintWriter pw = new PrintWriter(errors)) {
           e.printStackTrace(pw);
         }
+        response.addGenerationError("Failed to generate tasks for task type " + taskType + " for table " + tableName
+            + "\n Reason : " + errors);
         long failureRunTimestamp = System.currentTimeMillis();
         _taskManagerStatusCache.saveTaskGeneratorInfo(tableName, taskType,
             taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addErrorRunMessage(failureRunTimestamp,
@@ -684,17 +703,17 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         numErrorTasksScheduled++;
         LOGGER.error("Failed to schedule task type {} on minion instance {} with task configs: {}", taskType,
             minionInstanceTag, pinotTaskConfigs, e);
+        response.addSchedulingError(e.getMessage());
       }
     }
     if (numErrorTasksScheduled > 0) {
       LOGGER.warn("Failed to schedule {} tasks for task type type {}", numErrorTasksScheduled, taskType);
+      // No job got scheduled due to errors
+      if (numErrorTasksScheduled == minionInstanceTagToTaskConfigs.size()) {
+        return response;
+      }
     }
-    // No job got scheduled
-    if (numErrorTasksScheduled == minionInstanceTagToTaskConfigs.size() || submittedTaskNames.isEmpty()) {
-      return null;
-    }
-    // atleast one job got scheduled
-    return submittedTaskNames;
+    return response.setScheduledTaskNames(submittedTaskNames);
   }
 
   @Override
@@ -761,5 +780,37 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       return false;
     }
     return true;
+  }
+
+  public static class TaskSchedulingInfo {
+    private List<String> _scheduledTaskNames;
+    private final List<String> _generationErrors = new ArrayList<>();
+    private final List<String> _schedulingErrors = new ArrayList<>();
+
+    @Nullable
+    public List<String> getScheduledTaskNames() {
+      return _scheduledTaskNames;
+    }
+
+    public TaskSchedulingInfo setScheduledTaskNames(List<String> scheduledTaskNames) {
+      _scheduledTaskNames = scheduledTaskNames;
+      return this;
+    }
+
+    public List<String> getGenerationErrors() {
+      return _generationErrors;
+    }
+
+    public void addGenerationError(String generationError) {
+      _generationErrors.add(generationError);
+    }
+
+    public List<String> getSchedulingErrors() {
+      return _schedulingErrors;
+    }
+
+    public void addSchedulingError(String schedulingError) {
+      _schedulingErrors.add(schedulingError);
+    }
   }
 }

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -110,7 +110,13 @@ const TaskQueueTable = (props) => {
     if (get(res, `${taskType}`, null) === null) {
       dispatch({
         type: 'error',
-        message: `Could not schedule task`,
+        message: `Could not schedule task.\nTask generation errors : ${get(res, 'generationErrors', 'none')}.\nTask scheduling errors : ${get(res, 'schedulingErrors', 'none')}`,
+        show: true
+      });
+    } else if (get(res, `${taskType}`, null) === '') {
+      dispatch({
+        type: 'success',
+        message: `No task to schedule`,
         show: true
       });
     } else {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -193,7 +193,8 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
       throws Exception {
     testValidateTaskGeneration(taskManager -> {
       // Validate schedule tasks for table when task queue is in stopped state
-      List<String> taskIDs = taskManager.scheduleTaskForTable("SegmentGenerationAndPushTask", "myTable", null);
+      List<String> taskIDs = taskManager.scheduleTaskForTable("SegmentGenerationAndPushTask", "myTable", null)
+          .getScheduledTaskNames();
       assertNull(taskIDs);
       return null;
     });

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -409,11 +409,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(SINGLE_LEVEL_CONCAT_TEST_TABLE);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+        .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
@@ -524,11 +525,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(SINGLE_LEVEL_CONCAT_METADATA_TEST_TABLE);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+        .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
@@ -632,11 +634,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(SINGLE_LEVEL_ROLLUP_TEST_TABLE);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+        .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), 1);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
@@ -783,11 +786,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(MULTI_LEVEL_CONCAT_TEST_TABLE);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        _taskManager.scheduleAllTasksForTable(offlineTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+        .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = _taskManager.scheduleAllTasksForTable(offlineTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertEquals(_helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
@@ -915,11 +919,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
 //      assertEquals(helixTaskResourceManager.getSubtaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
       assertTrue(helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
@@ -1020,11 +1025,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     int numTasks = 0;
     List<String> taskList;
-    for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = taskManager.scheduleAllTasksForTable(realtimeTableName, null).
+        get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0); tasks != null;
+        taskList = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       assertTrue(helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
 
@@ -1061,11 +1066,12 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     uploadSegments(MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE, TableType.REALTIME, _tarDir5);
     waitForAllDocsLoaded(600_000L);
 
-    for (String tasks =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE)
-            .get(0); tasks != null; taskList =
-        taskManager.scheduleAllTasksForTable(realtimeTableName, null).get(MinionConstants.MergeRollupTask.TASK_TYPE),
-        tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
+    for (String tasks = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+        .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames().get(0);
+        tasks != null;
+        taskList = taskManager.scheduleAllTasksForTable(realtimeTableName, null)
+            .get(MinionConstants.MergeRollupTask.TASK_TYPE).getScheduledTaskNames(),
+            tasks = taskList != null ? taskList.get(0) : null, numTasks++) {
       waitForTaskToComplete();
       // Check metrics
       long numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -136,7 +136,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     assertEquals(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).size(), 0);
 
     // Should create the task queues and generate a task in the same minion instance
-    List<String> task1 = _taskManager.scheduleAllTasksForAllTables(null).get(TASK_TYPE);
+    List<String> task1 =
+        _taskManager.scheduleAllTasksForAllTables(null).get(TASK_TYPE).getScheduledTaskNames();
     assertNotNull(task1);
     assertEquals(task1.size(), 1);
     assertTrue(_helixTaskResourceManager.getTaskQueues()
@@ -150,7 +151,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     verifyTaskCount(task1.get(0), 0, 1, 1, 2);
     // Should generate one more task, with two sub-tasks. Both of these sub-tasks will wait
     // since we have one minion instance that is still running one of the sub-tasks.
-    List<String> task2 = _taskManager.scheduleTaskForAllTables(TASK_TYPE, null);
+    List<String> task2 = _taskManager.scheduleTaskForAllTables(TASK_TYPE, null).getScheduledTaskNames();
     assertNotNull(task2);
     assertEquals(task2.size(), 1);
     assertTrue(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).contains(task2.get(0)));


### PR DESCRIPTION
## Description
The task schedule endpoint on controller does not give the user any visibility into how the scheduling went when there is a `taskType : null` response 

- did it failed to schedule the tasks 
- was there no work to be scheduled

To relay more info back to the user, this PR enhances the return types of `PinotTaskManager` schedule methods to a wrapper object that contains the generation and scheduling errors along with the names of scheduled tasks

In order to not break the schedule endpoints the error info is returned as separate entry in the response map as below

### Earlier response

#### Successful schedule
```
{
  "RealtimeToOfflineSegmentsTask": "Task_RealtimeToOfflineSegmentsTask_xxxxx"
}
```

#### Successful schedule with no tasks to schedule or failed schedule
```
{
  "RealtimeToOfflineSegmentsTask": null
}
```

### Improved response

#### Successful schedule without any errors
```
{
  "RealtimeToOfflineSegmentsTask": "Task_RealtimeToOfflineSegmentsTask_xxxxx",
  "generationErrors": "",
  "schedulingErrors": ""
}
```

#### Successful schedule with no tasks to schedule
```
{
  "RealtimeToOfflineSegmentsTask": "",
  "generationErrors": "",
  "schedulingErrors": ""
}
```

#### Failed schedule with errors during task generation
```
{
  "RealtimeToOfflineSegmentsTask": null,
  "generationErrors": "Failed to generate tasks for task type RealtimeToOfflineSegmentsTask for table abc. Reason : xyz",
  "schedulingErrors": ""
}
```

## UI Changes
This PR also makes the UI change for `Schedule Now` cta

When task is scheduled
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/b978e2c1-18c9-4037-80a3-35410af10b13" />

When there is nothing to schedule
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/784bbd7f-fdf3-42d8-885a-c5f490592b4b" />

When there are scheduling errors
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/079bbb1a-7fdc-46ad-86ca-f52b85c4f4fa" />

## Backward incompatible changes

The `PinotTaskManager` schedule methods have changed return types from either `List<String>` to `TaskSchedulingInfo` or `Map<String, List<String>>` to `Map<String, TaskSchedulingInfo>`

Schedule methods used to return null as scheduled task names list incase of both scheduling failures as well as no task to schedule. Now that behaviour is changed to null in case of scheduling failures and empty list when there is no task to be scheduled.

