### PR TITLE
Fix application qps quota stalls.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
@@ -825,6 +825,7 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
         quota.setNumOnlineBrokers(onlineBrokerCount);
       }
       if (quota.getOverallRate() >= MIN_APP_QUOTA) {
+        // number of permits must be positive but dividing by broker's count can result in 0
         double qpsQuota = Math.max(quota.getOverallRate() / onlineBrokerCount, MIN_APP_QUOTA);
         quota.setRateLimiter(RateLimiter.create(qpsQuota));
       }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -338,7 +338,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
   }
 
   @Test
-  public void tesCreateAndUpdateAppRateLimiterChangesRateLimiterMap() {
+  public void testCreateAndUpdateAppRateLimiterChangesRateLimiterMap() {
     Map<String, Double> apps = new HashMap<>();
     apps.put("app1", null);
     apps.put("app2", 1d);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotApplicationQuotaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotApplicationQuotaRestletResource.java
@@ -71,7 +71,7 @@ public class PinotApplicationQuotaRestletResource {
   PinotHelixResourceManager _pinotHelixResourceManager;
 
   /**
-   * API to get application quota configs. Will return null if application quotas are not defined
+   * API to get application quota configs. Will return empty map if application quotas are not defined at all.
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
@@ -88,7 +88,7 @@ public class PinotApplicationQuotaRestletResource {
   }
 
   /**
-   * API to get application quota configs. Will return null if application quotas are not defined
+   * API to get application quota config. Will return null if application quotas is not defined.
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
@@ -104,15 +104,16 @@ public class PinotApplicationQuotaRestletResource {
 
     HelixConfigScope scope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
         _pinotHelixResourceManager.getHelixClusterName()).build();
+
     HelixAdmin helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
     String defaultQuota =
         helixAdmin.getConfig(scope, Collections.singletonList(CommonConstants.Helix.APPLICATION_MAX_QUERIES_PER_SECOND))
-            .getOrDefault(CommonConstants.Helix.APPLICATION_MAX_QUERIES_PER_SECOND, null);
+            .get(CommonConstants.Helix.APPLICATION_MAX_QUERIES_PER_SECOND);
     return defaultQuota != null ? Double.parseDouble(defaultQuota) : null;
   }
 
   /**
-   * API to update the quota configs for application
+   * API to update the quota config for application.
    */
   @POST
   @Produces(MediaType.APPLICATION_JSON)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotApplicationQuotaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotApplicationQuotaRestletResource.java
@@ -102,8 +102,9 @@ public class PinotApplicationQuotaRestletResource {
       return quotas.get(appName);
     }
 
-    HelixConfigScope scope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
-        _pinotHelixResourceManager.getHelixClusterName()).build();
+    HelixConfigScope scope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
+        .forCluster(_pinotHelixResourceManager.getHelixClusterName())
+        .build();
 
     HelixAdmin helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
     String defaultQuota =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryQuotaClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryQuotaClusterIntegrationTest.java
@@ -319,7 +319,7 @@ public class QueryQuotaClusterIntegrationTest extends BaseClusterIntegrationTest
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
-      }, 5000, "Failed to reflect query quota on rate limiter in 5s.");
+      }, 10000, "Failed to reflect query quota on rate limiter in 5s.");
     } catch (AssertionError ae) {
       throw new AssertionError(
           ae.getMessage() + " Expected quota:" + quotaQps + " but is: " + _quota + " set on: " + _quotaSource, ae);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryQuotaClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryQuotaClusterIntegrationTest.java
@@ -319,7 +319,7 @@ public class QueryQuotaClusterIntegrationTest extends BaseClusterIntegrationTest
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
-      }, 10000, "Failed to reflect query quota on rate limiter in 5s.");
+      }, 5000, "Failed to reflect query quota on rate limiter in 5s.");
     } catch (AssertionError ae) {
       throw new AssertionError(
           ae.getMessage() + " Expected quota:" + quotaQps + " but is: " + _quota + " set on: " + _quotaSource, ae);


### PR DESCRIPTION
PR fixes https://github.com/apache/pinot/issues/14852. 
It removes slow & locking ZK queries from the hot path (query execution) and depends on background messaging to keep quotas in sync. 
It changes application quota logic slightly so that non-positive quota values mean that quota is disabled and can be acquired anytime.

While checking the logic I also found that:
- quota values between (0.0, 1) should make it impossible to acquire quota and effectively block queries with given application name
- similar thing can happen when quota value is higher than 1 but smaller than number of online brokers . That's because quota is evenly split between online brokers. 