### PR TITLE
Allow using hint to force enable/disable colocated join

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -135,6 +135,12 @@ public class PinotHintOptions {
     public static DistributionType getRightDistributionType(Map<String, String> joinHintOptions) {
       return DistributionType.fromHint(joinHintOptions.get(RIGHT_DISTRIBUTION_TYPE));
     }
+
+    @Nullable
+    public static Boolean isColocatedByJoinKeys(Join join) {
+      String hint = PinotHintStrategyTable.getHintOption(join.getHints(), JOIN_HINT_OPTIONS, IS_COLOCATED_BY_JOIN_KEYS);
+      return hint != null ? Boolean.parseBoolean(hint) : null;
+    }
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalExchange.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalExchange.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.calcite.rel.logical;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -43,40 +44,51 @@ public class PinotLogicalExchange extends Exchange {
   // TODO: Revisit this as we add more custom distribution types.
   private final List<Integer> _keys;
 
+  // Can be used to override the partitioning info calculated from the distribution trait.
+  private final Boolean _prePartitioned;
+
   private PinotLogicalExchange(RelOptCluster cluster, RelTraitSet traitSet, RelNode input, RelDistribution distribution,
-      PinotRelExchangeType exchangeType, List<Integer> keys) {
+      PinotRelExchangeType exchangeType, List<Integer> keys, @Nullable Boolean prePartitioned) {
     super(cluster, traitSet, input, distribution);
+    assert traitSet.containsIfApplicable(Convention.NONE);
     _exchangeType = exchangeType;
     _keys = keys;
-    assert traitSet.containsIfApplicable(Convention.NONE);
+    _prePartitioned = prePartitioned;
   }
 
   public static PinotLogicalExchange create(RelNode input, RelDistribution distribution) {
-    return create(input, distribution, PinotRelExchangeType.getDefaultExchangeType(), distribution.getKeys());
+    return create(input, distribution, (Boolean) null);
   }
 
-  public static PinotLogicalExchange create(RelNode input, RelDistribution distribution, List<Integer> keys) {
-    return create(input, distribution, PinotRelExchangeType.getDefaultExchangeType(), keys);
+  public static PinotLogicalExchange create(RelNode input, RelDistribution distribution,
+      @Nullable Boolean prePartitioned) {
+    return create(input, distribution, distribution.getKeys(), prePartitioned);
+  }
+
+  public static PinotLogicalExchange create(RelNode input, RelDistribution distribution, List<Integer> keys,
+      @Nullable Boolean prePartitioned) {
+    return create(input, distribution, PinotRelExchangeType.getDefaultExchangeType(), keys, prePartitioned);
   }
 
   public static PinotLogicalExchange create(RelNode input, RelDistribution distribution,
       PinotRelExchangeType exchangeType) {
-    return create(input, distribution, exchangeType, distribution.getKeys());
+    return create(input, distribution, exchangeType, distribution.getKeys(), null);
   }
 
   public static PinotLogicalExchange create(RelNode input, RelDistribution distribution,
-      PinotRelExchangeType exchangeType, List<Integer> keys) {
+      PinotRelExchangeType exchangeType, List<Integer> keys, @Nullable Boolean prePartitioned) {
     RelOptCluster cluster = input.getCluster();
     distribution = RelDistributionTraitDef.INSTANCE.canonize(distribution);
     RelTraitSet traitSet = input.getTraitSet().replace(Convention.NONE).replace(distribution);
-    return new PinotLogicalExchange(cluster, traitSet, input, distribution, exchangeType, keys);
+    return new PinotLogicalExchange(cluster, traitSet, input, distribution, exchangeType, keys, prePartitioned);
   }
 
   //~ Methods ----------------------------------------------------------------
 
   @Override
   public Exchange copy(RelTraitSet traitSet, RelNode newInput, RelDistribution newDistribution) {
-    return new PinotLogicalExchange(getCluster(), traitSet, newInput, newDistribution, _exchangeType, _keys);
+    return new PinotLogicalExchange(getCluster(), traitSet, newInput, newDistribution, _exchangeType, _keys,
+        _prePartitioned);
   }
 
   @Override
@@ -99,5 +111,10 @@ public class PinotLogicalExchange extends Exchange {
 
   public List<Integer> getKeys() {
     return _keys;
+  }
+
+  @Nullable
+  public Boolean getPrePartitioned() {
+    return _prePartitioned;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -21,6 +21,7 @@ package org.apache.pinot.calcite.rel.rules;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelDistributions;
@@ -78,19 +79,21 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       newRight = right;
     } else {
       // Hash join
+      // Force pre-partitioned exchange when colocated join hint is provided
+      Boolean prePartitioned = PinotHintOptions.JoinHintOptions.isColocatedByJoinKeys(join);
       // TODO: Validate if the configured distribution types are valid
       if (leftDistributionType == null) {
         // By default, hash distribute the left side if there are join keys, otherwise randomly distribute
         leftDistributionType = !joinInfo.leftKeys.isEmpty() ? PinotHintOptions.DistributionType.HASH
             : PinotHintOptions.DistributionType.RANDOM;
       }
-      newLeft = createExchangeForHashJoin(leftDistributionType, joinInfo.leftKeys, left);
+      newLeft = createExchangeForHashJoin(leftDistributionType, joinInfo.leftKeys, left, prePartitioned);
       if (rightDistributionType == null) {
         // By default, hash distribute the right side if there are join keys, otherwise broadcast
         rightDistributionType = !joinInfo.rightKeys.isEmpty() ? PinotHintOptions.DistributionType.HASH
             : PinotHintOptions.DistributionType.BROADCAST;
       }
-      newRight = createExchangeForHashJoin(rightDistributionType, joinInfo.rightKeys, right);
+      newRight = createExchangeForHashJoin(rightDistributionType, joinInfo.rightKeys, right, prePartitioned);
     }
 
     // TODO: Consider creating different JOIN Rel for each join strategy
@@ -104,7 +107,7 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       case LOCAL:
         // NOTE: We use SINGLETON to represent local distribution. Add keys to the exchange because we might want to
         //       switch it to HASH distribution to increase parallelism. See MailboxAssignmentVisitor for details.
-        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys);
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys, null);
       case HASH:
         Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
         return PinotLogicalExchange.create(child, RelDistributions.hash(keys));
@@ -116,19 +119,19 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
   }
 
   private static PinotLogicalExchange createExchangeForHashJoin(PinotHintOptions.DistributionType distributionType,
-      List<Integer> keys, RelNode child) {
+      List<Integer> keys, RelNode child, @Nullable Boolean prePartitioned) {
     switch (distributionType) {
       case LOCAL:
         // NOTE: We use SINGLETON to represent local distribution. Add keys to the exchange because we might want to
         //       switch it to HASH distribution to increase parallelism. See MailboxAssignmentVisitor for details.
-        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys);
+        return PinotLogicalExchange.create(child, RelDistributions.SINGLETON, keys, prePartitioned);
       case HASH:
         Preconditions.checkArgument(!keys.isEmpty(), "Hash distribution requires join keys");
-        return PinotLogicalExchange.create(child, RelDistributions.hash(keys));
+        return PinotLogicalExchange.create(child, RelDistributions.hash(keys), prePartitioned);
       case BROADCAST:
-        return PinotLogicalExchange.create(child, RelDistributions.BROADCAST_DISTRIBUTED);
+        return PinotLogicalExchange.create(child, RelDistributions.BROADCAST_DISTRIBUTED, prePartitioned);
       case RANDOM:
-        return PinotLogicalExchange.create(child, RelDistributions.RANDOM_DISTRIBUTED);
+        return PinotLogicalExchange.create(child, RelDistributions.RANDOM_DISTRIBUTED, prePartitioned);
       default:
         throw new IllegalArgumentException("Unsupported distribution type: " + distributionType + " for hash join");
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
@@ -30,7 +30,6 @@ import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
-import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
 
@@ -153,10 +152,8 @@ public class PinotJoinToDynamicBroadcastRule extends RelOptRule {
     // when colocated join hint is given, dynamic broadcast exchange can be hash-distributed b/c
     //    1. currently, dynamic broadcast only works against main table off leaf-stage; (e.g. receive node on leaf)
     //    2. when hash key are the same but hash functions are different, it can be done via normal hash shuffle.
-    boolean isColocatedJoin =
-        PinotHintStrategyTable.isHintOptionTrue(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
-            PinotHintOptions.JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS);
-    RelDistribution relDistribution = isColocatedJoin ? RelDistributions.hash(join.analyzeCondition().rightKeys)
+    boolean colocatedByJoinKeys = Boolean.TRUE.equals(PinotHintOptions.JoinHintOptions.isColocatedByJoinKeys(join));
+    RelDistribution relDistribution = colocatedByJoinKeys ? RelDistributions.hash(join.analyzeCondition().rightKeys)
         : RelDistributions.BROADCAST_DISTRIBUTED;
     PinotLogicalExchange dynamicBroadcastExchange =
         PinotLogicalExchange.create(right.getInput(), relDistribution, PinotRelExchangeType.PIPELINE_BREAKER);


### PR DESCRIPTION
It can be used in 2 scenarios:
1. When the distribution trait is not able to detect the colocation, force enabling it
2. Force disabling it for debugging purpose