### PR TITLE
Support distribution type hint to allow broadcast join

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.calcite.rel.hint;
 
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.hint.RelHint;
@@ -83,6 +86,9 @@ public class PinotHintOptions {
     // "lookup" can be used when the right table is a dimension table replicated to all workers
     public static final String LOOKUP_JOIN_STRATEGY = "lookup";
 
+    public static final String LEFT_DISTRIBUTION_TYPE = "left_distribution_type";
+    public static final String RIGHT_DISTRIBUTION_TYPE = "right_distribution_type";
+
     /**
      * Max rows allowed to build the right table hash collection.
      */
@@ -105,11 +111,64 @@ public class PinotHintOptions {
      */
     public static final String APPEND_DISTINCT_TO_SEMI_JOIN_PROJECT = "append_distinct_to_semi_join_project";
 
+    @Nullable
+    public static Map<String, String> getJoinHintOptions(Join join) {
+      return PinotHintStrategyTable.getHintOptions(join.getHints(), JOIN_HINT_OPTIONS);
+    }
+
+    @Nullable
+    public static String getJoinStrategyHint(Join join) {
+      return PinotHintStrategyTable.getHintOption(join.getHints(), JOIN_HINT_OPTIONS, JOIN_STRATEGY);
+    }
+
     // TODO: Consider adding a Join implementation with join strategy.
     public static boolean useLookupJoinStrategy(Join join) {
-      return LOOKUP_JOIN_STRATEGY.equalsIgnoreCase(
-          PinotHintStrategyTable.getHintOption(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
-              PinotHintOptions.JoinHintOptions.JOIN_STRATEGY));
+      return LOOKUP_JOIN_STRATEGY.equalsIgnoreCase(getJoinStrategyHint(join));
+    }
+
+    @Nullable
+    public static DistributionType getLeftDistributionType(Map<String, String> joinHintOptions) {
+      return DistributionType.fromHint(joinHintOptions.get(LEFT_DISTRIBUTION_TYPE));
+    }
+
+    @Nullable
+    public static DistributionType getRightDistributionType(Map<String, String> joinHintOptions) {
+      return DistributionType.fromHint(joinHintOptions.get(RIGHT_DISTRIBUTION_TYPE));
+    }
+  }
+
+  /**
+   * Similar to {@link RelDistribution.Type}, it contains the distribution types to be used to shuffle data.
+   */
+  public enum DistributionType {
+    LOCAL,      // Distribute data locally without ser/de
+    HASH,       // Distribute data by hash partitioning
+    BROADCAST,  // Distribute data by broadcasting the data to all workers
+    RANDOM;     // Distribute data randomly
+
+    public static final String LOCAL_HINT = "local";
+    public static final String HASH_HINT = "hash";
+    public static final String BROADCAST_HINT = "broadcast";
+    public static final String RANDOM_HINT = "random";
+
+    @Nullable
+    public static DistributionType fromHint(@Nullable String hint) {
+      if (hint == null) {
+        return null;
+      }
+      if (hint.equalsIgnoreCase(LOCAL_HINT)) {
+        return LOCAL;
+      }
+      if (hint.equalsIgnoreCase(HASH_HINT)) {
+        return HASH;
+      }
+      if (hint.equalsIgnoreCase(BROADCAST_HINT)) {
+        return BROADCAST;
+      }
+      if (hint.equalsIgnoreCase(RANDOM_HINT)) {
+        return RANDOM;
+      }
+      throw new IllegalArgumentException("Unsupported distribution type hint: " + hint);
     }
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelDistributions;
@@ -52,27 +55,78 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
     RelNode left = PinotRuleUtils.unboxRel(join.getInput(0));
     RelNode right = PinotRuleUtils.unboxRel(join.getInput(1));
     JoinInfo joinInfo = join.analyzeCondition();
+    Map<String, String> joinHintOptions = PinotHintOptions.JoinHintOptions.getJoinHintOptions(join);
+    PinotHintOptions.DistributionType leftDistributionType;
+    PinotHintOptions.DistributionType rightDistributionType;
+    if (joinHintOptions != null) {
+      leftDistributionType = PinotHintOptions.JoinHintOptions.getLeftDistributionType(joinHintOptions);
+      rightDistributionType = PinotHintOptions.JoinHintOptions.getRightDistributionType(joinHintOptions);
+    } else {
+      leftDistributionType = null;
+      rightDistributionType = null;
+    }
     RelNode newLeft;
     RelNode newRight;
     if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
-      // Lookup join - add local exchange on the left side
-      newLeft = PinotLogicalExchange.create(left, RelDistributions.SINGLETON);
+      if (leftDistributionType == null) {
+        // By default, use local distribution for the left side
+        leftDistributionType = PinotHintOptions.DistributionType.LOCAL;
+      }
+      newLeft = createExchangeForLookupJoin(leftDistributionType, joinInfo.leftKeys, left);
+      Preconditions.checkArgument(rightDistributionType == null,
+          "Right distribution type hint is not supported for lookup join");
       newRight = right;
     } else {
-      // Regular join - add exchange on both sides
-      if (joinInfo.leftKeys.isEmpty()) {
-        // Broadcast the right side if there is no join key
-        newLeft = PinotLogicalExchange.create(left, RelDistributions.RANDOM_DISTRIBUTED);
-        newRight = PinotLogicalExchange.create(right, RelDistributions.BROADCAST_DISTRIBUTED);
-      } else {
-        // Use hash exchange when there are join keys
-        newLeft = PinotLogicalExchange.create(left, RelDistributions.hash(joinInfo.leftKeys));
-        newRight = PinotLogicalExchange.create(right, RelDistributions.hash(joinInfo.rightKeys));
+      // Hash join
+      // TODO: Validate if the configured distribution types are valid
+      if (leftDistributionType == null) {
+        // By default, hash distribute the left side if there are join keys, otherwise randomly distribute
+        leftDistributionType = !joinInfo.leftKeys.isEmpty() ? PinotHintOptions.DistributionType.HASH
+            : PinotHintOptions.DistributionType.RANDOM;
       }
+      newLeft = createExchangeForHashJoin(leftDistributionType, joinInfo.leftKeys, left);
+      if (rightDistributionType == null) {
+        // By default, hash distribute the right side if there are join keys, otherwise broadcast
+        rightDistributionType = !joinInfo.rightKeys.isEmpty() ? PinotHintOptions.DistributionType.HASH
+            : PinotHintOptions.DistributionType.BROADCAST;
+      }
+      newRight = createExchangeForHashJoin(rightDistributionType, joinInfo.rightKeys, right);
     }
 
     // TODO: Consider creating different JOIN Rel for each join strategy
     call.transformTo(join.copy(join.getTraitSet(), join.getCondition(), newLeft, newRight, join.getJoinType(),
         join.isSemiJoinDone()));
+  }
+
+  private static PinotLogicalExchange createExchangeForLookupJoin(PinotHintOptions.DistributionType distributionType,
+      List<Integer> keys, RelNode child) {
+    switch (distributionType) {
+      case LOCAL:
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON);
+      case HASH:
+        Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
+        return PinotLogicalExchange.create(child, RelDistributions.hash(keys));
+      case RANDOM:
+        return PinotLogicalExchange.create(child, RelDistributions.RANDOM_DISTRIBUTED);
+      default:
+        throw new IllegalArgumentException("Unsupported distribution type: " + distributionType + " for lookup join");
+    }
+  }
+
+  private static PinotLogicalExchange createExchangeForHashJoin(PinotHintOptions.DistributionType distributionType,
+      List<Integer> keys, RelNode child) {
+    switch (distributionType) {
+      case LOCAL:
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON);
+      case HASH:
+        Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
+        return PinotLogicalExchange.create(child, RelDistributions.hash(keys));
+      case BROADCAST:
+        return PinotLogicalExchange.create(child, RelDistributions.BROADCAST_DISTRIBUTED);
+      case RANDOM:
+        return PinotLogicalExchange.create(child, RelDistributions.RANDOM_DISTRIBUTED);
+      default:
+        throw new IllegalArgumentException("Unsupported distribution type: " + distributionType + " for hash join");
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
@@ -124,8 +124,7 @@ public class PinotJoinToDynamicBroadcastRule extends RelOptRule {
     Join join = call.rel(0);
 
     // Do not apply this rule if join strategy is explicitly set to something other than dynamic broadcast
-    String joinStrategy = PinotHintStrategyTable.getHintOption(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
-        PinotHintOptions.JoinHintOptions.JOIN_STRATEGY);
+    String joinStrategy = PinotHintOptions.JoinHintOptions.getJoinStrategyHint(join);
     if (joinStrategy != null && !joinStrategy.equals(
         PinotHintOptions.JoinHintOptions.DYNAMIC_BROADCAST_JOIN_STRATEGY)) {
       return false;

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -758,6 +758,60 @@
       }
     ]
   },
+  "broadcast_join_planning_tests": {
+    "queries": [
+      {
+        "description": "Simple broadcast join",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Broadcast join with filter on both left and right table",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col2 = 'foo' AND b.col2 = 'bar'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
+          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalFilter(condition=[=($1, _UTF-8'bar')])",
+          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Broadcast join with transformation on both left and right table joined key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ a.col1, b.col2 FROM a JOIN b ON upper(a.col1) = upper(b.col1)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($1, $3)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col2=[$1], $f8=[UPPER($0)])",
+          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      }
+    ]
+  },
   "exception_throwing_join_planning_tests": {
     "queries": [
       {

--- a/pinot-query-runtime/src/test/resources/queries/QueryHints.json
+++ b/pinot-query-runtime/src/test/resources/queries/QueryHints.json
@@ -126,6 +126,14 @@
         "sql": "SET stageParallelism=2; SELECT {tbl1}.name, SUM({tbl2}.num) FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ ON {tbl1}.num = {tbl2}.num GROUP BY {tbl1}.name"
       },
       {
+        "description": "Broadcast JOIN without partition hint",
+        "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+      },
+      {
+        "description": "Broadcast JOIN with partition hint",
+        "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+      },
+      {
         "description": "Colocated, Dynamic broadcast SEMI-JOIN with partition column",
         "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {tbl1}.num, {tbl1}.name FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ WHERE {tbl2}.val IN ('xxx', 'yyy'))"
       },


### PR DESCRIPTION
Add support for customizing distribution type with join hint.

Allowed distribution types:
- `LOCAL`
- `HASH`
- `BROADCAST`
- `RANDOM`

Added 2 new join hint:
- `left_distribution_type`
- `right_distribution_type`

To achieve broadcast join without shuffling left side:
```
SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col2 = 'foo' AND b.col2 = 'bar'
```

Related to #14518 