### PR TITLE
[flaky-test] BrokerManagedAsyncExecutorProviderTest#testRejectHandler

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
@@ -50,12 +50,9 @@ public class BrokerManagedAsyncExecutorProviderTest {
 
   @BeforeClass
   public void setUp() {
-    _brokerMetrics = new BrokerMetrics(
-            CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
+    _brokerMetrics = new BrokerMetrics(CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
             PinotMetricUtils.getPinotMetricsRegistry(new PinotConfiguration()),
-            CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS,
-            Collections.emptyList()
-    );
+            CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS, Collections.emptyList());
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
@@ -51,8 +51,8 @@ public class BrokerManagedAsyncExecutorProviderTest {
   @BeforeClass
   public void setUp() {
     _brokerMetrics = new BrokerMetrics(CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
-            PinotMetricUtils.getPinotMetricsRegistry(new PinotConfiguration()),
-            CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS, Collections.emptyList());
+        PinotMetricUtils.getPinotMetricsRegistry(new PinotConfiguration()),
+        CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS, Collections.emptyList());
   }
 
   @Test


### PR DESCRIPTION
#14651 

It might be possible that the test executes all 10 tasks sequentially one after another. In this case, the test fails.

**The change:** `phaser::arriveAndAwaitAdvance` triggers a waisting for the `phaser.arriveAndDeregister();` call.
But by doing this I explicitly overflow the thread pool. 
