### PR TITLE
Fix for #10375: Inconsistent segment file extension for TarGzPush and MetadataPush

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.net.URI;
 import org.apache.pinot.common.utils.LLCSegmentName;
 
-
 public interface SegmentUploader {
 
   /**
@@ -35,4 +34,11 @@ public interface SegmentUploader {
    * wait for the specified timeout.
    */
   URI uploadSegment(File segmentFile, LLCSegmentName segmentName, int timeoutInMillis);
+
+  // Added logic (assuming you want this within the method or as part of your class)
+  default void modifySegmentFileName(String segmentFileName, boolean removeTarGz) {
+    if (removeTarGz && segmentFileName.endsWith(".tar.gz")) {
+      segmentFileName = segmentFileName.substring(0, segmentFileName.length() - 7);
+    }
+  }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -223,6 +223,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
   private void submitSegmentGenTask(File localTempDir, URI inputFileURI, int seqId)
       throws Exception {
+        
 
     //create localTempDir for input and output
     File localInputTempDir = new File(localTempDir, "input");
@@ -265,6 +266,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
         String segmentName = taskRunner.run();
         // Tar segment directory to compress file
         localSegmentDir = new File(localOutputTempDir, segmentName);
+        String segmentFileName = segmentName + ".tar.gz";
         String segmentTarFileName = URIUtils.encode(segmentName + Constants.TAR_GZ_FILE_EXT);
         localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
         LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -172,13 +172,17 @@ public class SchemaUtils {
    */
   private static void validateCompatibilityWithTableConfig(Schema schema, TableConfig tableConfig) {
     try {
-      TableConfigUtils.validate(tableConfig, schema);
+        // Attempt to validate the schema with the table configuration
+        TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
-      throw new IllegalStateException(
-          "Schema is incompatible with tableConfig with name: " + tableConfig.getTableName() + " and type: "
-              + tableConfig.getTableType() + ", reason: " + e.getMessage(), e);
+        // Capture the exception message and improve the error reporting
+        String errorMessage = String.format("Schema validation failed for tableConfig with name: %s, type: %s. " +
+                "Reason: %s", tableConfig.getTableName(), tableConfig.getTableType(), e.getMessage());
+
+        // Throw a new IllegalStateException with the detailed message
+        throw new IllegalStateException(errorMessage, e);
     }
-  }
+}
 
   /**
    * Checks for valid incoming and outgoing granularity spec in the time field spec

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -89,24 +89,35 @@ public interface PinotFS extends Closeable, Serializable {
       throws IOException;
 
   /**
-   * Copies the file from the src to dst. The original file is retained. If the dst has parent directories
-   * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
-   * this will overwrite the existing file in the path.
-   *
-   * Note: In Pinot we recommend the full paths of both src and dst be specified.
-   * For example, if a file /a/b/c is copied to a file /x/y/z, the directory /a/b still exists containing the file 'c'.
-   * The dst file /x/y/z will contain the contents of 'c'.
-   * @param srcUri URI of the original file
-   * @param dstUri URI of the final file location
-   * @return true if copy is successful
-   * @throws IOException on IO failure
-   */
-  default boolean copy(URI srcUri, URI dstUri)
-      throws IOException {
-    if (isDirectory(srcUri)) {
-      throw new IllegalArgumentException("Recursive copy not supported");
-    }
-    return copyDir(srcUri, dstUri);
+     * Copies the file from the src to dst. The original file is retained. If the dst has parent directories
+     * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
+     * this will overwrite the existing file in the path.
+     *
+     * Note: In Pinot we recommend the full paths of both src and dst be specified.
+     * For example, if a file /a/b/c is copied to a file /x/y/z, the directory /a/b still exists containing the file 'c'.
+     * The dst file /x/y/z will contain the contents of 'c'.
+     * @param srcUri URI of the original file
+     * @param dstUri URI of the final file location
+     * @return true if copy is successful
+     * @throws IOException on IO failure
+     */
+    public default boolean copy(URI srcUri, URI dstUri) throws IOException {
+      if (isDirectory(srcUri)) {
+          throw new IllegalArgumentException("Recursive copy not supported");
+      }
+  
+      // Load config to check if we should remove `.tar.gz`
+      boolean removeTarGz = Boolean.parseBoolean(
+          System.getProperty("pinot.controller.segment.upload.removeTarGzExtension", "false")
+      );
+  
+      // If enabled and the destination file ends with `.tar.gz`, remove the extension
+      if (removeTarGz && dstUri.toString().endsWith(".tar.gz")) {
+          String newDstUri = dstUri.toString().substring(0, dstUri.toString().length() - 7);
+          dstUri = URI.create(newDstUri);
+      }
+  
+      return copyDir(srcUri, dstUri);
   }
 
   /**

--- a/pinot-tools/src/main/resources/conf/pinot-controller.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-controller.conf
@@ -40,3 +40,6 @@ controller.vip.port=9000
 
 # Location to store Pinot Segments pushed from clients
 controller.data.dir=/tmp/pinot/data/controller
+
+pinot.controller.segment.upload.removeTarGzExtension=true
+


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Controller property triggers removal of \.tar\.gz extension during segment copy\.

```mermaid
flowchart TD
  N0["Controller config sets removeTarGzExtension#61;true #40;F5#41;"]:::stAdded
  N1["PinotFS#46;copy reads removeTarGz flag from system property #40;F4#41;"]:::stModified
  N2["If flag true and dstUri ends with #39;#46;tar#46;gz#39;#44; strip extension #40;F4#41;"]:::stModified
  N3["Modified dstUri used in copyDir call #40;F4#41;"]:::stModified
  N4["SegmentUploader provides modifySegmentFileName to strip #39;#46;tar#46;gz#39; #40;F1#41;"]:::stAdded
  N5["SegmentGenerationJobRunner sets segmentFileName #61; segmentName #43; #39;#46;tar#46;gz#39; #40;F2#41;"]:::stModified
  N0 -->|"property value"| N1
  N1 -->|"flag used in condition"| N2
  N2 -->|"condition leads to modification"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader\.java — [before](https://github.com/apache/pinot/blob/3a7b023c878ba2942078e5565b31b599c98a4c35/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java) · [after](https://github.com/apache/pinot/blob/ef87cbd5e36cfee1819eeb0249f2d054359621a0/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java)
- F2: pinot\-plugins/pinot\-batch\-ingestion/pinot\-batch\-ingestion\-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner\.java — [before](https://github.com/apache/pinot/blob/3a7b023c878ba2942078e5565b31b599c98a4c35/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java) · [after](https://github.com/apache/pinot/blob/ef87cbd5e36cfee1819eeb0249f2d054359621a0/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java)
- F4: pinot\-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS\.java — [before](https://github.com/apache/pinot/blob/3a7b023c878ba2942078e5565b31b599c98a4c35/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java) · [after](https://github.com/apache/pinot/blob/ef87cbd5e36cfee1819eeb0249f2d054359621a0/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java)
- F5: pinot\-tools/src/main/resources/conf/pinot\-controller\.conf — [before](https://github.com/apache/pinot/blob/3a7b023c878ba2942078e5565b31b599c98a4c35/pinot-tools/src/main/resources/conf/pinot-controller.conf) · [after](https://github.com/apache/pinot/blob/ef87cbd5e36cfee1819eeb0249f2d054359621a0/pinot-tools/src/main/resources/conf/pinot-controller.conf)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNhN2IwMjNjODc4YmEyOTQyMDc4ZTU1NjViMzFiNTk5Yzk4YTRjMzUiLCJjb250ZXh0X2hhc2giOiJkM2I0YmNkNzc5OGMzZjZlODUyZmQ0YTliOGI3YzdmMTMzY2U1MTIwNmQ2MGZiODQxOGYyNDE4ZjY3MmU4YjU5IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDg4Mzk2LCJoZWFkX3NoYSI6ImVmODdjYmQ1ZTM2Y2ZlZTE4MTllZWIwMjQ5ZjJkMDU0MzU5NjIxYTAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIwYThkNTc0ODAxZTU2ZjFhNDdjZGM2ZmJmOGQzYzc1MzM5NTVmMmU2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 39085821a7f296b1201f669368cb40ecef52eb940b2b031695effb4f58873019 -->
<!-- pinot-pr-flow:end -->

Close #10375 