### PR TITLE
Fix configuration handling during MergeRollupTask execution

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -138,28 +138,6 @@ public class MergeTaskUtils {
   }
 
   /**
-   * Returns a map from column name to the aggregation function parameters associated with it based on the task config.
-   */
-  public static Map<String, Map<String, String>> getAggregationFunctionParameters(Map<String, String> taskConfig) {
-    Map<String, Map<String, String>> aggregationFunctionParameters = new HashMap<>();
-    String prefix = MergeTask.AGGREGATION_FUNCTION_PARAMETERS_PREFIX;
-
-    for (Map.Entry<String, String> entry : taskConfig.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      if (key.startsWith(prefix)) {
-        String[] parts = key.substring(prefix.length()).split("\\.", 2);
-        if (parts.length == 2) {
-          String metricColumn = parts[0];
-          String paramName = parts[1];
-          aggregationFunctionParameters.computeIfAbsent(metricColumn, k -> new HashMap<>()).put(paramName, value);
-        }
-      }
-    }
-    return aggregationFunctionParameters;
-  }
-
-  /**
    * Returns the segment config based on the task config.
    */
   public static SegmentConfig getSegmentConfig(Map<String, String> taskConfig) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -93,7 +93,7 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
 
     // Aggregation function parameters
     segmentProcessorConfigBuilder.setAggregationFunctionParameters(
-        MergeTaskUtils.getAggregationFunctionParameters(configs));
+        MergeRollupTaskUtils.getAggregationFunctionParameters(configs));
 
     // Segment config
     segmentProcessorConfigBuilder.setSegmentConfig(MergeTaskUtils.getSegmentConfig(configs));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -38,6 +38,7 @@ import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.plugin.minion.tasks.BaseMultipleSegmentsConversionExecutor;
 import org.apache.pinot.plugin.minion.tasks.MergeTaskUtils;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
+import org.apache.pinot.plugin.minion.tasks.mergerollup.MergeRollupTaskUtils;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -151,7 +152,7 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
 
     // Aggregation function parameters
     segmentProcessorConfigBuilder.setAggregationFunctionParameters(
-        MergeTaskUtils.getAggregationFunctionParameters(configs));
+        MergeRollupTaskUtils.getAggregationFunctionParameters(configs));
 
     // Segment config
     segmentProcessorConfigBuilder.setSegmentConfig(MergeTaskUtils.getSegmentConfig(configs));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
@@ -173,23 +173,6 @@ public class MergeTaskUtilsTest {
   }
 
   @Test
-  public void testGetAggregationFunctionParameters() {
-    Map<String, String> taskConfig = new HashMap<>();
-    taskConfig.put(MergeTask.AGGREGATION_FUNCTION_PARAMETERS_PREFIX + "metricColumnA.param1", "value1");
-    taskConfig.put(MergeTask.AGGREGATION_FUNCTION_PARAMETERS_PREFIX + "metricColumnA.param2", "value2");
-    taskConfig.put(MergeTask.AGGREGATION_FUNCTION_PARAMETERS_PREFIX + "metricColumnB.param1", "value3");
-    taskConfig.put("otherPrefix.metricColumnC.param1", "value1");
-    taskConfig.put("aggregationFunction.metricColumnD.param2", "value2");
-    Map<String, Map<String, String>> result = MergeTaskUtils.getAggregationFunctionParameters(taskConfig);
-    assertEquals(result.size(), 2);
-    assertTrue(result.containsKey("metricColumnA"));
-    assertTrue(result.containsKey("metricColumnB"));
-    assertEquals(result.get("metricColumnA").get("param1"), "value1");
-    assertEquals(result.get("metricColumnA").get("param2"), "value2");
-    assertEquals(result.get("metricColumnB").get("param1"), "value3");
-  }
-
-  @Test
   public void testGetSegmentConfig() {
     Map<String, String> taskConfig = new HashMap<>();
     taskConfig.put(MergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY, "10000");

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorTest.java
@@ -133,7 +133,7 @@ public class MergeRollupTaskExecutorTest {
     configs.put(MinionConstants.TABLE_NAME_KEY, "testTable_OFFLINE");
     configs.put(MinionConstants.MergeRollupTask.MERGE_LEVEL_KEY, "daily");
     configs.put(MinionConstants.MergeTask.MERGE_TYPE_KEY, "rollup");
-    configs.put(MinionConstants.MergeRollupTask.ERASE_DIMENSION_VALUES_KEY, D1);
+    configs.put("daily." + MinionConstants.MergeRollupTask.ERASE_DIMENSION_VALUES_KEY, D1);
 
     PinotTaskConfig pinotTaskConfig = new PinotTaskConfig(MinionConstants.MergeRollupTask.TASK_TYPE, configs);
     List<SegmentConversionResult> conversionResults =


### PR DESCRIPTION
Aggregation function parameters and dimensions to erase were being extracted directly from the task configuration without prepending the merge level key.

For example, the task config is encoded by the Task generator as follows:
```
   "hourly.keyA":  "some value",
   "hourly.keyB": "some other value",
   "mergeLevel": "hourly"
```
Any lookups on the configuration during task execution have to include the mergeLevel prefix in order to resolve lookups correctly.

There were three options in trying to address this bugfix:

1. Change the encoding of the task config - TaskGenerator would need to strip out the merge level prefix and thus make it easier for key extraction.  Problem is that this could break existing functionality.
2. Re-encode all keys without the prefix in the task config.  This would bloat the config.
3. Include the merge level prefix in any key lookups - this approach is followed in this PR.

This PR should be tagged with `bugfix`

