### PR TITLE
[perf] Run Inverted Index Before Other Operators

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -219,7 +219,8 @@ public class FilterOperatorUtils {
           if (filterOperator instanceof SortedIndexBasedFilterOperator) {
             return PrioritizedFilterOperator.HIGH_PRIORITY;
           }
-          if (filterOperator instanceof BitmapBasedFilterOperator) {
+          if (filterOperator instanceof BitmapBasedFilterOperator
+              || filterOperator instanceof InvertedIndexFilterOperator) {
             return PrioritizedFilterOperator.MEDIUM_PRIORITY;
           }
           if (filterOperator instanceof RangeIndexBasedFilterOperator


### PR DESCRIPTION
Resolves #14744

This is still not the "ideal approach". Currently we *always* reorder AND predicates based on these priorities, but sometimes users may have selective filters which are lower priority.

We could do more sophisticated optimizations in the future, like dynamically re-arranging predicates, which could be helpful for scenarios where we have 1000s of segments to be filtered in a single server.

But I'll defer that to later.