### PR TITLE
Allow overriding cluster configs in quickstarts

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -298,6 +298,13 @@ public class MultistageEngineQuickStart extends Quickstart {
   }
 
   @Override
+  protected Map<String, String> getClusterConfigOverrides() {
+    return Map.of(
+        CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "50"
+    );
+  }
+
+  @Override
   protected int getNumQuickstartRunnerServers() {
     return 3;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -291,6 +291,10 @@ public abstract class QuickStartBase {
     }
   }
 
+  protected Map<String, String> getClusterConfigOverrides() {
+    return Map.of();
+  }
+
   protected String[] getDefaultBatchTableDirectories() {
     return DEFAULT_OFFLINE_TABLE_DIRECTORIES;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -67,7 +67,7 @@ public class Quickstart extends QuickStartBase {
 
     QuickstartRunner runner =
         new QuickstartRunner(quickstartTableRequests, 1, 1, getNumQuickstartRunnerServers(), 1, quickstartRunnerDir,
-            true, getAuthProvider(), getConfigOverrides(), _zkExternalAddress, true);
+            true, getAuthProvider(), getConfigOverrides(), _zkExternalAddress, true, getClusterConfigOverrides());
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker, server and minion *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -29,6 +29,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -69,6 +74,7 @@ public class QuickstartRunner {
   private final boolean _enableTenantIsolation;
   private final AuthProvider _authProvider;
   private final Map<String, Object> _configOverrides;
+  private final Map<String, String> _clusterConfigOverrides;
   private final boolean _deleteExistingData;
 
   // If this field is non-null, an embedded Zookeeper instance will not be launched
@@ -82,12 +88,13 @@ public class QuickstartRunner {
       int numServers, int numMinions, File tempDir, Map<String, Object> configOverrides)
       throws Exception {
     this(tableRequests, numControllers, numBrokers, numServers, numMinions, tempDir, true, null, configOverrides, null,
-        true);
+        true, Map.of());
   }
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, int numMinions, File tempDir, boolean enableIsolation, AuthProvider authProvider,
-      Map<String, Object> configOverrides, String zkExternalAddress, boolean deleteExistingData)
+      Map<String, Object> configOverrides, String zkExternalAddress, boolean deleteExistingData,
+      Map<String, String> clusterConfigOverrides)
       throws Exception {
     _tableRequests = tableRequests;
     _numControllers = numControllers;
@@ -98,6 +105,7 @@ public class QuickstartRunner {
     _enableTenantIsolation = enableIsolation;
     _authProvider = authProvider;
     _configOverrides = new HashMap<>(configOverrides);
+    _clusterConfigOverrides = clusterConfigOverrides;
     if (numMinions > 0) {
       // configure the controller to schedule tasks when minion is enabled
       _configOverrides.put("controller.task.scheduler.enabled", true);
@@ -127,10 +135,21 @@ public class QuickstartRunner {
           .setTenantIsolation(_enableTenantIsolation)
           .setDataDir(new File(_tempDir, DEFAULT_CONTROLLER_DIR + i).getAbsolutePath())
           .setConfigOverrides(_configOverrides);
+
       if (!controllerStarter.execute()) {
         throw new RuntimeException("Failed to start Controller");
       }
       _controllerPorts.add(DEFAULT_CONTROLLER_PORT + i);
+    }
+
+    HelixManager helixManager =
+        HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "localhost_" + _controllerPorts.get(0),
+            InstanceType.CONTROLLER, _zkExternalAddress != null ? _zkExternalAddress : ZK_ADDRESS);
+    helixManager.connect();
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(CLUSTER_NAME).build();
+    for (Map.Entry<String, String> entry : _clusterConfigOverrides.entrySet()) {
+      helixManager.getConfigAccessor().set(scope, entry.getKey(), entry.getValue());
     }
   }
 


### PR DESCRIPTION
- The quickstarts currently allow overriding controller / broker / server / minion configs but not cluster configs. 
- This patch allows overriding cluster configs in quickstarts which is useful to easily test scenarios involving custom cluster configurations.