### PR TITLE
Change formatter to align parameters in method declaration

### DIFF
--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -34,9 +34,9 @@
   </option>
   <option name="OTHER_INDENT_OPTIONS">
     <value>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
       <option name="USE_TAB_CHARACTER" value="false"/>
       <option name="SMART_TABS" value="false"/>
       <option name="LABEL_INDENT_SIZE" value="0"/>
@@ -49,36 +49,36 @@
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5"/>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
-      <package name="" withSubpackages="true" static="false"/>
-      <emptyLine/>
-      <package name="" withSubpackages="true" static="true"/>
+      <package name="" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
   <option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
   <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true"/>
   <option name="JD_ADD_BLANK_AFTER_RETURN" value="true"/>
   <option name="JD_KEEP_INVALID_TAGS" value="false"/>
-  <option name="KEEP_LINE_BREAKS" value="true"/>
+  <option name="KEEP_LINE_BREAKS" value="true" />
   <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
-  <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
-  <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
-  <option name="BRACE_STYLE" value="2"/>
-  <option name="CLASS_BRACE_STYLE" value="2"/>
-  <option name="METHOD_BRACE_STYLE" value="2"/>
-  <option name="ELSE_ON_NEW_LINE" value="true"/>
-  <option name="WHILE_ON_NEW_LINE" value="true"/>
-  <option name="CATCH_ON_NEW_LINE" value="true"/>
-  <option name="FINALLY_ON_NEW_LINE" value="true"/>
-  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
-  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
-  <option name="CALL_PARAMETERS_WRAP" value="5"/>
-  <option name="METHOD_PARAMETERS_WRAP" value="5"/>
-  <option name="THROWS_LIST_WRAP" value="1"/>
-  <option name="THROWS_KEYWORD_WRAP" value="2"/>
-  <option name="WRAP_COMMENTS" value="true"/>
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+  <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
+  <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+  <option name="BRACE_STYLE" value="2" />
+  <option name="CLASS_BRACE_STYLE" value="2" />
+  <option name="METHOD_BRACE_STYLE" value="2" />
+  <option name="ELSE_ON_NEW_LINE" value="true" />
+  <option name="WHILE_ON_NEW_LINE" value="true" />
+  <option name="CATCH_ON_NEW_LINE" value="true" />
+  <option name="FINALLY_ON_NEW_LINE" value="true" />
+  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+  <option name="CALL_PARAMETERS_WRAP" value="5" />
+  <option name="METHOD_PARAMETERS_WRAP" value="5" />
+  <option name="THROWS_LIST_WRAP" value="1" />
+  <option name="THROWS_KEYWORD_WRAP" value="2" />
+  <option name="WRAP_COMMENTS" value="true" />
   <JSON>
     <option name="OBJECT_WRAPPING" value="5" />
     <option name="ARRAY_WRAPPING" value="5" />
@@ -87,148 +87,148 @@
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>
   <ADDITIONAL_INDENT_OPTIONS fileType="scala">
-    <option name="INDENT_SIZE" value="2"/>
-    <option name="TAB_SIZE" value="2"/>
+    <option name="INDENT_SIZE" value="2" />
+    <option name="TAB_SIZE" value="2" />
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="txt">
-    <option name="INDENT_SIZE" value="2"/>
+    <option name="INDENT_SIZE" value="2" />
   </ADDITIONAL_INDENT_OPTIONS>
   <codeStyleSettings language="CFML">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="BRACE_STYLE" value="2"/>
-    <option name="ELSE_ON_NEW_LINE" value="true"/>
-    <option name="WHILE_ON_NEW_LINE" value="true"/>
-    <option name="CATCH_ON_NEW_LINE" value="true"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="5"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="5" />
+    <option name="METHOD_PARAMETERS_WRAP" value="5" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <Properties>
     <option name="KEEP_BLANK_LINES" value="true"/>
   </Properties>
   <codeStyleSettings language="CSS">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="CoffeeScript">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
-    <option name="BRACE_STYLE" value="2"/>
-    <option name="CLASS_BRACE_STYLE" value="2"/>
-    <option name="METHOD_BRACE_STYLE" value="2"/>
-    <option name="ELSE_ON_NEW_LINE" value="true"/>
-    <option name="WHILE_ON_NEW_LINE" value="true"/>
-    <option name="CATCH_ON_NEW_LINE" value="true"/>
-    <option name="FINALLY_ON_NEW_LINE" value="true"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="5"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="5" />
+    <option name="METHOD_PARAMETERS_WRAP" value="5" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="GSP">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="Groovy">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
-    <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
-    <option name="CALL_PARAMETERS_WRAP" value="1"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="EXTENDS_LIST_WRAP" value="1"/>
-    <option name="THROWS_LIST_WRAP" value="1"/>
-    <option name="THROWS_KEYWORD_WRAP" value="2"/>
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
-    <option name="BINARY_OPERATION_WRAP" value="1"/>
-    <option name="TERNARY_OPERATION_WRAP" value="1"/>
-    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false"/>
-    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false"/>
-    <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="IF_BRACE_FORCE" value="3"/>
-    <option name="WHILE_BRACE_FORCE" value="3"/>
-    <option name="FOR_BRACE_FORCE" value="3"/>
-    <option name="ENUM_CONSTANTS_WRAP" value="5"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false" />
+    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="ENUM_CONSTANTS_WRAP" value="5" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="HTML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="120"/>
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
-    <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
-    <option name="ALIGN_MULTILINE_FOR" value="false"/>
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="1"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="RESOURCE_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_LIST_WRAP" value="1"/>
-    <option name="THROWS_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
-    <option name="THROWS_KEYWORD_WRAP" value="2"/>
-    <option name="METHOD_CALL_CHAIN_WRAP" value="5"/>
-    <option name="BINARY_OPERATION_WRAP" value="1"/>
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
-    <option name="TERNARY_OPERATION_WRAP" value="1"/>
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-    <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
-    <option name="ASSIGNMENT_WRAP" value="1"/>
-    <option name="WRAP_COMMENTS" value="true"/>
-    <option name="ASSERT_STATEMENT_WRAP" value="1"/>
-    <option name="IF_BRACE_FORCE" value="3"/>
-    <option name="DOWHILE_BRACE_FORCE" value="3"/>
-    <option name="WHILE_BRACE_FORCE" value="3"/>
-    <option name="FOR_BRACE_FORCE" value="3"/>
-    <option name="WRAP_LONG_LINES" value="true"/>
-    <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
-    <option name="VARIABLE_ANNOTATION_WRAP" value="2"/>
-    <option name="ENUM_CONSTANTS_WRAP" value="5"/>
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="true"/>
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="RESOURCE_LIST_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="WRAP_COMMENTS" value="true" />
+    <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="WRAP_LONG_LINES" value="true" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
+    <option name="ENUM_CONSTANTS_WRAP" value="5" />
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
     <arrangement>
       <groups>
@@ -238,273 +238,273 @@
         </group>
       </groups>
       <rules>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PUBLIC/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PROTECTED/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PACKAGE_PRIVATE/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PRIVATE/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PUBLIC/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PROTECTED/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PACKAGE_PRIVATE/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PRIVATE/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PUBLIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PROTECTED/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PACKAGE_PRIVATE/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <FINAL/>
-              <PRIVATE/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PUBLIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PROTECTED/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PACKAGE_PRIVATE/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <FIELD/>
-              <PRIVATE/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <FIELD/>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <CONSTRUCTOR/>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <METHOD/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <METHOD/>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <ENUM/>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <INTERFACE/>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <AND>
-              <CLASS/>
-              <STATIC/>
-            </AND>
-          </match>
-        </rule>
-        <rule>
-          <match>
-            <CLASS/>
-          </match>
-        </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PUBLIC />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PROTECTED />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PACKAGE_PRIVATE />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PRIVATE />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PUBLIC />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PROTECTED />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PACKAGE_PRIVATE />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PRIVATE />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PUBLIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PROTECTED />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PACKAGE_PRIVATE />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <FINAL />
+                <PRIVATE />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PUBLIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PROTECTED />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PACKAGE_PRIVATE />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <FIELD />
+                <PRIVATE />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <FIELD />
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <CONSTRUCTOR />
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <METHOD />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <METHOD />
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <ENUM />
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <INTERFACE />
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <AND>
+                <CLASS />
+                <STATIC />
+              </AND>
+            </match>
+          </rule>
+          <rule>
+            <match>
+              <CLASS />
+            </match>
+          </rule>
       </rules>
     </arrangement>
   </codeStyleSettings>
   <codeStyleSettings language="JSP">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
-    <option name="ALIGN_MULTILINE_FOR" value="false"/>
-    <option name="CALL_PARAMETERS_WRAP" value="1"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="BINARY_OPERATION_WRAP" value="1"/>
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
-    <option name="TERNARY_OPERATION_WRAP" value="1"/>
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-    <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
-    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-    <option name="IF_BRACE_FORCE" value="3"/>
-    <option name="DOWHILE_BRACE_FORCE" value="3"/>
-    <option name="WHILE_BRACE_FORCE" value="3"/>
-    <option name="FOR_BRACE_FORCE" value="3"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="LESS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SASS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SCSS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SQL">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="TypeScript">
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="BRACE_STYLE" value="2"/>
-    <option name="CLASS_BRACE_STYLE" value="2"/>
-    <option name="METHOD_BRACE_STYLE" value="2"/>
-    <option name="ELSE_ON_NEW_LINE" value="true"/>
-    <option name="WHILE_ON_NEW_LINE" value="true"/>
-    <option name="CATCH_ON_NEW_LINE" value="true"/>
-    <option name="FINALLY_ON_NEW_LINE" value="true"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="5"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
-    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="5" />
+    <option name="METHOD_PARAMETERS_WRAP" value="5" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
     </indentOptions>
     <arrangement>
       <rules>

--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -34,9 +34,9 @@
   </option>
   <option name="OTHER_INDENT_OPTIONS">
     <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
       <option name="USE_TAB_CHARACTER" value="false"/>
       <option name="SMART_TABS" value="false"/>
       <option name="LABEL_INDENT_SIZE" value="0"/>
@@ -49,36 +49,36 @@
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5"/>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
-      <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
+      <package name="" withSubpackages="true" static="false"/>
+      <emptyLine/>
+      <package name="" withSubpackages="true" static="true"/>
     </value>
   </option>
   <option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
   <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true"/>
   <option name="JD_ADD_BLANK_AFTER_RETURN" value="true"/>
   <option name="JD_KEEP_INVALID_TAGS" value="false"/>
-  <option name="KEEP_LINE_BREAKS" value="true" />
+  <option name="KEEP_LINE_BREAKS" value="true"/>
   <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-  <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
-  <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
-  <option name="BRACE_STYLE" value="2" />
-  <option name="CLASS_BRACE_STYLE" value="2" />
-  <option name="METHOD_BRACE_STYLE" value="2" />
-  <option name="ELSE_ON_NEW_LINE" value="true" />
-  <option name="WHILE_ON_NEW_LINE" value="true" />
-  <option name="CATCH_ON_NEW_LINE" value="true" />
-  <option name="FINALLY_ON_NEW_LINE" value="true" />
-  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-  <option name="CALL_PARAMETERS_WRAP" value="5" />
-  <option name="METHOD_PARAMETERS_WRAP" value="5" />
-  <option name="THROWS_LIST_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="2" />
-  <option name="WRAP_COMMENTS" value="true" />
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+  <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
+  <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
+  <option name="BRACE_STYLE" value="2"/>
+  <option name="CLASS_BRACE_STYLE" value="2"/>
+  <option name="METHOD_BRACE_STYLE" value="2"/>
+  <option name="ELSE_ON_NEW_LINE" value="true"/>
+  <option name="WHILE_ON_NEW_LINE" value="true"/>
+  <option name="CATCH_ON_NEW_LINE" value="true"/>
+  <option name="FINALLY_ON_NEW_LINE" value="true"/>
+  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+  <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
+  <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
+  <option name="CALL_PARAMETERS_WRAP" value="5"/>
+  <option name="METHOD_PARAMETERS_WRAP" value="5"/>
+  <option name="THROWS_LIST_WRAP" value="1"/>
+  <option name="THROWS_KEYWORD_WRAP" value="2"/>
+  <option name="WRAP_COMMENTS" value="true"/>
   <JSON>
     <option name="OBJECT_WRAPPING" value="5" />
     <option name="ARRAY_WRAPPING" value="5" />
@@ -87,148 +87,148 @@
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>
   <ADDITIONAL_INDENT_OPTIONS fileType="scala">
-    <option name="INDENT_SIZE" value="2" />
-    <option name="TAB_SIZE" value="2" />
+    <option name="INDENT_SIZE" value="2"/>
+    <option name="TAB_SIZE" value="2"/>
   </ADDITIONAL_INDENT_OPTIONS>
   <ADDITIONAL_INDENT_OPTIONS fileType="txt">
-    <option name="INDENT_SIZE" value="2" />
+    <option name="INDENT_SIZE" value="2"/>
   </ADDITIONAL_INDENT_OPTIONS>
   <codeStyleSettings language="CFML">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BRACE_STYLE" value="2" />
-    <option name="ELSE_ON_NEW_LINE" value="true" />
-    <option name="WHILE_ON_NEW_LINE" value="true" />
-    <option name="CATCH_ON_NEW_LINE" value="true" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="5" />
-    <option name="METHOD_PARAMETERS_WRAP" value="5" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BRACE_STYLE" value="2"/>
+    <option name="ELSE_ON_NEW_LINE" value="true"/>
+    <option name="WHILE_ON_NEW_LINE" value="true"/>
+    <option name="CATCH_ON_NEW_LINE" value="true"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+    <option name="CALL_PARAMETERS_WRAP" value="5"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <Properties>
     <option name="KEEP_BLANK_LINES" value="true"/>
   </Properties>
   <codeStyleSettings language="CSS">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="CoffeeScript">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
-    <option name="BRACE_STYLE" value="2" />
-    <option name="CLASS_BRACE_STYLE" value="2" />
-    <option name="METHOD_BRACE_STYLE" value="2" />
-    <option name="ELSE_ON_NEW_LINE" value="true" />
-    <option name="WHILE_ON_NEW_LINE" value="true" />
-    <option name="CATCH_ON_NEW_LINE" value="true" />
-    <option name="FINALLY_ON_NEW_LINE" value="true" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="5" />
-    <option name="METHOD_PARAMETERS_WRAP" value="5" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
+    <option name="BRACE_STYLE" value="2"/>
+    <option name="CLASS_BRACE_STYLE" value="2"/>
+    <option name="METHOD_BRACE_STYLE" value="2"/>
+    <option name="ELSE_ON_NEW_LINE" value="true"/>
+    <option name="WHILE_ON_NEW_LINE" value="true"/>
+    <option name="CATCH_ON_NEW_LINE" value="true"/>
+    <option name="FINALLY_ON_NEW_LINE" value="true"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
+    <option name="CALL_PARAMETERS_WRAP" value="5"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <codeStyleSettings language="GSP">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="Groovy">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-    <option name="BLANK_LINES_AFTER_PACKAGE" value="2" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="2" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false" />
-    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="ENUM_CONSTANTS_WRAP" value="5" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+    <option name="BLANK_LINES_AFTER_PACKAGE" value="2"/>
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_LIST_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="2"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="ENUM_CONSTANTS_WRAP" value="5"/>
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="HTML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="120" />
-    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="2" />
+    <option name="RIGHT_MARGIN" value="120"/>
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="2"/>
     <option name="ALIGN_MULTILINE_PARAMETERS" value="true"/>
-    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="RESOURCE_LIST_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="2" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ASSIGNMENT_WRAP" value="1" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="ASSERT_STATEMENT_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="WRAP_LONG_LINES" value="true" />
-    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
-    <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
-    <option name="ENUM_CONSTANTS_WRAP" value="5" />
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="ALIGN_MULTILINE_THROWS_LIST" value="true"/>
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="RESOURCE_LIST_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_LIST_WRAP" value="1"/>
+    <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="2"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
+    <option name="ASSIGNMENT_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="ASSERT_STATEMENT_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="WRAP_LONG_LINES" value="true"/>
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
+    <option name="VARIABLE_ANNOTATION_WRAP" value="2"/>
+    <option name="ENUM_CONSTANTS_WRAP" value="5"/>
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
     <arrangement>
       <groups>
@@ -238,273 +238,273 @@
         </group>
       </groups>
       <rules>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PUBLIC />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PROTECTED />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PACKAGE_PRIVATE />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PRIVATE />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PUBLIC />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PROTECTED />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PACKAGE_PRIVATE />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PRIVATE />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PUBLIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PROTECTED />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PACKAGE_PRIVATE />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <FINAL />
-                <PRIVATE />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PUBLIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PROTECTED />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PACKAGE_PRIVATE />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <FIELD />
-                <PRIVATE />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <FIELD />
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <CONSTRUCTOR />
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <METHOD />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <METHOD />
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <ENUM />
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <INTERFACE />
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <AND>
-                <CLASS />
-                <STATIC />
-              </AND>
-            </match>
-          </rule>
-          <rule>
-            <match>
-              <CLASS />
-            </match>
-          </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PUBLIC/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PROTECTED/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PACKAGE_PRIVATE/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PRIVATE/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PUBLIC/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PROTECTED/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PACKAGE_PRIVATE/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PRIVATE/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PUBLIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PROTECTED/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PACKAGE_PRIVATE/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <FINAL/>
+              <PRIVATE/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PUBLIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PROTECTED/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PACKAGE_PRIVATE/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <FIELD/>
+              <PRIVATE/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <FIELD/>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <CONSTRUCTOR/>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <METHOD/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <METHOD/>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <ENUM/>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <INTERFACE/>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <AND>
+              <CLASS/>
+              <STATIC/>
+            </AND>
+          </match>
+        </rule>
+        <rule>
+          <match>
+            <CLASS/>
+          </match>
+        </rule>
       </rules>
     </arrangement>
   </codeStyleSettings>
   <codeStyleSettings language="JSP">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="LESS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SASS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SCSS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SQL">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <codeStyleSettings language="TypeScript">
-    <option name="KEEP_LINE_BREAKS" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BRACE_STYLE" value="2" />
-    <option name="CLASS_BRACE_STYLE" value="2" />
-    <option name="METHOD_BRACE_STYLE" value="2" />
-    <option name="ELSE_ON_NEW_LINE" value="true" />
-    <option name="WHILE_ON_NEW_LINE" value="true" />
-    <option name="CATCH_ON_NEW_LINE" value="true" />
-    <option name="FINALLY_ON_NEW_LINE" value="true" />
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="5" />
-    <option name="METHOD_PARAMETERS_WRAP" value="5" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_LINE_BREAKS" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BRACE_STYLE" value="2"/>
+    <option name="CLASS_BRACE_STYLE" value="2"/>
+    <option name="METHOD_BRACE_STYLE" value="2"/>
+    <option name="ELSE_ON_NEW_LINE" value="true"/>
+    <option name="WHILE_ON_NEW_LINE" value="true"/>
+    <option name="CATCH_ON_NEW_LINE" value="true"/>
+    <option name="FINALLY_ON_NEW_LINE" value="true"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
+    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true"/>
+    <option name="CALL_PARAMETERS_WRAP" value="5"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="5"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
     <arrangement>
       <rules>


### PR DESCRIPTION
PR changes IJ formatter to align multiline method declaration parameters. 
Current settings make multi-parameter declarations hard to read because everything is crammed into as few lines as possible.
With alignment enabled, declaration such as :
```java
public MultistageGroupByExecutor(int[] groupKeyIds, AggregationFunction[] aggFunctions, int[] filterArgIds,
      int maxFilterArgId, AggType aggType, boolean leafReturnFinalResult, DataSchema resultSchema,
      Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
```
can be reformatted as 
```java
public MultistageGroupByExecutor(int[] groupKeyIds,
                                 AggregationFunction[] aggFunctions,
                                 int[] filterArgIds,
                                 int maxFilterArgId, AggType aggType,
                                 boolean leafReturnFinalResult,
                                 DataSchema resultSchema,
                                 Map<String, String> opChainMetadata,
                                 @Nullable PlanNode.NodeHint nodeHint) {
```
or 
```java
public MultistageGroupByExecutor(
      int[] groupKeyIds,
      AggregationFunction[] aggFunctions,
      int[] filterArgIds,
      int maxFilterArgId, AggType aggType,
      boolean leafReturnFinalResult,
      DataSchema resultSchema,
      Map<String, String> opChainMetadata,
      @Nullable PlanNode.NodeHint nodeHint) {
```
or differently - with multiple parameters per line - but with first parameter always aligned.
