### PR TITLE
Allow optional second argument (max map size) for FREQUENTSTRINGSSKETCH / FREQUENTLONGSSKETCH in the multi-stage engine

### DIFF
--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -257,7 +257,11 @@ public class QueryEnvironmentTestBase {
         new Object[]{"SELECT ts_timestamp - CAST(123456789 AS TIMESTAMP) FROM a"},
         new Object[]{"SELECT SUB(ts_timestamp, CAST(123456789 AS TIMESTAMP)) FROM a"},
         new Object[]{"SELECT ts_timestamp + CAST(123456789 AS TIMESTAMP) FROM a"},
-        new Object[]{"SELECT ADD(ts_timestamp, CAST(123456789 AS TIMESTAMP)) FROM a"}
+        new Object[]{"SELECT ADD(ts_timestamp, CAST(123456789 AS TIMESTAMP)) FROM a"},
+        new Object[]{"SELECT FREQUENT_STRINGS_SKETCH(col1, 512) FROM a"},
+        new Object[]{"SELECT FREQUENT_STRINGS_SKETCH(col1) FROM a"},
+        new Object[]{"SELECT FREQUENT_LONGS_SKETCH(col3, 1024) FROM a"},
+        new Object[]{"SELECT FREQUENT_LONGS_SKETCH(col3) FROM a"},
     };
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -142,8 +142,10 @@ public enum AggregationFunctionType {
   FOURTHMOMENT("fourthMoment", ReturnTypes.DOUBLE, OperandTypes.ANY, SqlTypeName.OTHER),
 
   // Datasketches Frequent Items support
-  FREQUENTSTRINGSSKETCH("frequentStringsSketch", ReturnTypes.VARCHAR, OperandTypes.ANY, SqlTypeName.OTHER),
-  FREQUENTLONGSSKETCH("frequentLongsSketch", ReturnTypes.VARCHAR, OperandTypes.ANY, SqlTypeName.OTHER),
+  FREQUENTSTRINGSSKETCH("frequentStringsSketch", ReturnTypes.VARCHAR,
+      OperandTypes.family(List.of(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER), i -> i == 1), SqlTypeName.OTHER),
+  FREQUENTLONGSSKETCH("frequentLongsSketch", ReturnTypes.VARCHAR,
+      OperandTypes.family(List.of(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER), i -> i == 1), SqlTypeName.OTHER),
 
   // Geo aggregation functions
   STUNION("STUnion", ReturnTypes.VARBINARY, OperandTypes.BINARY, SqlTypeName.OTHER),


### PR DESCRIPTION
- Currently, attempting to use `FREQUENTSTRINGSSKETCH` / `FREQUENTLONGSSKETCH` with the optional second argument that determines the max map size causes a query compilation failure in the multi-stage engine.
- This is due to a bug in how these functions are registered with Calcite (the second optional argument wasn't included in the definition). 
- This patch fixes the issue by adding an optional second argument of integer type for the max map size.