### PR TITLE
Add debug API for pauseless tables. Add pauselessFSM as an option in realtimeQuickStart

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
@@ -29,11 +30,15 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -45,8 +50,11 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
@@ -299,6 +307,74 @@ public class PinotRealtimeTableResource {
           String.format("Failed to get consuming segments info for table %s. %s", realtimeTableName, e.getMessage()),
           Response.Status.INTERNAL_SERVER_ERROR, e);
     }
+  }
+
+  @GET
+  @Path("/tables/{tableName}/pauselessDebugInfo")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_DEBUG_INFO)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Returns state of pauseless table", notes =
+      "Gets the segments that are in error state and optionally gets COMMITTING segments based on the "
+          + "includeCommittingSegments parameter")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 404, message = "Table not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public String getPauslessTableDebugInfo(
+      @ApiParam(value = "Realtime table name with or without type", required = true, example = "myTable | "
+          + "myTable_REALTIME") @PathParam("tableName") String realtimeTableName,
+      @ApiParam(value = "Flag to include committing segment info") @QueryParam("includeCommittingSegments")
+      @DefaultValue("false") boolean includeCommittingSegments,
+      @Context HttpHeaders headers) {
+    realtimeTableName = DatabaseUtils.translateTableName(realtimeTableName, headers);
+    try {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(realtimeTableName);
+      if (TableType.OFFLINE == tableType) {
+        throw new IllegalStateException("Cannot get consuming segments info for OFFLINE table: " + realtimeTableName);
+      }
+      String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(realtimeTableName);
+
+      Map<String, Object> result = new HashMap<>();
+      result.put("instanceToErrorSegmentsMap", getInstanceToErrorSegmentsMap(tableNameWithType));
+
+      if (includeCommittingSegments) {
+        result.put("committingSegments", getCommittingSegments(tableNameWithType));
+      }
+      return JsonUtils.objectToPrettyString(result);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to get pauseless debug info for table %s. %s", realtimeTableName, e.getMessage()),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  public Set<String> getCommittingSegments(String tableNameWithType) {
+    List<SegmentZKMetadata> segmentZKMetadataList =
+        ZKMetadataProvider.getSegmentsZKMetadata(_pinotHelixResourceManager.getPropertyStore(), tableNameWithType);
+    return segmentZKMetadataList.stream()
+        .filter(
+            segmentZKMetadata -> segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING)
+        .map(SegmentZKMetadata::getSegmentName)
+        .collect(Collectors.toSet());
+  }
+
+  private Map<String, Set<String>> getInstanceToErrorSegmentsMap(String tableNameWithType) {
+    ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
+    Preconditions.checkState(externalView != null, "External view does not exist for table: " + tableNameWithType);
+
+    Map<String, Set<String>> instanceToErrorSegmentsMap = new HashMap<>();
+
+    for (String segmentName : externalView.getPartitionSet()) {
+      Map<String, String> externalViewStateMap = externalView.getStateMap(segmentName);
+      for (String instance : externalViewStateMap.keySet()) {
+        if (CommonConstants.Helix.StateModel.SegmentStateModel.ERROR.equals(
+            externalViewStateMap.get(instance))) {
+          instanceToErrorSegmentsMap.computeIfAbsent(instance, unused -> new HashSet<>()).add(segmentName);
+        }
+      }
+    }
+    return instanceToErrorSegmentsMap;
   }
 
   private void validateTable(String tableNameWithType) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.PinotAdministrator;
@@ -50,6 +51,8 @@ public class RealtimeQuickStart extends QuickStartBase {
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configOverrides = new HashMap<>();
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
+        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
     return configOverrides;
   }
 


### PR DESCRIPTION
 - There exists no API to quickly analyze the state of segments for a pauseless table.
 - The major issues that a pauseless table can run into are:
     - Segments in ERROR state due to missing data
     - Segments with ZK metadata status as COMMITTING due to failure of segment commit  protocol.
 - This API provides a way to fetch segment level information for the above two scenarios. 
 
Testing: 

Tested the API by introducing a lag when the segment is being committed and is yet to be marked `DONE`. 

<img width="1477" alt="Screenshot 2025-02-05 at 11 31 14 AM" src="https://github.com/user-attachments/assets/98d9e4ce-d41b-481d-82de-eda20ed7d8fa" />
<img width="711" alt="Screenshot 2025-02-05 at 11 31 26 AM" src="https://github.com/user-attachments/assets/a3bdf0af-c469-43c7-a7fb-5790dd66b8ad" />
<img width="1153" alt="Screenshot 2025-02-05 at 11 35 14 AM" src="https://github.com/user-attachments/assets/70929030-f263-4000-9e0a-cea62a075965" />
