### PR TITLE
Include information on whether a query is using SSQE or MSQE in QueryLogger

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -120,21 +120,36 @@ public class QueryLogger {
     private final RequestContext _requestContext;
     private final String _table;
     private final BrokerResponse _response;
-    private final boolean _isMultiStageQueryEngine;
+    private final QueryEngine _queryEngine;
     @Nullable
     private final RequesterIdentity _identity;
     @Nullable
     private final ServerStats _serverStats;
 
     public QueryLogParams(RequestContext requestContext, String table, BrokerResponse response,
-        boolean isMultiStageQueryEngine, @Nullable RequesterIdentity identity, @Nullable ServerStats serverStats) {
+        QueryEngine queryEngine, @Nullable RequesterIdentity identity, @Nullable ServerStats serverStats) {
       _requestContext = requestContext;
       // NOTE: Passing table name separately because table name within request context is always raw table name.
       _table = table;
       _response = response;
-      _isMultiStageQueryEngine = isMultiStageQueryEngine;
+      _queryEngine = queryEngine;
       _identity = identity;
       _serverStats = serverStats;
+    }
+
+    public enum QueryEngine {
+      SINGLE_STAGE("singleStage"),
+      MULTI_STAGE("multiStage");
+
+      private final String _name;
+
+      QueryEngine(String name) {
+        _name = name;
+      }
+
+      private String getName() {
+        return _name;
+      }
     }
   }
 
@@ -258,10 +273,10 @@ public class QueryLogger {
         }
       }
     },
-    IS_MULTI_STAGE_QUERY_ENGINE("isMultiStageQueryEngine") {
+    QUERY_ENGINE("queryEngine") {
       @Override
       void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
-        builder.append(params._isMultiStageQueryEngine);
+        builder.append(params._queryEngine.getName());
       }
     };
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -120,17 +120,19 @@ public class QueryLogger {
     private final RequestContext _requestContext;
     private final String _table;
     private final BrokerResponse _response;
+    private boolean _isMultiStageQueryEngine;
     @Nullable
     private final RequesterIdentity _identity;
     @Nullable
     private final ServerStats _serverStats;
 
     public QueryLogParams(RequestContext requestContext, String table, BrokerResponse response,
-        @Nullable RequesterIdentity identity, @Nullable ServerStats serverStats) {
+        boolean isMultiStageQueryEngine, @Nullable RequesterIdentity identity, @Nullable ServerStats serverStats) {
       _requestContext = requestContext;
       // NOTE: Passing table name separately because table name within request context is always raw table name.
       _table = table;
       _response = response;
+      _isMultiStageQueryEngine = isMultiStageQueryEngine;
       _identity = identity;
       _serverStats = serverStats;
     }
@@ -254,6 +256,12 @@ public class QueryLogger {
         } else {
           builder.append(CommonConstants.UNKNOWN);
         }
+      }
+    },
+    IS_MULTI_STAGE_QUERY_ENGINE("isMultiStageQueryEngine") {
+      @Override
+      void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
+        builder.append(params._isMultiStageQueryEngine);
       }
     };
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -120,7 +120,7 @@ public class QueryLogger {
     private final RequestContext _requestContext;
     private final String _table;
     private final BrokerResponse _response;
-    private boolean _isMultiStageQueryEngine;
+    private final boolean _isMultiStageQueryEngine;
     @Nullable
     private final RequesterIdentity _identity;
     @Nullable

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -863,8 +863,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
       // Log query and stats
       _queryLogger.log(
-          new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, false, requesterIdentity,
-              serverStats));
+          new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,
+              QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, requesterIdentity, serverStats));
 
       return brokerResponse;
     } finally {
@@ -909,7 +909,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
     brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
     _queryLogger.log(
-        new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, false, requesterIdentity, null));
+        new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,
+            QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, requesterIdentity, null));
     return brokerResponse;
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -863,7 +863,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
       // Log query and stats
       _queryLogger.log(
-          new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, requesterIdentity, serverStats));
+          new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, false, requesterIdentity,
+              serverStats));
 
       return brokerResponse;
     } finally {
@@ -908,7 +909,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
     brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
     _queryLogger.log(
-        new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, requesterIdentity, null));
+        new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse, false, requesterIdentity, null));
     return brokerResponse;
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -318,8 +318,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
       // Log query and stats
       _queryLogger.log(
-          new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse, true,
-              requesterIdentity, null));
+          new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse,
+              QueryLogger.QueryLogParams.QueryEngine.MULTI_STAGE, requesterIdentity, null));
 
       return brokerResponse;
     } finally {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -318,8 +318,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
       // Log query and stats
       _queryLogger.log(
-          new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse, requesterIdentity,
-              null));
+          new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse, true,
+              requesterIdentity, null));
 
       return brokerResponse;
     } finally {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -110,6 +110,7 @@ public class QueryLoggerTest {
         + "offlineThreadCpuTimeNs(total/thread/sysActivity/resSer):45/14/15/16,"
         + "realtimeThreadCpuTimeNs(total/thread/sysActivity/resSer):54/17/18/19,"
         + "clientIp=ip,"
+        + "isMultiStageQueryEngine=false,"
         + "query=SELECT * FROM foo");
     //@formatter:on
   }
@@ -281,6 +282,6 @@ public class QueryLoggerTest {
     ServerStats serverStats = new ServerStats();
     serverStats.setServerStats("serverStats");
 
-    return new QueryLogger.QueryLogParams(requestContext, "table", response, identity, serverStats);
+    return new QueryLogger.QueryLogParams(requestContext, "table", response, false, identity, serverStats);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -110,7 +110,7 @@ public class QueryLoggerTest {
         + "offlineThreadCpuTimeNs(total/thread/sysActivity/resSer):45/14/15/16,"
         + "realtimeThreadCpuTimeNs(total/thread/sysActivity/resSer):54/17/18/19,"
         + "clientIp=ip,"
-        + "isMultiStageQueryEngine=false,"
+        + "queryEngine=singleStage,"
         + "query=SELECT * FROM foo");
     //@formatter:on
   }
@@ -282,6 +282,7 @@ public class QueryLoggerTest {
     ServerStats serverStats = new ServerStats();
     serverStats.setServerStats("serverStats");
 
-    return new QueryLogger.QueryLogParams(requestContext, "table", response, false, identity, serverStats);
+    return new QueryLogger.QueryLogParams(requestContext, "table", response,
+        QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, identity, serverStats);
   }
 }


### PR DESCRIPTION
- Currently, the only way to distinguish between SSQE and MSQE queries via query logs in Pinot brokers is to check whether `serverStats` is empty (MSQE) or not (SSQE).
- This isn't reliable or convenient and we should explicitly indicate which query engine the query is executing with for easier log analysis. 