### PR TITLE
Disabling parallelProtection when its not needed (pushParallelism of 1)

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -62,6 +62,7 @@ import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.common.utils.http.HttpClientConfig;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
@@ -1262,6 +1263,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
       tableParams.add(new BasicNameValuePair(QueryParameters.TABLE_TYPE, tableType.name()));
     }
     return tableParams;
+  }
+
+  public static NameValuePair makeParallelProtectionParam(PushJobSpec jobSpec) {
+    String enableParallelProtection = jobSpec.getPushParallelism() > 1 ? "true" : "false";
+    NameValuePair parallelProtectionParam =
+        new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
+            enableParallelProtection);
+    return parallelProtectionParam;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -140,6 +140,7 @@ public class SegmentPushUtils implements Serializable {
     List<Header> headers = AuthProviderUtils.toRequestHeaders(authProvider);
     List<NameValuePair> parameters = FileUploadDownloadClient.makeTableParam(tableName);
     PushJobSpec pushJobSpec = spec.getPushJobSpec();
+    parameters.add(FileUploadDownloadClient.makeParallelProtectionParam(pushJobSpec));
     if (pushJobSpec != null && pushJobSpec.isBatchSegmentUpload()) {
       // segments are uploaded in batch when batch mode is enabled.
       sendSegmentsUriAndMetadata(spec, fileSystem, segmentUriToTarPathMap, headers, parameters);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
@@ -29,8 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -51,6 +55,21 @@ public class SegmentPushUtilsTest {
   @AfterMethod
   public void tearDown() throws IOException {
     FileUtils.deleteDirectory(_tempDir);
+  }
+
+  @Test
+  public void testSegmentParallelProtectionUploadParam() {
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    NameValuePair nameValuePair = FileUploadDownloadClient.makeParallelProtectionParam(pushJobSpec);
+    Assert.assertEquals(nameValuePair.getName(),
+        FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION);
+    Assert.assertEquals(nameValuePair.getValue(), "false");
+    pushJobSpec.setPushParallelism(2);
+    nameValuePair = FileUploadDownloadClient.makeParallelProtectionParam(pushJobSpec);
+    Assert.assertEquals(nameValuePair.getName(),
+        FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION);
+    Assert.assertEquals(nameValuePair.getValue(), "true");
   }
 
   @Test


### PR DESCRIPTION
**Problem**:
The race handling for parallel push protection does not take into account tier configs. See [the check](https://github.com/apache/pinot/blob/a29ecd7c27020a3ce598cfe3bc56f9c3016adb3a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java#L557) that looks for Zk version to determine if there's a race (i.e version 0 indicates no race and > 0 indicates a race). However [we have this update to Zk](https://github.com/apache/pinot/blob/a29ecd7c27020a3ce598cfe3bc56f9c3016adb3a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java#L3640
) in the presence of tiered config and this happens in the segment-server assignment path just after creation of Zk metadata which transitions the version from 0->1. The version check fails and we end up deleting the segment even when there's no race. 
**Solution:**
As a workaround, disabling parallelProtection when pushParallelism is 1 . For batch load we dont need this feature (push parallelism) as we are uploading a bug batch of segments in one go. These uploads are also metadata pushes to the controller which is lightweight. 
Not changing the default at the API level, for backwards compatibility. The spark users of this feature.

The existing integ test SegmentUploadIntegrationTest uses the default pushParallelism (1). Verified that parallel protection is set to false. 
