### PR TITLE
Added the anonymous credentials provider to S3PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -79,6 +79,7 @@ public class S3Config {
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_TIME_TO_LIVE = "connectionTimeToLive";
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_ACQUISITION_TIMEOUT = "connectionAcquisitionTimeout";
   private static final String CROSS_REGION_ACCESS_ENABLED = "crossRegionAccessEnabled";
+  public static final String ANONYMOUS_CREDENTIALS_PROVIDER = "anonymousCredentialsProvider";
 
   private final String _accessKey;
   private final String _secretKey;
@@ -101,6 +102,7 @@ public class S3Config {
   private final long _multiPartUploadPartSize;
   private final ApacheHttpClient.Builder _httpClientBuilder;
   private final boolean _enableCrossRegionAccess;
+  private final boolean _anonymousCredentialsProvider;
 
   public S3Config(PinotConfiguration pinotConfig) {
     _disableAcl = pinotConfig.getProperty(DISABLE_ACL_CONFIG_KEY, DEFAULT_DISABLE_ACL);
@@ -108,6 +110,8 @@ public class S3Config {
     _secretKey = pinotConfig.getProperty(SECRET_KEY);
     _region = pinotConfig.getProperty(REGION);
     _endpoint = pinotConfig.getProperty(ENDPOINT);
+    _anonymousCredentialsProvider = Boolean.parseBoolean(
+        pinotConfig.getProperty(ANONYMOUS_CREDENTIALS_PROVIDER, "false"));
 
     _storageClass = pinotConfig.getProperty(STORAGE_CLASS);
     if (_storageClass != null) {
@@ -274,5 +278,9 @@ public class S3Config {
 
   public boolean isCrossRegionAccessEnabled() {
     return _enableCrossRegionAccess;
+  }
+
+  public boolean isAnonymousCredentialsProvider() {
+    return _anonymousCredentialsProvider;
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.apache.pinot.spi.filesystem.FileMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -120,6 +121,8 @@ public class S3PinotFS extends BasePinotFS {
         AwsBasicCredentials awsBasicCredentials =
             AwsBasicCredentials.create(s3Config.getAccessKey(), s3Config.getSecretKey());
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
+      } else if (s3Config.isAnonymousCredentialsProvider()) {
+        awsCredentialsProvider = AnonymousCredentialsProvider.create();
       } else {
         awsCredentialsProvider = DefaultCredentialsProvider.builder().build();
       }


### PR DESCRIPTION
The anonymous credentials provider is useful to ingest from public buckets for test and demo purposes.

## Testing
Tested locally with the following sample job spec.

```
executionFrameworkSpec:
    name: 'standalone'
    segmentGenerationJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentGenerationJobRunner'
    segmentTarPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentTarPushJobRunner'
    segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
    segmentMetadataPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner'
jobType: SegmentCreationAndTarPush 
inputDirURI: 's3://my.public.bucket/'
outputDirURI: '/path/to/output/dir'
overwriteOutput: true
pinotFSSpecs:
    - scheme: s3
      className: org.apache.pinot.plugin.filesystem.S3PinotFS
      configs:
        region: 'us-west-2'
        anonymousCredentialsProvider: true
recordReaderSpec:
    dataFormat: 'csv'
    className: 'org.apache.pinot.plugin.inputformat.csv.CSVRecordReader'
    configClassName: 'org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig'
tableSpec:
    tableName: 'myTable'
    tableConfigURI: 'http://localhost:9000/tables/myTable'
pinotClusterSpecs:
    - controllerURI: 'http://localhost:9000'
pushJobSpec:
  pushAttempts: 2
  pushRetryIntervalMillis: 1000
```