### PR TITLE
Allow periodic tasks to run with properties via the POST API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -65,6 +66,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   private final boolean _segmentAutoResetOnErrorAtValidation;
 
   public static final String OFFSET_CRITERIA = "offsetCriteria";
+  public static final String RUN_SEGMENT_LEVEL_VALIDATION = "runSegmentLevelValidation";
 
   public RealtimeSegmentValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
@@ -89,8 +91,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     Context context = new Context();
     // Run segment level validation only if certain time has passed after previous run
     long currentTimeMs = System.currentTimeMillis();
-    if (TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastSegmentLevelValidationRunTimeMs)
-        >= _segmentLevelValidationIntervalInSeconds) {
+    if (shouldRunSegmentValidation(periodicTaskProperties, currentTimeMs)) {
       LOGGER.info("Run segment-level validation");
       context._runSegmentLevelValidation = true;
       _lastSegmentLevelValidationRunTimeMs = currentTimeMs;
@@ -240,6 +241,24 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     if (!_llcRealtimeSegmentManager.syncCommittingSegments(realtimeTableName, committingSegments)) {
       LOGGER.error("Failed to add committing segments for table: {}", realtimeTableName);
     }
+  }
+
+  private boolean shouldRunSegmentValidation(Properties periodicTaskProperties, long currentTimeMs) {
+    boolean runValidation = Optional.ofNullable(
+            periodicTaskProperties.getProperty(RUN_SEGMENT_LEVEL_VALIDATION))
+        .map(value -> {
+          try {
+            return Boolean.parseBoolean(value);
+          } catch (Exception e) {
+            return false;
+          }
+        })
+        .orElse(false);
+
+    boolean timeThresholdMet = TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastSegmentLevelValidationRunTimeMs)
+        >= _segmentLevelValidationIntervalInSeconds;
+
+    return runValidation || timeThresholdMet;
   }
 
   @Override


### PR DESCRIPTION
POST API: 
- Current perodic task run API does not take periodic task properties as input. 
- Introduce a POST API to allow passing in periodic task properties as well. 

Running segment level validaitons in RealtimeSegmentValidationManager
- The RealtimeSegmentValidationManager performs segment level validations to upload segments that have missing url. 
- Segment level validation run at a specific frequency and cannot be triggered using the controller periodic task API
- The addition of above APi allows passage of task properties. 
- Additional field is checked in the task properties to run segment level validations even when time constraints are not met. 

Local Testing: 

The segment level validations run even when the time constraints are not met. 
![trigger_validations](https://github.com/user-attachments/assets/094f6ec0-a4a3-467f-a556-065bdf417d74)

![Returning_true_for_validations](https://github.com/user-attachments/assets/4a42cfc7-ce42-4c2d-96f3-b2326d7d0321)
![Running_validations](https://github.com/user-attachments/assets/58653e85-8be8-43ca-902e-92928ce27162)
