### PR TITLE
Enforce query timeout on query compilation in the multi-stage query engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -202,9 +202,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         case SELECT:
         default:
           try {
-            QueryEnvironment finalQueryEnvironment1 = queryEnvironment;
+            QueryEnvironment finalQueryEnvironment = queryEnvironment;
             queryPlanResult = planQueryWithTimeout(requestId, query,
-                () -> finalQueryEnvironment1.planQuery(query, sqlNodeAndOptions, requestId), queryTimer.getRemainingTime());
+                () -> finalQueryEnvironment.planQuery(query, sqlNodeAndOptions, requestId),
+                queryTimer.getRemainingTime());
           } catch (TimeoutException | InterruptedException e) {
             requestContext.setErrorCode(QueryException.BROKER_TIMEOUT_ERROR_CODE);
             return new BrokerResponseNative(QueryException.BROKER_TIMEOUT_ERROR);
@@ -221,7 +222,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     } catch (Throwable t) {
       if (queryEnvironment != null) {
         Set<String> resolvedTables = queryEnvironment.getResolvedTables();
-        if (resolvedTables != null && resolvedTables.size() > 0) {
+        if (resolvedTables != null && !resolvedTables.isEmpty()) {
           // validate table access to prevent schema leak via error messages
           TableAuthorizationResult tableAuthorizationResult =
               hasTableAccess(requesterIdentity, resolvedTables, requestContext, httpHeaders);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -26,7 +26,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -56,6 +61,7 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.ExceptionUtils;
+import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.common.utils.Timer;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.tls.TlsUtils;
@@ -94,6 +100,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final QueryDispatcher _queryDispatcher;
   private final boolean _explainAskingServerDefault;
   private final MultiStageQueryThrottler _queryThrottler;
+  private final ExecutorService _queryCompileExecutor;
 
   public MultiStageBrokerRequestHandler(PinotConfiguration config, String brokerId, BrokerRoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
@@ -114,6 +121,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.MultiStageQueryRunner.KEY_OF_MULTISTAGE_EXPLAIN_INCLUDE_SEGMENT_PLAN,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_MULTISTAGE_EXPLAIN_INCLUDE_SEGMENT_PLAN);
     _queryThrottler = queryThrottler;
+    _queryCompileExecutor = Executors.newFixedThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 2),
+        new NamedThreadFactory("multi-stage-query-compile-executor"));
   }
 
   @Override
@@ -123,6 +132,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
   @Override
   public void shutDown() {
+    _queryCompileExecutor.shutdown();
     _queryDispatcher.shutdown();
   }
 
@@ -138,11 +148,13 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     long compilationStartTimeNs = System.nanoTime();
     long queryTimeoutMs;
     QueryEnvironment queryEnvironment = null;
+    Timer queryTimer;
     QueryEnvironment.QueryPlannerResult queryPlanResult;
     String database;
     try {
       Long timeoutMsFromQueryOption = QueryOptionsUtils.getTimeoutMs(queryOptions);
       queryTimeoutMs = timeoutMsFromQueryOption != null ? timeoutMsFromQueryOption : _brokerTimeoutMs;
+      queryTimer = new Timer(queryTimeoutMs);
       database = DatabaseUtils.extractDatabaseFromQueryRequest(queryOptions, httpHeaders);
       boolean inferPartitionHint = _config.getProperty(CommonConstants.Broker.CONFIG_OF_INFER_PARTITION_HINT,
           CommonConstants.Broker.DEFAULT_INFER_PARTITION_HINT);
@@ -166,7 +178,15 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
               ? fragment -> requestPhysicalPlan(fragment, requestContext, queryTimeoutMs, queryOptions)
               : null;
 
-          queryPlanResult = queryEnvironment.explainQuery(query, sqlNodeAndOptions, requestId, fragmentToPlanNode);
+          try {
+            QueryEnvironment finalQueryEnvironment = queryEnvironment;
+            queryPlanResult = planQueryWithTimeout(requestId, query,
+                () -> finalQueryEnvironment.explainQuery(query, sqlNodeAndOptions, requestId, fragmentToPlanNode),
+                queryTimer.getRemainingTime());
+          } catch (TimeoutException | InterruptedException e) {
+            requestContext.setErrorCode(QueryException.BROKER_TIMEOUT_ERROR_CODE);
+            return new BrokerResponseNative(QueryException.BROKER_TIMEOUT_ERROR);
+          }
           String plan = queryPlanResult.getExplainPlan();
           Set<String> tableNames = queryPlanResult.getTableNames();
           TableAuthorizationResult tableAuthorizationResult =
@@ -181,7 +201,14 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
           return constructMultistageExplainPlan(query, plan);
         case SELECT:
         default:
-          queryPlanResult = queryEnvironment.planQuery(query, sqlNodeAndOptions, requestId);
+          try {
+            QueryEnvironment finalQueryEnvironment1 = queryEnvironment;
+            queryPlanResult = planQueryWithTimeout(requestId, query,
+                () -> finalQueryEnvironment1.planQuery(query, sqlNodeAndOptions, requestId), queryTimer.getRemainingTime());
+          } catch (TimeoutException | InterruptedException e) {
+            requestContext.setErrorCode(QueryException.BROKER_TIMEOUT_ERROR_CODE);
+            return new BrokerResponseNative(QueryException.BROKER_TIMEOUT_ERROR);
+          }
           break;
       }
     } catch (DatabaseConflictException e) {
@@ -191,7 +218,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_VALIDATION_ERROR, e));
     } catch (WebApplicationException e) {
       throw e;
-    } catch (RuntimeException e) {
+    } catch (Throwable t) {
       if (queryEnvironment != null) {
         Set<String> resolvedTables = queryEnvironment.getResolvedTables();
         if (resolvedTables != null && resolvedTables.size() > 0) {
@@ -204,10 +231,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         }
       }
 
-      String consolidatedMessage = ExceptionUtils.consolidateExceptionMessages(e);
+      String consolidatedMessage = ExceptionUtils.consolidateExceptionMessages(t);
       LOGGER.warn("Caught exception planning request {}: {}, {}", requestId, query, consolidatedMessage);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
-      if (e.getMessage().matches(".* Column .* not found in any table'")) {
+      if (t.getMessage() != null && t.getMessage().matches(".* Column .* not found in any table'")) {
         requestContext.setErrorCode(QueryException.UNKNOWN_COLUMN_ERROR_CODE);
         return new BrokerResponseNative(
             QueryException.getException(QueryException.UNKNOWN_COLUMN_ERROR, consolidatedMessage));
@@ -250,12 +277,12 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       return new BrokerResponseNative(QueryException.getException(QueryException.QUOTA_EXCEEDED_ERROR, errorMessage));
     }
 
-    Timer queryTimer = new Timer(queryTimeoutMs);
     int estimatedNumQueryThreads = dispatchableSubPlan.getEstimatedNumQueryThreads();
     try {
       // It's fine to block in this thread because we use a separate thread pool from the main Jersey server to process
       // these requests.
-      if (!_queryThrottler.tryAcquire(estimatedNumQueryThreads, queryTimeoutMs, TimeUnit.MILLISECONDS)) {
+      if (!_queryThrottler.tryAcquire(estimatedNumQueryThreads, queryTimer.getRemainingTime(),
+          TimeUnit.MILLISECONDS)) {
         LOGGER.warn("Timed out waiting to execute request {}: {}", requestId, query);
         requestContext.setErrorCode(QueryException.EXECUTION_TIMEOUT_ERROR_CODE);
         return new BrokerResponseNative(QueryException.EXECUTION_TIMEOUT_ERROR);
@@ -354,6 +381,29 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       failureMessage = "Reason: " + failureMessage;
     }
     throw new WebApplicationException("Permission denied." + failureMessage, Response.Status.FORBIDDEN);
+  }
+
+  /**
+   * Runs the query planning in a separate thread so that we can enforce a timeout on it (in some rare cases,
+   * we can see query compilation taking a very long time).
+   */
+  private QueryEnvironment.QueryPlannerResult planQueryWithTimeout(long requestId, String query,
+      Callable<QueryEnvironment.QueryPlannerResult> queryPlannerResultCallable, long timeoutMs)
+      throws Throwable {
+    Future<QueryEnvironment.QueryPlannerResult> queryPlanResultFuture = _queryCompileExecutor.submit(
+        queryPlannerResultCallable);
+    try {
+      return queryPlanResultFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      LOGGER.warn("Timed out while planning query {}: {}", requestId, query);
+      queryPlanResultFuture.cancel(true);
+      throw e;
+    } catch (InterruptedException e) {
+      LOGGER.warn("Interrupt received while planning query {}: {}", requestId, query);
+      throw e;
+    } catch (ExecutionException e) {
+      throw e.getCause();
+    }
   }
 
   private Collection<PlanNode> requestPhysicalPlan(DispatchablePlanFragment fragment,

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -28,6 +29,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -42,6 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
@@ -1487,6 +1490,79 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     long result = jsonNode.get("resultTable").get("rows").get(0).get(0).asLong();
 
     assertTrue(result > 0);
+  }
+
+  @Test
+  public void testQueryCompileBrokerTimeout() throws Exception {
+    // See https://github.com/apache/pinot/issues/13617. This test can be updated / removed when that issue is closed
+    String query = "SET timeoutMs=100; SELECT Carrier\n"
+        + "FROM (\n"
+        + "         SELECT Carrier\n"
+        + "         FROM mytable\n"
+        + "         WHERE Carrier IN (\n"
+        + "             'a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9',\n"
+        + "             'a10', 'a11', 'a12', 'a13', 'a14', 'a15', 'a16', 'a17', 'a18', 'a19',\n"
+        + "             'a20', 'a21', 'a22', 'a23', 'a24', 'a25', 'a26', 'a27', 'a28', 'a29',\n"
+        + "             'a30', 'a31', 'a32', 'a33', 'a34', 'a35', 'a36', 'a37', 'a38', 'a39',\n"
+        + "             'a40', 'a41', 'a42', 'a43', 'a44', 'a45', 'a46', 'a47', 'a48', 'a49',\n"
+        + "             'a50', 'a51', 'a52', 'a53', 'a54', 'a55', 'a56', 'a57', 'a58', 'a59',\n"
+        + "             'a60', 'a61', 'a62', 'a63', 'a64', 'a65', 'a66', 'a67', 'a68', 'a69',\n"
+        + "             'a70', 'a71', 'a72', 'a73', 'a74', 'a75', 'a76', 'a77', 'a78', 'a79',\n"
+        + "             'a80', 'a81', 'a82', 'a83', 'a84', 'a85', 'a86', 'a87', 'a88', 'a89',\n"
+        + "             'a90', 'a91', 'a92', 'a93', 'a94', 'a95', 'a96', 'a97', 'a98', 'a99',\n"
+        + "             'a100', 'a101', 'a102', 'a103', 'a104', 'a105', 'a106', 'a107', 'a108', 'a109',\n"
+        + "             'a110', 'a111', 'a112', 'a113', 'a114', 'a115', 'a116', 'a117', 'a118', 'a119',\n"
+        + "             'a120', 'a121', 'a122', 'a123', 'a124', 'a125', 'a126', 'a127', 'a128', 'a129',\n"
+        + "             'a130', 'a131', 'a132', 'a133', 'a134', 'a135', 'a136', 'a137', 'a138', 'a139',\n"
+        + "             'a140', 'a141', 'a142', 'a143', 'a144', 'a145', 'a146', 'a147', 'a148', 'a149',\n"
+        + "             'a150', 'a151', 'a152', 'a153', 'a154', 'a155', 'a156', 'a157', 'a158', 'a159',\n"
+        + "             'a160', 'a161', 'a162', 'a163', 'a164', 'a165', 'a166', 'a167', 'a168', 'a169',\n"
+        + "             'a170', 'a171', 'a172', 'a173', 'a174', 'a175', 'a176', 'a177', 'a178', 'a179',\n"
+        + "             'a180', 'a181', 'a182', 'a183', 'a184', 'a185', 'a186', 'a187', 'a188', 'a189',\n"
+        + "             'a190', 'a191', 'a192', 'a193', 'a194', 'a195', 'a196', 'a197', 'a198', 'a199',\n"
+        + "             'a200', 'a201', 'a202', 'a203', 'a204', 'a205', 'a206', 'a207', 'a208', 'a209',\n"
+        + "             'a210', 'a211', 'a212', 'a213', 'a214', 'a215', 'a216', 'a217', 'a218', 'a219',\n"
+        + "             'a220', 'a221', 'a222', 'a223', 'a224', 'a225', 'a226', 'a227', 'a228', 'a229',\n"
+        + "             'a230', 'a231', 'a232', 'a233', 'a234', 'a235', 'a236', 'a237', 'a238', 'a239',\n"
+        + "             'a240', 'a241', 'a242', 'a243', 'a244', 'a245', 'a246', 'a247', 'a248', 'a249',\n"
+        + "             'a250', 'a251', 'a252', 'a253', 'a254', 'a255', 'a256', 'a257', 'a258', 'a259',\n"
+        + "             'a260', 'a261', 'a262', 'a263', 'a264', 'a265', 'a266', 'a267', 'a268', 'a269',\n"
+        + "             'a270', 'a271', 'a272', 'a273', 'a274', 'a275', 'a276', 'a277', 'a278', 'a279',\n"
+        + "             'a280', 'a281', 'a282', 'a283', 'a284', 'a285', 'a286', 'a287', 'a288', 'a289',\n"
+        + "             'a290', 'a291', 'a292', 'a293', 'a294', 'a295', 'a296', 'a297', 'a298', 'a299',\n"
+        + "             'a300', 'a301', 'a302', 'a303', 'a304', 'a305', 'a306', 'a307', 'a308', 'a309',\n"
+        + "             'a310', 'a311', 'a312', 'a313', 'a314', 'a315', 'a316', 'a317', 'a318', 'a319',\n"
+        + "             'a320', 'a321', 'a322', 'a323', 'a324', 'a325', 'a326', 'a327', 'a328', 'a329',\n"
+        + "             'a330', 'a331', 'a332', 'a333', 'a334', 'a335', 'a336', 'a337', 'a338', 'a339',\n"
+        + "             'a340', 'a341', 'a342', 'a343', 'a344', 'a345', 'a346', 'a347', 'a348', 'a349',\n"
+        + "             'a350', 'a351', 'a352', 'a353', 'a354', 'a355', 'a356', 'a357', 'a358', 'a359',\n"
+        + "             'a360', 'a361', 'a362', 'a363', 'a364', 'a365', 'a366', 'a367', 'a368', 'a369',\n"
+        + "             'a370', 'a371', 'a372', 'a373', 'a374', 'a375', 'a376', 'a377', 'a378', 'a379',\n"
+        + "             'a380', 'a381', 'a382', 'a383', 'a384', 'a385', 'a386', 'a387', 'a388', 'a389',\n"
+        + "             'a390', 'a391', 'a392', 'a393', 'a394', 'a395', 'a396', 'a397', 'a398', 'a399',\n"
+        + "             'a400', 'a401', 'a402', 'a403', 'a404', 'a405', 'a406', 'a407', 'a408', 'a409',\n"
+        + "             'a410', 'a411', 'a412', 'a413', 'a414', 'a415', 'a416', 'a417', 'a418', 'a419',\n"
+        + "             'a420', 'a421', 'a422', 'a423', 'a424', 'a425', 'a426', 'a427', 'a428', 'a429',\n"
+        + "             'a430', 'a431', 'a432', 'a433', 'a434', 'a435', 'a436', 'a437', 'a438', 'a439',\n"
+        + "             'a440', 'a441', 'a442', 'a443', 'a444', 'a445', 'a446', 'a447', 'a448', 'a449',\n"
+        + "             'a450', 'a451', 'a452', 'a453', 'a454', 'a455', 'a456', 'a457', 'a458', 'a459',\n"
+        + "             'a460', 'a461', 'a462', 'a463', 'a464', 'a465', 'a466', 'a467', 'a468', 'a469',\n"
+        + "             'a470', 'a471', 'a472', 'a473', 'a474', 'a475', 'a476', 'a477', 'a478', 'a479',\n"
+        + "             'a480', 'a481', 'a482', 'a483', 'a484', 'a485', 'a486', 'a487', 'a488', 'a489',\n"
+        + "             'a490', 'a491', 'a492', 'a493', 'a494', 'a495', 'a496', 'a497', 'a498', 'a499'\n"
+        + "         )\n"
+        + "     )\n"
+        + "GROUP BY Carrier;";
+
+    JsonNode result = postQuery(query);
+    JsonNode exceptionsJson = result.get("exceptions");
+    Iterator<JsonNode> exIterator = exceptionsJson.iterator();
+    assertTrue(exIterator.hasNext(), "Expected a timeout exception but did not find one");
+    ObjectNode exception = (ObjectNode) exIterator.next();
+    assertEquals(exception.get(ProcessingException._Fields.ERROR_CODE.getFieldName()).asInt(),
+        QueryException.BROKER_TIMEOUT_ERROR_CODE);
+    assertEquals(exception.get(ProcessingException._Fields.MESSAGE.getFieldName()).asText(),
+        QueryException.BROKER_TIMEOUT_ERROR.getMessage());
   }
 
   public void testNumServersQueried() throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -96,7 +96,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
             .build();
     _helixManager.getConfigAccessor()
-        .set(scope, CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10");
+        .set(scope, CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "30");
 
     startBroker();
     startServer();


### PR DESCRIPTION
- In some rare scenarios, query compilation itself can take a very long time in the multi-stage query engine (see https://github.com/apache/pinot/issues/13617 for example).
- In these cases, the query timeout is not enforced, and the response can take arbitrarily long.
- This patch fixes the issue by enforcing the query timeout on the compilation phase as well. Subsequent operations like query dispatch and reduce will operate with the remaining timeout duration.