### PR TITLE
safe copy in local pinot fs

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -214,7 +214,7 @@ public class LocalPinotFS extends BasePinotFS {
         if (recursive) {
           FileUtils.copyDirectory(srcFile, tmpFile);
         } else {
-          throw new LocalPinotFSException(
+          throw new IOException(
               srcFile.getAbsolutePath() + " is a directory and recursive copy is not enabled.");
         }
       } else {
@@ -224,23 +224,21 @@ public class LocalPinotFS extends BasePinotFS {
       // Step 3: Verify CRC of the temporary file
       long tmpCrc = calculateCrc(tmpFile);
       if (srcCrc != tmpCrc) {
-        throw new LocalPinotFSException("CRC mismatch: source and temporary files are not identical.");
+        throw new IOException("CRC mismatch: source and temporary files are not identical.");
       }
 
       if (dstFile.exists() && !dstFile.renameTo(backupFile)) {
-        throw new LocalPinotFSException("Failed to rename destination file to backup file.");
+        throw new IOException("Failed to rename destination file to backup file.");
       }
 
       // Step 4: Rename the temporary file to the destination file
       if (!tmpFile.renameTo(dstFile)) {
-        throw new LocalPinotFSException("Failed to rename temporary file to destination file.");
+        throw new IOException("Failed to rename temporary file to destination file.");
       }
       FileUtils.deleteQuietly(backupFile);
-    } catch (IOException e) {
+    } catch (Exception e) {
       // Cleanup the temporary file in case of errors
-      if (tmpFile.exists() && !FileUtils.deleteQuietly(tmpFile)) {
-        throw new LocalPinotFSException("Failed to clean up temporary file after failed copy." + e.getMessage());
-      }
+      FileUtils.deleteQuietly(tmpFile);
       throw new LocalPinotFSException(e);
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -265,10 +265,6 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   public static class LocalPinotFSException extends IOException {
-    LocalPinotFSException(String message) {
-      super("LocalPinotFS: " + message);
-    }
-
     LocalPinotFSException(Throwable e) {
       super(e);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -206,7 +206,7 @@ public class LocalPinotFS extends BasePinotFS {
 
     // Create a temporary file in the same directory as dstFile
     File tmpFile = new File(dstFile.getParent(), dstFile.getName() + TMP);
-    File backupFile = new File(dstFile.getParent(), dstFile.getName() + BACKUP);
+    File backupFile = new File(dstFile.getParent(), dstFile.getName() + BACKUP + System.currentTimeMillis());
 
     try {
       // Step 2: Copy the file or directory into the temporary file
@@ -238,6 +238,7 @@ public class LocalPinotFS extends BasePinotFS {
       FileUtils.deleteQuietly(backupFile);
     } catch (Exception e) {
       // Cleanup the temporary file in case of errors
+      // intentionally not deleting the backup file if anything goes wrong
       FileUtils.deleteQuietly(tmpFile);
       throw new LocalPinotFSException(e);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -45,6 +45,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class LocalPinotFS extends BasePinotFS {
 
+  public static final String BACKUP = ".backup";
+
   @Override
   public void init(PinotConfiguration configuration) {
   }
@@ -201,7 +203,7 @@ public class LocalPinotFS extends BasePinotFS {
 
     if (oldFileExists) {
       // Step 2: Rename destination file if it exists
-      File backupFile = new File(dstFile.getAbsolutePath() + ".backup");
+      File backupFile = new File(dstFile.getAbsolutePath() + BACKUP);
       if (!dstFile.renameTo(backupFile)) {
         throw new IOException("Failed to rename destination file to backup.");
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -245,6 +245,8 @@ public class LocalPinotFS extends BasePinotFS {
       throw e;
     }
 
+    // We do not put this in finally block because we want the backup file to remain in the disk
+    // if anything goes south before this point
     if (oldFileExists) {
       // Step 5: Delete old file if CRC matches
       if (!FileUtils.deleteQuietly(backupFile)) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -210,7 +210,7 @@ public class LocalPinotFS extends BasePinotFS {
       // Step 2: Rename destination file if it exists
       backupFile = new File(dstFile.getAbsolutePath() + BACKUP + System.currentTimeMillis());
       if (!dstFile.renameTo(backupFile)) {
-        throw new LocalPinotFSException("LocalPinotFS: Failed to rename destination file to backup.");
+        throw new LocalPinotFSException("Failed to rename destination file to backup.");
       }
     }
 
@@ -232,14 +232,14 @@ public class LocalPinotFS extends BasePinotFS {
       long dstCrc = calculateCrc(dstFile);
       if (srcCrc != dstCrc) {
 
-        throw new LocalPinotFSException("LocalPinotFS: CRC mismatch: source and destination files are not identical.");
+        throw new LocalPinotFSException("CRC mismatch: source and destination files are not identical.");
       }
     } catch (IOException e) {
       // Restore destination file from backup if copy fails
       if (oldFileExists) {
         if (!dstFile.delete() || !backupFile.renameTo(dstFile)) {
           throw new LocalPinotFSException(
-              "LocalPinotFS: Failed to restore destination file from backup after failed copy.");
+              "Failed to restore destination file from backup after failed copy.");
         }
       } else {
         dstFile.delete();
@@ -279,7 +279,7 @@ public class LocalPinotFS extends BasePinotFS {
 
   public static class LocalPinotFSException extends IOException {
     LocalPinotFSException(String message) {
-      super(message);
+      super("LocalPinotFS: " + message);
     }
 
     LocalPinotFSException(Throwable e) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -51,13 +51,15 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean mkdir(URI uri) throws IOException {
+  public boolean mkdir(URI uri)
+      throws IOException {
     FileUtils.forceMkdir(toFile(uri));
     return true;
   }
 
   @Override
-  public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
+  public boolean delete(URI segmentUri, boolean forceDelete)
+      throws IOException {
     File file = toFile(segmentUri);
     if (file.isDirectory()) {
       // Returns false if directory isn't empty
@@ -74,7 +76,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean doMove(URI srcUri, URI dstUri) throws IOException {
+  public boolean doMove(URI srcUri, URI dstUri)
+      throws IOException {
     File srcFile = toFile(srcUri);
     File dstFile = toFile(dstUri);
     if (srcFile.isDirectory()) {
@@ -86,7 +89,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean copyDir(URI srcUri, URI dstUri) throws IOException {
+  public boolean copyDir(URI srcUri, URI dstUri)
+      throws IOException {
     copy(toFile(srcUri), toFile(dstUri), true);
     return true;
   }
@@ -106,7 +110,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
+  public String[] listFiles(URI fileUri, boolean recursive)
+      throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
@@ -118,7 +123,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive) throws IOException {
+  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
+      throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> getFileMetadata(new File(file, s))).collect(Collectors.toList());
@@ -140,17 +146,20 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
+  public void copyToLocalFile(URI srcUri, File dstFile)
+      throws Exception {
     copy(toFile(srcUri), dstFile, false);
   }
 
   @Override
-  public void copyFromLocalFile(File srcFile, URI dstUri) throws Exception {
+  public void copyFromLocalFile(File srcFile, URI dstUri)
+      throws Exception {
     copy(srcFile, toFile(dstUri), false);
   }
 
   @Override
-  public void copyFromLocalDir(File srcFile, URI dstUri) throws Exception {
+  public void copyFromLocalDir(File srcFile, URI dstUri)
+      throws Exception {
     if (!srcFile.isDirectory()) {
       throw new IllegalArgumentException(srcFile.getAbsolutePath() + " is not a directory");
     }
@@ -168,7 +177,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean touch(URI uri) throws IOException {
+  public boolean touch(URI uri)
+      throws IOException {
     File file = toFile(uri);
     if (!file.exists()) {
       return file.createNewFile();
@@ -177,7 +187,8 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public InputStream open(URI uri) throws IOException {
+  public InputStream open(URI uri)
+      throws IOException {
     return new BufferedInputStream(new FileInputStream(toFile(uri)));
   }
 
@@ -187,7 +198,8 @@ public class LocalPinotFS extends BasePinotFS {
     return new File(URLDecoder.decode(uri.getRawPath(), StandardCharsets.UTF_8));
   }
 
-  private static void copy(File srcFile, File dstFile, boolean recursive) throws IOException {
+  private static void copy(File srcFile, File dstFile, boolean recursive)
+      throws IOException {
     boolean oldFileExists = dstFile.exists(); // Automatically set oldFileExists if the old file exists
 
     // Step 1: Calculate CRC of srcFile/directory
@@ -241,7 +253,8 @@ public class LocalPinotFS extends BasePinotFS {
     }
   }
 
-  private static long calculateCrc(File file) throws IOException {
+  private static long calculateCrc(File file)
+      throws IOException {
     CRC32 crc = new CRC32();
     if (file.isDirectory()) {
       for (File subFile : FileUtils.listFiles(file, null, true)) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
-import java.util.zip.CheckedInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -52,15 +51,13 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean mkdir(URI uri)
-      throws IOException {
+  public boolean mkdir(URI uri) throws IOException {
     FileUtils.forceMkdir(toFile(uri));
     return true;
   }
 
   @Override
-  public boolean delete(URI segmentUri, boolean forceDelete)
-      throws IOException {
+  public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
     File file = toFile(segmentUri);
     if (file.isDirectory()) {
       // Returns false if directory isn't empty
@@ -77,8 +74,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean doMove(URI srcUri, URI dstUri)
-      throws IOException {
+  public boolean doMove(URI srcUri, URI dstUri) throws IOException {
     File srcFile = toFile(srcUri);
     File dstFile = toFile(dstUri);
     if (srcFile.isDirectory()) {
@@ -90,8 +86,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean copyDir(URI srcUri, URI dstUri)
-      throws IOException {
+  public boolean copyDir(URI srcUri, URI dstUri) throws IOException {
     copy(toFile(srcUri), toFile(dstUri), true);
     return true;
   }
@@ -111,8 +106,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public String[] listFiles(URI fileUri, boolean recursive)
-      throws IOException {
+  public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
@@ -124,39 +118,39 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
-      throws IOException {
+  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive) throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
       return Arrays.stream(file.list()).map(s -> getFileMetadata(new File(file, s))).collect(Collectors.toList());
     } else {
       try (Stream<Path> pathStream = Files.walk(Paths.get(fileUri))) {
-        return pathStream.filter(s -> !s.equals(file.toPath())).map(p -> getFileMetadata(p.toFile()))
+        return pathStream.filter(s -> !s.equals(file.toPath()))
+            .map(p -> getFileMetadata(p.toFile()))
             .collect(Collectors.toList());
       }
     }
   }
 
   private static FileMetadata getFileMetadata(File file) {
-    return new FileMetadata.Builder().setFilePath(file.getAbsolutePath()).setLastModifiedTime(file.lastModified())
-        .setLength(file.length()).setIsDirectory(file.isDirectory()).build();
+    return new FileMetadata.Builder().setFilePath(file.getAbsolutePath())
+        .setLastModifiedTime(file.lastModified())
+        .setLength(file.length())
+        .setIsDirectory(file.isDirectory())
+        .build();
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, File dstFile)
-      throws Exception {
+  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
     copy(toFile(srcUri), dstFile, false);
   }
 
   @Override
-  public void copyFromLocalFile(File srcFile, URI dstUri)
-      throws Exception {
+  public void copyFromLocalFile(File srcFile, URI dstUri) throws Exception {
     copy(srcFile, toFile(dstUri), false);
   }
 
   @Override
-  public void copyFromLocalDir(File srcFile, URI dstUri)
-      throws Exception {
+  public void copyFromLocalDir(File srcFile, URI dstUri) throws Exception {
     if (!srcFile.isDirectory()) {
       throw new IllegalArgumentException(srcFile.getAbsolutePath() + " is not a directory");
     }
@@ -174,8 +168,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean touch(URI uri)
-      throws IOException {
+  public boolean touch(URI uri) throws IOException {
     File file = toFile(uri);
     if (!file.exists()) {
       return file.createNewFile();
@@ -184,8 +177,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public InputStream open(URI uri)
-      throws IOException {
+  public InputStream open(URI uri) throws IOException {
     return new BufferedInputStream(new FileInputStream(toFile(uri)));
   }
 
@@ -235,8 +227,7 @@ public class LocalPinotFS extends BasePinotFS {
         if (!dstFile.delete() || !backupFile.renameTo(dstFile)) {
           throw new IOException("Failed to restore destination file from backup after failed copy.");
         }
-      }
-      else {
+      } else {
         dstFile.delete();
       }
       throw e;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -208,7 +208,7 @@ public class LocalPinotFS extends BasePinotFS {
 
     if (oldFileExists) {
       // Step 2: Rename destination file if it exists
-      backupFile = new File(dstFile.getAbsolutePath() + BACKUP);
+      backupFile = new File(dstFile.getAbsolutePath() + BACKUP + System.currentTimeMillis());
       if (!dstFile.renameTo(backupFile)) {
         throw new IOException("Failed to rename destination file to backup.");
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -29,8 +29,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
@@ -203,7 +206,12 @@ public class LocalPinotFS extends BasePinotFS {
 
     // Create a temporary file in the same directory as dstFile
     File tmpFile = new File(dstFile.getParent(), dstFile.getName() + TMP);
-    File backupFile = new File(dstFile.getParent(), dstFile.getName() + BACKUP + System.currentTimeMillis());
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss.SSS");
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC")); // Set time zone to UTC
+    File backupFile = new File(
+        dstFile.getParent(),
+        dstFile.getName() + BACKUP + "_" + sdf.format(new Date())
+    );
 
     try {
       // Step 1: Copy the file or directory into the temporary file

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.CRC32;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -200,10 +200,11 @@ public class LocalPinotFS extends BasePinotFS {
 
     // Step 1: Calculate CRC of srcFile/directory
     long srcCrc = calculateCrc(srcFile);
+    File backupFile = null;
 
     if (oldFileExists) {
       // Step 2: Rename destination file if it exists
-      File backupFile = new File(dstFile.getAbsolutePath() + BACKUP);
+      backupFile = new File(dstFile.getAbsolutePath() + BACKUP);
       if (!dstFile.renameTo(backupFile)) {
         throw new IOException("Failed to rename destination file to backup.");
       }
@@ -228,7 +229,7 @@ public class LocalPinotFS extends BasePinotFS {
 
     if (oldFileExists) {
       // Step 5: Delete old file if CRC matches
-      if (!FileUtils.deleteQuietly(srcFile)) {
+      if (!FileUtils.deleteQuietly(backupFile)) {
         throw new IOException("Failed to delete source file after successful copy.");
       }
     }


### PR DESCRIPTION
Fix the issue described in https://github.com/apache/pinot/issues/14869

~This code introduces some overhead, mainly in calculating CRC 32 for the files.~

copy the src file into a temp file in the same folder as the dst file
rename dst file in deep store (iff the old file exists) to a backup file
rename the temp file to the dst file
delete the backup file (iff the old file exists)

update Jan 23:
did more analysis the crc would not work on our largest data set, the data is too much for the controller to handle