### PR TITLE
Add serverStats to BrokerQueryEventListener

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -859,7 +859,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       // Log query and stats
       _queryLogger.log(
           new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, requesterIdentity, serverStats));
-
+      requestContext.setServerStatsMap(serverStats.getServerStatsMap());
       return brokerResponse;
     } finally {
       Tracing.ThreadAccountantOps.clear();
@@ -1898,13 +1898,22 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
    */
   public static class ServerStats {
     private String _serverStats;
+    private Map<String, Map<String, Integer>> _serverStatsMap;
 
     public String getServerStats() {
       return _serverStats;
     }
 
+    public Map getServerStatsMap() {
+      return _serverStatsMap;
+    }
+
     public void setServerStats(String serverStats) {
       _serverStats = serverStats;
+    }
+
+    public void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap) {
+      _serverStatsMap = serverStatsMap;
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -101,6 +101,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.DatabaseConflictException;
 import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.trace.ServerStatsInfo;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
@@ -1898,7 +1899,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
    */
   public static class ServerStats {
     private String _serverStats;
-    private Map<String, Map<String, Integer>> _serverStatsMap;
+    private Map<String, ServerStatsInfo> _serverStatsMap;
 
     public String getServerStats() {
       return _serverStats;
@@ -1912,7 +1913,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       _serverStats = serverStats;
     }
 
-    public void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap) {
+    public void setServerStatsMap(Map<String, ServerStatsInfo> serverStatsMap) {
       _serverStatsMap = serverStatsMap;
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -126,6 +126,7 @@ public class SingleConnectionBrokerRequestHandler extends BaseSingleStageBrokerR
         System.nanoTime() - scatterGatherStartTimeNs);
     // TODO Use scatterGatherStats as serverStats
     serverStats.setServerStats(asyncQueryResponse.getServerStats());
+    serverStats.setServerStatsMap(asyncQueryResponse.getServerStatsMap());
 
     int numServersQueried = finalResponses.size();
     long totalResponseSize = 0;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.datatable.DataTable;
@@ -143,6 +144,21 @@ public class AsyncQueryResponse implements QueryResponse {
       stringBuilder.append(';').append(entry.getKey().getShortName()).append('=').append(entry.getValue().toString());
     }
     return stringBuilder.toString();
+  }
+
+  @Override
+  public Map<String, Map<String, Integer>> getServerStatsMap() {
+    return _responseMap.entrySet().stream()
+        .collect(Collectors.toMap(
+            entry -> entry.getKey().getShortName(),
+            entry -> Map.of(
+                "SubmitDelayMs", entry.getValue().getSubmitDelayMs(),
+                "ResponseDelayMs", entry.getValue().getResponseDelayMs(),
+                "ResponseSize", entry.getValue().getResponseSize(),
+                "DeserializationTimeMs", entry.getValue().getDeserializationTimeMs(),
+                "RequestSentDelayMs", entry.getValue().getRequestSentDelayMs()
+            )
+        ));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.trace.ServerStatsInfo;
 
 
 /**
@@ -147,17 +148,16 @@ public class AsyncQueryResponse implements QueryResponse {
   }
 
   @Override
-  public Map<String, Map<String, Integer>> getServerStatsMap() {
+  public Map<String, ServerStatsInfo> getServerStatsMap() {
     return _responseMap.entrySet().stream()
         .collect(Collectors.toMap(
-            entry -> entry.getKey().getShortName(),
-            entry -> Map.of(
-                "SubmitDelayMs", entry.getValue().getSubmitDelayMs(),
-                "ResponseDelayMs", entry.getValue().getResponseDelayMs(),
-                "ResponseSize", entry.getValue().getResponseSize(),
-                "DeserializationTimeMs", entry.getValue().getDeserializationTimeMs(),
-                "RequestSentDelayMs", entry.getValue().getRequestSentDelayMs()
-            )
+            entry -> entry.getKey().getInstanceId(),
+            entry -> new ServerStatsInfo(
+                entry.getValue().getSubmitDelayMs(),
+                entry.getValue().getRequestSentDelayMs(),
+                entry.getValue().getResponseDelayMs(),
+                entry.getValue().getResponseSize(),
+                entry.getValue().getDeserializationTimeMs())
         ));
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.trace.ServerStatsInfo;
 
 
 /**
@@ -62,7 +63,7 @@ public interface QueryResponse {
    */
   String getServerStats();
 
-  Map<String, Map<String, Integer>> getServerStatsMap();
+  Map<String, ServerStatsInfo> getServerStatsMap();
 
   /**
    * Returns the time taken for the server to respond to the query.

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
@@ -62,6 +62,8 @@ public interface QueryResponse {
    */
   String getServerStats();
 
+  Map<String, Map<String, Integer>> getServerStatsMap();
+
   /**
    * Returns the time taken for the server to respond to the query.
    * @param serverRoutingInstance

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
@@ -81,7 +81,7 @@ public class DefaultRequestContext implements RequestScope {
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<String> _processingExceptions = new ArrayList<>();
   private Map<String, List<String>> _requestHttpHeaders = new HashMap<>();
-  private Map<String, Map<String, Integer>> _serverStatsMap = new HashMap<>();
+  private Map<String, ServerStatsInfo> _serverStatsMap = new HashMap<>();
 
   public DefaultRequestContext() {
   }
@@ -575,12 +575,12 @@ public class DefaultRequestContext implements RequestScope {
   }
 
   @Override
-  public Map<String, Map<String, Integer>> getServerStatsMap() {
+  public Map<String, ServerStatsInfo> getServerStatsMap() {
     return _serverStatsMap;
   }
 
   @Override
-  public void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap) {
+  public void setServerStatsMap(Map<String, ServerStatsInfo> serverStatsMap) {
     _serverStatsMap.putAll(serverStatsMap);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
@@ -81,6 +81,7 @@ public class DefaultRequestContext implements RequestScope {
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<String> _processingExceptions = new ArrayList<>();
   private Map<String, List<String>> _requestHttpHeaders = new HashMap<>();
+  private Map<String, Map<String, Integer>> _serverStatsMap = new HashMap<>();
 
   public DefaultRequestContext() {
   }
@@ -571,6 +572,16 @@ public class DefaultRequestContext implements RequestScope {
   @Override
   public void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders) {
     _requestHttpHeaders.putAll(requestHttpHeaders);
+  }
+
+  @Override
+  public Map<String, Map<String, Integer>> getServerStatsMap() {
+    return _serverStatsMap;
+  }
+
+  @Override
+  public void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap) {
+    _serverStatsMap.putAll(serverStatsMap);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -229,9 +229,9 @@ public interface RequestContext {
    */
   void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders);
 
-  Map<String, Map<String, Integer>> getServerStatsMap();
+  Map<String, ServerStatsInfo> getServerStatsMap();
 
-  void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap);
+  void setServerStatsMap(Map<String, ServerStatsInfo> serverStatsMap);
 
   enum FanoutType {
     OFFLINE, REALTIME, HYBRID

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -229,6 +229,10 @@ public interface RequestContext {
    */
   void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders);
 
+  Map<String, Map<String, Integer>> getServerStatsMap();
+
+  void setServerStatsMap(Map<String, Map<String, Integer>> serverStatsMap);
+
   enum FanoutType {
     OFFLINE, REALTIME, HYBRID
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/ServerStatsInfo.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/ServerStatsInfo.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.trace;
+
+public class ServerStatsInfo {
+    private final long _submitRequestTimeMs;
+    private final int _requestSentLatencyMs;
+    private final long _receiveDataTableTimeMs;
+    private final int _responseSize;
+    private final int _deserializationTimeMs;
+
+    public ServerStatsInfo(long submitRequestTimeMs, int requestSentLatencyMs,
+        long receiveDataTableTimeMs, int responseSize, int deserializationTimeMs) {
+      _submitRequestTimeMs = submitRequestTimeMs;
+      _requestSentLatencyMs = requestSentLatencyMs;
+      _receiveDataTableTimeMs = receiveDataTableTimeMs;
+      _responseSize = responseSize;
+      _deserializationTimeMs = deserializationTimeMs;
+    }
+
+    public long getSubmitRequestTimeMs() {
+      return _submitRequestTimeMs;
+    }
+
+    public int getRequestSentLatencyMs() {
+      return _requestSentLatencyMs;
+    }
+
+    public long getReceiveDataTableTimeMs() {
+      return _receiveDataTableTimeMs;
+    }
+
+    public int getResponseSize() {
+      return _responseSize;
+    }
+
+    public int getDeserializationTimeMs() {
+      return _deserializationTimeMs;
+    }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/trace/ServerStatsInfoTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/trace/ServerStatsInfoTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.trace;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ServerStatsInfoTest {
+  ServerStatsInfo _serverStatsInfo = new ServerStatsInfo(1, 2, 3, 4, 5);
+
+  @Test
+  public void testServerStatsInfoValues() {
+    assertEquals(1, _serverStatsInfo.getSubmitRequestTimeMs());
+    assertEquals(2, _serverStatsInfo.getRequestSentLatencyMs());
+    assertEquals(3, _serverStatsInfo.getReceiveDataTableTimeMs());
+    assertEquals(4, _serverStatsInfo.getResponseSize());
+    assertEquals(5, _serverStatsInfo.getDeserializationTimeMs());
+  }
+}


### PR DESCRIPTION
Adds server stats to BrokerQueryEventListener, which are published on query completion. 

### Tested locally:

![image](https://github.com/user-attachments/assets/4c046348-8aa7-4de5-a50e-02bd22b568db)

