### PR TITLE
Fix NPE caused by MultiStageQueryThrottler

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -406,7 +406,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       clusterConfigChangeHandler.init(_spectatorHelixManager);
     }
     _clusterConfigChangeHandlers.add(_queryQuotaManager);
-    _clusterConfigChangeHandlers.add(_multiStageQueryThrottler);
+    if (_multiStageQueryThrottler != null) {
+      _clusterConfigChangeHandlers.add(_multiStageQueryThrottler);
+    }
     for (ClusterChangeHandler idealStateChangeHandler : _idealStateChangeHandlers) {
       idealStateChangeHandler.init(_spectatorHelixManager);
     }
@@ -416,7 +418,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     }
     _externalViewChangeHandlers.add(_routingManager);
     _externalViewChangeHandlers.add(_queryQuotaManager);
-    _externalViewChangeHandlers.add(_multiStageQueryThrottler);
+    if (_multiStageQueryThrottler != null) {
+      _externalViewChangeHandlers.add(_multiStageQueryThrottler);
+    }
     for (ClusterChangeHandler instanceConfigChangeHandler : _instanceConfigChangeHandlers) {
       instanceConfigChangeHandler.init(_spectatorHelixManager);
     }


### PR DESCRIPTION
This PR fixes the NPE which is caused by `MultiStageQueryThrottler` being null when multi-stage engine feature is disabled.

To be more specific, when the multi-stage engine is disabled, the `MultiStageQueryThrottler` reference will be null. This makes the `ClusterChangeMediator` fail to process cluster changes like cluster config changes and external view changes.

https://github.com/apache/pinot/blob/25fc74650532490a9684e18fa288743137f953bd/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java#L344

Sample error messages:
```
2025/01/09 19:43:44.610 ERROR [ClusterChangeMediator] [ClusterChangeHandlingThread] [pinot-broker] [] Caught exception within cluster change handling thread
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "changeHandler" is null
        at org.apache.pinot.broker.broker.helix.ClusterChangeMediator.processClusterChange(ClusterChangeMediator.java:134) ~[org.apache.pinot.pinot-broker-1.3.0-dev-1461.jar:...]
        at org.apache.pinot.broker.broker.helix.ClusterChangeMediator.lambda$new$0(ClusterChangeMediator.java:98) ~[org.apache.pinot.pinot-broker-1.3.0-dev-1461.jar:...]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```