### PR TITLE
Skip task scheduling error entries while processing scheduled tasks

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -141,6 +141,8 @@ public class PinotTaskRestletResource {
 
   private static final String TASK_QUEUE_STATE_STOP = "STOP";
   private static final String TASK_QUEUE_STATE_RESUME = "RESUME";
+  public static final String GENERATION_ERRORS_KEY = "generationErrors";
+  public static final String SCHEDULING_ERRORS_KEY = "schedulingErrors";
 
   @Inject
   PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
@@ -667,8 +669,8 @@ public class PinotTaskRestletResource {
         schedulingErrors.addAll(value.getSchedulingErrors());
       });
     }
-    response.put("generationErrors", String.join(",", generationErrors));
-    response.put("schedulingErrors", String.join(",", schedulingErrors));
+    response.put(GENERATION_ERRORS_KEY, String.join(",", generationErrors));
+    response.put(SCHEDULING_ERRORS_KEY, String.join(",", schedulingErrors));
     return response;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -35,6 +35,7 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.minion.MinionClient;
 import org.apache.pinot.common.utils.tls.TlsUtils;
+import org.apache.pinot.controller.api.resources.PinotTaskRestletResource;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -308,6 +309,11 @@ public class BootstrapTableTool {
       try {
         boolean allCompleted = true;
         for (String taskType : scheduledTasks.keySet()) {
+          // ignore the error message entries
+          if (taskType.equals(PinotTaskRestletResource.GENERATION_ERRORS_KEY)
+              || taskType.equals(PinotTaskRestletResource.SCHEDULING_ERRORS_KEY)) {
+            continue;
+          }
           String taskName = scheduledTasks.get(taskType);
           String taskState = _minionClient.getTaskState(taskName);
           if (!COMPLETED.equalsIgnoreCase(taskState)) {


### PR DESCRIPTION
Fixes the issue flagged [here](https://github.com/apache/pinot/pull/14754#pullrequestreview-2559192477) 