### PR TITLE
Enhance data schema generation for empty response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -841,7 +841,9 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
       // server returns STRING as default dataType for all columns in (some) scenarios where no rows are returned
       // this is an attempt to return more faithful information based on other sources
-      ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
+      if (brokerResponse.getNumRowsResultSet() == 0) {
+        ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
+      }
 
       // Set total query processing time
       long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -419,10 +419,6 @@ public class DataSchema {
       return INTEGRAL_ARRAY_TYPES.contains(this);
     }
 
-    public boolean isUnknown() {
-      return UNKNOWN.equals(this);
-    }
-
     public boolean isCompatible(ColumnDataType anotherColumnDataType) {
       // All numbers are compatible with each other
       return this == anotherColumnDataType || (this.isNumber() && anotherColumnDataType.isNumber()) || (

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
@@ -41,7 +41,6 @@ import org.apache.pinot.spi.utils.InstanceTypeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -55,6 +54,15 @@ import static org.testng.Assert.assertTrue;
 public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet {
   private static final int NUM_BROKERS = 1;
   private static final int NUM_SERVERS = 1;
+  private static final String[] SELECT_STAR_TYPES = new String[]{
+      "INT", "INT", "LONG", "INT", "FLOAT", "DOUBLE", "INT", "STRING", "INT", "INT", "INT", "INT", "STRING", "INT",
+      "STRING", "INT", "INT", "INT", "INT", "INT", "DOUBLE", "FLOAT", "INT", "STRING", "INT", "STRING", "INT", "INT",
+      "INT", "STRING", "STRING", "INT", "STRING", "INT", "INT", "INT", "INT", "INT_ARRAY", "INT", "INT_ARRAY",
+      "STRING_ARRAY", "INT", "INT", "FLOAT_ARRAY", "INT", "STRING_ARRAY", "LONG_ARRAY", "INT_ARRAY", "INT_ARRAY",
+      "INT", "INT", "STRING", "INT", "INT", "INT", "INT", "INT", "INT", "STRING", "INT", "INT", "INT", "STRING",
+      "STRING", "INT", "STRING", "INT", "INT", "STRING_ARRAY", "INT", "STRING", "INT", "INT", "INT", "STRING", "INT",
+      "INT", "INT", "INT"
+  };
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =
       new ArrayList<>(getNumBrokers() + getNumServers());
@@ -134,11 +142,6 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
     waitForAllDocsLoaded(600_000L);
   }
 
-  @BeforeMethod
-  public void resetMultiStage() {
-    setUseMultiStageQueryEngine(false);
-  }
-
   protected void startBrokers()
       throws Exception {
     startBrokers(getNumBrokers());
@@ -184,21 +187,17 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testCompiledByV2StarField() throws Exception {
+  public void testStarField()
+      throws Exception {
     String sqlQuery = "SELECT * FROM myTable WHERE AirlineID = 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
-    assertDataTypes(response, "INT", "INT", "LONG", "INT", "FLOAT", "DOUBLE", "INT", "STRING", "INT", "INT", "INT",
-        "INT", "STRING", "INT", "STRING", "INT", "INT", "INT", "INT", "INT", "DOUBLE", "FLOAT", "INT", "STRING", "INT",
-        "STRING", "INT", "INT", "INT", "STRING", "STRING", "INT", "STRING", "INT", "INT", "INT", "INT", "INT_ARRAY",
-        "INT", "INT_ARRAY", "STRING_ARRAY", "INT", "INT", "FLOAT_ARRAY", "INT", "STRING_ARRAY", "LONG_ARRAY",
-        "INT_ARRAY", "INT_ARRAY", "INT", "INT", "STRING", "INT", "INT", "INT", "INT", "INT", "INT", "STRING", "INT",
-        "INT", "INT", "STRING", "STRING", "INT", "STRING", "INT", "INT", "STRING_ARRAY", "INT", "STRING", "INT", "INT",
-        "INT", "STRING", "INT", "INT", "INT", "INT");
+    assertDataTypes(response, SELECT_STAR_TYPES);
   }
 
   @Test
-  public void testCompiledByV2SelectionFields() throws Exception {
+  public void testSelectionFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, ArrTime, ArrTimeBlk FROM myTable WHERE AirlineID = 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
@@ -206,7 +205,8 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testCompiledByV2TrasformedFields() throws Exception {
+  public void testTransformedFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, ArrTime, ArrTime+1 FROM myTable WHERE AirlineID = 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
@@ -214,7 +214,8 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testCompiledByV2AggregatedFields() throws Exception {
+  public void testAggregatedFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, avg(ArrTime) FROM myTable WHERE AirlineID = 0 GROUP BY AirlineID LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
@@ -222,29 +223,27 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testSchemaFallbackStarField() throws Exception {
+  public void testSchemaFallbackStarField()
+      throws Exception {
     String sqlQuery = "SELECT * FROM myTable WHERE AirlineID = 0 AND add(AirTime, AirTime, ArrTime) > 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
-    assertDataTypes(response, "INT", "INT", "LONG", "INT", "FLOAT", "DOUBLE", "INT", "STRING", "INT", "INT", "INT",
-        "INT", "STRING", "INT", "STRING", "INT", "INT", "INT", "INT", "INT", "DOUBLE", "FLOAT", "INT", "STRING", "INT",
-        "STRING", "INT", "INT", "INT", "STRING", "STRING", "INT", "STRING", "INT", "INT", "INT", "INT", "INT", "INT",
-        "INT", "STRING", "INT", "INT", "FLOAT", "INT", "STRING", "LONG", "INT", "INT", "INT", "INT", "STRING", "INT",
-        "INT", "INT", "INT", "INT", "INT", "STRING", "INT", "INT", "INT", "STRING", "STRING", "INT", "STRING", "INT",
-        "INT", "STRING", "INT", "STRING", "INT", "INT", "INT", "STRING", "INT", "INT", "INT", "INT");
+    assertDataTypes(response, SELECT_STAR_TYPES);
   }
 
   @Test
-  public void testSchemaFallbackSelectionFields() throws Exception {
+  public void testSchemaFallbackSelectionFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, ArrTime, ArrTimeBlk FROM myTable"
-      + " WHERE AirlineID = 0 AND add(ArrTime, ArrTime, ArrTime) > 0 LIMIT 1";
+        + " WHERE AirlineID = 0 AND add(ArrTime, ArrTime, ArrTime) > 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
     assertNoRowsReturned(response);
     assertDataTypes(response, "LONG", "INT", "STRING");
   }
 
   @Test
-  public void testSchemaFallbackTransformedFields() throws Exception {
+  public void testSchemaFallbackTransformedFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, ArrTime, ArrTime+1 FROM myTable"
         + " WHERE AirlineID = 0 AND add(ArrTime, ArrTime, ArrTime) > 0 LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
@@ -253,7 +252,8 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testSchemaFallbackAggregatedFields() throws Exception {
+  public void testSchemaFallbackAggregatedFields()
+      throws Exception {
     String sqlQuery = "SELECT AirlineID, avg(ArrTime) FROM myTable"
         + " WHERE AirlineID = 0 AND add(ArrTime, ArrTime, ArrTime) > 0 GROUP BY AirlineID LIMIT 1";
     JsonNode response = postQuery(sqlQuery);
@@ -262,23 +262,12 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testDataSchemaForBrokerPrunedEmptyResults() throws Exception {
+  public void testDataSchemaForBrokerPrunedEmptyResults()
+      throws Exception {
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.setRoutingConfig(
         new RoutingConfig(null, Collections.singletonList(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE), null, null));
     updateTableConfig(tableConfig);
-
-    TestUtils.waitForCondition(aVoid -> {
-      try {
-        TableConfig cfg = getOfflineTableConfig();
-        if (cfg.getRoutingConfig() == null || cfg.getRoutingConfig().getSegmentPrunerTypes().isEmpty()) {
-          return false;
-        }
-        return true;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, 600_000L, "Failed to update table config");
 
     String query =
         "Select DestAirportID, Carrier from myTable WHERE DaysSinceEpoch < -1231231 and FlightNum > 121231231231";
@@ -293,23 +282,10 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
     assertNoRowsReturned(queryResponse);
     assertDataTypes(queryResponse, "INT", "STRING");
 
-    // Reset and remove the Time Segment Pruner
-    tableConfig = getOfflineTableConfig();
-    tableConfig.setRoutingConfig(new RoutingConfig(null, Collections.emptyList(), null, null));
+    // Reset the routing config
+    tableConfig.setRoutingConfig(null);
     updateTableConfig(tableConfig);
-    TestUtils.waitForCondition(aVoid -> {
-      try {
-        TableConfig cfg = getOfflineTableConfig();
-        if (cfg.getRoutingConfig() == null || cfg.getRoutingConfig().getSegmentPrunerTypes().size() > 0) {
-          return false;
-        }
-        return true;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, 600_000L, "Failed to update table config");
   }
-
 
   private void assertNoRowsReturned(JsonNode response) {
     assertNotNull(response.get("resultTable"));
@@ -317,7 +293,8 @@ public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet 
     assertEquals(response.get("resultTable").get("rows").size(), 0);
   }
 
-  private void assertDataTypes(JsonNode response, String... types) throws Exception {
+  private void assertDataTypes(JsonNode response, String... types)
+      throws Exception {
     assertNotNull(response.get("resultTable"));
     assertNotNull(response.get("resultTable").get("dataSchema"));
     assertNotNull(response.get("resultTable").get("dataSchema").get("columnDataTypes"));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -89,7 +89,6 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.function.scalar.StringFunctions.*;
@@ -265,11 +264,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         throw new RuntimeException(e);
       }
     }, 600_000L, "Failed to reload table with force download");
-  }
-
-  @BeforeMethod
-  public void resetMultiStage() {
-    setUseMultiStageQueryEngine(false);
   }
 
   protected void startBrokers()


### PR DESCRIPTION
This is a followup on #14836 with the following enhancements:
- Handle MV column type properly
- Handle the case when different number of columns are returned in single-stage vs multi-stage engine
- More exception handling to prevent it from throwing exception