### PR TITLE
Upgrade AWS SDK to 2.30; update tests to disable default integrity protection

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3PinotFSTest.java
@@ -41,6 +41,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -527,6 +529,9 @@ public class S3PinotFSTest {
     return S3Client.builder().region(Region.of("us-east-1"))
         .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar")))
         .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
-        .endpointOverride(URI.create(endpoint)).build();
+        .endpointOverride(URI.create(endpoint))
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+        .build();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <audienceannotations.version>0.15.0</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.29.52</aws.sdk.version>
+    <aws.sdk.version>2.30.4</aws.sdk.version>
     <azure.sdk.version>1.2.30</azure.sdk.version>
     <azure.msal4j.version>1.18.0</azure.msal4j.version>
     <joda-time.version>2.13.0</joda-time.version>


### PR DESCRIPTION
- Recent dependabot AWS SDK upgrades have been failing in CI due to some failed assertions in `S3PinotFSTest` - https://github.com/apache/pinot/pull/14907, https://github.com/apache/pinot/pull/14825.
- The reason for this is the default integrity protection change - https://github.com/aws/aws-sdk-java-v2/discussions/5802. This isn't supported by the S3 mock testcontainer library that we're using for testing.
- The solution is to disable the integrity protection in the test client (see https://github.com/aws/aws-sdk-java-v2/issues/5819#issuecomment-2610172816).