### PR TITLE
Add support for copy file with subdirectories for ADLSGen2PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -482,12 +482,7 @@ public class ADLSGen2PinotFS extends BasePinotFS {
     LOGGER.debug("copyToLocalFile is called with srcUri='{}', dstFile='{}'", srcUri, dstFile);
 
     // Create parent directories if they don't exist.
-    File parent = dstFile.getParentFile();
-    if (parent != null && !parent.exists()) {
-      if (!parent.mkdirs()) {
-        throw new IOException("Failed to create parent directories for: " + dstFile);
-      }
-    }
+    FileUtils.forceMkdir(dstFile.getParentFile());
 
     if (dstFile.exists()) {
       if (dstFile.isDirectory()) {

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -480,6 +480,15 @@ public class ADLSGen2PinotFS extends BasePinotFS {
   public void copyToLocalFile(URI srcUri, File dstFile)
       throws Exception {
     LOGGER.debug("copyToLocalFile is called with srcUri='{}', dstFile='{}'", srcUri, dstFile);
+
+    // Create parent directories if they don't exist.
+    File parent = dstFile.getParentFile();
+    if (parent != null && !parent.exists()) {
+      if (!parent.mkdirs()) {
+        throw new IOException("Failed to create parent directories for: " + dstFile);
+      }
+    }
+
     if (dstFile.exists()) {
       if (dstFile.isDirectory()) {
         FileUtils.deleteDirectory(dstFile);


### PR DESCRIPTION
## Issue

Currently if the source has a file buried under multiple subdirectories, then the `copyToLocalFile` method fails because it does not recreate the parent directories locally.

## Fix

Create the parent directories for the file locally if they exist.