### PR TITLE
Add DR and Failure scenario handling for Pauseless Ingestion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.segment;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentZKMetadataUtils {
+  private SegmentZKMetadataUtils() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentZKMetadataUtils.class);
+  public static final ObjectMapper MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    mapper.configure(MapperFeature.AUTO_DETECT_FIELDS, true);
+    mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, true);
+    mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, true);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return mapper;
+  }
+
+  public static String serialize(SegmentZKMetadata metadata) throws IOException {
+    if (metadata == null) {
+      return null;
+    }
+    return MAPPER.writeValueAsString(metadata.toZNRecord());
+  }
+
+  public static SegmentZKMetadata deserialize(String jsonString) throws IOException {
+    if (jsonString == null || jsonString.isEmpty()) {
+      return null;
+    }
+    ObjectNode objectNode = (ObjectNode) MAPPER.readTree(jsonString);
+    ZNRecord znRecord = MAPPER.treeToValue(objectNode, ZNRecord.class);
+    return new SegmentZKMetadata(znRecord);
+  }
+
+  public static SegmentZKMetadata deserialize(ObjectNode objectNode) throws IOException {
+    if (objectNode == null) {
+      return null;
+    }
+    ZNRecord znRecord = MAPPER.treeToValue(objectNode, ZNRecord.class);
+    return new SegmentZKMetadata(znRecord);
+  }
+
+  public static SegmentZKMetadata deserialize(byte[] bytes) throws IOException {
+    if (bytes == null || bytes.length == 0) {
+      return null;
+    }
+    ZNRecord znRecord = MAPPER.readValue(bytes, ZNRecord.class);
+    return new SegmentZKMetadata(znRecord);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtilsTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.segment;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class SegmentZKMetadataUtilsTest {
+
+  private SegmentZKMetadata _testMetadata;
+  private static final String TEST_SEGMENT_NAME = "testSegment";
+  private static final String TEST_TABLE_SEGMENT = "mytable__0__0__20220722T2342Z";
+
+  @BeforeMethod
+  public void setUp() {
+    // Create a test metadata object with sample data
+    _testMetadata = new SegmentZKMetadata(TEST_SEGMENT_NAME);
+    _testMetadata.setStartTime(1234567890L);
+    _testMetadata.setEndTime(1234567899L);
+    _testMetadata.setTimeUnit(TimeUnit.SECONDS);
+    _testMetadata.setIndexVersion("v1");
+    _testMetadata.setTotalDocs(1000);
+    _testMetadata.setSizeInBytes(1024 * 1024);
+    _testMetadata.setCrc(123456L);
+    _testMetadata.setCreationTime(System.currentTimeMillis());
+  }
+
+  @Test
+  public void testSerialize() throws IOException {
+    // Test successful serialization
+    String serialized = SegmentZKMetadataUtils.serialize(_testMetadata);
+
+    // Verify basic properties
+    assertNotNull(serialized, "Serialized string should not be null");
+    assertTrue(serialized.contains(TEST_SEGMENT_NAME), "Serialized string should contain segment name");
+    assertTrue(serialized.contains("SECONDS"), "Serialized string should contain time unit");
+
+    // Verify JSON structure
+    ObjectNode jsonNode = (ObjectNode) SegmentZKMetadataUtils.MAPPER.readTree(serialized);
+    assertTrue(jsonNode.has("simpleFields"), "Should contain simpleFields");
+    assertTrue(jsonNode.has("mapFields"), "Should contain mapFields");
+  }
+
+  @Test
+  public void testSerializeNull() throws IOException {
+    assertNull(SegmentZKMetadataUtils.serialize(null), "Serializing null should return null");
+  }
+
+  @Test
+  public void testDeserializeString() throws IOException {
+    String errorStr = "{\"id\":\"" + TEST_TABLE_SEGMENT + "\",\"simpleFields\":"
+        + "{\"segment.crc\":\"2624963047\",\"segment.creation.time\":\"1658533353347\","
+        + "\"segment.download.url\":\"http://localhost:18998/segments/mytable/" + TEST_TABLE_SEGMENT + "\","
+        + "\"segment.end.time\":\"1405296000000\",\"segment.flush.threshold.size\":\"2500\","
+        + "\"segment.index.version\":\"v3\",\"segment.realtime.endOffset\":\"2500\","
+        + "\"segment.realtime.numReplicas\":\"1\",\"segment.realtime.startOffset\":\"0\","
+        + "\"segment.realtime.status\":\"DONE\",\"segment.start.time\":\"1404086400000\","
+        + "\"segment.time.unit\":\"MILLISECONDS\",\"segment.total.docs\":\"2500\"},"
+        + "\"mapFields\":{},\"listFields\":{}}";
+
+    SegmentZKMetadata segmentZKMetadata = SegmentZKMetadataUtils.deserialize(errorStr);
+
+    // Verify deserialized properties
+    assertEquals(segmentZKMetadata.getSegmentName(), TEST_TABLE_SEGMENT,
+        "Segment name should match expected value");
+    assertEquals(segmentZKMetadata.getEndTimeMs(), 1405296000000L,
+        "End time should match expected value");
+    assertEquals(segmentZKMetadata.getCrc(), 2624963047L,
+        "CRC should match expected value");
+  }
+
+  @Test
+  public void testDeserializeObjectNode() throws IOException {
+    String errorStr = "{\"id\":\"" + TEST_TABLE_SEGMENT + "\",\"simpleFields\":"
+        + "{\"segment.crc\":\"2624963047\",\"segment.creation.time\":\"1658533353347\","
+        + "\"segment.download.url\":\"http://localhost:18998/segments/mytable/" + TEST_TABLE_SEGMENT + "\","
+        + "\"segment.end.time\":\"1405296000000\",\"segment.flush.threshold.size\":\"2500\","
+        + "\"segment.index.version\":\"v3\",\"segment.realtime.endOffset\":\"2500\","
+        + "\"segment.realtime.numReplicas\":\"1\",\"segment.realtime.startOffset\":\"0\","
+        + "\"segment.realtime.status\":\"DONE\",\"segment.start.time\":\"1404086400000\","
+        + "\"segment.time.unit\":\"MILLISECONDS\",\"segment.total.docs\":\"2500\"},"
+        + "\"mapFields\":{},\"listFields\":{}}";
+
+    JsonNode zkChildren = SegmentZKMetadataUtils.MAPPER.readTree(errorStr);
+    SegmentZKMetadata segmentZKMetadata = SegmentZKMetadataUtils.deserialize((ObjectNode) zkChildren);
+
+    assertEquals(segmentZKMetadata.getSegmentName(), TEST_TABLE_SEGMENT,
+        "Segment name should match expected value");
+    assertEquals(segmentZKMetadata.getEndTimeMs(), 1405296000000L,
+        "End time should match expected value");
+  }
+
+  @Test
+  public void testDeserializeBytes() throws IOException {
+    String serialized = SegmentZKMetadataUtils.serialize(_testMetadata);
+    byte[] bytes = serialized.getBytes();
+
+    SegmentZKMetadata deserialized = SegmentZKMetadataUtils.deserialize(bytes);
+
+    assertNotNull(deserialized, "Deserialized object should not be null");
+    assertEquals(deserialized.getSegmentName(), _testMetadata.getSegmentName(),
+        "Segment names should match");
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -406,6 +406,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get the Pinot llc realtime segment manager
+   *
+   * @return Pinot llc realtime segment manager
+   */
+  public PinotLLCRealtimeSegmentManager getPinotLLCRealtimeSegmentManager() {
+    return _pinotLLCRealtimeSegmentManager;
+  }
+
+  /**
    * Get the linage manager.
    *
    * @return lineage manager

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -2152,7 +2152,8 @@ public class PinotLLCRealtimeSegmentManager {
         }
 
         // Step 3: “No peer has that segment.” => Re-ingest from one server that is supposed to host it and is alive
-        LOGGER.info("Segment {} in table {} is COMMITTING with missing download URL and no peer copy. Triggering re-ingestion.",
+        LOGGER.info(
+            "Segment {} in table {} is COMMITTING with missing download URL and no peer copy. Triggering re-ingestion.",
             segmentName, tableNameWithType);
 
         // Find at least one server that should host this segment and is alive

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/FailureInjectionUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/FailureInjectionUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.util;
+
+import java.util.Map;
+
+
+public class FailureInjectionUtils {
+  public static final String FAULT_BEFORE_COMMIT_END_METADATA = "FaultBeforeCommitEndMetadata";
+  public static final String FAULT_BEFORE_IDEAL_STATE_UPDATE = "FaultBeforeIdealStateUpdate";
+  public static final String FAULT_BEFORE_NEW_SEGMENT_METADATA_CREATION = "FaultBeforeNewSegmentCreation";
+
+  private FailureInjectionUtils() {
+  }
+
+  public static void injectFailure(String faultTypeKey, Map<String, String> managerConfigs) {
+    String faultTypeConfig = managerConfigs.getOrDefault(faultTypeKey, "false");
+    if (Boolean.parseBoolean(faultTypeConfig)) {
+      throw new RuntimeException("Injecting failure: " + faultTypeKey);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -177,7 +177,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
       _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
     }
 
-    _llcRealtimeSegmentManager.reIngestSegmentsWithMissingDownloadUrl(tableConfig.getTableName());
+    _llcRealtimeSegmentManager.reIngestSegmentsWithErrorState(tableConfig.getTableName());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -172,12 +172,13 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     // Update the total document count gauge
     _validationMetrics.updateTotalDocumentCountGauge(realtimeTableName, computeTotalDocumentCount(segmentsZKMetadata));
 
+    _llcRealtimeSegmentManager.reIngestSegmentsWithErrorState(tableConfig.getTableName());
+//    _llcRealtimeSegmentManager.resetUploadedSegmentsInErrorState(tableConfig.getTableName());
+
     // Check missing segments and upload them to the deep store
     if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
       _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
     }
-
-    _llcRealtimeSegmentManager.reIngestSegmentsWithErrorState(tableConfig.getTableName());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -176,6 +176,8 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
       _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
     }
+
+    _llcRealtimeSegmentManager.reIngestSegmentsWithMissingDownloadUrl(tableConfig.getTableName());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -108,12 +108,13 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigMaps(tableConfig).stream().map(
         streamConfig -> new StreamConfig(tableConfig.getTableName(), streamConfig)
     ).collect(Collectors.toList());
-    if (context._runSegmentLevelValidation) {
-      runSegmentLevelValidation(tableConfig);
-    }
 
     if (shouldEnsureConsuming(tableNameWithType)) {
       _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfigs, context._offsetCriteria);
+    }
+
+    if (context._runSegmentLevelValidation) {
+      runSegmentLevelValidation(tableConfig);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -51,7 +51,6 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.common.restlet.resources.TableLLCSegmentUploadResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.URIUtils;
@@ -1113,9 +1112,11 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // its final location. This is the expected segment location.
     String expectedSegmentLocation =
         segmentManager.createSegmentPath(RAW_TABLE_NAME, segmentsZKMetadata.get(0).getSegmentName()).toString();
+    SegmentZKMetadata segmentZKMetadataCopy =
+        new SegmentZKMetadata(new ZNRecord(segmentsZKMetadata.get(0).toZNRecord()));
+    segmentZKMetadataCopy.setDownloadUrl(tempSegmentFileLocation.getPath());
     when(segmentManager._mockedFileUploadDownloadClient.uploadLLCToSegmentStore(serverUploadRequestUrl0)).thenReturn(
-        new TableLLCSegmentUploadResponse(segmentsZKMetadata.get(0).getSegmentName(), 12345678L,
-            tempSegmentFileLocation.getPath()));
+        segmentZKMetadataCopy);
 
     // Change 2nd segment status to be DONE, but with default peer download url.
     // Verify later the download url isn't fixed after upload failure.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1057,7 +1057,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   }
 
   @VisibleForTesting
-  SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
+  protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
     // for partial upsert tables, do not release _partitionGroupConsumerSemaphore proactively and rely on offload()
     // to release the semaphore. This ensures new consuming segment is not consuming until the segment replacement is
     // complete.
@@ -1244,7 +1244,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     return true;
   }
 
-  private void closeStreamConsumers() {
+  protected void closeStreamConsumers() {
     closePartitionGroupConsumer();
     closePartitionMetadataProvider();
     if (_acquiredConsumerSemaphore.compareAndSet(true, false)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -544,9 +544,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
             : null;
     RealtimeSegmentDataManager realtimeSegmentDataManager =
-        new RealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(), indexLoadingConfig,
-            schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
-            partitionDedupMetadataManager, _isTableReadyToConsumeData);
+        createRealtimeSegmentDataManager(zkMetadata, tableConfig, indexLoadingConfig, schema, llcSegmentName, semaphore,
+            partitionUpsertMetadataManager, partitionDedupMetadataManager, _isTableReadyToConsumeData);
     registerSegment(segmentName, realtimeSegmentDataManager, partitionUpsertMetadataManager);
     if (partitionUpsertMetadataManager != null) {
       partitionUpsertMetadataManager.trackNewlyAddedSegment(segmentName);
@@ -555,6 +554,16 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1);
 
     _logger.info("Added new CONSUMING segment: {}", segmentName);
+  }
+
+  protected RealtimeSegmentDataManager createRealtimeSegmentDataManager(SegmentZKMetadata zkMetadata,
+      TableConfig tableConfig, IndexLoadingConfig indexLoadingConfig, Schema schema, LLCSegmentName llcSegmentName,
+      Semaphore semaphore, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      PartitionDedupMetadataManager partitionDedupMetadataManager, BooleanSupplier isTableReadyToConsumeData)
+      throws AttemptsExceededException, RetriableOperationException {
+    return new RealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
+        indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
+        partitionDedupMetadataManager, isTableReadyToConsumeData);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionCommitEndMetadataFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionCommitEndMetadataFailureTest.java
@@ -1,0 +1,232 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
+import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class PauselessRealtimeIngestionCommitEndMetadataFailureTest extends BaseClusterIntegrationTest {
+
+  private static final int NUM_REALTIME_SEGMENTS = 48;
+  protected static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PauselessRealtimeIngestionCommitEndMetadataFailureTest.class);
+  private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
+  private List<File> _avroFiles;
+
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
+    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
+        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
+    // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
+    // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        500);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    // Set segment store uri to the one used by controller as data dir (i.e. deep store)
+    try {
+      LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),
+          new URI(_controllerConfig.getDataDir()).getScheme());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    // Start a customized controller with more frequent realtime segment validation
+    startController();
+    startBroker();
+    startServer();
+
+    // load data in kafka
+    _avroFiles = unpackAvroData(_tempDir);
+    startKafka();
+    pushAvroIntoKafka(_avroFiles);
+
+    // create schema for non-pauseless table
+    Schema schema = createSchema();
+    schema.setSchemaName(DEFAULT_TABLE_NAME_2);
+    addSchema(schema);
+
+    // add non-pauseless table
+    TableConfig tableConfig2 = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig2.setTableName(DEFAULT_TABLE_NAME_2);
+    tableConfig2.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig2.getValidationConfig().setRetentionTimeValue("100000");
+    addTableConfig(tableConfig2);
+
+    // Ensure that the commit protocol for all the segments have completed before injecting failure
+    waitForDocsLoaded(600_000L, true, tableConfig2.getTableName());
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableConfig2.getTableName());
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    // inject failure in the commit protocol for the pauseless table
+    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+        .enableTestFault(FailureInjectionUtils.FAULT_BEFORE_COMMIT_END_METADATA);
+
+    // create schema for pauseless table
+    schema.setSchemaName(DEFAULT_TABLE_NAME);
+    addSchema(schema);
+
+    // add pauseless table
+    TableConfig tableConfig = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig.getValidationConfig().setRetentionTimeValue("100000");
+    tableConfig.getIndexingConfig().setPauselessConsumptionEnabled(true);
+    tableConfig.getIndexingConfig().getStreamConfigs().put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
+    addTableConfig(tableConfig);
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @Test
+  public void testSegmentAssignment()
+      throws Exception {
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS);
+    assertUploadUrlEmpty(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType));
+    // this sleep has been introduced to ensure that the RealtimeSegmentValidationManager can
+    // run segment level validations. The segment is not fixed by the validation manager in case the desired time
+    // can not elapsed
+    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    // wait for the url to show up after running validation manager
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType),
+        _helixResourceManager.getSegmentsZKMetadata(TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2)));
+  }
+
+  private void compareZKMetadataForSegments(List<SegmentZKMetadata> segmentsZKMetadata,
+      List<SegmentZKMetadata> segmentsZKMetadata1) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata);
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap1 = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata1);
+    segmentZKMetadataMap.forEach((segmentKey, segmentZKMetadata) -> {
+      SegmentZKMetadata segmentZKMetadata1 = segmentZKMetadataMap1.get(segmentKey);
+      areSegmentZkMetadataSame(segmentZKMetadata, segmentZKMetadata1);
+    });
+  }
+
+  private void areSegmentZkMetadataSame(SegmentZKMetadata segmentZKMetadata, SegmentZKMetadata segmentZKMetadata1) {
+    if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+      return;
+    }
+    assertEquals(segmentZKMetadata.getStatus(), segmentZKMetadata1.getStatus());
+    assertEquals(segmentZKMetadata.getStartOffset(), segmentZKMetadata1.getStartOffset());
+    assertEquals(segmentZKMetadata.getEndOffset(), segmentZKMetadata1.getEndOffset());
+    assertEquals(segmentZKMetadata.getTotalDocs(), segmentZKMetadata1.getTotalDocs());
+    assertEquals(segmentZKMetadata.getStartTimeMs(), segmentZKMetadata1.getStartTimeMs());
+    assertEquals(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata1.getEndTimeMs());
+  }
+
+  private Map<String, SegmentZKMetadata> getPartitionSegmentNumberToMetadataMap(
+      List<SegmentZKMetadata> segmentsZKMetadata) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
+      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
+    }
+    return segmentZKMetadataMap;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    LOGGER.info("Tearing down...");
+    dropRealtimeTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopKafka();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private void verifyIdealState(String tableName, int numSegmentsExpected) {
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, tableName);
+    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
+    assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  private void assertUploadUrlEmpty(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      assertNull(segmentZKMetadata.getDownloadUrl());
+    }
+  }
+
+  private boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
+          && segmentZKMetadata.getDownloadUrl() == null) {
+        LOGGER.warn("URl not found for segment: {}", segmentZKMetadata.getSegmentName());
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionIdealStateUpdateFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionIdealStateUpdateFailureTest.java
@@ -1,0 +1,263 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
+import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class PauselessRealtimeIngestionIdealStateUpdateFailureTest extends BaseClusterIntegrationTest {
+  private static final int NUM_REALTIME_SEGMENTS = 48;
+  protected static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
+  private static final int NUM_REALTIME_SEGMENTS_WITH_FAILURE = 2;
+  private static final int NUM_REALTIME_SEGMENTS_ZK_METADATA_WITH_FAILURE = 4;
+  protected static final long DEFAULT_COUNT_STAR_RESULT_WITH_FAILURE = 5000;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PauselessRealtimeIngestionCommitEndMetadataFailureTest.class);
+  private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
+  private List<File> _avroFiles;
+  private static boolean _failureEnabled = false;
+
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
+    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
+        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
+    // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
+    // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        500);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    // Set segment store uri to the one used by controller as data dir (i.e. deep store)
+    try {
+      LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),
+          new URI(_controllerConfig.getDataDir()).getScheme());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    // Start a customized controller with more frequent realtime segment validation
+    startController();
+    startBroker();
+    startServer();
+
+    // load data in kafka
+    _avroFiles = unpackAvroData(_tempDir);
+    startKafka();
+    pushAvroIntoKafka(_avroFiles);
+
+    // create schema for non-pauseless table
+    Schema schema = createSchema();
+    schema.setSchemaName(DEFAULT_TABLE_NAME_2);
+    addSchema(schema);
+
+    // add non-pauseless table
+    TableConfig tableConfig2 = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig2.setTableName(DEFAULT_TABLE_NAME_2);
+    tableConfig2.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig2.getValidationConfig().setRetentionTimeValue("100000");
+    addTableConfig(tableConfig2);
+
+    // Ensure that the commit protocol for all the segments have completed before injecting failure
+    waitForDocsLoaded(600_000L, true, tableConfig2.getTableName());
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableConfig2.getTableName());
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    // inject failure in the commit protocol for the pauseless table
+    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+        .enableTestFault(FailureInjectionUtils.FAULT_BEFORE_IDEAL_STATE_UPDATE);
+    _failureEnabled = true;
+
+    // create schema for pauseless table
+    schema.setSchemaName(DEFAULT_TABLE_NAME);
+    addSchema(schema);
+
+    // add pauseless table
+    TableConfig tableConfig = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig.getValidationConfig().setRetentionTimeValue("100000");
+    tableConfig.getIndexingConfig().setPauselessConsumptionEnabled(true);
+    tableConfig.getIndexingConfig().getStreamConfigs().put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
+    addTableConfig(tableConfig);
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @Test
+  public void testSegmentAssignment()
+      throws Exception {
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    String tableNameWithType2 = TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2);
+    // ensure that the metadata and ideal state only contain 2 segments.
+    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS_WITH_FAILURE);
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return segmentZKMetadataList.size() == NUM_REALTIME_SEGMENTS_ZK_METADATA_WITH_FAILURE;
+    }, 1000, 100000, "New Segment ZK Metadata not created");
+
+    // this sleep has been introduced to ensure that the RealtimeSegmentValidationManager can
+    // run segment level validations. The segment is not fixed by the validation manager in case the desired time
+    // can not elapsed
+    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    _failureEnabled = false;
+    // inject failure in the commit protocol for the pauseless table
+    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+        .disableTestFault(FailureInjectionUtils.FAULT_BEFORE_IDEAL_STATE_UPDATE);
+
+    // Run validation manager. This should
+    // 1. Fix url for the segment that failed commit
+    // 2. Restart ingestion
+    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    // verify all the documents are loaded for both the tables
+    waitForAllDocsLoaded(600_000L);
+    waitForDocsLoaded(600_000L, true, tableNameWithType2);
+    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS);
+    verifyIdealState(tableNameWithType2, NUM_REALTIME_SEGMENTS);
+    // wait for the url to show up after running validation manager
+
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType),
+        _helixResourceManager.getSegmentsZKMetadata(tableNameWithType2));
+  }
+
+  private void compareZKMetadataForSegments(List<SegmentZKMetadata> segmentsZKMetadata,
+      List<SegmentZKMetadata> segmentsZKMetadata1) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata);
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap1 = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata1);
+    segmentZKMetadataMap.forEach((segmentKey, segmentZKMetadata) -> {
+      SegmentZKMetadata segmentZKMetadata1 = segmentZKMetadataMap1.get(segmentKey);
+      areSegmentZkMetadataSame(segmentZKMetadata, segmentZKMetadata1);
+    });
+  }
+
+  protected long getCountStarResult() {
+    if (_failureEnabled) {
+      return DEFAULT_COUNT_STAR_RESULT_WITH_FAILURE;
+    }
+    return DEFAULT_COUNT_STAR_RESULT;
+  }
+
+  private void areSegmentZkMetadataSame(SegmentZKMetadata segmentZKMetadata, SegmentZKMetadata segmentZKMetadata1) {
+    if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+      return;
+    }
+    assertEquals(segmentZKMetadata.getStatus(), segmentZKMetadata1.getStatus());
+    assertEquals(segmentZKMetadata.getStartOffset(), segmentZKMetadata1.getStartOffset());
+    assertEquals(segmentZKMetadata.getEndOffset(), segmentZKMetadata1.getEndOffset());
+    assertEquals(segmentZKMetadata.getTotalDocs(), segmentZKMetadata1.getTotalDocs());
+    assertEquals(segmentZKMetadata.getStartTimeMs(), segmentZKMetadata1.getStartTimeMs());
+    assertEquals(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata1.getEndTimeMs());
+  }
+
+  private Map<String, SegmentZKMetadata> getPartitionSegmentNumberToMetadataMap(
+      List<SegmentZKMetadata> segmentsZKMetadata) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
+      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
+    }
+    return segmentZKMetadataMap;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    LOGGER.info("Tearing down...");
+    dropRealtimeTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopKafka();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private void verifyIdealState(String tableName, int numSegmentsExpected) {
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, tableName);
+    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
+    assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  private void assertUploadUrlEmpty(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      assertNull(segmentZKMetadata.getDownloadUrl());
+    }
+  }
+
+  private boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
+          && segmentZKMetadata.getDownloadUrl() == null) {
+        LOGGER.warn("URl not found for segment: {}", segmentZKMetadata.getSegmentName());
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest.java
@@ -1,0 +1,263 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
+import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest extends BaseClusterIntegrationTest {
+  private static final int NUM_REALTIME_SEGMENTS = 48;
+  protected static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
+  private static final int NUM_REALTIME_SEGMENTS_WITH_FAILURE = 2;
+  private static final int NUM_REALTIME_SEGMENTS_ZK_METADATA_WITH_FAILURE = 2;
+  protected static final long DEFAULT_COUNT_STAR_RESULT_WITH_FAILURE = 5000;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PauselessRealtimeIngestionCommitEndMetadataFailureTest.class);
+  private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
+  private List<File> _avroFiles;
+  private static boolean _failureEnabled = false;
+
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
+    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
+        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
+    // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
+    // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        500);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    // Set segment store uri to the one used by controller as data dir (i.e. deep store)
+    try {
+      LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),
+          new URI(_controllerConfig.getDataDir()).getScheme());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    // Start a customized controller with more frequent realtime segment validation
+    startController();
+    startBroker();
+    startServer();
+
+    // load data in kafka
+    _avroFiles = unpackAvroData(_tempDir);
+    startKafka();
+    pushAvroIntoKafka(_avroFiles);
+
+    // create schema for non-pauseless table
+    Schema schema = createSchema();
+    schema.setSchemaName(DEFAULT_TABLE_NAME_2);
+    addSchema(schema);
+
+    // add non-pauseless table
+    TableConfig tableConfig2 = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig2.setTableName(DEFAULT_TABLE_NAME_2);
+    tableConfig2.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig2.getValidationConfig().setRetentionTimeValue("100000");
+    addTableConfig(tableConfig2);
+
+    // Ensure that the commit protocol for all the segments have completed before injecting failure
+    waitForDocsLoaded(600_000L, true, tableConfig2.getTableName());
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableConfig2.getTableName());
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    // inject failure in the commit protocol for the pauseless table
+    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+        .enableTestFault(FailureInjectionUtils.FAULT_BEFORE_NEW_SEGMENT_METADATA_CREATION);
+    _failureEnabled = true;
+
+    // create schema for pauseless table
+    schema.setSchemaName(DEFAULT_TABLE_NAME);
+    addSchema(schema);
+
+    // add pauseless table
+    TableConfig tableConfig = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig.getValidationConfig().setRetentionTimeValue("100000");
+    tableConfig.getIndexingConfig().setPauselessConsumptionEnabled(true);
+    tableConfig.getIndexingConfig().getStreamConfigs().put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
+    addTableConfig(tableConfig);
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @Test
+  public void testSegmentAssignment()
+      throws Exception {
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    String tableNameWithType2 = TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2);
+    // ensure that the metadata and ideal state only contain 2 segments.
+    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS_WITH_FAILURE);
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return segmentZKMetadataList.size() == NUM_REALTIME_SEGMENTS_ZK_METADATA_WITH_FAILURE;
+    }, 1000, 100000, "New Segment ZK Metadata not created");
+
+    // this sleep has been introduced to ensure that the RealtimeSegmentValidationManager can
+    // run segment level validations. The segment is not fixed by the validation manager in case the desired time
+    // can not elapsed
+    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    _failureEnabled = false;
+    // inject failure in the commit protocol for the pauseless table
+    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+        .disableTestFault(FailureInjectionUtils.FAULT_BEFORE_NEW_SEGMENT_METADATA_CREATION);
+
+    // Run validation manager. This should
+    // 1. Fix url for the segment that failed commit
+    // 2. Restart ingestion
+    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    // verify all the documents are loaded for both the tables
+    waitForAllDocsLoaded(600_000L);
+    waitForDocsLoaded(600_000L, true, tableNameWithType2);
+    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS);
+    verifyIdealState(tableNameWithType2, NUM_REALTIME_SEGMENTS);
+    // wait for the url to show up after running validation manager
+
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType),
+        _helixResourceManager.getSegmentsZKMetadata(tableNameWithType2));
+  }
+
+  private void compareZKMetadataForSegments(List<SegmentZKMetadata> segmentsZKMetadata,
+      List<SegmentZKMetadata> segmentsZKMetadata1) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata);
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap1 = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata1);
+    segmentZKMetadataMap.forEach((segmentKey, segmentZKMetadata) -> {
+      SegmentZKMetadata segmentZKMetadata1 = segmentZKMetadataMap1.get(segmentKey);
+      areSegmentZkMetadataSame(segmentZKMetadata, segmentZKMetadata1);
+    });
+  }
+
+  protected long getCountStarResult() {
+    if (_failureEnabled) {
+      return DEFAULT_COUNT_STAR_RESULT_WITH_FAILURE;
+    }
+    return DEFAULT_COUNT_STAR_RESULT;
+  }
+
+  private void areSegmentZkMetadataSame(SegmentZKMetadata segmentZKMetadata, SegmentZKMetadata segmentZKMetadata1) {
+    if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+      return;
+    }
+    assertEquals(segmentZKMetadata.getStatus(), segmentZKMetadata1.getStatus());
+    assertEquals(segmentZKMetadata.getStartOffset(), segmentZKMetadata1.getStartOffset());
+    assertEquals(segmentZKMetadata.getEndOffset(), segmentZKMetadata1.getEndOffset());
+    assertEquals(segmentZKMetadata.getTotalDocs(), segmentZKMetadata1.getTotalDocs());
+    assertEquals(segmentZKMetadata.getStartTimeMs(), segmentZKMetadata1.getStartTimeMs());
+    assertEquals(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata1.getEndTimeMs());
+  }
+
+  private Map<String, SegmentZKMetadata> getPartitionSegmentNumberToMetadataMap(
+      List<SegmentZKMetadata> segmentsZKMetadata) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
+      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
+    }
+    return segmentZKMetadataMap;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    LOGGER.info("Tearing down...");
+    dropRealtimeTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopKafka();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private void verifyIdealState(String tableName, int numSegmentsExpected) {
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, tableName);
+    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
+    assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  private void assertUploadUrlEmpty(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      assertNull(segmentZKMetadata.getDownloadUrl());
+    }
+  }
+
+  private boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
+          && segmentZKMetadata.getDownloadUrl() == null) {
+        LOGGER.warn("URl not found for segment: {}", segmentZKMetadata.getSegmentName());
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -1,0 +1,298 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
+import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
+import org.apache.pinot.server.starter.helix.BaseServerStarter;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClusterIntegrationTest {
+
+  private static final int NUM_REALTIME_SEGMENTS = 48;
+  protected static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PauselessRealtimeIngestionSegmentCommitFailureTest.class);
+  private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
+  private List<File> _avroFiles;
+
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
+    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
+        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
+    // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
+    // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        500);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    // Set segment store uri to the one used by controller as data dir (i.e. deep store)
+    try {
+      LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),
+          new URI(_controllerConfig.getDataDir()).getScheme());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    // Start a customized controller with more frequent realtime segment validation
+    startController();
+    startBroker();
+    startServer();
+
+    // load data in kafka
+    _avroFiles = unpackAvroData(_tempDir);
+    startKafka();
+    pushAvroIntoKafka(_avroFiles);
+
+    // create schema for non-pauseless table
+    Schema schema = createSchema();
+    schema.setSchemaName(DEFAULT_TABLE_NAME_2);
+    addSchema(schema);
+
+    // add non-pauseless table
+    TableConfig tableConfig2 = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig2.setTableName(DEFAULT_TABLE_NAME_2);
+    tableConfig2.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig2.getValidationConfig().setRetentionTimeValue("100000");
+    addTableConfig(tableConfig2);
+
+    // Ensure that the commit protocol for all the segments have completed before injecting failure
+    waitForDocsLoaded(600_000L, true, tableConfig2.getTableName());
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableConfig2.getTableName());
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    // inject failure in the commit protocol for the pauseless table
+//    _helixResourceManager.getPinotLLCRealtimeSegmentManager()
+//        .enableTestFault(FailureInjectionUtils.FAULT_BEFORE_COMMIT_END_METADATA);
+
+    // create schema for pauseless table
+    schema.setSchemaName(DEFAULT_TABLE_NAME);
+    addSchema(schema);
+
+    // add pauseless table
+    TableConfig tableConfig = createRealtimeTableConfig(_avroFiles.get(0));
+    tableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
+    tableConfig.getValidationConfig().setRetentionTimeValue("100000");
+    tableConfig.getIndexingConfig().setPauselessConsumptionEnabled(true);
+    tableConfig.getIndexingConfig().getStreamConfigs().put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
+    addTableConfig(tableConfig);
+    Thread.sleep(1000L);
+    waitForDocsLoaded(600_000L, true, getTableName(), getCountStarResult() / 2);
+//
+//    // Make segment data directory read-only to error out the segment commit
+    makeTableDataDirUnwritable();
+
+    Thread.sleep(10000L);
+
+//    waitForAllDocsLoaded(600_000L);
+  }
+
+  private void makeTableDataDirUnwritable() {
+    File dataDir = _serverStarters.get(0).getServerInstance().getInstanceDataManager()
+        .getTableDataManager(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(DEFAULT_TABLE_NAME))
+        .getTableDataDir();
+    for (File file : dataDir.listFiles()) {
+      file.setWritable(false, false);
+    }
+    dataDir.setWritable(false, false);
+
+    LOGGER.info("Data dir {} is not writable", dataDir.getAbsolutePath());
+  }
+
+  private void makeTableDataDirWritable() {
+    File dataDir = _serverStarters.get(0).getServerInstance().getInstanceDataManager()
+        .getTableDataManager(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(DEFAULT_TABLE_NAME))
+        .getTableDataDir();
+    for (File file : dataDir.listFiles()) {
+      file.setWritable(true, false);
+    }
+    dataDir.setWritable(true, false);
+
+    LOGGER.info("Data dir {} is writable", dataDir.getAbsolutePath());
+  }
+
+  protected void waitForDocsLoaded(long timeoutMs, boolean raiseError, String tableName, long numDocs) {
+    TestUtils.waitForCondition(() -> getCurrentCountStarResult(tableName) >= numDocs, 100L, timeoutMs,
+        "Failed to load " + numDocs + " documents, found: " + getCurrentCountStarResult(tableName), raiseError, Duration.ofMillis(timeoutMs / 10));
+  }
+
+  @Test
+  public void testSegmentAssignment()
+      throws Exception {
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+//    verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS);
+    assertTrue(atLeaseOneErrorSegmentInExternalView(tableNameWithType));
+//    assertUploadUrlEmpty(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType));
+    // this sleep has been introduced to ensure that the RealtimeSegmentValidationManager can
+    // run segment level validations. The segment is not fixed by the validation manager in case the desired time
+    // can not elapsed
+    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    makeTableDataDirWritable();
+    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    // wait for the url to show up after running validation manager
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return assertUrlPresent(segmentZKMetadataList);
+    }, 1000, 100000, "Some segments still have missing url");
+
+    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType),
+        _helixResourceManager.getSegmentsZKMetadata(TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2)));
+  }
+
+  private void compareZKMetadataForSegments(List<SegmentZKMetadata> segmentsZKMetadata,
+      List<SegmentZKMetadata> segmentsZKMetadata1) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata);
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap1 = getPartitionSegmentNumberToMetadataMap(segmentsZKMetadata1);
+    segmentZKMetadataMap.forEach((segmentKey, segmentZKMetadata) -> {
+      SegmentZKMetadata segmentZKMetadata1 = segmentZKMetadataMap1.get(segmentKey);
+      areSegmentZkMetadataSame(segmentZKMetadata, segmentZKMetadata1);
+    });
+  }
+
+  private void areSegmentZkMetadataSame(SegmentZKMetadata segmentZKMetadata, SegmentZKMetadata segmentZKMetadata1) {
+    if (segmentZKMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+      return;
+    }
+    assertEquals(segmentZKMetadata.getStatus(), segmentZKMetadata1.getStatus());
+    assertEquals(segmentZKMetadata.getStartOffset(), segmentZKMetadata1.getStartOffset());
+    assertEquals(segmentZKMetadata.getEndOffset(), segmentZKMetadata1.getEndOffset());
+    assertEquals(segmentZKMetadata.getTotalDocs(), segmentZKMetadata1.getTotalDocs());
+    assertEquals(segmentZKMetadata.getStartTimeMs(), segmentZKMetadata1.getStartTimeMs());
+    assertEquals(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata1.getEndTimeMs());
+  }
+
+  private Map<String, SegmentZKMetadata> getPartitionSegmentNumberToMetadataMap(
+      List<SegmentZKMetadata> segmentsZKMetadata) {
+    Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
+      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
+    }
+    return segmentZKMetadataMap;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    LOGGER.info("Tearing down...");
+    dropRealtimeTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopKafka();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private void verifyIdealState(String tableName, int numSegmentsExpected) {
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, tableName);
+    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
+    assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  private boolean atLeaseOneErrorSegmentInExternalView(String tableName) {
+    ExternalView resourceEV = _helixResourceManager.getHelixAdmin()
+        .getResourceExternalView(_helixResourceManager.getHelixClusterName(), tableName);
+    Map<String, Map<String, String>> segmentAssigment =  resourceEV.getRecord().getMapFields();
+    System.out.println("EXTERNAL VIEW");
+    try {
+      System.out.println(JsonUtils.objectToPrettyString(segmentAssigment));
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    for (Map<String, String> serverToStateMap : segmentAssigment.values()) {
+      for (String state : serverToStateMap.values()) {
+        if (state.equals("ERROR")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private void assertUploadUrlEmpty(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      assertNull(segmentZKMetadata.getDownloadUrl());
+    }
+  }
+
+  private boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {
+    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
+      if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
+          && segmentZKMetadata.getDownloadUrl() == null) {
+        LOGGER.warn("URl not found for segment: {}", segmentZKMetadata.getSegmentName());
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingRealtimeSegmentDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingRealtimeSegmentDataManager.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.realtime;
+
+import java.util.concurrent.Semaphore;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
+import org.apache.pinot.spi.utils.retry.RetriableOperationException;
+
+
+/**
+ * A specialized RealtimeSegmentDataManager that lets us inject a forced failure
+ * in the commit step, which occurs strictly after the segmentConsumed message.
+ */
+public class FailureInjectingRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
+
+  // This flag controls whether commit should forcibly fail.
+  private final boolean _failCommit;
+
+  /**
+   * Creates a manager that will forcibly fail the commit segment step.
+   */
+  public FailureInjectingRealtimeSegmentDataManager(SegmentZKMetadata segmentZKMetadata,
+      TableConfig tableConfig, RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir,
+      IndexLoadingConfig indexLoadingConfig, Schema schema, LLCSegmentName llcSegmentName,
+      Semaphore partitionGroupConsumerSemaphore, ServerMetrics serverMetrics,
+      boolean failCommit) throws AttemptsExceededException, RetriableOperationException {
+    // Pass through to the real parent constructor
+    super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
+        indexLoadingConfig, schema, llcSegmentName, partitionGroupConsumerSemaphore, serverMetrics,
+        null /* no PartitionUpsertMetadataManager */, null /* no PartitionDedupMetadataManager */,
+        () -> true /* isReadyToConsumeData always true for tests */);
+
+    _failCommit = failCommit;
+  }
+
+  protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
+     if (_failCommit) {
+      System.out.println("Forcing failure in buildSegmentInternal");
+      throw new RuntimeException("Forced failure in buildSegmentInternal");
+     }
+      return super.buildSegmentInternal(forCommit);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingRealtimeTableDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingRealtimeTableDataManager.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.realtime;
+
+import java.util.concurrent.Semaphore;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.PauselessConsumptionUtils;
+import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
+import org.apache.pinot.spi.utils.retry.RetriableOperationException;
+
+
+public class FailureInjectingRealtimeTableDataManager extends RealtimeTableDataManager {
+  private volatile boolean _hasFailedOnce = false;
+
+  public FailureInjectingRealtimeTableDataManager(Semaphore segmentBuildSemaphore) {
+    this(segmentBuildSemaphore, () -> true);
+  }
+
+  public FailureInjectingRealtimeTableDataManager(Semaphore segmentBuildSemaphore,
+      Supplier<Boolean> isServerReadyToServeQueries) {
+    super(segmentBuildSemaphore, isServerReadyToServeQueries);
+  }
+
+  @Override
+  protected RealtimeSegmentDataManager createRealtimeSegmentDataManager(SegmentZKMetadata zkMetadata,
+      TableConfig tableConfig, IndexLoadingConfig indexLoadingConfig, Schema schema, LLCSegmentName llcSegmentName,
+      Semaphore semaphore, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      PartitionDedupMetadataManager partitionDedupMetadataManager, BooleanSupplier isTableReadyToConsumeData)
+      throws AttemptsExceededException, RetriableOperationException {
+
+    boolean addFailureToCommits = PauselessConsumptionUtils.isPauselessEnabled(tableConfig);
+
+    if (addFailureToCommits) {
+      if (_hasFailedOnce) {
+        addFailureToCommits = false;
+      } else {
+        _hasFailedOnce = true;
+      }
+    }
+    return new FailureInjectingRealtimeSegmentDataManager(zkMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
+        indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, addFailureToCommits);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingTableDataManagerProvider.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/FailureInjectingTableDataManagerProvider.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.realtime;
+
+import com.google.common.cache.Cache;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
+import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
+import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
+import org.apache.pinot.core.data.manager.provider.TableDataManagerProvider;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.utils.SegmentLocks;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+
+
+/**
+ * Default implementation of {@link TableDataManagerProvider}.
+ */
+public class FailureInjectingTableDataManagerProvider implements TableDataManagerProvider {
+  private InstanceDataManagerConfig _instanceDataManagerConfig;
+  private HelixManager _helixManager;
+  private SegmentLocks _segmentLocks;
+  private Semaphore _segmentBuildSemaphore;
+
+  @Override
+  public void init(InstanceDataManagerConfig instanceDataManagerConfig, HelixManager helixManager,
+      SegmentLocks segmentLocks) {
+    _instanceDataManagerConfig = instanceDataManagerConfig;
+    _helixManager = helixManager;
+    _segmentLocks = segmentLocks;
+    int maxParallelSegmentBuilds = instanceDataManagerConfig.getMaxParallelSegmentBuilds();
+    _segmentBuildSemaphore = maxParallelSegmentBuilds > 0 ? new Semaphore(maxParallelSegmentBuilds, true) : null;
+  }
+
+  @Override
+  public TableDataManager getTableDataManager(TableConfig tableConfig, @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      Supplier<Boolean> isServerReadyToServeQueries) {
+    TableDataManager tableDataManager;
+    switch (tableConfig.getTableType()) {
+      case OFFLINE:
+        if (tableConfig.isDimTable()) {
+          tableDataManager = DimensionTableDataManager.createInstanceByTableName(tableConfig.getTableName());
+        } else {
+          tableDataManager = new OfflineTableDataManager();
+        }
+        break;
+      case REALTIME:
+        Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(tableConfig).get(0);
+        if (Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
+            && StringUtils.isEmpty(_instanceDataManagerConfig.getSegmentStoreUri())) {
+          throw new IllegalStateException(String.format("Table has enabled %s config. But the server has not "
+                  + "configured the segmentstore uri. Configure the server config %s",
+              StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI));
+        }
+        tableDataManager =
+            new FailureInjectingRealtimeTableDataManager(_segmentBuildSemaphore, isServerReadyToServeQueries);
+        break;
+      default:
+        throw new IllegalStateException();
+    }
+    tableDataManager.init(_instanceDataManagerConfig, _helixManager, _segmentLocks, tableConfig, segmentPreloadExecutor,
+        errorCache);
+    return tableDataManager;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
@@ -233,8 +233,7 @@ public class ReIngestionResource {
 
         pushSegmentMetadata(tableNameWithType, request.getUploadURI(), segmentTarFile, headers, segmentName);
 
-        LOGGER.info("Re-ingesteed Segment {} uploaded successfully", segmentName);
-
+        LOGGER.info("Re-ingested Segment {} uploaded successfully", segmentName);
       } catch (Exception e) {
         return Response.serverError().entity("Error during re-ingestion: " + e.getMessage()).build();
       } finally {
@@ -298,8 +297,8 @@ public class ReIngestionResource {
   public void pushSegmentMetadata(String tableNameWithType, String controllerUrl, File segmentFile,
       List<Header> authHeaders, String segmentName)
       throws Exception {
-    LOGGER.info("Pushing metadata of segment {} of table {} to controller: {}", segmentFile.getName(), tableNameWithType,
-        controllerUrl);
+    LOGGER.info("Pushing metadata of segment {} of table {} to controller: {}", segmentFile.getName(),
+        tableNameWithType, controllerUrl);
     String tableName = tableNameWithType;
     File segmentMetadataFile = generateSegmentMetadataTar(segmentFile);
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
@@ -76,10 +76,19 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
-@Api(tags = "ReIngestion", authorizations = {@Authorization(value = "Bearer")})
-@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
-    HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = "Bearer")))
+
+@Api(tags = "ReIngestion", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
+    @Authorization(value = DATABASE)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        key = SWAGGER_AUTHORIZATION_KEY,
+        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
+    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
+        description = "Database context passed through http header. If no context is provided 'default' database "
+            + "context will be considered.")}))
 @Path("/")
 public class ReIngestionResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReIngestionResource.class);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReIngestionResource.java
@@ -1,0 +1,391 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import com.google.common.base.Function;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.commons.io.FileUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.TarCompressionUtils;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.server.api.resources.reingestion.ReIngestionRequest;
+import org.apache.pinot.server.api.resources.reingestion.ReIngestionResponse;
+import org.apache.pinot.server.api.resources.reingestion.utils.SimpleRealtimeSegmentDataManager;
+import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Api(tags = "ReIngestion", authorizations = {@Authorization(value = "Bearer")})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
+    HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = "Bearer")))
+@Path("/")
+public class ReIngestionResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReIngestionResource.class);
+  public static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
+  //TODO: Maximum number of concurrent re-ingestions allowed should be configurable
+  private static final int MAX_PARALLEL_REINGESTIONS = 10;
+
+  // Map to track ongoing ingestion per segment
+  private static final ConcurrentHashMap<String, AtomicBoolean> SEGMENT_INGESTION_MAP = new ConcurrentHashMap<>();
+
+  // Semaphore to enforce global concurrency limit
+  private static final Semaphore REINGESTION_SEMAPHORE = new Semaphore(MAX_PARALLEL_REINGESTIONS);
+
+  @Inject
+  private ServerInstance _serverInstance;
+
+  @POST
+  @Path("/reIngestSegment")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Re-ingest segment", notes = "Re-ingest data for a segment from startOffset to endOffset and "
+      + "upload the segment")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success", response = ReIngestionResponse.class), @ApiResponse(code = 500,
+      message = "Internal server error", response = ErrorInfo.class)
+  })
+  public Response reIngestSegment(ReIngestionRequest request) {
+    try {
+      String tableNameWithType = request.getTableNameWithType();
+      String segmentName = request.getSegmentName();
+
+      // Try to acquire a permit from the semaphore to ensure we don't exceed max concurrency
+      if (!REINGESTION_SEMAPHORE.tryAcquire()) {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+            .entity("Too many re-ingestions in progress. Please try again later.")
+            .build();
+      }
+
+      // Check if the segment is already being re-ingested
+      AtomicBoolean isIngesting = SEGMENT_INGESTION_MAP.computeIfAbsent(segmentName, k -> new AtomicBoolean(false));
+      if (!isIngesting.compareAndSet(false, true)) {
+        // The segment is already being ingested
+        REINGESTION_SEMAPHORE.release();
+        return Response.status(Response.Status.CONFLICT)
+            .entity("Re-ingestion for segment: " + segmentName + " is already in progress.")
+            .build();
+      }
+
+      InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
+      if (instanceDataManager == null) {
+        throw new WebApplicationException(new RuntimeException("Invalid server initialization"),
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+
+      TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableNameWithType);
+      if (tableDataManager == null) {
+        throw new WebApplicationException("Table data manager not found for table: " + tableNameWithType,
+            Response.Status.NOT_FOUND);
+      }
+
+      IndexLoadingConfig indexLoadingConfig = tableDataManager.fetchIndexLoadingConfig();
+      LOGGER.info("Executing re-ingestion for table: {}, segment: {}", tableNameWithType, segmentName);
+
+      // Get TableConfig and Schema
+      TableConfig tableConfig = indexLoadingConfig.getTableConfig();
+      if (tableConfig == null) {
+        throw new WebApplicationException("Table config not found for table: " + tableNameWithType,
+            Response.Status.NOT_FOUND);
+      }
+
+      Schema schema = indexLoadingConfig.getSchema();
+      if (schema == null) {
+        throw new WebApplicationException("Schema not found for table: " + tableNameWithType,
+            Response.Status.NOT_FOUND);
+      }
+
+      // Fetch SegmentZKMetadata
+      SegmentZKMetadata segmentZKMetadata = tableDataManager.fetchZKMetadata(segmentName);
+      if (segmentZKMetadata == null) {
+        throw new WebApplicationException("Segment metadata not found for segment: " + segmentName,
+            Response.Status.NOT_FOUND);
+      }
+
+      // Get startOffset, endOffset, partitionGroupId
+      String startOffsetStr = segmentZKMetadata.getStartOffset();
+      String endOffsetStr = segmentZKMetadata.getEndOffset();
+
+      if (startOffsetStr == null || endOffsetStr == null) {
+        return Response.serverError().entity("Start offset or end offset is null for segment: " + segmentName).build();
+      }
+
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      int partitionGroupId = llcSegmentName.getPartitionGroupId();
+
+      Map<String, String> streamConfigMap;
+      try {
+        streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(tableConfig).get(0);
+      } catch (Exception e) {
+        return Response.serverError().entity("Failed to get stream config for table: " + tableNameWithType).build();
+      }
+
+      StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
+
+      // Set up directories
+      File resourceTmpDir = new File(FileUtils.getTempDirectory(), "resourceTmpDir_" + System.currentTimeMillis());
+      File resourceDataDir = new File(FileUtils.getTempDirectory(), "resourceDataDir_" + System.currentTimeMillis());
+
+      if (!resourceTmpDir.exists()) {
+        resourceTmpDir.mkdirs();
+      }
+      if (!resourceDataDir.exists()) {
+        resourceDataDir.mkdirs();
+      }
+
+      LOGGER.info("Starting SimpleRealtimeSegmentDataManager...");
+      // Instantiate SimpleRealtimeSegmentDataManager
+      SimpleRealtimeSegmentDataManager manager =
+          new SimpleRealtimeSegmentDataManager(segmentName, tableNameWithType, partitionGroupId, segmentZKMetadata,
+              tableConfig, schema, indexLoadingConfig, streamConfig, startOffsetStr, endOffsetStr, resourceTmpDir,
+              resourceDataDir, _serverInstance.getServerMetrics());
+
+      try {
+
+        manager.startConsumption();
+
+        waitForCondition((Void) -> manager.isDoneConsuming(), 1000, 300000, 0);
+
+        manager.stopConsumption();
+
+        // After ingestion is complete, get the segment
+        if (!manager.isSuccess()) {
+          throw new Exception("Consumer failed to reingest data: " + manager.getConsumptionException());
+        }
+
+
+        LOGGER.info("Starting build for segment {}", segmentName);
+        SimpleRealtimeSegmentDataManager.SegmentBuildDescriptor segmentBuildDescriptor =
+            manager.buildSegmentInternal();
+
+        // Get the segment directory
+        File segmentTarFile = segmentBuildDescriptor.getSegmentTarFile();
+
+        if (segmentTarFile == null) {
+          throw new Exception("Failed to build segment: " + segmentName);
+        }
+
+        //TODO: Find a way to get auth token here using injection instead of request param
+        String authToken = request.getAuthToken();
+        AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(authToken);
+        List<Header> headers = AuthProviderUtils.toRequestHeaders(authProvider);
+
+        pushSegmentMetadata(tableNameWithType, request.getUploadURI(), segmentTarFile, headers, segmentName);
+
+        LOGGER.info("Re-ingesteed Segment {} uploaded successfully", segmentName);
+
+      } catch (Exception e) {
+        return Response.serverError().entity("Error during re-ingestion: " + e.getMessage()).build();
+      } finally {
+        // Clean up
+        manager.offload();
+        manager.destroy();
+
+        // Delete temporary directories
+        FileUtils.deleteQuietly(resourceTmpDir);
+        FileUtils.deleteQuietly(resourceDataDir);
+
+        isIngesting.set(false);
+      }
+      // Return success response
+      return Response.ok().entity(new ReIngestionResponse("Segment re-ingested and uploaded successfully")).build();
+    } catch (Exception e) {
+      LOGGER.error("Error during re-ingestion", e);
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    } finally {
+      REINGESTION_SEMAPHORE.release();
+    }
+  }
+
+  private void waitForCondition(
+      Function<Void, Boolean> condition, long checkIntervalMs, long timeoutMs, long gracePeriodMs) {
+    long endTime = System.currentTimeMillis() + timeoutMs;
+
+    // Adding grace period before starting the condition checks
+    if (gracePeriodMs > 0) {
+      LOGGER.info("Waiting for a grace period of {} ms before starting condition checks", gracePeriodMs);
+      try {
+        Thread.sleep(gracePeriodMs);
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Interrupted during grace period wait", e);
+      }
+    }
+
+    while (System.currentTimeMillis() < endTime) {
+      try {
+        if (Boolean.TRUE.equals(condition.apply(null))) {
+          LOGGER.info("Condition satisfied: {}", condition);
+          return;
+        }
+        Thread.sleep(checkIntervalMs);
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while checking the condition", e);
+      }
+    }
+
+    throw new RuntimeException("Timeout waiting for condition: " + condition);
+  }
+
+  /**
+   * Push segment metadata to the Pinot Controller in METADATA mode.
+   *
+   * @param tableNameWithType The table name with type (e.g., "myTable_OFFLINE")
+   * @param controllerUrl The base URL of the Pinot Controller (e.g., "http://controller-host:9000")
+   * @param segmentFile   The local segment tar.gz file
+   * @param authHeaders   A map of authentication or additional headers for the request
+   */
+  public void pushSegmentMetadata(String tableNameWithType, String controllerUrl, File segmentFile,
+      List<Header> authHeaders, String segmentName)
+      throws Exception {
+    LOGGER.info("Pushing metadata of segment {} of table {} to controller: {}", segmentFile.getName(), tableNameWithType,
+        controllerUrl);
+    String tableName = tableNameWithType;
+    File segmentMetadataFile = generateSegmentMetadataTar(segmentFile);
+
+    LOGGER.info("Generated segment metadata tar file: {}", segmentMetadataFile.getAbsolutePath());
+    try {
+      // Prepare headers
+      List<Header> headers = authHeaders;
+
+      // The upload type must be METADATA
+      headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
+          FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+
+      // The DOWNLOAD_URI header specifies where the controller can fetch the segment if needed
+      headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentFile.toURI().toString()));
+      headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE, "true"));
+
+      // Set table name parameter
+      List<NameValuePair> parameters = getSegmentPushCommonParams(tableNameWithType);
+
+      // Construct the endpoint URI
+      URI uploadEndpoint = FileUploadDownloadClient.getUploadSegmentURI(new URI(controllerUrl));
+
+      LOGGER.info("Uploading segment metadata to: {} with headers: {}", uploadEndpoint, headers);
+
+      // Perform the metadata upload
+      SimpleHttpResponse response =
+          FILE_UPLOAD_DOWNLOAD_CLIENT.uploadSegmentMetadata(uploadEndpoint, segmentName, segmentMetadataFile, headers,
+              parameters, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+
+      LOGGER.info("Response for pushing metadata of segment {} of table {} to {} - {}: {}", segmentName, tableName,
+          controllerUrl, response.getStatusCode(), response.getResponse());
+    } finally {
+      FileUtils.deleteQuietly(segmentMetadataFile);
+    }
+  }
+
+  private List<NameValuePair> getSegmentPushCommonParams(String tableNameWithType) {
+    List<NameValuePair> params = new ArrayList<>();
+    params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
+        "true"));
+    params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+        TableNameBuilder.extractRawTableName(tableNameWithType)));
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    if (tableType != null) {
+      params.add(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_TYPE, tableType.toString()));
+    } else {
+      throw new RuntimeException(String.format("Failed to determine the tableType from name: %s", tableNameWithType));
+    }
+    return params;
+  }
+
+  /**
+   * Generate a tar.gz file containing only the metadata files (metadata.properties, creation.meta)
+   * from a given Pinot segment tar.gz file.
+   */
+  private File generateSegmentMetadataTar(File segmentTarFile)
+      throws Exception {
+
+    if (!segmentTarFile.exists()) {
+      throw new IllegalArgumentException("Segment tar file does not exist: " + segmentTarFile.getAbsolutePath());
+    }
+
+    LOGGER.info("Generating segment metadata tar file from segment tar: {}", segmentTarFile.getAbsolutePath());
+    File tempDir = Files.createTempDirectory("pinot-segment-temp").toFile();
+    String uuid = UUID.randomUUID().toString();
+    try {
+      File metadataDir = new File(tempDir, "segmentMetadataDir-" + uuid);
+      if (!metadataDir.mkdirs()) {
+        throw new RuntimeException("Failed to create metadata directory: " + metadataDir.getAbsolutePath());
+      }
+
+      LOGGER.info("Trying to untar Metadata file from: [{}] to [{}]", segmentTarFile, metadataDir);
+      TarCompressionUtils.untarOneFile(segmentTarFile, V1Constants.MetadataKeys.METADATA_FILE_NAME,
+          new File(metadataDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+
+      // Extract creation.meta
+      LOGGER.info("Trying to untar CreationMeta file from: [{}] to [{}]", segmentTarFile, metadataDir);
+      TarCompressionUtils.untarOneFile(segmentTarFile, V1Constants.SEGMENT_CREATION_META,
+          new File(metadataDir, V1Constants.SEGMENT_CREATION_META));
+
+      File segmentMetadataFile =
+          new File(FileUtils.getTempDirectory(), "segmentMetadata-" + UUID.randomUUID() + ".tar.gz");
+      TarCompressionUtils.createCompressedTarFile(metadataDir, segmentMetadataFile);
+      return segmentMetadataFile;
+    } finally {
+      FileUtils.deleteQuietly(tempDir);
+    }
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionRequest.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionRequest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources.reingestion;
+
+public class ReIngestionRequest {
+  private String _tableNameWithType;
+  private String _segmentName;
+  private String _uploadURI;
+  private boolean _uploadSegment;
+  private String _authToken;
+
+  // Getters and setters
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public void setTableNameWithType(String tableNameWithType) {
+    this._tableNameWithType = tableNameWithType;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public void setSegmentName(String segmentName) {
+    this._segmentName = segmentName;
+  }
+
+  public String getUploadURI() {
+    return _uploadURI;
+  }
+
+  public void setUploadURI(String uploadURI) {
+    this._uploadURI = uploadURI;
+  }
+
+  public boolean isUploadSegment() {
+    return _uploadSegment;
+  }
+
+  public void setUploadSegment(boolean uploadSegment) {
+    _uploadSegment = uploadSegment;
+  }
+
+  public String getAuthToken() {
+    return _authToken;
+  }
+
+  public void setAuthToken(String authToken) {
+    _authToken = authToken;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionRequest.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionRequest.java
@@ -25,13 +25,12 @@ public class ReIngestionRequest {
   private boolean _uploadSegment;
   private String _authToken;
 
-  // Getters and setters
   public String getTableNameWithType() {
     return _tableNameWithType;
   }
 
   public void setTableNameWithType(String tableNameWithType) {
-    this._tableNameWithType = tableNameWithType;
+    _tableNameWithType = tableNameWithType;
   }
 
   public String getSegmentName() {
@@ -39,7 +38,7 @@ public class ReIngestionRequest {
   }
 
   public void setSegmentName(String segmentName) {
-    this._segmentName = segmentName;
+    _segmentName = segmentName;
   }
 
   public String getUploadURI() {
@@ -47,7 +46,7 @@ public class ReIngestionRequest {
   }
 
   public void setUploadURI(String uploadURI) {
-    this._uploadURI = uploadURI;
+    _uploadURI = uploadURI;
   }
 
   public boolean isUploadSegment() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionResponse.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionResponse.java
@@ -22,7 +22,7 @@ public class ReIngestionResponse {
   private String _message;
 
   public ReIngestionResponse(String message) {
-    this._message = message;
+    _message = message;
   }
 
   // Getter and setter
@@ -31,6 +31,6 @@ public class ReIngestionResponse {
   }
 
   public void setMessage(String message) {
-    this._message = message;
+    _message = message;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionResponse.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/ReIngestionResponse.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources.reingestion;
+
+public class ReIngestionResponse {
+  private String _message;
+
+  public ReIngestionResponse(String message) {
+    this._message = message;
+  }
+
+  // Getter and setter
+  public String getMessage() {
+    return _message;
+  }
+
+  public void setMessage(String message) {
+    this._message = message;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
@@ -462,8 +462,9 @@ public class SimpleRealtimeSegmentDataManager extends SegmentDataManager {
           //  However this is not an issue for Kafka, since partitionGroups never expire and every partitionGroup has
           //  a single partition
           //  Fix this before opening support for partitioning in Kinesis
-          int numPartitionGroups = _partitionMetadataProvider.computePartitionGroupMetadata(getClientId(), _streamConfig,
-              Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
+          int numPartitionGroups =
+              _partitionMetadataProvider.computePartitionGroupMetadata(getClientId(), _streamConfig,
+                  Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
 
           if (numPartitionGroups != numPartitions) {
             _logger.info(
@@ -516,7 +517,8 @@ public class SimpleRealtimeSegmentDataManager extends SegmentDataManager {
     final SegmentMetadataImpl _segmentMetadata;
 
     public SegmentBuildDescriptor(@Nullable File segmentTarFile, @Nullable Map<String, File> metadataFileMap,
-        StreamPartitionMsgOffset offset, long buildTimeMillis, long waitTimeMillis, long segmentSizeBytes, SegmentMetadataImpl segmentMetadata) {
+        StreamPartitionMsgOffset offset, long buildTimeMillis, long waitTimeMillis, long segmentSizeBytes,
+        SegmentMetadataImpl segmentMetadata) {
       _segmentTarFile = segmentTarFile;
       _metadataFileMap = metadataFileMap;
       _offset = _offsetFactory.create(offset);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
@@ -174,12 +174,13 @@ public class SimpleRealtimeSegmentDataManager extends SegmentDataManager {
 
     // Initialize mutable segment with configurations
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
-        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType).setSegmentName(_segmentName)
-            .setStreamName(_streamConfig.getTopicName()).setSegmentZKMetadata(_segmentZKMetadata)
-            .setStatsHistory(statsHistory).setSchema(_schema).setCapacity(capacity)
-            .setAvgNumMultiValues(avgNumMultiValues).setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
-            .setFieldConfigList(tableConfig.getFieldConfigList())
-            .setConsumerDir(_resourceDataDir.getAbsolutePath()).setMemoryManager(
+        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType)
+            .setSegmentName(_segmentName).setStreamName(_streamConfig.getTopicName())
+            .setSegmentZKMetadata(_segmentZKMetadata).setStatsHistory(statsHistory).setSchema(_schema)
+            .setCapacity(capacity).setAvgNumMultiValues(avgNumMultiValues)
+            .setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
+            .setFieldConfigList(tableConfig.getFieldConfigList()).setConsumerDir(_resourceDataDir.getAbsolutePath())
+            .setMemoryManager(
                 new MmapMemoryManager(FileUtils.getTempDirectory().getAbsolutePath(), _segmentNameStr, _serverMetrics));
 
     setPartitionParameters(realtimeSegmentConfigBuilder, _tableConfig.getIndexingConfig().getSegmentPartitionConfig());

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
@@ -174,10 +174,11 @@ public class SimpleRealtimeSegmentDataManager extends SegmentDataManager {
 
     // Initialize mutable segment with configurations
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
-        new RealtimeSegmentConfig.Builder().setTableNameWithType(_tableNameWithType).setSegmentName(_segmentName)
+        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType).setSegmentName(_segmentName)
             .setStreamName(_streamConfig.getTopicName()).setSegmentZKMetadata(_segmentZKMetadata)
             .setStatsHistory(statsHistory).setSchema(_schema).setCapacity(capacity)
             .setAvgNumMultiValues(avgNumMultiValues).setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
+            .setFieldConfigList(tableConfig.getFieldConfigList())
             .setConsumerDir(_resourceDataDir.getAbsolutePath()).setMemoryManager(
                 new MmapMemoryManager(FileUtils.getTempDirectory().getAbsolutePath(), _segmentNameStr, _serverMetrics));
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/reingestion/utils/SimpleRealtimeSegmentDataManager.java
@@ -1,0 +1,565 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources.reingestion.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.TarCompressionUtils;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
+import org.apache.pinot.segment.local.io.writer.impl.MmapMemoryManager;
+import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
+import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
+import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
+import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.utils.IngestionUtils;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.SegmentZKPropsConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamDataDecoder;
+import org.apache.pinot.spi.stream.StreamDataDecoderImpl;
+import org.apache.pinot.spi.stream.StreamDataDecoderResult;
+import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.retry.RetryPolicies;
+import org.apache.pinot.spi.utils.retry.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Simplified Segment Data Manager for ingesting data from a start offset to an end offset.
+ */
+public class SimpleRealtimeSegmentDataManager extends SegmentDataManager {
+
+  private static final int DEFAULT_CAPACITY = 100_000;
+  private static final int DEFAULT_FETCH_TIMEOUT_MS = 5000;
+  public static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
+
+  private final String _segmentName;
+  private final String _tableNameWithType;
+  private final int _partitionGroupId;
+  private final String _segmentNameStr;
+  private final SegmentZKMetadata _segmentZKMetadata;
+  private final TableConfig _tableConfig;
+  private final Schema _schema;
+  private final StreamConfig _streamConfig;
+  private final StreamPartitionMsgOffsetFactory _offsetFactory;
+  private final StreamConsumerFactory _consumerFactory;
+  private StreamMetadataProvider _partitionMetadataProvider;
+  private final PartitionGroupConsumer _consumer;
+  private final StreamDataDecoder _decoder;
+  private final MutableSegmentImpl _realtimeSegment;
+  private final File _resourceTmpDir;
+  private final File _resourceDataDir;
+  private final Logger _logger;
+  private Thread _consumerThread;
+  private final AtomicBoolean _shouldStop = new AtomicBoolean(false);
+  private final AtomicBoolean _isDoneConsuming = new AtomicBoolean(false);
+  private final StreamPartitionMsgOffset _startOffset;
+  private final StreamPartitionMsgOffset _endOffset;
+  private volatile StreamPartitionMsgOffset _currentOffset;
+  private volatile int _numRowsIndexed = 0;
+  private final String _segmentStoreUriStr;
+  private final int _fetchTimeoutMs;
+  private final TransformPipeline _transformPipeline;
+  private volatile boolean _isSuccess = false;
+  private volatile Throwable _consumptionException;
+  private final ServerMetrics _serverMetrics;
+
+  public SimpleRealtimeSegmentDataManager(String segmentName, String tableNameWithType, int partitionGroupId,
+      SegmentZKMetadata segmentZKMetadata, TableConfig tableConfig, Schema schema,
+      IndexLoadingConfig indexLoadingConfig, StreamConfig streamConfig, String startOffsetStr, String endOffsetStr,
+      File resourceTmpDir, File resourceDataDir, ServerMetrics serverMetrics)
+      throws Exception {
+
+    _segmentName = segmentName;
+    _tableNameWithType = tableNameWithType;
+    _partitionGroupId = partitionGroupId;
+    _segmentZKMetadata = segmentZKMetadata;
+    _tableConfig = tableConfig;
+    _schema = schema;
+    _segmentStoreUriStr = indexLoadingConfig.getSegmentStoreURI();
+    _streamConfig = streamConfig;
+    _resourceTmpDir = resourceTmpDir;
+    _resourceDataDir = resourceDataDir;
+    _serverMetrics = serverMetrics;
+    _logger = LoggerFactory.getLogger(SimpleRealtimeSegmentDataManager.class.getName() + "_" + _segmentName);
+
+    _offsetFactory = StreamConsumerFactoryProvider.create(_streamConfig).createStreamMsgOffsetFactory();
+    _startOffset = _offsetFactory.create(startOffsetStr);
+    _endOffset = _offsetFactory.create(endOffsetStr);
+
+    String clientId = getClientId();
+
+    _consumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    _partitionMetadataProvider = _consumerFactory.createPartitionMetadataProvider(clientId, _partitionGroupId);
+    _segmentNameStr = _segmentZKMetadata.getSegmentName();
+
+    // Create a simple PartitionGroupConsumptionStatus
+    PartitionGroupConsumptionStatus partitionGroupConsumptionStatus =
+        new PartitionGroupConsumptionStatus(_partitionGroupId, 0, _startOffset, null, null);
+
+    _consumer = _consumerFactory.createPartitionGroupConsumer(clientId, partitionGroupConsumptionStatus);
+
+    // Initialize decoder
+    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema);
+    _decoder = createDecoder(fieldsToRead);
+
+    // Fetch capacity from indexLoadingConfig or use default
+    int capacity = streamConfig.getFlushThresholdRows();
+    if (capacity <= 0) {
+      capacity = DEFAULT_CAPACITY;
+    }
+
+    // Fetch average number of multi-values from indexLoadingConfig
+    int avgNumMultiValues = indexLoadingConfig.getRealtimeAvgMultiValueCount();
+
+    // Load stats history, here we are using the same stats while as the RealtimeSegmentDataManager so that we are
+    // much more efficient in allocating buffers. It also works with empty file
+    String tableDataDir = indexLoadingConfig.getInstanceDataManagerConfig() != null
+        ? indexLoadingConfig.getInstanceDataManagerConfig().getInstanceDataDir() + File.separator + _tableNameWithType
+        : resourceTmpDir.getAbsolutePath();
+    File statsHistoryFile = new File(tableDataDir, "segment-stats.ser");
+    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsHistoryFile);
+
+    // Initialize mutable segment with configurations
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
+        new RealtimeSegmentConfig.Builder().setTableNameWithType(_tableNameWithType).setSegmentName(_segmentName)
+            .setStreamName(_streamConfig.getTopicName()).setSegmentZKMetadata(_segmentZKMetadata)
+            .setStatsHistory(statsHistory).setSchema(_schema).setCapacity(capacity)
+            .setAvgNumMultiValues(avgNumMultiValues).setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
+            .setConsumerDir(_resourceDataDir.getAbsolutePath()).setMemoryManager(
+                new MmapMemoryManager(FileUtils.getTempDirectory().getAbsolutePath(), _segmentNameStr, _serverMetrics));
+
+    setPartitionParameters(realtimeSegmentConfigBuilder, _tableConfig.getIndexingConfig().getSegmentPartitionConfig());
+
+    _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), _serverMetrics);
+
+    _transformPipeline = new TransformPipeline(tableConfig, schema);
+
+    // Initialize fetch timeout
+    _fetchTimeoutMs =
+        _streamConfig.getFetchTimeoutMillis() > 0 ? _streamConfig.getFetchTimeoutMillis() : DEFAULT_FETCH_TIMEOUT_MS;
+  }
+
+  private String getClientId() {
+    return _tableNameWithType + "-" + _partitionGroupId;
+  }
+
+  public void startConsumption() {
+    // Start the consumer thread
+    _consumerThread = new Thread(new PartitionConsumer(), _segmentName);
+    _consumerThread.start();
+  }
+
+  private StreamDataDecoder createDecoder(Set<String> fieldsToRead)
+      throws Exception {
+    AtomicReference<StreamDataDecoder> localStreamDataDecoder = new AtomicReference<>();
+    RetryPolicy retryPolicy = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 1.2f);
+    retryPolicy.attempt(() -> {
+      try {
+        StreamMessageDecoder streamMessageDecoder = createMessageDecoder(fieldsToRead);
+        localStreamDataDecoder.set(new StreamDataDecoderImpl(streamMessageDecoder));
+        return true;
+      } catch (Exception e) {
+        _logger.warn("Failed to create StreamMessageDecoder. Retrying...", e);
+        return false;
+      }
+    });
+    return localStreamDataDecoder.get();
+  }
+
+  /**
+   * Creates a {@link StreamMessageDecoder} using properties in {@link StreamConfig}.
+   *
+   * @param fieldsToRead The fields to read from the source stream
+   * @return The initialized StreamMessageDecoder
+   */
+  private StreamMessageDecoder createMessageDecoder(Set<String> fieldsToRead) {
+    String decoderClass = _streamConfig.getDecoderClass();
+    try {
+      StreamMessageDecoder decoder = PluginManager.get().createInstance(decoderClass);
+      decoder.init(fieldsToRead, _streamConfig, _tableConfig, _schema);
+      return decoder;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Caught exception while creating StreamMessageDecoder from stream config: " + _streamConfig, e);
+    }
+  }
+
+  private class PartitionConsumer implements Runnable {
+    @Override
+    public void run() {
+      try {
+        _consumer.start(_startOffset);
+        _currentOffset = _startOffset;
+        TransformPipeline.Result reusedResult = new TransformPipeline.Result();
+        while (!_shouldStop.get() && _currentOffset.compareTo(_endOffset) < 0) {
+          // Fetch messages
+          MessageBatch messageBatch = _consumer.fetchMessages(_currentOffset, _fetchTimeoutMs);
+
+          int messageCount = messageBatch.getMessageCount();
+
+          for (int i = 0; i < messageCount; i++) {
+            if (_shouldStop.get()) {
+              break;
+            }
+            StreamMessage streamMessage = messageBatch.getStreamMessage(i);
+            if (streamMessage.getMetadata() != null && streamMessage.getMetadata().getOffset() != null
+                && streamMessage.getMetadata().getOffset().compareTo(_endOffset) >= 0) {
+              _shouldStop.set(true);
+              _logger.info("Reached end offset: {} for partition group: {}", _endOffset, _partitionGroupId);
+              break;
+            }
+
+            // Decode message
+            StreamDataDecoderResult decodedResult = _decoder.decode(streamMessage);
+            if (decodedResult.getException() == null) {
+              // Index message
+              GenericRow row = decodedResult.getResult();
+
+              _transformPipeline.processRow(row, reusedResult);
+
+              List<GenericRow> transformedRows = reusedResult.getTransformedRows();
+
+              // TODO: Do enrichment and transforms before indexing
+              for (GenericRow transformedRow : transformedRows) {
+                _realtimeSegment.index(transformedRow, streamMessage.getMetadata());
+                _numRowsIndexed++;
+              }
+            } else {
+              _logger.warn("Failed to decode message at offset {}: {}", _currentOffset, decodedResult.getException());
+            }
+          }
+
+          _currentOffset = messageBatch.getOffsetOfNextBatch();
+        }
+        _isSuccess = true;
+      } catch (Exception e) {
+        _logger.error("Exception in consumer thread", e);
+        _consumptionException = e;
+        throw new RuntimeException(e);
+      } finally {
+        try {
+          _consumer.close();
+        } catch (Exception e) {
+          _logger.warn("Failed to close consumer", e);
+        }
+        _isDoneConsuming.set(true);
+      }
+    }
+  }
+
+  public void stopConsumption() {
+    _shouldStop.set(true);
+    if (_consumerThread.isAlive()) {
+      _consumerThread.interrupt();
+      try {
+        _consumerThread.join();
+      } catch (InterruptedException e) {
+        _logger.warn("Interrupted while waiting for consumer thread to finish");
+      }
+    }
+  }
+
+  @Override
+  public MutableSegment getSegment() {
+    return _realtimeSegment;
+  }
+
+  @Override
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  @Override
+  protected void doDestroy() {
+    _realtimeSegment.destroy();
+  }
+
+  @Override
+  public void doOffload() {
+    stopConsumption();
+  }
+
+  public boolean isDoneConsuming() {
+    return _isDoneConsuming.get();
+  }
+
+  public boolean isSuccess() {
+    return _isSuccess;
+  }
+
+  public Throwable getConsumptionException() {
+    return _consumptionException;
+  }
+
+  @VisibleForTesting
+  public SegmentBuildDescriptor buildSegmentInternal() throws Exception {
+    _logger.info("Building segment from {} to {}", _startOffset, _currentOffset);
+    final long lockAcquireTimeMillis = now();
+    // Build a segment from in-memory rows.
+    // Use a temporary directory
+    Path tempSegmentFolder = null;
+    try {
+      tempSegmentFolder =
+          java.nio.file.Files.createTempDirectory(_resourceTmpDir.toPath(), "tmp-" + _segmentNameStr + "-");
+    } catch (IOException e) {
+      _logger.error("Failed to create temporary directory for segment build", e);
+      return null;
+    }
+
+    SegmentZKPropsConfig segmentZKPropsConfig = new SegmentZKPropsConfig();
+    segmentZKPropsConfig.setStartOffset(_startOffset.toString());
+    segmentZKPropsConfig.setEndOffset(_endOffset.toString());
+
+    // Build the segment
+    RealtimeSegmentConverter converter =
+        new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, tempSegmentFolder.toString(),
+            _schema, _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
+            _tableConfig.getIndexingConfig().isNullHandlingEnabled());
+    try {
+      converter.build(null, _serverMetrics);
+    } catch (Exception e) {
+      _logger.error("Failed to build segment", e);
+      FileUtils.deleteQuietly(tempSegmentFolder.toFile());
+      return null;
+    }
+    final long buildTimeMillis = now() - lockAcquireTimeMillis;
+
+    File dataDir = _resourceDataDir;
+    File indexDir = new File(dataDir, _segmentNameStr);
+    FileUtils.deleteQuietly(indexDir);
+
+    File tempIndexDir = new File(tempSegmentFolder.toFile(), _segmentNameStr);
+    if (!tempIndexDir.exists()) {
+      _logger.error("Temp index directory {} does not exist", tempIndexDir);
+      FileUtils.deleteQuietly(tempSegmentFolder.toFile());
+      return null;
+    }
+    try {
+      FileUtils.moveDirectory(tempIndexDir, indexDir);
+    } catch (IOException e) {
+      _logger.error("Caught exception while moving index directory from: {} to: {}", tempIndexDir, indexDir, e);
+      return null;
+    } finally {
+      FileUtils.deleteQuietly(tempSegmentFolder.toFile());
+    }
+
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
+
+    long segmentSizeBytes = FileUtils.sizeOfDirectory(indexDir);
+    File segmentTarFile = new File(dataDir, _segmentNameStr + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    try {
+      TarCompressionUtils.createCompressedTarFile(indexDir, segmentTarFile);
+    } catch (IOException e) {
+      _logger.error("Caught exception while tarring index directory from: {} to: {}", indexDir, segmentTarFile, e);
+      return null;
+    }
+
+    File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
+    if (metadataFile == null) {
+      _logger.error("Failed to find metadata file under index directory: {}", indexDir);
+      return null;
+    }
+    File creationMetaFile = SegmentDirectoryPaths.findCreationMetaFile(indexDir);
+    if (creationMetaFile == null) {
+      _logger.error("Failed to find creation meta file under index directory: {}", indexDir);
+      return null;
+    }
+    Map<String, File> metadataFiles = new HashMap<>();
+    metadataFiles.put(V1Constants.MetadataKeys.METADATA_FILE_NAME, metadataFile);
+    metadataFiles.put(V1Constants.SEGMENT_CREATION_META, creationMetaFile);
+    return new SegmentBuildDescriptor(segmentTarFile, metadataFiles, _currentOffset, buildTimeMillis, buildTimeMillis,
+        segmentSizeBytes, segmentMetadata);
+  }
+
+  protected long now() {
+    return System.currentTimeMillis();
+  }
+
+  public void removeSegmentFile(SegmentBuildDescriptor segmentBuildDescriptor) {
+    if (segmentBuildDescriptor != null) {
+      segmentBuildDescriptor.deleteSegmentFile();
+    }
+  }
+
+  /*
+   * set the following partition parameters in RT segment config builder:
+   *  - partition column
+   *  - partition function
+   *  - partition group id
+   */
+  private void setPartitionParameters(RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder,
+      SegmentPartitionConfig segmentPartitionConfig) {
+    if (segmentPartitionConfig != null) {
+      Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+      if (columnPartitionMap.size() == 1) {
+        Map.Entry<String, ColumnPartitionConfig> entry = columnPartitionMap.entrySet().iterator().next();
+        String partitionColumn = entry.getKey();
+        ColumnPartitionConfig columnPartitionConfig = entry.getValue();
+        String partitionFunctionName = columnPartitionConfig.getFunctionName();
+
+        // NOTE: Here we compare the number of partitions from the config and the stream, and log a warning and emit a
+        //       metric when they don't match, but use the one from the stream. The mismatch could happen when the
+        //       stream partitions are changed, but the table config has not been updated to reflect the change.
+        //       In such case, picking the number of partitions from the stream can keep the segment properly
+        //       partitioned as long as the partition function is not changed.
+        int numPartitions = columnPartitionConfig.getNumPartitions();
+        try {
+          // TODO: currentPartitionGroupConsumptionStatus should be fetched from idealState + segmentZkMetadata,
+          //  so that we get back accurate partitionGroups info
+          //  However this is not an issue for Kafka, since partitionGroups never expire and every partitionGroup has
+          //  a single partition
+          //  Fix this before opening support for partitioning in Kinesis
+          int numPartitionGroups = _partitionMetadataProvider.computePartitionGroupMetadata(getClientId(), _streamConfig,
+              Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
+
+          if (numPartitionGroups != numPartitions) {
+            _logger.info(
+                "Number of stream partitions: {} does not match number of partitions in the partition config: {}, "
+                    + "using number of stream " + "partitions", numPartitionGroups, numPartitions);
+            numPartitions = numPartitionGroups;
+          }
+        } catch (Exception e) {
+          _logger.warn("Failed to get number of stream partitions in 5s, "
+              + "using number of partitions in the partition config: {}", numPartitions, e);
+          createPartitionMetadataProvider("Timeout getting number of stream partitions");
+        }
+
+        realtimeSegmentConfigBuilder.setPartitionColumn(partitionColumn);
+        realtimeSegmentConfigBuilder.setPartitionFunction(
+            PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions, null));
+        realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
+      } else {
+        _logger.warn("Cannot partition on multiple columns: {}", columnPartitionMap.keySet());
+      }
+    }
+  }
+
+  /**
+   * Creates a new stream metadata provider
+   */
+  private void createPartitionMetadataProvider(String reason) {
+    closePartitionMetadataProvider();
+    _logger.info("Creating new partition metadata provider, reason: {}", reason);
+    _partitionMetadataProvider = _consumerFactory.createPartitionMetadataProvider(getClientId(), _partitionGroupId);
+  }
+
+  private void closePartitionMetadataProvider() {
+    if (_partitionMetadataProvider != null) {
+      try {
+        _partitionMetadataProvider.close();
+      } catch (Exception e) {
+        _logger.warn("Could not close stream metadata provider", e);
+      }
+    }
+  }
+
+  public class SegmentBuildDescriptor {
+    final File _segmentTarFile;
+    final Map<String, File> _metadataFileMap;
+    final StreamPartitionMsgOffset _offset;
+    final long _waitTimeMillis;
+    final long _buildTimeMillis;
+    final long _segmentSizeBytes;
+    final SegmentMetadataImpl _segmentMetadata;
+
+    public SegmentBuildDescriptor(@Nullable File segmentTarFile, @Nullable Map<String, File> metadataFileMap,
+        StreamPartitionMsgOffset offset, long buildTimeMillis, long waitTimeMillis, long segmentSizeBytes, SegmentMetadataImpl segmentMetadata) {
+      _segmentTarFile = segmentTarFile;
+      _metadataFileMap = metadataFileMap;
+      _offset = _offsetFactory.create(offset);
+      _buildTimeMillis = buildTimeMillis;
+      _waitTimeMillis = waitTimeMillis;
+      _segmentSizeBytes = segmentSizeBytes;
+      _segmentMetadata = segmentMetadata;
+    }
+
+    public StreamPartitionMsgOffset getOffset() {
+      return _offset;
+    }
+
+    public long getBuildTimeMillis() {
+      return _buildTimeMillis;
+    }
+
+    public long getWaitTimeMillis() {
+      return _waitTimeMillis;
+    }
+
+    @Nullable
+    public File getSegmentTarFile() {
+      return _segmentTarFile;
+    }
+
+    @Nullable
+    public Map<String, File> getMetadataFiles() {
+      return _metadataFileMap;
+    }
+
+    public long getSegmentSizeBytes() {
+      return _segmentSizeBytes;
+    }
+
+    public void deleteSegmentFile() {
+      if (_segmentTarFile != null) {
+        FileUtils.deleteQuietly(_segmentTarFile);
+      }
+    }
+
+    public SegmentMetadataImpl getSegmentMetadata() {
+      return _segmentMetadata;
+    }
+  }
+}


### PR DESCRIPTION
# Pauseless Ingestion Failure Resolution


Please refer to PR: https://github.com/apache/pinot/pull/14741 for happy path. This PR aims to only cover the failure scenarios. Once the above one is merged a better diff covering only failures will be visible.

To view only diff covering failure scenarios, for the time being, refer to: 

## Summary 
This PR aims to provide ways to resolve the failure scenarios that we can encounter during pauseless ingestion. The detailed list of failure scenarios can be found here: [link](https://docs.google.com/document/d/1d-xttk7sXFIOqfyZvYw5W_KeGS6Ztmi8eYevBcCrT_c/edit?tab=t.0#heading=h.hjzp2hlg4d4o)  along with the failure handling strategies: [link](https://docs.google.com/document/d/1d-xttk7sXFIOqfyZvYw5W_KeGS6Ztmi8eYevBcCrT_c/edit?tab=t.0#heading=h.32w9tdojyszg)
 
Following sequence diagrams summarizes the failure scenarios and the resolution. 
 ![Screenshot 2025-01-03 at 2 53 46 PM](https://github.com/user-attachments/assets/4a1155cd-fd7f-4832-91ac-16b2d4851963)
![Screenshot 2025-01-03 at 2 54 45 PM](https://github.com/user-attachments/assets/a9b01529-2331-4a9d-8e73-423c23eefb2c)

## Failure Scenarios & Resolution Approaches


Failures encountered during the commit protocol can be categorized into two types: recoverable and unrecoverable failures.

**Recoverable failures** are those in which at least one of the servers retains the segment on disk.

**Unrecoverable failures** occur when none of the servers have the segment on disk.

### Recoverable Failures

Recoverable failures will be addressed through RealtimeSegmentValidationManager. This approach will handle scenarios such as **upload** failures and **incomplete** commit protocol executions.

The controller or server can run into issues in between any of the steps of the commit protocol as listed below:

Request Type: **COMMIT_START** 
1. Update the Segment ZK metadata for the committing segment (seg__0__0)
    - Change status to **COMMITTING**
    - Set endOffset
2. Create Segment ZK metadata for the new segment (seg__0__1) with status IN_PROGRESS 
3. Update the Ideal State for the: 
    - Committing segment (seg__0__0) to ONLINE
    - New/ Consuming segment (seg__0__1) to CONSUMING

Request Type: **COMMIT_END_METADATA**
4. Update Segment ZK metadata for the committing segment (seg__0__0):
    - Change status to DONE.
    - Update deepstore url.
    - Any additional metadata.
    
The RealtimeSegmentValidationManager figures out which step of the commit protocol failed and how can it be fixed. This is very similar to how commit protocol failures were handled before with some minor changes.

### Non-recoverable Failures

These failures require ingesting the segment again from upstream, followed by build, upload and ZK metadata update. 





