### PR TITLE
Revert "Bump org.codehaus.mojo:buildnumber-maven-plugin from 3.2.0 to 3.2.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2260,7 +2260,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Reverts apache/pinot#13931

We found the [issue](https://github.com/mojohaus/buildnumber-maven-plugin/issues/229) with this version, resulting in the release's validation failure. 