### PR TITLE
Releases partitionGroupConsumerSemaphore incase of Errors

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentErrorInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentErrorInfo.java
@@ -60,7 +60,7 @@ public class SegmentErrorInfo {
    * @param errorMessage Error message
    * @param exception Exception
    */
-  public SegmentErrorInfo(long timestampMs, String errorMessage, Exception exception) {
+  public SegmentErrorInfo(long timestampMs, String errorMessage, Throwable exception) {
     _timestamp = DateTimeUtils.epochToDefaultDateFormat(timestampMs);
     _errorMessage = errorMessage;
     _stackTrace = (exception != null) ? ExceptionUtils.getStackTrace(exception) : null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1691,6 +1691,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
       // Hence releasing the semaphore here to unblock reset operation via Helix Admin.
       _partitionGroupConsumerSemaphore.release();
+      _acquiredConsumerSemaphore.set(false);
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),
           "Failed to initialize segment data manager", t));
       _segmentLogger.warn(

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1686,17 +1686,17 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
       _allowConsumptionDuringCommit = !_realtimeTableDataManager.isPartialUpsertEnabled() ? true
           : _tableConfig.getUpsertConfig().isAllowPartialUpsertConsumptionDuringCommit();
-    } catch (Exception e) {
+    } catch (Throwable t) {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
       // Hence releasing the semaphore here to unblock reset operation via Helix Admin.
       _partitionGroupConsumerSemaphore.release();
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),
-          "Failed to initialize segment data manager", e));
+          "Failed to initialize segment data manager", t));
       _segmentLogger.warn(
           "Scheduling task to call controller to mark the segment as OFFLINE in Ideal State due"
            + " to initialization error: '{}'",
-          e.getMessage());
+          t.getMessage());
       // Since we are going to throw exception from this thread (helix execution thread), the externalview
       // entry for this segment will be ERROR. We allow time for Helix to make this transition, and then
       // invoke controller API mark it OFFLINE in the idealstate.
@@ -1714,7 +1714,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           return;
         }
       }).start();
-      throw e;
+      throw t;
     }
   }
 


### PR DESCRIPTION
Release partitionGroupConsumerSemaphore incase of any Errors not handled currently like OOMError.

**Note:** In [catch](https://github.com/apache/pinot/blob/be2632554e95fa58de769e411b9504644a4c489c/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java#L1711) block , The segment is marked as stopped consuming. 
So now incase of any Error like OOM in a server, All segments will be marked as offline across all servers.
