### PR TITLE
Rework MSE query throttling to take into account estimated number of threads used by a query

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
@@ -37,8 +37,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class helps limit the number of multi-stage queries being executed concurrently. Note that the cluster
- * configuration is a "per server" value and the broker currently simply assumes that a query will be across all
- * servers. Another assumption here is that queries are evenly distributed across brokers.
+ * configuration is a "per server" value and the broker currently computes the max server query threads as
+ * <em>CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS * numServers / numBrokers</em>. Note that the config value,
+ * number of servers, and number of brokers are all dynamically updated here.
+ * <p>
+ * Another assumption made here is that queries are evenly distributed across brokers.
+ * <p>
+ * This is designed to limit the number of multi-stage queries being concurrently executed across a cluster and is not
+ * intended to prevent individual large queries from being executed.
  */
 public class MultiStageQueryThrottler implements ClusterChangeHandler {
 
@@ -50,10 +56,10 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
   private int _numBrokers;
   private int _numServers;
   /**
-   * If _maxConcurrentQueries is <= 0, it means that the cluster is not configured to limit the number of multi-stage
+   * If _maxServerQueryThreads is <= 0, it means that the cluster is not configured to limit the number of multi-stage
    * queries that can be executed concurrently. In this case, we should not block the query.
    */
-  private int _maxConcurrentQueries;
+  private int _maxServerQueryThreads;
   private AdjustableSemaphore _semaphore;
 
   @Override
@@ -63,11 +69,11 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
     _helixConfigScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
         _helixManager.getClusterName()).build();
 
-    _maxConcurrentQueries = Integer.parseInt(
+    _maxServerQueryThreads = Integer.parseInt(
         _helixAdmin.getConfig(_helixConfigScope,
-                Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES))
-            .getOrDefault(CommonConstants.Helix.CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES,
-                CommonConstants.Helix.DEFAULT_MAX_CONCURRENT_MULTI_STAGE_QUERIES));
+                Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS))
+            .getOrDefault(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS,
+                CommonConstants.Helix.DEFAULT_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS));
 
     List<String> clusterInstances = _helixAdmin.getInstancesInCluster(_helixManager.getClusterName());
     _numBrokers = Math.max(1, (int) clusterInstances.stream()
@@ -77,36 +83,49 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
         .filter(instance -> instance.startsWith(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE))
         .count());
 
-    if (_maxConcurrentQueries > 0) {
-      _semaphore = new AdjustableSemaphore(Math.max(1, _maxConcurrentQueries * _numServers / _numBrokers), true);
+    if (_maxServerQueryThreads > 0) {
+      _semaphore = new AdjustableSemaphore(Math.max(1, _maxServerQueryThreads * _numServers / _numBrokers), true);
     }
   }
 
   /**
    * Returns true if the query can be executed (waiting until it can be executed if necessary), false otherwise.
    * <p>
-   * {@link #release()} should be called after the query is done executing. It is the responsibility of the caller to
-   * ensure that {@link #release()} is called exactly once for each call to this method.
+   * {@link #release(int)} should be called after the query is done executing. It is the responsibility of the caller to
+   * ensure that {@link #release(int)} is called exactly once for each call to this method.
    *
+   * @param numQueryThreads the estimated number of query server threads
    * @param timeout the maximum time to wait
    * @param unit the time unit of the timeout argument
+   *
    * @throws InterruptedException if the current thread is interrupted
+   * @throws RuntimeException if the query can never be dispatched due to the number of estimated query server threads
+   * being greater than the maximum number of server query threads calculated on the basis of
+   * <em>CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS * numServers / numBrokers</em>
    */
-  public boolean tryAcquire(long timeout, TimeUnit unit)
+  public boolean tryAcquire(int numQueryThreads, long timeout, TimeUnit unit)
       throws InterruptedException {
-    if (_maxConcurrentQueries <= 0) {
+    if (_maxServerQueryThreads <= 0) {
       return true;
     }
-    return _semaphore.tryAcquire(timeout, unit);
+
+    if (numQueryThreads > _semaphore.getTotalPermits()) {
+      throw new RuntimeException(
+          "Can't dispatch query because the estimated number of server threads for this query is too large for the "
+              + "configured value of '" + CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS
+              + "'. Consider increasing the value of this configuration");
+    }
+
+    return _semaphore.tryAcquire(numQueryThreads, timeout, unit);
   }
 
   /**
    * Should be called after the query is done executing. It is the responsibility of the caller to ensure that this
-   * method is called exactly once for each call to {@link #tryAcquire(long, TimeUnit)}.
+   * method is called exactly once for each call to {@link #tryAcquire(int, long, TimeUnit)}.
    */
-  public void release() {
-    if (_maxConcurrentQueries > 0) {
-      _semaphore.release();
+  public void release(int numQueryThreads) {
+    if (_maxServerQueryThreads > 0) {
+      _semaphore.release(numQueryThreads);
     }
   }
 
@@ -128,23 +147,22 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
       if (numBrokers != _numBrokers || numServers != _numServers) {
         _numBrokers = numBrokers;
         _numServers = numServers;
-        if (_maxConcurrentQueries > 0) {
-          _semaphore.setPermits(Math.max(1, _maxConcurrentQueries * _numServers / _numBrokers));
+        if (_maxServerQueryThreads > 0) {
+          _semaphore.setPermits(Math.max(1, _maxServerQueryThreads * _numServers / _numBrokers));
         }
       }
     } else {
-      int maxConcurrentQueries = Integer.parseInt(
-          _helixAdmin.getConfig(_helixConfigScope,
-                  Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES))
-              .getOrDefault(CommonConstants.Helix.CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES,
-                  CommonConstants.Helix.DEFAULT_MAX_CONCURRENT_MULTI_STAGE_QUERIES));
+      int maxServerQueryThreads = Integer.parseInt(_helixAdmin.getConfig(_helixConfigScope,
+              Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS))
+          .getOrDefault(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS,
+              CommonConstants.Helix.DEFAULT_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS));
 
-      if (_maxConcurrentQueries == maxConcurrentQueries) {
+      if (_maxServerQueryThreads == maxServerQueryThreads) {
         return;
       }
 
-      if (_maxConcurrentQueries <= 0 && maxConcurrentQueries > 0
-          || _maxConcurrentQueries > 0 && maxConcurrentQueries <= 0) {
+      if (_maxServerQueryThreads <= 0 && maxServerQueryThreads > 0
+          || _maxServerQueryThreads > 0 && maxServerQueryThreads <= 0) {
         // This operation isn't safe to do while queries are running so we require a restart of the broker for this
         // change to take effect.
         LOGGER.warn("Enabling or disabling limitation of the maximum number of multi-stage queries running "
@@ -152,10 +170,10 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
         return;
       }
 
-      if (maxConcurrentQueries > 0) {
-        _semaphore.setPermits(Math.max(1, maxConcurrentQueries * _numServers / _numBrokers));
+      if (maxServerQueryThreads > 0) {
+        _semaphore.setPermits(Math.max(1, maxServerQueryThreads * _numServers / _numBrokers));
       }
-      _maxConcurrentQueries = maxConcurrentQueries;
+      _maxServerQueryThreads = maxServerQueryThreads;
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -87,13 +87,13 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     startZk();
     startController();
 
-    // Set the max concurrent multi-stage queries to 5 for the cluster, so that we can test the query queueing logic
+    // Set the multi-stage max server query threads for the cluster, so that we can test the query queueing logic
     // in the MultiStageBrokerRequestHandler
     HelixConfigScope scope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
             .build();
-    _helixManager.getConfigAccessor().set(scope, CommonConstants.Helix.CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES,
-        "5");
+    _helixManager.getConfigAccessor()
+        .set(scope, CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10");
 
     startBroker();
     startServer();
@@ -717,7 +717,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
-  public void testVariadicFunction() throws Exception {
+  public void testVariadicFunction()
+      throws Exception {
     String sqlQuery = "SELECT ARRAY_TO_MV(VALUE_IN(RandomAirports, 'MFR', 'SUN', 'GTR')) as airport, count(*) "
         + "FROM mytable WHERE ARRAY_TO_MV(RandomAirports) IN ('MFR', 'SUN', 'GTR') GROUP BY airport";
     JsonNode jsonNode = postQuery(sqlQuery);
@@ -729,7 +730,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
 
   @Test(dataProvider = "polymorphicScalarComparisonFunctionsDataProvider")
   public void testPolymorphicScalarComparisonFunctions(String type, String literal, String lesserLiteral,
-      Object expectedValue) throws Exception {
+      Object expectedValue)
+      throws Exception {
 
     // Queries written this way will trigger the PinotEvaluateLiteralRule which will call the scalar comparison function
     // on the literals. Simpler queries like SELECT ... WHERE 'test' = 'test' will not trigger the optimization rule
@@ -770,7 +772,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
-  public void testPolymorphicScalarComparisonFunctionsDifferentType() throws Exception {
+  public void testPolymorphicScalarComparisonFunctionsDifferentType()
+      throws Exception {
     // Don't support comparison for literals with different types
     String sqlQueryPrefix = "WITH data as (SELECT 1 as \"foo\" FROM mytable) "
         + "SELECT * FROM data WHERE \"foo\" ";
@@ -816,8 +819,10 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     inputs.add(new Object[]{"FLOAT", "CAST(1.234 AS FLOAT)", "CAST(1.23 AS FLOAT)", "1.234"});
     inputs.add(new Object[]{"DOUBLE", "1.234", "1.23", "1.234"});
     inputs.add(new Object[]{"BOOLEAN", "CAST(true AS BOOLEAN)", "CAST(FALSE AS BOOLEAN)", "true"});
-    inputs.add(new Object[]{"TIMESTAMP", "CAST(1723593600000 AS TIMESTAMP)", "CAST (1623593600000 AS TIMESTAMP)",
-        new DateTime(1723593600000L, DateTimeZone.getDefault()).toString("yyyy-MM-dd HH:mm:ss.S")});
+    inputs.add(new Object[]{
+        "TIMESTAMP", "CAST(1723593600000 AS TIMESTAMP)", "CAST (1623593600000 AS TIMESTAMP)",
+        new DateTime(1723593600000L, DateTimeZone.getDefault()).toString("yyyy-MM-dd HH:mm:ss.S")
+    });
 
     return inputs.toArray(new Object[0][]);
   }
@@ -943,7 +948,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
-  public void testLiteralFilterReduce() throws Exception {
+  public void testLiteralFilterReduce()
+      throws Exception {
     String sqlQuery = "SELECT * FROM (SELECT CASE WHEN AirTime > 0 THEN 'positive' ELSE 'negative' END AS AirTime "
         + "FROM mytable) WHERE AirTime IN ('positive', 'negative')";
     JsonNode jsonNode = postQuery(sqlQuery);
@@ -1096,7 +1102,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
-  public void testMVNumericCastInFilter() throws Exception {
+  public void testMVNumericCastInFilter()
+      throws Exception {
     String sqlQuery = "SELECT COUNT(*) FROM mytable WHERE ARRAY_TO_MV(CAST(DivAirportIDs AS BIGINT ARRAY)) > 0";
     JsonNode jsonNode = postQuery(sqlQuery);
     assertNoError(jsonNode);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -242,9 +242,9 @@ public class CommonConstants {
     public static final boolean DEFAULT_MULTI_STAGE_ENGINE_TLS_ENABLED = false;
 
     // This is a "beta" config and can be changed or even removed in future releases.
-    public static final String CONFIG_OF_MAX_CONCURRENT_MULTI_STAGE_QUERIES =
-        "pinot.beta.multistage.engine.max.server.concurrent.queries";
-    public static final String DEFAULT_MAX_CONCURRENT_MULTI_STAGE_QUERIES = "-1";
+    public static final String CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS =
+        "pinot.beta.multistage.engine.max.server.query.threads";
+    public static final String DEFAULT_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS = "-1";
   }
 
   public static class Broker {


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/14574 introduced a mechanism to throttle multi-stage engine queries at the broker level using a new beta cluster config. The mechanism treated all queries as equivalent and assumed that queries were evenly distributed across brokers.
- This patch updates the mechanism to take into account the estimated number of threads that would be spawned in the servers for a query instead. The beta cluster config is also changed to reflect this. This is a better model since users no longer need to tweak the config based on their exact query workload and can instead use an estimated value based on the cluster size and instance sizes. Furthermore, mixed workloads will be better supported with larger queries potentially being blocked for longer while smaller queries are executed (query starvation and timeout is a possibility with this primitive model though).
- Note that prior to this change, there was actually an issue with the way the throttling threshold was determined - each broker calculated the threshold as `maxConcurrentQueries * numServers / numBrokers`. Since the max concurrent queries is a "per server" config, the calculation incorrectly makes the assumption that queries are executed on a single server (instead of assuming that they're dispatched to all servers which is a better assumption).
- With the change here to throttle based on the estimated number of threads, the throttling threshold becomes `maxServerQueryThreads * numServers / numBrokers` which only makes the assumption that queries are evenly distributed across brokers (and no assumptions about the fanout to servers). This feature isn't intended to completely prevent large queries from executing so the cluster config should be set to a value that is at least large enough to accommodate queries that can spawn up to `maxServerQueryThreads * numServers / numBrokers` number of threads.
- An alternate implementation could be to track the estimated number of threads on a per server basis (using the worker <-> server mapping in the query plan) but this has a lot more edge cases and also much higher overhead on large clusters with a large number of servers (since we'd need to acquire permits for many servers for every single query).