### PR TITLE
Support local replicated join and local exchange parallelism

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.routing;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -54,6 +55,13 @@ public interface RoutingManager {
    */
   @Nullable
   RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId);
+
+  /**
+   * Returns the segments that are relevant for the given broker request. Returns {@code null} if the table does not
+   * exist.
+   */
+  @Nullable
+  List<String> getSegments(BrokerRequest brokerRequest);
 
   /**
    * Validate routing exist for a table

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -173,26 +173,37 @@ public class PinotHintOptions {
   }
 
   public static class TableHintOptions {
+
     /**
      * Indicates the key to partition the table by.
      * This must be equal to the keyset in {@code tableIndexConfig.segmentPartitionConfig.columnPartitionMap}.
      */
     public static final String PARTITION_KEY = "partition_key";
+
     /**
      * The function to use to partition the table.
      * This must be equal to {@code functionName} in {@code tableIndexConfig.segmentPartitionConfig.columnPartitionMap}.
      */
     public static final String PARTITION_FUNCTION = "partition_function";
+
     /**
      * The size of each partition.
      * This must be equal to {@code numPartition} in {@code tableIndexConfig.segmentPartitionConfig.columnPartitionMap}.
      */
     public static final String PARTITION_SIZE = "partition_size";
+
     /**
      * The number of workers per partition.
      * How many threads to use in the following stage after partition is joined.
      * When partition info is set, each partition is processed as a separate query in the leaf stage.
+     * When partition info is not set, we count all data processed in the leaf stage as the same partition.
      */
     public static final String PARTITION_PARALLELISM = "partition_parallelism";
+
+    /**
+     * Indicates whether the table is replicated across all workers. When table is replicated across all workers, we can
+     * execute the same query on all workers to achieve broadcast without network shuffle.
+     */
+    public static final String IS_REPLICATED = "is_replicated";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -102,7 +102,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       List<Integer> keys, RelNode child) {
     switch (distributionType) {
       case LOCAL:
-        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON);
+        // NOTE: We use SINGLETON to represent local distribution. Add keys to the exchange because we might want to
+        //       switch it to HASH distribution to increase parallelism. See MailboxAssignmentVisitor for details.
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys);
       case HASH:
         Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
         return PinotLogicalExchange.create(child, RelDistributions.hash(keys));
@@ -117,7 +119,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       List<Integer> keys, RelNode child) {
     switch (distributionType) {
       case LOCAL:
-        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON);
+        // NOTE: We use SINGLETON to represent local distribution. Add keys to the exchange because we might want to
+        //       switch it to HASH distribution to increase parallelism. See MailboxAssignmentVisitor for details.
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys);
       case HASH:
         Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
         return PinotLogicalExchange.create(child, RelDistributions.hash(keys));

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -147,34 +147,38 @@ public final class RelToPlanNodeConverter {
   }
 
   private ExchangeNode convertLogicalExchange(Exchange node) {
+    RelDistribution distribution = node.getDistribution();
+    RelDistribution.Type distributionType = distribution.getType();
+    boolean prePartitioned;
+    if (distributionType == RelDistribution.Type.HASH_DISTRIBUTED) {
+      RelDistribution inputDistributionTrait = node.getInputs().get(0).getTraitSet().getDistribution();
+      prePartitioned = distribution.equals(inputDistributionTrait);
+    } else {
+      prePartitioned = false;
+    }
     PinotRelExchangeType exchangeType;
+    List<Integer> keys;
     List<RelFieldCollation> collations;
     boolean sortOnSender;
     boolean sortOnReceiver;
     if (node instanceof PinotLogicalSortExchange) {
       PinotLogicalSortExchange sortExchange = (PinotLogicalSortExchange) node;
       exchangeType = sortExchange.getExchangeType();
+      keys = distribution.getKeys();
       collations = sortExchange.getCollation().getFieldCollations();
       sortOnSender = sortExchange.isSortOnSender();
       sortOnReceiver = sortExchange.isSortOnReceiver();
     } else {
       assert node instanceof PinotLogicalExchange;
-      exchangeType = ((PinotLogicalExchange) node).getExchangeType();
+      PinotLogicalExchange exchange = (PinotLogicalExchange) node;
+      exchangeType = exchange.getExchangeType();
+      keys = exchange.getKeys();
       collations = null;
       sortOnSender = false;
       sortOnReceiver = false;
     }
-    RelDistribution distribution = node.getDistribution();
-    RelDistribution.Type distributionType = distribution.getType();
-    List<Integer> keys;
-    boolean prePartitioned;
-    if (distributionType == RelDistribution.Type.HASH_DISTRIBUTED) {
-      keys = distribution.getKeys();
-      RelDistribution inputDistributionTrait = node.getInputs().get(0).getTraitSet().getDistribution();
-      prePartitioned = distribution.equals(inputDistributionTrait);
-    } else {
+    if (keys.isEmpty()) {
       keys = null;
-      prePartitioned = false;
     }
     return new ExchangeNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), convertInputs(node.getInputs()),
         exchangeType, distributionType, keys, prePartitioned, collations, sortOnSender, sortOnReceiver, null);

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.query.testutils;
 
+import com.google.common.collect.Maps;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -56,14 +57,14 @@ public class MockRoutingManagerFactory {
   private final Map<String, Schema> _schemaMap;
   private final Set<String> _hybridTables;
   private final Map<String, ServerInstance> _serverInstances;
-  private final Map<String, Map<ServerInstance, ServerRouteInfo>> _tableServerSegmentsMap;
+  private final Map<String, Map<String, List<ServerInstance>>> _tableSegmentServersMap;
 
   public MockRoutingManagerFactory(int... ports) {
     _tableNameMap = new HashMap<>();
     _schemaMap = new HashMap<>();
     _hybridTables = new HashSet<>();
     _serverInstances = new HashMap<>();
-    _tableServerSegmentsMap = new HashMap<>();
+    _tableSegmentServersMap = new HashMap<>();
     for (int port : ports) {
       _serverInstances.put(toHostname(port), getServerInstance(HOST_NAME, port, port, port, port));
     }
@@ -88,18 +89,39 @@ public class MockRoutingManagerFactory {
 
   public void registerSegment(int insertToServerPort, String tableNameWithType, String segmentName) {
     ServerInstance serverInstance = _serverInstances.get(toHostname(insertToServerPort));
-    _tableServerSegmentsMap.computeIfAbsent(tableNameWithType, k -> new HashMap<>())
-        .computeIfAbsent(serverInstance, k -> new ServerRouteInfo(new ArrayList<>(), null)).getSegments()
-        .add(segmentName);
+    _tableSegmentServersMap.computeIfAbsent(tableNameWithType, k -> new HashMap<>())
+        .computeIfAbsent(segmentName, k -> new ArrayList<>())
+        .add(serverInstance);
   }
 
   public RoutingManager buildRoutingManager(@Nullable Map<String, TablePartitionInfo> partitionInfoMap) {
-    Map<String, RoutingTable> routingTableMap = new HashMap<>();
-    _tableServerSegmentsMap.forEach((tableNameWithType, serverSegmentsMap) -> {
-      RoutingTable fakeRoutingTable = new RoutingTable(serverSegmentsMap, Collections.emptyList(), 0);
-      routingTableMap.put(tableNameWithType, fakeRoutingTable);
-    });
-    return new FakeRoutingManager(routingTableMap, _hybridTables, partitionInfoMap, _serverInstances);
+    int numTables = _tableSegmentServersMap.size();
+    Map<String, RoutingTable> routingTableMap = Maps.newHashMapWithExpectedSize(numTables);
+    Map<String, List<String>> tableSegmentsMap = Maps.newHashMapWithExpectedSize(numTables);
+    int serverId = 0;
+    for (Map.Entry<String, Map<String, List<ServerInstance>>> entry : _tableSegmentServersMap.entrySet()) {
+      String tableNameWithType = entry.getKey();
+      Map<String, List<ServerInstance>> segmentServersMap = entry.getValue();
+      Map<ServerInstance, ServerRouteInfo> serverRouteInfoMap = new HashMap<>();
+      for (Map.Entry<String, List<ServerInstance>> segmentServersEntry : segmentServersMap.entrySet()) {
+        String segment = segmentServersEntry.getKey();
+        List<ServerInstance> servers = segmentServersEntry.getValue();
+        ServerInstance server;
+        int numServers = servers.size();
+        if (numServers == 1) {
+          server = servers.get(0);
+        } else {
+          server = servers.get(serverId % numServers);
+          serverId++;
+        }
+        serverRouteInfoMap.computeIfAbsent(server, k -> new ServerRouteInfo(new ArrayList<>(), null))
+            .getSegments()
+            .add(segment);
+      }
+      routingTableMap.put(tableNameWithType, new RoutingTable(serverRouteInfoMap, List.of(), 0));
+      tableSegmentsMap.put(tableNameWithType, new ArrayList<>(segmentServersMap.keySet()));
+    }
+    return new FakeRoutingManager(routingTableMap, tableSegmentsMap, _hybridTables, partitionInfoMap, _serverInstances);
   }
 
   public TableCache buildTableCache() {
@@ -136,12 +158,15 @@ public class MockRoutingManagerFactory {
 
   private static class FakeRoutingManager implements RoutingManager {
     private final Map<String, RoutingTable> _routingTableMap;
+    private final Map<String, List<String>> _segmentsMap;
     private final Set<String> _hybridTables;
     private final Map<String, TablePartitionInfo> _partitionInfoMap;
     private final Map<String, ServerInstance> _serverInstances;
 
-    public FakeRoutingManager(Map<String, RoutingTable> routingTableMap, Set<String> hybridTables,
-        @Nullable Map<String, TablePartitionInfo> partitionInfoMap, Map<String, ServerInstance> serverInstances) {
+    public FakeRoutingManager(Map<String, RoutingTable> routingTableMap, Map<String, List<String>> segmentsMap,
+        Set<String> hybridTables, @Nullable Map<String, TablePartitionInfo> partitionInfoMap,
+        Map<String, ServerInstance> serverInstances) {
+      _segmentsMap = segmentsMap;
       _routingTableMap = routingTableMap;
       _hybridTables = hybridTables;
       _partitionInfoMap = partitionInfoMap;
@@ -153,10 +178,18 @@ public class MockRoutingManagerFactory {
       return _serverInstances;
     }
 
+    @Nullable
     @Override
     public RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId) {
       String tableNameWithType = brokerRequest.getPinotQuery().getDataSource().getTableName();
       return _routingTableMap.get(tableNameWithType);
+    }
+
+    @Nullable
+    @Override
+    public List<String> getSegments(BrokerRequest brokerRequest) {
+      String tableNameWithType = brokerRequest.getPinotQuery().getDataSource().getTableName();
+      return _segmentsMap.get(tableNameWithType);
     }
 
     @Override

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -812,6 +812,60 @@
       }
     ]
   },
+  "local_replicated_join_planning_test": {
+    "queries": [
+      {
+        "description": "Simple local replicated join",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ a.col1, b.col2 FROM a JOIN b /*+ tableOptions(is_replicated = 'true') */ ON a.col1 = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Broadcast join with filter on both left and right table",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ a.col1, b.col2 FROM a JOIN b /*+ tableOptions(is_replicated = 'true') */ ON a.col1 = b.col1 WHERE a.col2 = 'foo' AND b.col2 = 'bar'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
+          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalFilter(condition=[=($1, _UTF-8'bar')])",
+          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Broadcast join with transformation on both left and right table joined key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ a.col1, b.col2 FROM a JOIN b /*+ tableOptions(is_replicated = 'true') */ ON upper(a.col1) = upper(b.col1)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($1, $3)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
+          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col2=[$1], $f8=[UPPER($0)])",
+          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      }
+    ]
+  },
   "exception_throwing_join_planning_tests": {
     "queries": [
       {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -560,6 +560,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public List<String> _partitionColumns;
       @JsonProperty("partitionCount")
       public Integer _partitionCount;
+      @JsonProperty("replicated")
+      public boolean _replicated;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/pinot-query-runtime/src/test/resources/queries/QueryHints.json
+++ b/pinot-query-runtime/src/test/resources/queries/QueryHints.json
@@ -126,12 +126,20 @@
         "sql": "SET stageParallelism=2; SELECT {tbl1}.name, SUM({tbl2}.num) FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ ON {tbl1}.num = {tbl2}.num GROUP BY {tbl1}.name"
       },
       {
-        "description": "Broadcast JOIN without partition hint",
+        "description": "Broadcast JOIN",
         "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
       },
       {
         "description": "Broadcast JOIN with partition hint",
         "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+      },
+      {
+        "description": "Broadcast JOIN with parallelism",
+        "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_parallelism='2') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+      },
+      {
+        "description": "Broadcast JOIN with partition hint and parallelism",
+        "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
       },
       {
         "description": "Colocated, Dynamic broadcast SEMI-JOIN with partition column",
@@ -575,5 +583,80 @@
         "sql": "SELECT {tbl2}.id, SUM({tbl1}.val) FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ ON {tbl1}.num = {tbl2}.num WHERE {tbl2}.data > 0 GROUP BY {tbl2}.id"
       }
     ]
-  }
+  },
+  "hint_option_replicated_table": {
+  "tables": {
+    "tbl1" : {
+      "schema": [
+        {"name": "num", "type": "INT"},
+        {"name": "name", "type": "STRING"}
+      ],
+      "inputs": [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+        [3, "yyy"],
+        [4, "e"],
+        [4, "e"],
+        [6, "e"],
+        [7, "d"],
+        [7, "f"],
+        [8, "z"]
+      ],
+      "partitionColumns": [
+        "num"
+      ]
+    },
+    "tbl2" : {
+      "schema": [
+        {"name": "num", "type": "INT"},
+        {"name": "val", "type": "STRING"}
+      ],
+      "inputs": [
+        [1, "xxx"],
+        [1, "xxx"],
+        [3, "yyy"],
+        [3, "zzz"],
+        [5, "zzz"],
+        [6, "e"],
+        [7, "d"],
+        [8, "z"]
+      ],
+      "replicated": true
+    }
+  },
+  "queries": [
+    {
+      "description": "Broadcast JOIN",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Broadcast JOIN with partition hint",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Broadcast JOIN with parallelism",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_parallelism='2') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Broadcast JOIN with partition hint and parallelism",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'broadcast') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Local replicated JOIN",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} JOIN {tbl2} /*+ tableOptions(is_replicated='true') */ ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Local replicated JOIN with partition hint",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */ JOIN {tbl2} /*+ tableOptions(is_replicated='true') */ ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Local replicated JOIN with parallelism",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_parallelism='2') */ JOIN {tbl2} /*+ tableOptions(is_replicated='true') */ ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Local replicated JOIN with partition hint and parallelism",
+      "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} /*+ tableOptions(is_replicated='true') */ ON {tbl1}.num = {tbl2}.num"
+    }
+  ]}
 }


### PR DESCRIPTION
Related to #14518 

Added a new table hint:
- `is_replicated` (boolean)

Support local replicated join by configuring both side as local distribution, and also hint right table as replicated:
```
SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ a.col1, b.col2 FROM a JOIN b /*+ tableOptions(is_replicated='true') */ ON a.col1 = b.col1
```

Also support parallelism for local exchange to increase the parallelism for intermediate stage with table hint `partition_parallelism`.