### PR TITLE
Optimize lookup table in join operator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -228,6 +228,7 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
 
   protected abstract List<Object[]> buildNonMatchRightRows();
 
+  // TODO: Optimize this to avoid unnecessary object copy.
   protected Object[] joinRow(@Nullable Object[] leftRow, @Nullable Object[] rightRow) {
     Object[] resultRow = new Object[_resultColumnSize];
     if (leftRow != null) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
@@ -34,7 +34,7 @@ public class DoubleLookupTable extends LookupTable {
 
   @Override
   public void addRow(Object key, Object[] row) {
-    _lookupTable.compute((double) key, (k, v) -> calculateValue(row, v));
+    _lookupTable.compute((double) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
@@ -53,8 +53,8 @@ public class DoubleLookupTable extends LookupTable {
 
   @Nullable
   @Override
-  public Object[] lookup(Object key) {
-    return (Object[]) _lookupTable.get((double) key);
+  public Object lookup(Object key) {
+    return _lookupTable.get((double) key);
   }
 
   @SuppressWarnings("rawtypes")

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import it.unimi.dsi.fastutil.doubles.Double2ObjectMap;
+import it.unimi.dsi.fastutil.doubles.Double2ObjectOpenHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * The {@code DoubleLookupTable} is a lookup table for double keys.
+ */
+@SuppressWarnings("unchecked")
+public class DoubleLookupTable extends LookupTable {
+  private final Double2ObjectOpenHashMap<Object> _lookupTable = new Double2ObjectOpenHashMap<>(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(Object key, Object[] row) {
+    _lookupTable.compute((double) key, (k, v) -> calculateValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Double2ObjectMap.Entry<Object> entry : _lookupTable.double2ObjectEntrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return _lookupTable.containsKey((double) key);
+  }
+
+  @Nullable
+  @Override
+  public Object[] lookup(Object key) {
+    return (Object[]) _lookupTable.get((double) key);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry> entrySet() {
+    return (Set) _lookupTable.double2ObjectEntrySet();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
@@ -34,7 +34,7 @@ public class FloatLookupTable extends LookupTable {
 
   @Override
   public void addRow(Object key, Object[] row) {
-    _lookupTable.compute((float) key, (k, v) -> calculateValue(row, v));
+    _lookupTable.compute((float) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
@@ -53,8 +53,8 @@ public class FloatLookupTable extends LookupTable {
 
   @Nullable
   @Override
-  public Object[] lookup(Object key) {
-    return (Object[]) _lookupTable.get((float) key);
+  public Object lookup(Object key) {
+    return _lookupTable.get((float) key);
   }
 
   @SuppressWarnings("rawtypes")

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import it.unimi.dsi.fastutil.floats.Float2ObjectMap;
+import it.unimi.dsi.fastutil.floats.Float2ObjectOpenHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * The {@code FloatLookupTable} is a lookup table for float keys.
+ */
+@SuppressWarnings("unchecked")
+public class FloatLookupTable extends LookupTable {
+  private final Float2ObjectOpenHashMap<Object> _lookupTable = new Float2ObjectOpenHashMap<>(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(Object key, Object[] row) {
+    _lookupTable.compute((float) key, (k, v) -> calculateValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Float2ObjectMap.Entry<Object> entry : _lookupTable.float2ObjectEntrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return _lookupTable.containsKey((float) key);
+  }
+
+  @Nullable
+  @Override
+  public Object[] lookup(Object key) {
+    return (Object[]) _lookupTable.get((float) key);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry> entrySet() {
+    return (Set) _lookupTable.float2ObjectEntrySet();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * The {@code IntLookupTable} is a lookup table for int keys.
+ */
+@SuppressWarnings("unchecked")
+public class IntLookupTable extends LookupTable {
+  private final Int2ObjectOpenHashMap<Object> _lookupTable = new Int2ObjectOpenHashMap<>(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(Object key, Object[] row) {
+    _lookupTable.compute((int) key, (k, v) -> calculateValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Int2ObjectMap.Entry<Object> entry : _lookupTable.int2ObjectEntrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return _lookupTable.containsKey((int) key);
+  }
+
+  @Nullable
+  @Override
+  public Object lookup(Object key) {
+    return _lookupTable.get((int) key);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry> entrySet() {
+    return (Set) _lookupTable.int2ObjectEntrySet();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
@@ -34,7 +34,7 @@ public class IntLookupTable extends LookupTable {
 
   @Override
   public void addRow(Object key, Object[] row) {
-    _lookupTable.compute((int) key, (k, v) -> calculateValue(row, v));
+    _lookupTable.compute((int) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
@@ -34,7 +34,7 @@ public class LongLookupTable extends LookupTable {
 
   @Override
   public void addRow(Object key, Object[] row) {
-    _lookupTable.compute((long) key, (k, v) -> calculateValue(row, v));
+    _lookupTable.compute((long) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * The {@code LongLookupTable} is a lookup table for long keys.
+ */
+@SuppressWarnings("unchecked")
+public class LongLookupTable extends LookupTable {
+  private final Long2ObjectOpenHashMap<Object> _lookupTable = new Long2ObjectOpenHashMap<>(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(Object key, Object[] row) {
+    _lookupTable.compute((long) key, (k, v) -> calculateValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Long2ObjectMap.Entry<Object> entry : _lookupTable.long2ObjectEntrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return _lookupTable.containsKey((long) key);
+  }
+
+  @Nullable
+  @Override
+  public Object lookup(Object key) {
+    return _lookupTable.get((long) key);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry> entrySet() {
+    return (Set) _lookupTable.long2ObjectEntrySet();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -38,7 +38,7 @@ public abstract class LookupTable {
   public abstract void addRow(Object key, Object[] row);
 
   @SuppressWarnings("unchecked")
-  protected Object calculateValue(Object[] row, @Nullable Object currentValue) {
+  protected Object computeNewValue(Object[] row, @Nullable Object currentValue) {
     if (currentValue == null) {
       return row;
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+public abstract class LookupTable {
+  // TODO: Make it configurable
+  protected static final int INITIAL_CAPACITY = 10000;
+
+  protected boolean _keysUnique = true;
+
+  /**
+   * Adds a row to the lookup table.
+   */
+  public abstract void addRow(Object key, Object[] row);
+
+  @SuppressWarnings("unchecked")
+  protected Object calculateValue(Object[] row, @Nullable Object currentValue) {
+    if (currentValue == null) {
+      return row;
+    } else {
+      _keysUnique = false;
+      if (currentValue instanceof List) {
+        ((List<Object[]>) currentValue).add(row);
+        return currentValue;
+      } else {
+        List<Object[]> rows = new ArrayList<>();
+        rows.add((Object[]) currentValue);
+        rows.add(row);
+        return rows;
+      }
+    }
+  }
+
+  /**
+   * Finishes adding rows to the lookup table. This method should be called after all rows are added to the lookup
+   * table, and before looking up rows.
+   */
+  public abstract void finish();
+
+  protected static void convertValueToList(Map.Entry<?, Object> entry) {
+    Object value = entry.getValue();
+    if (value instanceof Object[]) {
+      entry.setValue(Collections.singletonList(value));
+    }
+  }
+
+  /**
+   * Returns {@code true} when all the keys added to the lookup table are unique.
+   * When all keys are unique, the value of the lookup table is a single row ({@code Object[]}). When keys are not
+   * unique, the value of the lookup table is a list of rows ({@code List<Object[]>}).
+   */
+  public boolean isKeysUnique() {
+    return _keysUnique;
+  }
+
+  /**
+   * Returns {@code true} if the lookup table contains the given key.
+   */
+  public abstract boolean containsKey(Object key);
+
+  /**
+   * Returns the row/rows for the given key. When {@link #isKeysUnique} returns {@code true}, this method returns a
+   * single row ({@code Object[]}). When {@link #isKeysUnique} returns {@code false}, this method returns a list of rows
+   * ({@code List<Object[]>}). Returns {@code null} if the key does not exist in the lookup table.
+   */
+  @Nullable
+  public abstract Object lookup(Object key);
+
+  /**
+   * Returns all the entries in the lookup table. When {@link #isKeysUnique} returns {@code true}, the value of the
+   * entries is a single row ({@code Object[]}). When {@link #isKeysUnique} returns {@code false}, the value of the
+   * entries is a list of rows ({@code List<Object[]>}).
+   */
+  @SuppressWarnings("rawtypes")
+  public abstract Set<Map.Entry> entrySet();
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
@@ -33,7 +33,7 @@ public class ObjectLookupTable extends LookupTable {
 
   @Override
   public void addRow(Object key, Object[] row) {
-    _lookupTable.compute(key, (k, v) -> calculateValue(row, v));
+    _lookupTable.compute(key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * The {@code DoubleLookupTable} is a lookup table for non-primitive keys.
+ */
+@SuppressWarnings("unchecked")
+public class ObjectLookupTable extends LookupTable {
+  private final Map<Object, Object> _lookupTable = Maps.newHashMapWithExpectedSize(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(Object key, Object[] row) {
+    _lookupTable.compute(key, (k, v) -> calculateValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Map.Entry<Object, Object> entry : _lookupTable.entrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return _lookupTable.containsKey(key);
+  }
+
+  @Nullable
+  @Override
+  public Object lookup(Object key) {
+    return _lookupTable.get(key);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry> entrySet() {
+    return (Set) _lookupTable.entrySet();
+  }
+}


### PR DESCRIPTION
Optimize lookup table (right table) in `HashJoinOperator`:
- Use primitive key map for single join key of type `INT`, `LONG`, `FLOAT`, `DOUBLE`
- Specialize unique keys case to avoid creating `List`