### PR TITLE
Skip block split for local exchange

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -63,6 +63,11 @@ public class GrpcSendingMailbox implements SendingMailbox {
   }
 
   @Override
+  public boolean isLocal() {
+    return false;
+  }
+
+  @Override
   public void send(TransferableBlock block)
       throws IOException {
     if (isTerminated() || (isEarlyTerminated() && !block.isEndOfStreamBlock())) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -49,6 +49,11 @@ public class InMemorySendingMailbox implements SendingMailbox {
   }
 
   @Override
+  public boolean isLocal() {
+    return true;
+  }
+
+  @Override
   public void send(TransferableBlock block)
       throws TimeoutException {
     if (isTerminated() || (isEarlyTerminated() && !block.isEndOfStreamBlock())) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
@@ -30,6 +30,12 @@ import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 public interface SendingMailbox {
 
   /**
+   * Returns whether the mailbox is sending data to a local receiver, where blocks can be directly passed to the
+   * receiver.
+   */
+  boolean isLocal();
+
+  /**
    * Sends a block to the receiver. Note that SendingMailbox are required to acquire resources lazily in this call, and
    * they should <b>not</b> acquire any resources when they are created. This method should throw if there was an error
    * sending the data, since that would allow {@link BlockExchange} to exit early.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.runtime.blocks;
 
 import com.google.common.collect.Iterators;
 import java.util.Iterator;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 
 
 /**
@@ -29,10 +28,10 @@ import org.apache.pinot.common.datablock.BaseDataBlock;
  * underlying transport.
  */
 public interface BlockSplitter {
-  BlockSplitter NO_OP = (block, type, maxBlockSize) -> Iterators.singletonIterator(block);
+  BlockSplitter NO_OP = (block, maxBlockSize) -> Iterators.singletonIterator(block);
 
   /**
    * @return a list of blocks that was split from the original {@code block}
    */
-  Iterator<TransferableBlock> split(TransferableBlock block, BaseDataBlock.Type type, int maxBlockSize);
+  Iterator<TransferableBlock> split(TransferableBlock block, int maxBlockSize);
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 
 
@@ -63,7 +64,6 @@ public final class TransferableBlockUtils {
   }
 
   /**
-   *
    *  Split a block into multiple block so that each block size is within maxBlockSize. Currently,
    *  <ul>
    *    <li>For row data block, we split for row type dataBlock.</li>
@@ -72,31 +72,33 @@ public final class TransferableBlockUtils {
    *  </ul>
    *
    * @param block the data block
-   * @param type type of block
    * @param maxBlockSize Each chunk of data is estimated to be less than maxBlockSize
    * @return a list of data block chunks
    */
-  public static Iterator<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize) {
-    List<TransferableBlock> blockChunks = new ArrayList<>();
+  public static Iterator<TransferableBlock> splitBlock(TransferableBlock block, int maxBlockSize) {
+    DataBlock.Type type = block.getType();
     if (type == DataBlock.Type.ROW) {
       // Use estimated row size, this estimate is not accurate and is used to estimate numRowsPerChunk only.
-      int estimatedRowSizeInBytes = block.getDataSchema().getColumnNames().length * MEDIAN_COLUMN_SIZE_BYTES;
+      DataSchema dataSchema = block.getDataSchema();
+      assert dataSchema != null;
+      int estimatedRowSizeInBytes = dataSchema.getColumnNames().length * MEDIAN_COLUMN_SIZE_BYTES;
       int numRowsPerChunk = maxBlockSize / estimatedRowSizeInBytes;
       Preconditions.checkState(numRowsPerChunk > 0, "row size too large for query engine to handle, abort!");
 
-      int totalNumRows = block.getNumRows();
-      List<Object[]> allRows = block.getContainer();
-      int currentRow = 0;
-      while (currentRow < totalNumRows) {
-        List<Object[]> chunk = allRows.subList(currentRow, Math.min(currentRow + numRowsPerChunk, allRows.size()));
-        currentRow += numRowsPerChunk;
-        blockChunks.add(new TransferableBlock(chunk, block.getDataSchema(), block.getType()));
+      List<Object[]> rows = block.getContainer();
+      int numRows = rows.size();
+      int numChunks = (numRows + numRowsPerChunk - 1) / numRowsPerChunk;
+      if (numChunks == 1) {
+        return Iterators.singletonIterator(block);
+      }
+      List<TransferableBlock> blockChunks = new ArrayList<>(numChunks);
+      for (int fromIndex = 0; fromIndex < numRows; fromIndex += numRowsPerChunk) {
+        int toIndex = Math.min(fromIndex + numRowsPerChunk, numRows);
+        blockChunks.add(new TransferableBlock(rows.subList(fromIndex, toIndex), dataSchema, DataBlock.Type.ROW));
       }
       return blockChunks.iterator();
-    } else if (type == DataBlock.Type.METADATA) {
-      return Iterators.singletonIterator(block);
     } else {
-      throw new IllegalArgumentException("Unsupported data block type: " + type);
+      return Iterators.singletonIterator(block);
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
@@ -71,11 +71,12 @@ public class TransferableBlockUtilsTest {
     int estRowSizeInBytes = dataSchema.size() * TEST_EST_BYTES_PER_COLUMN;
     List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TOTAL_ROW_COUNT, 1);
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, dataSchema);
-    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock), DataBlock.Type.ROW,
-        estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+    validateBlocks(
+        TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock), estRowSizeInBytes * splitRowCount + 1), rows,
+        dataSchema);
     // compare non-serialized split
     validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, DataBlock.Type.ROW),
-        DataBlock.Type.ROW, estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+        estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
   }
 
   @Test
@@ -93,18 +94,15 @@ public class TransferableBlockUtilsTest {
     validateNonSplittableBlock(metadataBlock);
   }
 
-  private void validateNonSplittableBlock(BaseDataBlock nonSplittableBlock)
-      throws Exception {
+  private void validateNonSplittableBlock(BaseDataBlock nonSplittableBlock) {
     Iterator<TransferableBlock> transferableBlocks =
-        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), DataBlock.Type.METADATA,
-            4 * 1024 * 1024);
+        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), 4 * 1024 * 1024);
     Assert.assertTrue(transferableBlocks.hasNext());
     Assert.assertSame(transferableBlocks.next().getDataBlock(), nonSplittableBlock);
     Assert.assertFalse(transferableBlocks.hasNext());
   }
 
-  private void validateBlocks(Iterator<TransferableBlock> blocks, List<Object[]> rows, DataSchema dataSchema)
-      throws Exception {
+  private void validateBlocks(Iterator<TransferableBlock> blocks, List<Object[]> rows, DataSchema dataSchema) {
     int rowId = 0;
     while (blocks.hasNext()) {
       TransferableBlock block = blocks.next();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
@@ -151,8 +151,8 @@ public class BlockExchangeTest {
     TransferableBlock outBlockTwo =
         new TransferableBlock(ImmutableList.of(new Object[]{"two"}), schema, DataBlock.Type.ROW);
 
-    BlockExchange exchange = new TestBlockExchange(destinations,
-        (block, type, maxSize) -> ImmutableList.of(outBlockOne, outBlockTwo).iterator());
+    BlockExchange exchange =
+        new TestBlockExchange(destinations, (block, maxSize) -> ImmutableList.of(outBlockOne, outBlockTwo).iterator());
 
     // When:
     exchange.send(inBlock);
@@ -169,7 +169,7 @@ public class BlockExchangeTest {
 
   private static class TestBlockExchange extends BlockExchange {
     protected TestBlockExchange(List<SendingMailbox> destinations) {
-      this(destinations, (block, type, size) -> Iterators.singletonIterator(block));
+      this(destinations, (block, size) -> Iterators.singletonIterator(block));
     }
 
     protected TestBlockExchange(List<SendingMailbox> destinations, BlockSplitter splitter) {


### PR DESCRIPTION
- Skip splitting block for local exchange where block can be directly passed as in-memory object
- Enhance split when block is small