### PR TITLE
Separate NonEquiJoinOperator from HashJoinOperator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -1,0 +1,354 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions.JoinHintOptions;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
+import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code BaseJoinOperator} implements the basic join algorithm.
+ * <p>This algorithm assumes that the right table has to fit in memory since we are not supporting any spilling. It
+ * reads the complete right table and materialize the data in memory. Then for each of the left table row, it looks up
+ * for the corresponding row(s) from the right table, applies the non-equi evaluators and creates a joint row.
+ * <p>For each of the data block received from the left table, it generates a joint data block. The output is in the
+ * format of [left_row, right_row].
+ */
+// TODO: Support memory size based resource limit.
+public abstract class BaseJoinOperator extends MultiStageOperator {
+  protected static final Logger LOGGER = LoggerFactory.getLogger(BaseJoinOperator.class);
+  protected static final int DEFAULT_MAX_ROWS_IN_JOIN = 1024 * 1024; // 2^20, around 1MM rows
+  protected static final JoinOverFlowMode DEFAULT_JOIN_OVERFLOW_MODE = JoinOverFlowMode.THROW;
+
+  protected final MultiStageOperator _leftInput;
+  protected final MultiStageOperator _rightInput;
+  protected final JoinRelType _joinType;
+  protected final DataSchema _resultSchema;
+  protected final int _leftColumnSize;
+  protected final int _resultColumnSize;
+  protected final List<TransformOperand> _nonEquiEvaluators;
+  protected final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
+
+  // Below are specific parameters to protect the server from a very large join operation.
+  // Once the hash table reaches the limit, we will throw exception or break the right table build process.
+  // The limit also applies to the number of joined rows in blocks from the left table.
+  /**
+   * Max rows allowed to build the right table hash collection. Also max rows emitted in each join with a block from
+   * the left table.
+   */
+  protected final int _maxRowsInJoin;
+  /**
+   * Mode when join overflow happens, supported values: THROW or BREAK.
+   *   THROW(default): Break right table build process, and throw exception, no JOIN with left table performed.
+   *   BREAK: Break right table build process, continue to perform JOIN operation, results might be partial.
+   */
+  protected final JoinOverFlowMode _joinOverflowMode;
+
+  protected boolean _isRightTableBuilt;
+  protected TransferableBlock _upstreamErrorBlock;
+  protected MultiStageQueryStats _leftSideStats;
+  protected MultiStageQueryStats _rightSideStats;
+  // Used by non-inner join.
+  // Needed to indicate we have finished processing all results after returning last block.
+  protected boolean _isTerminated;
+
+  public BaseJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
+      MultiStageOperator rightInput, JoinNode node) {
+    super(context);
+    _leftInput = leftInput;
+    _rightInput = rightInput;
+    _joinType = node.getJoinType();
+    _leftColumnSize = leftSchema.size();
+    _resultSchema = node.getDataSchema();
+    _resultColumnSize = _resultSchema.size();
+    List<RexExpression> nonEquiConditions = node.getNonEquiConditions();
+    _nonEquiEvaluators = new ArrayList<>(nonEquiConditions.size());
+    for (RexExpression nonEquiCondition : nonEquiConditions) {
+      _nonEquiEvaluators.add(TransformOperandFactory.getTransformOperand(nonEquiCondition, _resultSchema));
+    }
+    Map<String, String> metadata = context.getOpChainMetadata();
+    PlanNode.NodeHint nodeHint = node.getNodeHint();
+    _maxRowsInJoin = getMaxRowsInJoin(metadata, nodeHint);
+    _joinOverflowMode = getJoinOverflowMode(metadata, nodeHint);
+  }
+
+  protected static int getMaxRowsInJoin(Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
+    if (nodeHint != null) {
+      Map<String, String> joinOptions = nodeHint.getHintOptions().get(PinotHintOptions.JOIN_HINT_OPTIONS);
+      if (joinOptions != null) {
+        String maxRowsInJoinStr = joinOptions.get(JoinHintOptions.MAX_ROWS_IN_JOIN);
+        if (maxRowsInJoinStr != null) {
+          return Integer.parseInt(maxRowsInJoinStr);
+        }
+      }
+    }
+    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(opChainMetadata);
+    return maxRowsInJoin != null ? maxRowsInJoin : DEFAULT_MAX_ROWS_IN_JOIN;
+  }
+
+  protected static JoinOverFlowMode getJoinOverflowMode(Map<String, String> contextMetadata,
+      @Nullable PlanNode.NodeHint nodeHint) {
+    if (nodeHint != null) {
+      Map<String, String> joinOptions = nodeHint.getHintOptions().get(PinotHintOptions.JOIN_HINT_OPTIONS);
+      if (joinOptions != null) {
+        String joinOverflowModeStr = joinOptions.get(JoinHintOptions.JOIN_OVERFLOW_MODE);
+        if (joinOverflowModeStr != null) {
+          return JoinOverFlowMode.valueOf(joinOverflowModeStr);
+        }
+      }
+    }
+    JoinOverFlowMode joinOverflowMode = QueryOptionsUtils.getJoinOverflowMode(contextMetadata);
+    return joinOverflowMode != null ? joinOverflowMode : DEFAULT_JOIN_OVERFLOW_MODE;
+  }
+
+  @Override
+  public void registerExecution(long time, int numRows) {
+    _statMap.merge(StatKey.EXECUTION_TIME_MS, time);
+    _statMap.merge(StatKey.EMITTED_ROWS, numRows);
+  }
+
+  @Override
+  public Type getOperatorType() {
+    // TODO: Add separate StatKey for each child join operator.
+    return Type.HASH_JOIN;
+  }
+
+  @Override
+  protected Logger logger() {
+    return LOGGER;
+  }
+
+  @Override
+  public List<MultiStageOperator> getChildOperators() {
+    return List.of(_leftInput, _rightInput);
+  }
+
+  @Override
+  protected TransferableBlock getNextBlock()
+      throws ProcessingException {
+    if (!_isRightTableBuilt) {
+      buildRightTable();
+    }
+    if (_upstreamErrorBlock != null) {
+      LOGGER.trace("Returning upstream error block for join operator");
+      return _upstreamErrorBlock;
+    }
+    TransferableBlock transferableBlock = buildJoinedDataBlock();
+    LOGGER.trace("Returning {} for join operator", transferableBlock);
+    return transferableBlock;
+  }
+
+  protected abstract void buildRightTable()
+      throws ProcessingException;
+
+  protected TransferableBlock buildJoinedDataBlock()
+      throws ProcessingException {
+    LOGGER.trace("Building joined data block for join operator");
+    // Keep reading the input blocks until we find a match row or all blocks are processed.
+    // TODO: Consider batching the rows to improve performance.
+    while (true) {
+      if (_upstreamErrorBlock != null) {
+        return _upstreamErrorBlock;
+      }
+      if (_isTerminated) {
+        assert _leftSideStats != null;
+        return TransferableBlockUtils.getEndOfStreamTransferableBlock(_leftSideStats);
+      }
+      LOGGER.trace("Processing next block on left input");
+      TransferableBlock leftBlock = _leftInput.nextBlock();
+      if (leftBlock.isErrorBlock()) {
+        return leftBlock;
+      }
+      if (leftBlock.isSuccessfulEndOfStreamBlock()) {
+        assert _rightSideStats != null;
+        _leftSideStats = leftBlock.getQueryStats();
+        assert _leftSideStats != null;
+        _leftSideStats.mergeInOrder(_rightSideStats, getOperatorType(), _statMap);
+        if (needUnmatchedRightRows()) {
+          List<Object[]> rows = buildNonMatchRightRows();
+          if (!rows.isEmpty()) {
+            _isTerminated = true;
+            return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
+          }
+        }
+        return leftBlock;
+      }
+      assert leftBlock.isDataBlock();
+      List<Object[]> rows = buildJoinedRows(leftBlock);
+      sampleAndCheckInterruption();
+      if (!rows.isEmpty()) {
+        return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
+      }
+    }
+  }
+
+  protected abstract List<Object[]> buildJoinedRows(TransferableBlock leftBlock)
+      throws ProcessingException;
+
+  protected abstract List<Object[]> buildNonMatchRightRows();
+
+  protected Object[] joinRow(@Nullable Object[] leftRow, @Nullable Object[] rightRow) {
+    Object[] resultRow = new Object[_resultColumnSize];
+    if (leftRow != null) {
+      System.arraycopy(leftRow, 0, resultRow, 0, leftRow.length);
+    }
+    if (rightRow != null) {
+      System.arraycopy(rightRow, 0, resultRow, _leftColumnSize, rightRow.length);
+    }
+    return resultRow;
+  }
+
+  protected boolean matchNonEquiConditions(Object[] row) {
+    if (_nonEquiEvaluators.isEmpty()) {
+      return true;
+    }
+    for (TransformOperand evaluator : _nonEquiEvaluators) {
+      if (!BooleanUtils.isTrueInternalValue(evaluator.apply(row))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  protected boolean needUnmatchedRightRows() {
+    return _joinType == JoinRelType.RIGHT || _joinType == JoinRelType.FULL;
+  }
+
+  protected boolean needUnmatchedLeftRows() {
+    return _joinType == JoinRelType.LEFT || _joinType == JoinRelType.FULL;
+  }
+
+  protected void earlyTerminateLeftInput() {
+    _leftInput.earlyTerminate();
+    TransferableBlock leftBlock = _leftInput.nextBlock();
+
+    while (!leftBlock.isSuccessfulEndOfStreamBlock()) {
+      if (leftBlock.isErrorBlock()) {
+        _upstreamErrorBlock = leftBlock;
+        return;
+      }
+      leftBlock = _leftInput.nextBlock();
+    }
+
+    assert leftBlock.isSuccessfulEndOfStreamBlock();
+    assert _rightSideStats != null;
+    _leftSideStats = leftBlock.getQueryStats();
+    assert _leftSideStats != null;
+    _leftSideStats.mergeInOrder(_rightSideStats, getOperatorType(), _statMap);
+    _isTerminated = true;
+  }
+
+  /**
+   * Checks if we have reached the rows limit for joined rows. If the limit has been reached, either an exception is
+   * thrown or the left input is early terminated based on the {@link #_joinOverflowMode}.
+   *
+   * @return {@code true} if the limit has been reached, {@code false} otherwise.
+   */
+  protected boolean isMaxRowsLimitReached(int numJoinedRows)
+      throws ProcessingException {
+    if (numJoinedRows == _maxRowsInJoin) {
+      if (_joinOverflowMode == JoinOverFlowMode.THROW) {
+        throwProcessingExceptionForJoinRowLimitExceeded(
+            "Cannot process join, reached number of rows limit: " + _maxRowsInJoin);
+      } else {
+        // Skip over remaining blocks until we reach the end of stream since we already breached the rows limit.
+        logger().info("Terminating join operator early as the maximum number of rows limit was reached: {}",
+            _maxRowsInJoin);
+        earlyTerminateLeftInput();
+        _statMap.merge(StatKey.MAX_ROWS_IN_JOIN_REACHED, true);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  protected static void throwProcessingExceptionForJoinRowLimitExceeded(String reason)
+      throws ProcessingException {
+    ProcessingException resourceLimitExceededException =
+        new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
+    resourceLimitExceededException.setMessage(reason
+        + ". Consider increasing the limit for the maximum number of rows in a join either via the query option '"
+        + QueryOptionKey.MAX_ROWS_IN_JOIN + "' or the '" + JoinHintOptions.MAX_ROWS_IN_JOIN + "' hint in the '"
+        + PinotHintOptions.JOIN_HINT_OPTIONS
+        + "'. Alternatively, if partial results are acceptable, the join overflow mode can be set to '"
+        + JoinOverFlowMode.BREAK.name() + "' either via the query option '" + QueryOptionKey.JOIN_OVERFLOW_MODE
+        + "' or the '" + JoinHintOptions.JOIN_OVERFLOW_MODE + "' hint in the '" + PinotHintOptions.JOIN_HINT_OPTIONS
+        + "'.");
+    throw resourceLimitExceededException;
+  }
+
+  public enum StatKey implements StatMap.Key {
+    //@formatter:off
+    EXECUTION_TIME_MS(StatMap.Type.LONG) {
+      @Override
+      public boolean includeDefaultInJson() {
+        return true;
+      }
+    },
+    EMITTED_ROWS(StatMap.Type.LONG) {
+      @Override
+      public boolean includeDefaultInJson() {
+        return true;
+      }
+    },
+    MAX_ROWS_IN_JOIN_REACHED(StatMap.Type.BOOLEAN),
+    /**
+     * How long (CPU time) has been spent on building the hash table.
+     */
+    TIME_BUILDING_HASH_TABLE_MS(StatMap.Type.LONG);
+    //@formatter:on
+
+    private final StatMap.Type _type;
+
+    StatKey(StatMap.Type type) {
+      _type = type;
+    }
+
+    @Override
+    public StatMap.Type getType() {
+      return _type;
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -24,174 +24,41 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
-import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
-import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.datatable.StatMap;
-import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.config.QueryOptionsUtils;
-import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
 import org.apache.pinot.query.planner.plannode.JoinNode;
-import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
-import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
-import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.utils.BooleanUtils;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * This {@code HashJoinOperator} implements the hash join algorithm.
- * <p>This algorithm assumes that the right table has to fit in memory since we are not supporting any spilling. It
- * reads the complete hash partitioned right table and materialize the data into a hash table. Then for each of the left
- * table row, it looks up for the corresponding row(s) from the hash table and create a joint row.
- * <p>For each of the data block received from the left table, it generates a joint data block. The output is in the
- * format of [left_row, right_row].
+ * This {@code HashJoinOperator} join algorithm with join keys. Right table is materialized into a hash table.
  */
-// TODO: Move inequi out of hashjoin. (https://github.com/apache/pinot/issues/9728)
 // TODO: Support memory size based resource limit.
-public class HashJoinOperator extends MultiStageOperator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(HashJoinOperator.class);
+public class HashJoinOperator extends BaseJoinOperator {
   private static final String EXPLAIN_NAME = "HASH_JOIN";
   private static final int INITIAL_HEURISTIC_SIZE = 16;
-  private static final int DEFAULT_MAX_ROWS_IN_JOIN = 1024 * 1024; // 2^20, around 1MM rows
-  private static final JoinOverFlowMode DEFAULT_JOIN_OVERFLOW_MODE = JoinOverFlowMode.THROW;
 
-  private static final Set<JoinRelType> SUPPORTED_JOIN_TYPES =
-      Set.of(JoinRelType.INNER, JoinRelType.LEFT, JoinRelType.RIGHT, JoinRelType.FULL, JoinRelType.SEMI,
-          JoinRelType.ANTI);
-
-  private final Map<Object, ArrayList<Object[]>> _broadcastRightTable;
-
-  // Used to track matched right rows.
-  // Only used for right join and full join to output non-matched right rows.
-  private final Map<Object, BitSet> _matchedRightRows;
-
-  private final MultiStageOperator _leftInput;
-  private final MultiStageOperator _rightInput;
-  private final JoinRelType _joinType;
   private final KeySelector<?> _leftKeySelector;
   private final KeySelector<?> _rightKeySelector;
-  private final DataSchema _resultSchema;
-  private final int _leftColumnSize;
-  private final int _resultColumnSize;
-  private final List<TransformOperand> _nonEquiEvaluators;
-  private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
-
-  // Below are specific parameters to protect the server from a very large join operation.
-  // Once the hash table reaches the limit, we will throw exception or break the right table build process.
-  // The limit also applies to the number of joined rows in blocks from the left table.
-  /**
-   * Max rows allowed to build the right table hash collection. Also max rows emitted in each join with a block from
-   * the left table.
-   */
-  private final int _maxRowsInJoin;
-  /**
-   * Mode when join overflow happens, supported values: THROW or BREAK.
-   *   THROW(default): Break right table build process, and throw exception, no JOIN with left table performed.
-   *   BREAK: Break right table build process, continue to perform JOIN operation, results might be partial.
-   */
-  private final JoinOverFlowMode _joinOverflowMode;
-
-  private boolean _isHashTableBuilt;
-  private TransferableBlock _upstreamErrorBlock;
-  private MultiStageQueryStats _leftSideStats;
-  private MultiStageQueryStats _rightSideStats;
-  // Used by non-inner join.
-  // Needed to indicate we have finished processing all results after returning last block.
-  private boolean _isTerminated;
+  private final Map<Object, ArrayList<Object[]>> _rightTable;
+  // Track matched right rows for right join and full join to output non-matched right rows.
+  // TODO: Revisit whether we should use IntList or RoaringBitmap for smaller memory footprint.
+  private final Map<Object, BitSet> _matchedRightRows;
 
   public HashJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
       MultiStageOperator rightInput, JoinNode node) {
-    super(context);
-    _leftInput = leftInput;
-    _rightInput = rightInput;
-    _joinType = node.getJoinType();
-    Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(_joinType), "Join type: % is not supported for hash join",
-        _joinType);
-
+    super(context, leftInput, leftSchema, rightInput, node);
+    Preconditions.checkState(!node.getLeftKeys().isEmpty(), "Hash join operator requires join keys");
     _leftKeySelector = KeySelectorFactory.getKeySelector(node.getLeftKeys());
     _rightKeySelector = KeySelectorFactory.getKeySelector(node.getRightKeys());
-    _leftColumnSize = leftSchema.size();
-    _resultSchema = node.getDataSchema();
-    _resultColumnSize = _resultSchema.size();
-    List<RexExpression> nonEquiConditions = node.getNonEquiConditions();
-    _nonEquiEvaluators = new ArrayList<>(nonEquiConditions.size());
-    for (RexExpression nonEquiCondition : nonEquiConditions) {
-      _nonEquiEvaluators.add(TransformOperandFactory.getTransformOperand(nonEquiCondition, _resultSchema));
-    }
-    _broadcastRightTable = new HashMap<>();
-    if (needUnmatchedRightRows()) {
-      _matchedRightRows = new HashMap<>();
-    } else {
-      _matchedRightRows = null;
-    }
-    Map<String, String> metadata = context.getOpChainMetadata();
-    PlanNode.NodeHint nodeHint = node.getNodeHint();
-    _maxRowsInJoin = getMaxRowsInJoin(metadata, nodeHint);
-    _joinOverflowMode = getJoinOverflowMode(metadata, nodeHint);
-  }
-
-  @Override
-  public void registerExecution(long time, int numRows) {
-    _statMap.merge(StatKey.EXECUTION_TIME_MS, time);
-    _statMap.merge(StatKey.EMITTED_ROWS, numRows);
-  }
-
-  @Override
-  public Type getOperatorType() {
-    return Type.HASH_JOIN;
-  }
-
-  @Override
-  protected Logger logger() {
-    return LOGGER;
-  }
-
-  private int getMaxRowsInJoin(Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
-    if (nodeHint != null) {
-      Map<String, String> joinOptions = nodeHint.getHintOptions().get(PinotHintOptions.JOIN_HINT_OPTIONS);
-      if (joinOptions != null) {
-        String maxRowsInJoinStr = joinOptions.get(PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN);
-        if (maxRowsInJoinStr != null) {
-          return Integer.parseInt(maxRowsInJoinStr);
-        }
-      }
-    }
-    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(opChainMetadata);
-    return maxRowsInJoin != null ? maxRowsInJoin : DEFAULT_MAX_ROWS_IN_JOIN;
-  }
-
-  private JoinOverFlowMode getJoinOverflowMode(Map<String, String> contextMetadata,
-      @Nullable PlanNode.NodeHint nodeHint) {
-    if (nodeHint != null) {
-      Map<String, String> joinOptions = nodeHint.getHintOptions().get(PinotHintOptions.JOIN_HINT_OPTIONS);
-      if (joinOptions != null) {
-        String joinOverflowModeStr = joinOptions.get(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE);
-        if (joinOverflowModeStr != null) {
-          return JoinOverFlowMode.valueOf(joinOverflowModeStr);
-        }
-      }
-    }
-    JoinOverFlowMode joinOverflowMode = QueryOptionsUtils.getJoinOverflowMode(contextMetadata);
-    return joinOverflowMode != null ? joinOverflowMode : DEFAULT_JOIN_OVERFLOW_MODE;
-  }
-
-  @Override
-  public List<MultiStageOperator> getChildOperators() {
-    return List.of(_leftInput, _rightInput);
+    _rightTable = new HashMap<>();
+    _matchedRightRows = needUnmatchedRightRows() ? new HashMap<>() : null;
   }
 
   @Override
@@ -200,22 +67,7 @@ public class HashJoinOperator extends MultiStageOperator {
   }
 
   @Override
-  protected TransferableBlock getNextBlock()
-      throws ProcessingException {
-    if (!_isHashTableBuilt) {
-      // Build JOIN hash table
-      buildBroadcastHashTable();
-    }
-    if (_upstreamErrorBlock != null) {
-      LOGGER.trace("Returning upstream error block for join operator");
-      return _upstreamErrorBlock;
-    }
-    TransferableBlock transferableBlock = buildJoinedDataBlock();
-    LOGGER.trace("Returning {} for join operator", transferableBlock);
-    return transferableBlock;
-  }
-
-  private void buildBroadcastHashTable()
+  protected void buildRightTable()
       throws ProcessingException {
     LOGGER.trace("Building hash table for join operator");
     long startTime = System.currentTimeMillis();
@@ -239,8 +91,8 @@ public class HashJoinOperator extends MultiStageOperator {
       }
       // put all the rows into corresponding hash collections keyed by the key selector function.
       for (Object[] row : container) {
-        ArrayList<Object[]> hashCollection = _broadcastRightTable.computeIfAbsent(_rightKeySelector.getKey(row),
-            k -> new ArrayList<>(INITIAL_HEURISTIC_SIZE));
+        ArrayList<Object[]> hashCollection =
+            _rightTable.computeIfAbsent(_rightKeySelector.getKey(row), k -> new ArrayList<>(INITIAL_HEURISTIC_SIZE));
         int size = hashCollection.size();
         if ((size & size - 1) == 0 && size < _maxRowsInJoin && size < Integer.MAX_VALUE / 2) { // is power of 2
           hashCollection.ensureCapacity(Math.min(size << 1, _maxRowsInJoin));
@@ -254,7 +106,7 @@ public class HashJoinOperator extends MultiStageOperator {
     if (rightBlock.isErrorBlock()) {
       _upstreamErrorBlock = rightBlock;
     } else {
-      _isHashTableBuilt = true;
+      _isRightTableBuilt = true;
       _rightSideStats = rightBlock.getQueryStats();
       assert _rightSideStats != null;
     }
@@ -262,48 +114,8 @@ public class HashJoinOperator extends MultiStageOperator {
     LOGGER.trace("Finished building hash table for join operator");
   }
 
-  private TransferableBlock buildJoinedDataBlock()
-      throws ProcessingException {
-    LOGGER.trace("Building joined data block for join operator");
-    // Keep reading the input blocks until we find a match row or all blocks are processed.
-    // TODO: Consider batching the rows to improve performance.
-    while (true) {
-      if (_upstreamErrorBlock != null) {
-        return _upstreamErrorBlock;
-      }
-      if (_isTerminated) {
-        assert _leftSideStats != null;
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock(_leftSideStats);
-      }
-      LOGGER.trace("Processing next block on left input");
-      TransferableBlock leftBlock = _leftInput.nextBlock();
-      if (leftBlock.isErrorBlock()) {
-        return leftBlock;
-      }
-      if (leftBlock.isSuccessfulEndOfStreamBlock()) {
-        assert _rightSideStats != null;
-        _leftSideStats = leftBlock.getQueryStats();
-        assert _leftSideStats != null;
-        _leftSideStats.mergeInOrder(_rightSideStats, getOperatorType(), _statMap);
-        if (needUnmatchedRightRows()) {
-          List<Object[]> rows = buildNonMatchRightRows();
-          if (!rows.isEmpty()) {
-            _isTerminated = true;
-            return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
-          }
-        }
-        return leftBlock;
-      }
-      assert leftBlock.isDataBlock();
-      List<Object[]> rows = buildJoinedRows(leftBlock);
-      sampleAndCheckInterruption();
-      if (!rows.isEmpty()) {
-        return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
-      }
-    }
-  }
-
-  private List<Object[]> buildJoinedRows(TransferableBlock leftBlock)
+  @Override
+  protected List<Object[]> buildJoinedRows(TransferableBlock leftBlock)
       throws ProcessingException {
     switch (_joinType) {
       case SEMI:
@@ -324,7 +136,7 @@ public class HashJoinOperator extends MultiStageOperator {
     for (Object[] leftRow : container) {
       Object key = _leftKeySelector.getKey(leftRow);
       // NOTE: Empty key selector will always give same hash code.
-      List<Object[]> rightRows = _broadcastRightTable.get(key);
+      List<Object[]> rightRows = _rightTable.get(key);
       if (rightRows == null) {
         if (needUnmatchedLeftRows()) {
           if (isMaxRowsLimitReached(rows.size())) {
@@ -376,7 +188,7 @@ public class HashJoinOperator extends MultiStageOperator {
     for (Object[] leftRow : container) {
       Object key = _leftKeySelector.getKey(leftRow);
       // SEMI-JOIN only checks existence of the key
-      if (_broadcastRightTable.containsKey(key)) {
+      if (_rightTable.containsKey(key)) {
         rows.add(leftRow);
       }
     }
@@ -391,7 +203,7 @@ public class HashJoinOperator extends MultiStageOperator {
     for (Object[] leftRow : container) {
       Object key = _leftKeySelector.getKey(leftRow);
       // ANTI-JOIN only checks non-existence of the key
-      if (!_broadcastRightTable.containsKey(key)) {
+      if (!_rightTable.containsKey(key)) {
         rows.add(leftRow);
       }
     }
@@ -399,9 +211,10 @@ public class HashJoinOperator extends MultiStageOperator {
     return rows;
   }
 
-  private List<Object[]> buildNonMatchRightRows() {
+  @Override
+  protected List<Object[]> buildNonMatchRightRows() {
     List<Object[]> rows = new ArrayList<>();
-    for (Map.Entry<Object, ArrayList<Object[]>> entry : _broadcastRightTable.entrySet()) {
+    for (Map.Entry<Object, ArrayList<Object[]>> entry : _rightTable.entrySet()) {
       List<Object[]> rightRows = entry.getValue();
       BitSet matchedIndices = _matchedRightRows.get(entry.getKey());
       if (matchedIndices == null) {
@@ -417,118 +230,5 @@ public class HashJoinOperator extends MultiStageOperator {
       }
     }
     return rows;
-  }
-
-  private Object[] joinRow(@Nullable Object[] leftRow, @Nullable Object[] rightRow) {
-    Object[] resultRow = new Object[_resultColumnSize];
-    if (leftRow != null) {
-      System.arraycopy(leftRow, 0, resultRow, 0, leftRow.length);
-    }
-    if (rightRow != null) {
-      System.arraycopy(rightRow, 0, resultRow, _leftColumnSize, rightRow.length);
-    }
-    return resultRow;
-  }
-
-  private boolean needUnmatchedRightRows() {
-    return _joinType == JoinRelType.RIGHT || _joinType == JoinRelType.FULL;
-  }
-
-  private boolean needUnmatchedLeftRows() {
-    return _joinType == JoinRelType.LEFT || _joinType == JoinRelType.FULL;
-  }
-
-  private void earlyTerminateLeftInput() {
-    _leftInput.earlyTerminate();
-    TransferableBlock leftBlock = _leftInput.nextBlock();
-
-    while (!leftBlock.isSuccessfulEndOfStreamBlock()) {
-      if (leftBlock.isErrorBlock()) {
-        _upstreamErrorBlock = leftBlock;
-        return;
-      }
-      leftBlock = _leftInput.nextBlock();
-    }
-
-    assert leftBlock.isSuccessfulEndOfStreamBlock();
-    assert _rightSideStats != null;
-    _leftSideStats = leftBlock.getQueryStats();
-    assert _leftSideStats != null;
-    _leftSideStats.mergeInOrder(_rightSideStats, getOperatorType(), _statMap);
-    _isTerminated = true;
-  }
-
-  /**
-   * Checks if we have reached the rows limit for joined rows. If the limit has been reached, either an exception is
-   * thrown or the left input is early terminated based on the {@link #_joinOverflowMode}.
-   *
-   * @return {@code true} if the limit has been reached, {@code false} otherwise.
-   */
-  private boolean isMaxRowsLimitReached(int numJoinedRows)
-      throws ProcessingException {
-    if (numJoinedRows == _maxRowsInJoin) {
-      if (_joinOverflowMode == JoinOverFlowMode.THROW) {
-        throwProcessingExceptionForJoinRowLimitExceeded(
-            "Cannot process join, reached number of rows limit: " + _maxRowsInJoin);
-      } else {
-        // Skip over remaining blocks until we reach the end of stream since we already breached the rows limit.
-        logger().info("Terminating join operator early as the maximum number of rows limit was reached: {}",
-            _maxRowsInJoin);
-        earlyTerminateLeftInput();
-        _statMap.merge(StatKey.MAX_ROWS_IN_JOIN_REACHED, true);
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private void throwProcessingExceptionForJoinRowLimitExceeded(String reason)
-      throws ProcessingException {
-    ProcessingException resourceLimitExceededException =
-        new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
-    resourceLimitExceededException.setMessage(reason
-        + ". Consider increasing the limit for the maximum number of rows in a join either via the query option '"
-        + CommonConstants.Broker.Request.QueryOptionKey.MAX_ROWS_IN_JOIN + "' or the '"
-        + PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN + "' hint in the '" + PinotHintOptions.JOIN_HINT_OPTIONS
-        + "'. Alternatively, if partial results are acceptable, the join overflow mode can be set to '"
-        + JoinOverFlowMode.BREAK.name() + "' either via the query option '"
-        + CommonConstants.Broker.Request.QueryOptionKey.JOIN_OVERFLOW_MODE + "' or the '"
-        + PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE + "' hint in the '" + PinotHintOptions.JOIN_HINT_OPTIONS
-        + "'.");
-    throw resourceLimitExceededException;
-  }
-
-  public enum StatKey implements StatMap.Key {
-    //@formatter:off
-    EXECUTION_TIME_MS(StatMap.Type.LONG) {
-      @Override
-      public boolean includeDefaultInJson() {
-        return true;
-      }
-    },
-    EMITTED_ROWS(StatMap.Type.LONG) {
-      @Override
-      public boolean includeDefaultInJson() {
-        return true;
-      }
-    },
-    MAX_ROWS_IN_JOIN_REACHED(StatMap.Type.BOOLEAN),
-    /**
-     * How long (CPU time) has been spent on building the hash table.
-     */
-    TIME_BUILDING_HASH_TABLE_MS(StatMap.Type.LONG);
-    //@formatter:on
-
-    private final StatMap.Type _type;
-
-    StatKey(StatMap.Type type) {
-      _type = type;
-    }
-
-    @Override
-    public StatMap.Type getType() {
-      return _type;
-    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
+
+
+/**
+ * The {@code NonEquiJoinOperator} implements the join algorithm without join keys. Right table is materialized into a
+ * list.
+ */
+public class NonEquiJoinOperator extends BaseJoinOperator {
+  private static final String EXPLAIN_NAME = "NON_EQUI_JOIN";
+
+  private final List<Object[]> _rightTable;
+  // Track matched right rows for right join and full join to output non-matched right rows.
+  // TODO: Revisit whether we should use IntList or RoaringBitmap for smaller memory footprint.
+  private BitSet _matchedRightRows;
+
+  public NonEquiJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
+      MultiStageOperator rightInput, JoinNode node) {
+    super(context, leftInput, leftSchema, rightInput, node);
+    Preconditions.checkState(node.getLeftKeys().isEmpty(), "Non-equi join operator cannot have join keys");
+    Preconditions.checkState(_joinType != JoinRelType.SEMI && _joinType != JoinRelType.ANTI,
+        "Non-equi join operator does not support semi or anti join");
+    _rightTable = new ArrayList<>();
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected void buildRightTable()
+      throws ProcessingException {
+    LOGGER.trace("Building right table for join operator");
+    long startTime = System.currentTimeMillis();
+    TransferableBlock rightBlock = _rightInput.nextBlock();
+    while (!TransferableBlockUtils.isEndOfStream(rightBlock)) {
+      List<Object[]> rows = rightBlock.getContainer();
+      int numRowsInRightTable = _rightTable.size();
+      // Row based overflow check.
+      if (rows.size() + numRowsInRightTable > _maxRowsInJoin) {
+        if (_joinOverflowMode == JoinOverFlowMode.THROW) {
+          throwProcessingExceptionForJoinRowLimitExceeded(
+              "Cannot build in memory right table for join operator, reached number of rows limit: " + _maxRowsInJoin);
+        } else {
+          // Just fill up the buffer.
+          int remainingRows = _maxRowsInJoin - numRowsInRightTable;
+          rows = rows.subList(0, remainingRows);
+          _statMap.merge(StatKey.MAX_ROWS_IN_JOIN_REACHED, true);
+          // setting only the rightTableOperator to be early terminated and awaits EOS block next.
+          _rightInput.earlyTerminate();
+        }
+      }
+      _rightTable.addAll(rows);
+      sampleAndCheckInterruption();
+      rightBlock = _rightInput.nextBlock();
+    }
+    if (rightBlock.isErrorBlock()) {
+      _upstreamErrorBlock = rightBlock;
+    } else {
+      _isRightTableBuilt = true;
+      if (needUnmatchedRightRows()) {
+        _matchedRightRows = new BitSet(_rightTable.size());
+      }
+      _rightSideStats = rightBlock.getQueryStats();
+      assert _rightSideStats != null;
+    }
+    _statMap.merge(StatKey.TIME_BUILDING_HASH_TABLE_MS, System.currentTimeMillis() - startTime);
+    LOGGER.trace("Finished building right table for join operator");
+  }
+
+  @Override
+  protected List<Object[]> buildJoinedRows(TransferableBlock leftBlock)
+      throws ProcessingException {
+    ArrayList<Object[]> rows = new ArrayList<>();
+    for (Object[] leftRow : leftBlock.getContainer()) {
+      // NOTE: Empty key selector will always give same hash code.
+      boolean hasMatchForLeftRow = false;
+      int numRightRows = _rightTable.size();
+      boolean maxRowsLimitReached = false;
+      for (int i = 0; i < numRightRows; i++) {
+        Object[] rightRow = _rightTable.get(i);
+        // TODO: Optimize this to avoid unnecessary object copy.
+        Object[] resultRow = joinRow(leftRow, rightRow);
+        if (matchNonEquiConditions(resultRow)) {
+          if (isMaxRowsLimitReached(rows.size())) {
+            maxRowsLimitReached = true;
+            break;
+          }
+          rows.add(resultRow);
+          hasMatchForLeftRow = true;
+          if (_matchedRightRows != null) {
+            _matchedRightRows.set(i);
+          }
+        }
+      }
+      if (maxRowsLimitReached) {
+        break;
+      }
+      if (!hasMatchForLeftRow && needUnmatchedLeftRows()) {
+        if (isMaxRowsLimitReached(rows.size())) {
+          break;
+        }
+        rows.add(joinRow(leftRow, null));
+      }
+    }
+    return rows;
+  }
+
+  @Override
+  protected List<Object[]> buildNonMatchRightRows() {
+    int numRightRows = _rightTable.size();
+    int numMatchedRightRows = _matchedRightRows.cardinality();
+    if (numMatchedRightRows == numRightRows) {
+      return List.of();
+    }
+    List<Object[]> rows = new ArrayList<>(numRightRows - numMatchedRightRows);
+    int unmatchedIndex = 0;
+    while ((unmatchedIndex = _matchedRightRows.nextClearBit(unmatchedIndex)) < numRightRows) {
+      rows.add(joinRow(null, _rightTable.get(unmatchedIndex++)));
+    }
+    return rows;
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.exception.QueryException;
@@ -46,7 +45,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 
-// TODO: Add more inequi join tests.
 public class HashJoinOperatorTest {
   private AutoCloseable _mocks;
   @Mock
@@ -119,36 +117,6 @@ public class HashJoinOperatorTest {
     assertEquals(resultRows.size(), 2);
     assertEquals(resultRows.get(0), new Object[]{2, "BB", 2, "Aa"});
     assertEquals(resultRows.get(1), new Object[]{2, "BB", 2, "BB"});
-  }
-
-  @Test
-  public void shouldHandleJoinOnEmptySelector() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    when(_leftInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    when(_rightInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    DataSchema resultSchema =
-        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
-            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
-        });
-    HashJoinOperator operator =
-        getOperator(leftSchema, resultSchema, JoinRelType.INNER, List.of(), List.of(), List.of());
-    List<Object[]> resultRows = operator.nextBlock().getContainer();
-    assertEquals(resultRows.size(), 6);
-    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
-    assertEquals(resultRows.get(1), new Object[]{1, "Aa", 2, "BB"});
-    assertEquals(resultRows.get(2), new Object[]{1, "Aa", 3, "BB"});
-    assertEquals(resultRows.get(3), new Object[]{2, "BB", 2, "Aa"});
-    assertEquals(resultRows.get(4), new Object[]{2, "BB", 2, "BB"});
-    assertEquals(resultRows.get(5), new Object[]{2, "BB", 3, "BB"});
   }
 
   @Test
@@ -243,65 +211,6 @@ public class HashJoinOperatorTest {
     HashJoinOperator operator =
         getOperator(leftSchema, resultSchema, JoinRelType.INNER, List.of(0), List.of(0), List.of());
     assertTrue(operator.nextBlock().isSuccessfulEndOfStreamBlock());
-  }
-
-  @Test
-  public void shouldHandleInequiJoinOnString() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    when(_leftInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    when(_rightInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    List<RexExpression> functionOperands = List.of(new RexExpression.InputRef(1), new RexExpression.InputRef(3));
-    List<RexExpression> nonEquiConditions =
-        List.of(new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.NOT_EQUALS.name(), functionOperands));
-    DataSchema resultSchema =
-        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
-            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
-        });
-    HashJoinOperator operator =
-        getOperator(leftSchema, resultSchema, JoinRelType.INNER, List.of(), List.of(), nonEquiConditions);
-    List<Object[]> resultRows = operator.nextBlock().getContainer();
-    assertEquals(resultRows.size(), 3);
-    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "BB"});
-    assertEquals(resultRows.get(1), new Object[]{1, "Aa", 3, "BB"});
-    assertEquals(resultRows.get(2), new Object[]{2, "BB", 2, "Aa"});
-  }
-
-  @Test
-  public void shouldHandleInequiJoinOnInt() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
-        ColumnDataType.INT, ColumnDataType.STRING
-    });
-    when(_leftInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    when(_rightInput.nextBlock()).thenReturn(
-            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{1, "BB"}))
-        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
-    List<RexExpression> functionOperands = List.of(new RexExpression.InputRef(0), new RexExpression.InputRef(2));
-    List<RexExpression> nonEquiConditions =
-        List.of(new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.NOT_EQUALS.name(), functionOperands));
-    DataSchema resultSchema =
-        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
-            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
-        });
-    HashJoinOperator operator =
-        getOperator(leftSchema, resultSchema, JoinRelType.INNER, List.of(), List.of(), nonEquiConditions);
-    List<Object[]> resultRows = operator.nextBlock().getContainer();
-    assertEquals(resultRows.size(), 2);
-    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
-    assertEquals(resultRows.get(1), new Object[]{2, "BB", 1, "BB"});
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperatorTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.List;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockTestUtils;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+
+
+// TODO: Add more tests.
+public class NonEquiJoinOperatorTest {
+  private AutoCloseable _mocks;
+  @Mock
+  private MultiStageOperator _leftInput;
+  @Mock
+  private MultiStageOperator _rightInput;
+  @Mock
+  private VirtualServerAddress _serverAddress;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = openMocks(this);
+    when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldHandleCrossJoin() {
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    when(_leftInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    when(_rightInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
+        });
+    NonEquiJoinOperator operator = getOperator(leftSchema, resultSchema, JoinRelType.INNER, List.of());
+    List<Object[]> resultRows = operator.nextBlock().getContainer();
+    assertEquals(resultRows.size(), 6);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{1, "Aa", 2, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{1, "Aa", 3, "BB"});
+    assertEquals(resultRows.get(3), new Object[]{2, "BB", 2, "Aa"});
+    assertEquals(resultRows.get(4), new Object[]{2, "BB", 2, "BB"});
+    assertEquals(resultRows.get(5), new Object[]{2, "BB", 3, "BB"});
+  }
+
+  @Test
+  public void shouldHandleNonEquiJoinOnString() {
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    when(_leftInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    when(_rightInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    List<RexExpression> functionOperands = List.of(new RexExpression.InputRef(1), new RexExpression.InputRef(3));
+    List<RexExpression> nonEquiConditions =
+        List.of(new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.NOT_EQUALS.name(), functionOperands));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
+        });
+    NonEquiJoinOperator operator = getOperator(leftSchema, resultSchema, JoinRelType.INNER, nonEquiConditions);
+    List<Object[]> resultRows = operator.nextBlock().getContainer();
+    assertEquals(resultRows.size(), 3);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "BB"});
+    assertEquals(resultRows.get(1), new Object[]{1, "Aa", 3, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{2, "BB", 2, "Aa"});
+  }
+
+  @Test
+  public void shouldHandleNonEquiJoinOnInt() {
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
+    });
+    when(_leftInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    when(_rightInput.nextBlock()).thenReturn(
+            OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{1, "BB"}))
+        .thenReturn(TransferableBlockTestUtils.getEndOfStreamTransferableBlock(0));
+    List<RexExpression> functionOperands = List.of(new RexExpression.InputRef(0), new RexExpression.InputRef(2));
+    List<RexExpression> nonEquiConditions =
+        List.of(new RexExpression.FunctionCall(ColumnDataType.BOOLEAN, SqlKind.NOT_EQUALS.name(), functionOperands));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
+        });
+    NonEquiJoinOperator operator = getOperator(leftSchema, resultSchema, JoinRelType.INNER, nonEquiConditions);
+    List<Object[]> resultRows = operator.nextBlock().getContainer();
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 1, "BB"});
+  }
+
+  private NonEquiJoinOperator getOperator(DataSchema leftSchema, DataSchema resultSchema, JoinRelType joinType,
+      List<RexExpression> nonEquiConditions, PlanNode.NodeHint nodeHint) {
+    return new NonEquiJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, leftSchema, _rightInput,
+        new JoinNode(-1, resultSchema, nodeHint, List.of(), joinType, List.of(), List.of(), nonEquiConditions,
+            JoinNode.JoinStrategy.HASH));
+  }
+
+  private NonEquiJoinOperator getOperator(DataSchema leftSchema, DataSchema resultSchema, JoinRelType joinType,
+      List<RexExpression> nonEquiConditions) {
+    return getOperator(leftSchema, resultSchema, joinType, nonEquiConditions, PlanNode.NodeHint.EMPTY);
+  }
+}


### PR DESCRIPTION
Close #9728 

Currently non-equi join is also executed with `HashJoinOperator` which is very inefficient because we can short-circuit a lot of places as there is no join key.
This PR extracts the common join logic into `BaseJoinOperator`, and adds a `NonEquiJoinOperator` to process join without key.