### PR TITLE
[pulsar] Added getTopics() implementation for Pulsar

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 public class PulsarConfig {
   public static final String STREAM_TYPE = "pulsar";
   public static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
+  public static final String SERVICE_HTTP_URL = "serviceHttpUrl";
   public static final String AUTHENTICATION_TOKEN = "authenticationToken";
   public static final String TLS_TRUST_CERTS_FILE_PATH = "tlsTrustCertsFilePath";
   public static final String OAUTH_ISSUER_URL = "issuerUrl";
@@ -53,6 +54,7 @@ public class PulsarConfig {
   private final String _subscriberId;
   private final String _pulsarTopicName;
   private final String _bootstrapServers;
+  private final String _serviceHttpUrl;
   private final SubscriptionInitialPosition _subscriptionInitialPosition;
   private final String _authenticationToken;
   private final String _tlsTrustCertsFilePath;
@@ -79,6 +81,7 @@ public class PulsarConfig {
     _bootstrapServers = getConfigValue(streamConfigMap, BOOTSTRAP_SERVERS);
     Preconditions.checkNotNull(_bootstrapServers, "No brokers provided in the config");
 
+    _serviceHttpUrl = getConfigValue(streamConfigMap, SERVICE_HTTP_URL);
     _subscriptionInitialPosition = PulsarUtils.offsetCriteriaToSubscription(streamConfig.getOffsetCriteria());
     _authenticationToken = getConfigValue(streamConfigMap, AUTHENTICATION_TOKEN);
     _tlsTrustCertsFilePath = getConfigValue(streamConfigMap, TLS_TRUST_CERTS_FILE_PATH);
@@ -147,6 +150,10 @@ public class PulsarConfig {
 
   public String getBootstrapServers() {
     return _bootstrapServers;
+  }
+
+  public String getServiceHttpUrl() {
+    return _serviceHttpUrl;
   }
 
   public SubscriptionInitialPosition getInitialSubscriberPosition() {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
@@ -176,5 +177,31 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
   public void close()
       throws IOException {
     super.close();
+  }
+
+  @Override
+  public List<TopicMetadata> getTopics() {
+    try {
+      return _pulsarAdmin.topics()
+          .getList(null)
+          .stream()
+          .map(topicName -> new PulsarTopicMetadata().setName(topicName))
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to list Pulsar topics", e);
+    }
+  }
+
+  public static class PulsarTopicMetadata implements TopicMetadata {
+    private String _name;
+
+    public String getName() {
+      return _name;
+    }
+
+    public PulsarTopicMetadata setName(String name) {
+      _name = name;
+      return this;
+    }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
@@ -35,6 +34,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.TransientConsumerException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -181,14 +181,25 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
 
   @Override
   public List<TopicMetadata> getTopics() {
-    try {
-      return _pulsarAdmin.topics()
-          .getList(null)
-          .stream()
-          .map(topicName -> new PulsarTopicMetadata().setName(topicName))
-          .collect(Collectors.toList());
+    try (PulsarAdmin pulsarAdmin = createPulsarAdmin()) {
+      // List to store all topics
+      List<TopicMetadata> allTopics = new ArrayList<>();
+
+      for (String tenant : pulsarAdmin.tenants().getTenants()) {
+        for (String namespace : pulsarAdmin.namespaces().getNamespaces(tenant)) {
+          // Fetch all topics for the namespace
+          List<String> topicNames = pulsarAdmin.topics().getList(namespace);
+
+          // Map topics to PulsarTopicMetadata and add to the list
+          topicNames.stream()
+              .map(topicName -> new PulsarTopicMetadata().setName(topicName))
+              .forEach(allTopics::add);
+        }
+      }
+
+      return allTopics;
     } catch (Exception e) {
-      throw new RuntimeException("Failed to list Pulsar topics", e);
+      throw new RuntimeException("Failed to list Pulsar topics across all tenants and namespaces", e);
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/test/java/org/apache/pinot/plugin/stream/pulsar/PulsarConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/test/java/org/apache/pinot/plugin/stream/pulsar/PulsarConsumerTest.java
@@ -25,12 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pinot.spi.stream.BytesStreamMessage;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Message;
@@ -153,6 +155,7 @@ public class PulsarConsumerTest {
     streamConfigMap.put("stream.pulsar.consumer.type", "simple");
     streamConfigMap.put("stream.pulsar.topic.name", topicName);
     streamConfigMap.put("stream.pulsar.bootstrap.servers", _pulsar.getPulsarBrokerUrl());
+    streamConfigMap.put("stream.pulsar.serviceHttpUrl", _pulsar.getHttpServiceUrl());
     streamConfigMap.put("stream.pulsar.consumer.prop.auto.offset.reset", "smallest");
     streamConfigMap.put("stream.pulsar.consumer.factory.class.name", PulsarConsumerFactory.class.getName());
     streamConfigMap.put("stream.pulsar.decoder.class.name", "dummy");
@@ -205,6 +208,19 @@ public class PulsarConsumerTest {
         // Start from middle
         testConsumer(consumer, 500, messageIds);
       }
+    }
+  }
+
+  @Test
+  public void testGetTopics() 
+      throws Exception {
+    try (PulsarStreamMetadataProvider metadataProvider = new PulsarStreamMetadataProvider(CLIENT_ID,
+        getStreamConfig("NON_EXISTING_TOPIC"))) {
+      List<StreamMetadataProvider.TopicMetadata> topics = metadataProvider.getTopics();
+      List<String> topicNames = topics.stream()
+          .map(StreamMetadataProvider.TopicMetadata::getName)
+          .collect(Collectors.toList());
+      assertTrue(topicNames.size() == 4);
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/test/java/org/apache/pinot/plugin/stream/pulsar/PulsarConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/test/java/org/apache/pinot/plugin/stream/pulsar/PulsarConsumerTest.java
@@ -212,8 +212,7 @@ public class PulsarConsumerTest {
   }
 
   @Test
-  public void testGetTopics() 
-      throws Exception {
+  public void testGetTopics() throws Exception {
     try (PulsarStreamMetadataProvider metadataProvider = new PulsarStreamMetadataProvider(CLIENT_ID,
         getStreamConfig("NON_EXISTING_TOPIC"))) {
       List<StreamMetadataProvider.TopicMetadata> topics = metadataProvider.getTopics();


### PR DESCRIPTION
Adds serviceHttpUrl config and topic listing capability to Pulsar stream ingestion

### Key Changes
- Added new `serviceHttpUrl` configuration parameter for PulsarConfig that is only used by pulsar admin client. This config is only used when creating the admin client. This maintains backward compatibility.
- Implemented `getTopics()` method in PulsarStreamMetadataProvider to list all topics across tenants and namespaces
- Created PulsarAdmin client functionality to enable topic listing operations

### Refactoring
- Extracted authentication configuration logic into separate methods
- Improved error handling in client creation and cleanup
- Enhanced code organization in PulsarPartitionLevelConnectionHandler

### Testing
- Added new test case `testGetTopics()` to verify topic listing functionality
- Updated existing tests to include serviceHttpUrl configuration
- Verified topic listing across multiple tenants and namespaces