### PR TITLE
Fix potential NPE in OffHeapSingleTreeBuilder.close()

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -343,7 +343,9 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   public void close()
       throws IOException {
     super.close();
-    _starTreeRecordBuffer.close();
+    if (_starTreeRecordBuffer != null) {
+      _starTreeRecordBuffer.close();
+    }
     _starTreeRecordOutputStream.close();
     FileUtils.forceDelete(_starTreeRecordFile);
   }


### PR DESCRIPTION
`_starTreeRecordBuffer` might not be set when star-tree build is interrupted (e.g. throws exception)