### PR TITLE
Remove erroring compress option from src binary release 

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -96,9 +96,6 @@
                     <descriptor>${pinot.root}/pinot-distribution/pinot-source-assembly.xml</descriptor>
                   </descriptors>
                   <appendAssemblyId>false</appendAssemblyId>
-                  <archiverConfig>
-                    <compress>${archiver.compress}</compress>
-                  </archiverConfig>
                   <recompressZippedFiles>${archiver.recompressZippedFiles}</recompressZippedFiles>
                 </configuration>
               </execution>


### PR DESCRIPTION
While releasing the Pinot 1.3.0 source binary using the below command, I was getting an error that `compress` is not available for class TarGZipArchive
```bash
$ mvn install -DskipTests -Papache-release,bin-dist,src-dist -T1C
...
Cannot find 'compress' in class org.codehaus.plexus.archiver.tar.TarGZipArchiver
...
```
This is the minor change to fix the error. 