### PR TITLE
Allow adding and subtracting timestamp types in the multi-stage engine

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -33,7 +34,9 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.fun.SqlLeadLagAggFunction;
+import org.apache.calcite.sql.fun.SqlMonotonicBinaryOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
@@ -68,6 +71,30 @@ public class PinotOperatorTable implements SqlOperatorTable {
   public static PinotOperatorTable instance() {
     return INSTANCE.get();
   }
+
+  // The standard Calcite + and - operators don't support operations on TIMESTAMP types. However, Pinot supports these
+  // operations, so we need to define our own operators. Note that Postgres supports - on TIMESTAMP types, but not +.
+  // Calcite only supports such operations if the second operand is an interval (similar to Postgres for the +
+  // operator).
+  public static final SqlBinaryOperator PINOT_PLUS =
+      new SqlMonotonicBinaryOperator(
+          "+",
+          SqlKind.PLUS,
+          40,
+          true,
+          ReturnTypes.NULLABLE_SUM,
+          InferTypes.FIRST_KNOWN,
+          OperandTypes.PLUS_OPERATOR.or(OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP)));
+
+  public static final SqlBinaryOperator PINOT_MINUS =
+      new SqlMonotonicBinaryOperator(
+          "-",
+          SqlKind.MINUS,
+          40,
+          true,
+          ReturnTypes.NULLABLE_SUM,
+          InferTypes.FIRST_KNOWN,
+          OperandTypes.MINUS_OPERATOR.or(OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP)));
 
   /**
    * This list includes the supported standard {@link SqlOperator}s defined in {@link SqlStdOperatorTable}.
@@ -105,12 +132,12 @@ public class PinotOperatorTable implements SqlOperatorTable {
       SqlStdOperatorTable.SEARCH,
       SqlStdOperatorTable.LESS_THAN,
       SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-      SqlStdOperatorTable.MINUS,
       SqlStdOperatorTable.MULTIPLY,
       SqlStdOperatorTable.NOT_EQUALS,
       SqlStdOperatorTable.OR,
-      SqlStdOperatorTable.PLUS,
       SqlStdOperatorTable.INTERVAL,
+      PINOT_MINUS,
+      PINOT_PLUS,
 
       // POSTFIX OPERATORS
       SqlStdOperatorTable.DESC,
@@ -231,8 +258,8 @@ public class PinotOperatorTable implements SqlOperatorTable {
       Pair.of(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, List.of("GREATER_THAN_OR_EQUAL")),
       Pair.of(SqlStdOperatorTable.LESS_THAN, List.of("LESS_THAN")),
       Pair.of(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, List.of("LESS_THAN_OR_EQUAL")),
-      Pair.of(SqlStdOperatorTable.MINUS, List.of("SUB", "MINUS")),
-      Pair.of(SqlStdOperatorTable.PLUS, List.of("ADD", "PLUS")),
+      Pair.of(PINOT_MINUS, List.of("SUB", "MINUS")),
+      Pair.of(PINOT_PLUS, List.of("ADD", "PLUS")),
       Pair.of(SqlStdOperatorTable.MULTIPLY, List.of("MULT", "TIMES"))
   );
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -253,7 +253,11 @@ public class QueryEnvironmentTestBase {
         new Object[]{"SELECT ts_timestamp FROM a WHERE ts_timestamp BETWEEN TIMESTAMP '2016-01-01 00:00:00' AND "
             + "TIMESTAMP '2016-01-01 10:00:00'"},
         new Object[]{"SELECT ts_timestamp FROM a WHERE ts_timestamp >= CAST(1454284798000 AS TIMESTAMP)"},
-        new Object[]{"SELECT TIMESTAMPADD(day, 10, NOW()) FROM a"}
+        new Object[]{"SELECT TIMESTAMPADD(day, 10, NOW()) FROM a"},
+        new Object[]{"SELECT ts_timestamp - CAST(123456789 AS TIMESTAMP) FROM a"},
+        new Object[]{"SELECT SUB(ts_timestamp, CAST(123456789 AS TIMESTAMP)) FROM a"},
+        new Object[]{"SELECT ts_timestamp + CAST(123456789 AS TIMESTAMP) FROM a"},
+        new Object[]{"SELECT ADD(ts_timestamp, CAST(123456789 AS TIMESTAMP)) FROM a"}
     };
   }
 


### PR DESCRIPTION
- Prior to https://github.com/apache/pinot/pull/14089, the `ADD` and `SUB` scalar functions in Pinot were not aliased to the Calcite standard operators `+` / `-`. This meant that the scalar function definition was used and that allowed for things like `SUB(ts_col1, ts_col2)` or `ADD(ts_col1, ts_literal)`.
- However, things like `ts_col1 - ts_col2` or `ts_col1 + ts_col2` were still not allowed since the Calcite standard operators only support these operand types - numeric and numeric, datetime types and intervals, or intervals and intervals (see [here](https://github.com/apache/calcite/blob/129e5cc89cafa0d55e3d4c1925ca7cafee888bdd/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java#L1251-L1273)). This led to an inconsistent experience with Pinot's operators. Also, note that Postgres supports directly subtracting timestamp types (but only adding timestamps to intervals).
- This patch fixes the above regression with `ADD` and `SUB`. Also, since Pinot uses long types for timestamps internally and we support such operations in the single-stage engine, this patch also adds support for timestamp types with `+` and `-` in the multi-stage engine.