### PR TITLE
~Fixes Helix threads getting blocked for Realtime Tables~

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1624,7 +1624,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         // reload segment metadata to get latest status
         segmentZKMetadata = _realtimeTableDataManager.fetchZKMetadata(_segmentNameStr);
 
-        if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.IN_PROGRESS) {
+        if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
           // segment has already been uploaded by another server.
           _segmentLogger.warn("segment: {} already exists. Skipping creation of RealtimeSegmentDataManager",
               _segmentNameStr);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1620,7 +1620,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     // Acquire semaphore to create stream consumers
     try {
-      while (!_partitionGroupConsumerSemaphore.tryAcquire(60, TimeUnit.SECONDS)) {
+      while (!_partitionGroupConsumerSemaphore.tryAcquire(5, TimeUnit.MINUTES)) {
         // reload segment metadata to get latest status
         segmentZKMetadata = _realtimeTableDataManager.fetchZKMetadata(_segmentNameStr);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1624,7 +1624,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         // reload segment metadata to get latest status
         segmentZKMetadata = _realtimeTableDataManager.fetchZKMetadata(_segmentNameStr);
 
-        if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+        if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.DONE) {
           // segment has already been uploaded by another server.
           _segmentLogger.warn("segment: {} already exists. Skipping creation of RealtimeSegmentDataManager",
               _segmentNameStr);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -529,10 +529,18 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     PartitionDedupMetadataManager partitionDedupMetadataManager =
         _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
             : null;
-    RealtimeSegmentDataManager realtimeSegmentDataManager =
-        new RealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(), indexLoadingConfig,
-            schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
-            partitionDedupMetadataManager, _isTableReadyToConsumeData);
+    RealtimeSegmentDataManager realtimeSegmentDataManager;
+    try {
+      realtimeSegmentDataManager =
+          new RealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(), indexLoadingConfig,
+              schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
+              partitionDedupMetadataManager, _isTableReadyToConsumeData);
+    } catch (SegmentAlreadyExistsException e) {
+      // Don't do anything since segment was already committed by another instance.
+      // Eventually this server should receive a CONSUMING -> ONLINE helix state transition
+      // to add it.
+      return;
+    }
     registerSegment(segmentName, realtimeSegmentDataManager, partitionUpsertMetadataManager);
     if (partitionUpsertMetadataManager != null) {
       partitionUpsertMetadataManager.trackNewlyAddedSegment(segmentName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentAlreadyExistsException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentAlreadyExistsException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+public class SegmentAlreadyExistsException extends RuntimeException {
+
+  public SegmentAlreadyExistsException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
**Problem**
Consider a scenario for Realtime Tables where
1. Table replication > 1
2. Table consuming from 'k' Kafka partitions 
3. A subset of servers is slow  in consuming segments. They can be slow in consumption due to various reasons like: partial upsert related logic handling, etc. 
4. Fast server has committed multiple segments.

In above case for slow servers, k helix threads will be in running state consuming data slowly from k partitions (result of catchup to final offset). 
But fast servers will commit segments and will be quite ahead from slow servers. 
In above case, the slow servers can eventually end up in a state where no helix task thread is free (`MAX_HELIX_TASK_THREADS - k` will be in a waiting state as they are waiting to acquire partition semaphore for `onBecomeConsumingFromOffline` event.)

**Solution**
1. Change semaphore acquire logic such that if a Helix threads fails to acquire the semaphore, check if the fast server has already committed the segment. If yes, simply return as eventually the slow server will receive a `consuming -> online` state transition message for the same segment.