### PR TITLE
Add text_match() transform function.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -94,6 +94,7 @@ public enum TransformFunctionType {
 
   // CASE WHEN function parsed as 'CASE_WHEN'
   CASE("case"),
+  TEXT_MATCH("textMatch", ReturnTypes.BOOLEAN, OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
 
   // date type conversion functions
   CAST("cast"),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TextMatchTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TextMatchTransformFunction.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.local.realtime.impl.invertedindex.NativeMutableTextIndex;
+import org.apache.pinot.segment.local.segment.index.readers.text.NativeTextIndexReader;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/*
+ * This class implements TEXT_MATCH() as a transform function.
+ */
+public class TextMatchTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "textMatch";
+  private String _predicate;
+  private TextIndexReader _textIndexReader;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+    super.init(arguments, columnContextMap);
+
+    TransformFunction columnArg = arguments.get(0);
+    if (!(columnArg instanceof IdentifierTransformFunction && columnArg.getResultMetadata().isSingleValue())) {
+      throw new IllegalArgumentException(
+          "The first argument of TEXT_MATCH transform function must be a single-valued column");
+    }
+    String columnName = ((IdentifierTransformFunction) columnArg).getColumnName();
+    DataSource dataSource = columnContextMap.get(columnName).getDataSource();
+    if (dataSource == null) {
+      throw new IllegalArgumentException("Cannot apply TEXT_MATCH on column: " + columnName + " without text index");
+    }
+    TextIndexReader indexReader = dataSource.getTextIndex();
+    if (indexReader == null) {
+      throw new IllegalArgumentException("Cannot apply TEXT_MATCH on column: " + columnName + " without text index");
+    }
+    if (indexReader instanceof NativeTextIndexReader
+        || indexReader instanceof NativeMutableTextIndex) {
+      throw new UnsupportedOperationException(
+          "TEXT_MATCH is not supported on column: " + columnName + " with native text index");
+    }
+
+    TransformFunction predicate = arguments.get(1);
+    if (!(predicate instanceof LiteralTransformFunction && predicate.getResultMetadata().isSingleValue())) {
+      throw new IllegalArgumentException(
+          "The second argument of TEXT_MATCH transform function must be a single-valued string literal");
+    }
+
+    _predicate = ((LiteralTransformFunction) predicate).getStringLiteral();
+    _textIndexReader = indexReader;
+  }
+
+  public int[] transformToIntValuesSV(ValueBlock valueBlock) {
+    int length = valueBlock.getNumDocs();
+    initIntValuesSV(length);
+
+    int[] docIds = valueBlock.getDocIds();
+    MutableRoaringBitmap indexDocIds = _textIndexReader.getDocIds(_predicate);
+
+    for (int i = 0; i < length; i++) {
+      if (indexDocIds.contains(docIds[i])) {
+        _intValuesSV[i] = 1;
+      }
+    }
+
+    return _intValuesSV;
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return BOOLEAN_SV_NO_DICTIONARY_METADATA;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -164,6 +164,7 @@ public class TransformFunctionFactory {
 
     typeToImplementation.put(TransformFunctionType.GROOVY, GroovyTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.CASE, CaseTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.TEXT_MATCH, TextMatchTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.EQUALS, EqualsTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.NOT_EQUALS, NotEqualsTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
@@ -37,8 +37,8 @@ public class FunctionRegistryTest {
       // Special placeholder functions without implementation
       TransformFunctionType.SCALAR,
       // Special functions that requires index
-      TransformFunctionType.JSON_EXTRACT_INDEX, TransformFunctionType.MAP_VALUE, TransformFunctionType.LOOKUP,
-      TransformFunctionType.TEXT_MATCH,
+      TransformFunctionType.JSON_EXTRACT_INDEX, TransformFunctionType.MAP_VALUE,
+      TransformFunctionType.LOOKUP, TransformFunctionType.TEXT_MATCH,
       // TODO: Support these functions
       TransformFunctionType.IN, TransformFunctionType.NOT_IN, TransformFunctionType.IS_TRUE,
       TransformFunctionType.IS_NOT_TRUE, TransformFunctionType.IS_FALSE, TransformFunctionType.IS_NOT_FALSE,

--- a/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
@@ -38,6 +38,7 @@ public class FunctionRegistryTest {
       TransformFunctionType.SCALAR,
       // Special functions that requires index
       TransformFunctionType.JSON_EXTRACT_INDEX, TransformFunctionType.MAP_VALUE, TransformFunctionType.LOOKUP,
+      TransformFunctionType.TEXT_MATCH,
       // TODO: Support these functions
       TransformFunctionType.IN, TransformFunctionType.NOT_IN, TransformFunctionType.IS_TRUE,
       TransformFunctionType.IS_NOT_TRUE, TransformFunctionType.IS_FALSE, TransformFunctionType.IS_NOT_FALSE,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -502,6 +503,49 @@ public class FluentQueryTest {
           tableText
       );
       thenResultIs(rows);
+
+      return this;
+    }
+
+    /**
+     * Asserts that the result of the query as string is the same as given "table".
+     *
+     * The table is a text table. The first row is the header, and the rest of the rows are
+     * the data. Each column must be separated by pipes ({@code |}).
+     * The header is a list of column names and types, e.g. {@code "column1[INT] | column2[STRING]"}.
+     * The data is a list of rows, each row is a list of values separated by pipes, ending with '\n'.
+     *
+     * Contrary to {@link #thenResultIs(String...)}, this method compares input table and query result as strings.
+     *
+     */
+    public QueryExecuted thenResultTextIs(String expected) {
+      if (_brokerResponse.getExceptionsSize() > 0) {
+        Assert.fail("Query failed with " + _brokerResponse.getExceptions());
+      }
+
+      DataSchema schema = _brokerResponse.getResultTable().getDataSchema();
+      DataSchema.ColumnDataType[] dataTypes = schema.getColumnDataTypes();
+      List<Object[]> actualRows = _brokerResponse.getResultTable().getRows();
+      StringBuilder buffer = new StringBuilder();
+      for (int i = 0, n = schema.size(); i < n; i++) {
+        if (i > 0) {
+          buffer.append(" | ");
+        }
+        buffer.append(schema.getColumnName(i)).append('[').append(schema.getColumnDataType(i)).append(']');
+      }
+
+      for (int row = 0; row < actualRows.size(); row++) {
+        buffer.append("\n");
+        Object[] rowData = actualRows.get(row);
+        for (int col = 0; col < rowData.length; col++) {
+          if (col > 0) {
+            buffer.append(" | ");
+          }
+          buffer.append(dataTypes[col].toDataType().toString(rowData[col]));
+        }
+      }
+
+      Assert.assertEquals(buffer.toString(), expected);
 
       return this;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
@@ -1,0 +1,370 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TextMatchTransformFunctionTest {
+
+  protected static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE)
+          .setTableName("testTable")
+          .addFieldConfig(
+              new FieldConfig("skills", FieldConfig.EncodingType.RAW,
+                  List.of(FieldConfig.IndexType.TEXT), null, null))
+          .build();
+
+  protected File _baseDir;
+
+  @BeforeClass
+  void createBaseDir() {
+    try {
+      _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  @AfterClass
+  void destroyBaseDir()
+      throws IOException {
+    if (_baseDir != null) {
+      FileUtils.deleteDirectory(_baseDir);
+    }
+  }
+
+  @Test
+  void testTextMatchValidation() {
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .givenTable(
+              new Schema.SchemaBuilder()
+                  .setSchemaName("testTable")
+                  .addMetricField("id", FieldSpec.DataType.INT)
+                  .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                  .build(),
+              TABLE_CONFIG)
+          .onFirstInstance(
+              new Object[]{1, "swimming"}
+          )
+          .whenQuery("select TEXT_MATCH(id, 'sewing') as match from testTable");
+      Assert.fail();
+    } catch (BadQueryRequestException e) {
+      Assert.assertEquals(e.getCause().getMessage(), "Cannot apply TEXT_MATCH on column: id without text index");
+    }
+
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .givenTable(
+              new Schema.SchemaBuilder()
+                  .setSchemaName("testTable")
+                  .addMetricField("id", FieldSpec.DataType.INT)
+                  .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                  .build(),
+              new TableConfigBuilder(TableType.OFFLINE)
+                  .setTableName("testTable")
+                  .addFieldConfig(
+                      new FieldConfig("skills", FieldConfig.EncodingType.RAW,
+                          List.of(FieldConfig.IndexType.TEXT), null,
+                          Map.of(FieldConfig.TEXT_FST_TYPE, FieldConfig.TEXT_NATIVE_FST_LITERAL)))
+                  .build())
+          .onFirstInstance(
+              new Object[]{1, "swimming"}
+          )
+          .whenQuery("select TEXT_MATCH(skills, 'sewing') as match from testTable");
+      Assert.fail();
+    } catch (BadQueryRequestException e) {
+      Assert.assertEquals(e.getCause().getMessage(),
+          "TEXT_MATCH is not supported on column: skills with native text index");
+    }
+
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .givenTable(
+              new Schema.SchemaBuilder()
+                  .setSchemaName("testTable")
+                  .addMetricField("id", FieldSpec.DataType.INT)
+                  .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                  .build(),
+              TABLE_CONFIG)
+          .onFirstInstance(
+              new Object[]{1, "sewing, cooking"}
+          )
+          .whenQuery("select TEXT_MATCH('id', 'sewing') as match from testTable");
+      Assert.fail();
+    } catch (BadQueryRequestException e) {
+      Assert.assertEquals(e.getCause().getMessage(),
+          "The first argument of TEXT_MATCH transform function must be a single-valued column");
+    }
+
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .givenTable(
+              new Schema.SchemaBuilder()
+                  .setSchemaName("testTable")
+                  .addMultiValueDimension("id", FieldSpec.DataType.STRING)
+                  .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                  .build(),
+              TABLE_CONFIG)
+          .onFirstInstance(
+              new Object[]{1, "sewing, cooking"}
+          )
+          .whenQuery("select TEXT_MATCH(id, 'sewing') as match from testTable");
+      Assert.fail();
+    } catch (BadQueryRequestException e) {
+      Assert.assertEquals(e.getCause().getMessage(),
+          "The first argument of TEXT_MATCH transform function must be a single-valued column");
+    }
+
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .givenTable(
+              new Schema.SchemaBuilder()
+                  .setSchemaName("testTable")
+                  .addMultiValueDimension("id", FieldSpec.DataType.STRING)
+                  .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                  .build(),
+              TABLE_CONFIG)
+          .onFirstInstance(
+              new Object[]{1, "sewing, cooking"}
+          )
+          .whenQuery("select TEXT_MATCH(skills, id) as match from testTable");
+      Assert.fail();
+    } catch (BadQueryRequestException e) {
+      Assert.assertEquals(e.getCause().getMessage(),
+          "The second argument of TEXT_MATCH transform function must be a single-valued string literal");
+    }
+  }
+
+  @Test
+  void testTextMatchAsTransformFunction() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMetricField("id", FieldSpec.DataType.INT)
+                .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                .build(),
+            TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, "sewing, cooking"},
+            new Object[]{2, "washing, cleaning"}
+        )
+        .andOnSecondInstance(
+            new Object[]{3, "skiing, running"},
+            new Object[]{4, "singing, sewing"}
+        )
+        .whenQuery("select id, skills, TEXT_MATCH(skills, 'sewing') as match from testTable order by id limit 100000")
+        .thenResultTextIs(
+            "id[INT] | skills[STRING] | match[BOOLEAN]\n"
+                + "1 | sewing, cooking | true\n"
+                + "2 | washing, cleaning | false\n"
+                + "3 | skiing, running | false\n"
+                + "4 | singing, sewing | true"
+        ).whenQuery(
+            "select id, skills, case when skills = 'AAA' then '?' "
+                + "when  TEXT_MATCH(skills, 'sewing') then 'ok' else 'wrong' end as status "
+                + "from testTable "
+                + "order by id "
+                + "limit 100000")
+        .thenResultTextIs(
+            "id[INT] | skills[STRING] | status[STRING]\n"
+                + "1 | sewing, cooking | ok\n"
+                + "2 | washing, cleaning | wrong\n"
+                + "3 | skiing, running | wrong\n"
+                + "4 | singing, sewing | ok"
+        ).whenQuery(
+            "select id, skills "
+                + "from testTable "
+                + "order by TEXT_MATCH(skills, 'sewing'), id "
+                + "limit 100000")
+        .thenResultTextIs(
+            "id[INT] | skills[STRING]\n"
+                + "2 | washing, cleaning\n"
+                + "3 | skiing, running\n"
+                + "1 | sewing, cooking\n"
+                + "4 | singing, sewing"
+        );
+  }
+
+  @Test
+  public void testTextMatchInAggregation() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMetricField("id", FieldSpec.DataType.INT)
+                .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                .build(),
+            TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, "sewing, cooking"},
+            new Object[]{2, "washing, cleaning"}
+        )
+        .andOnSecondInstance(
+            new Object[]{3, "skiing, running"},
+            new Object[]{4, "singing, sewing"}
+        )
+        .whenQuery("select TEXT_MATCH(skills, 'sewing') as match, count(*) "
+            + "from testTable "
+            + "group by 1 "
+            + "order by 1 ")
+        .thenResultTextIs(
+            "match[BOOLEAN] | count(*)[LONG]\n"
+                + "false | 2\n"
+                + "true | 2"
+        ).whenQuery("select TEXT_MATCH(skills, 'sewing') as match, count(*) "
+            + "from testTable "
+            + "group by 1 "
+            + "order by 1 ")
+        .thenResultTextIs(
+            "match[BOOLEAN] | count(*)[LONG]\n"
+                + "false | 2\n"
+                + "true | 2"
+        );
+  }
+
+  @Test
+  public void testExplainTextMatch() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMetricField("id", FieldSpec.DataType.INT)
+                .addSingleValueDimension("skills", FieldSpec.DataType.STRING)
+                .build(),
+            TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, "sewing, cooking"}
+        )
+        .whenQuery("explain plan for select TEXT_MATCH(skills, 'sewing') as match "
+            + "from testTable "
+            + "where TEXT_MATCH(skills, 'swimming')")
+        .thenResultTextIs(
+            "Operator[STRING] | Operator_Id[INT] | Parent_Id[INT]\n"
+                + "BROKER_REDUCE(limit:10) | 1 | 0\n"
+                + "COMBINE_SELECT | 2 | 1\n"
+                + "PLAN_START(numSegmentsForThisPlan:2) | -1 | -1\n"
+                + "SELECT(selectList:text_match(skills,'sewing')) | 3 | 2\n"
+                + "TRANSFORM(text_match(skills,'sewing')) | 4 | 3\n"
+                + "PROJECT(skills) | 5 | 4\n"
+                + "DOC_ID_SET | 6 | 5\n"
+                + "FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match(skills,"
+                + "'swimming')) | 7 | 6"
+        );
+  }
+
+  @Test
+  void testTextMatchComplexQuery() {
+    String query =
+        "SELECT "
+            + " ( "
+            + "   case "
+            + "     when agent is null then 'N/A' "
+            + "     when TEXT_MATCH(part, '_zz_') AND part IS NOT NULL then agent "
+            + "     else '' "
+            + "   end "
+            + " ) as val "
+            + "FROM testTable "
+            + " WHERE startTime BETWEEN 0 AND 1000000 "
+            + "  AND customerId = 'XYZ'  "
+            + "ORDER BY startTime ASC "
+            + "LIMIT 1000";
+
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addDimensionField("agent", FieldSpec.DataType.STRING, f -> {
+                  f.setNullable(true);
+                  f.setSingleValueField(true);
+                })
+                .addSingleValueDimension("customerId", FieldSpec.DataType.STRING)
+                .addSingleValueDimension("part", FieldSpec.DataType.STRING)
+                .addDateTime("startTime", FieldSpec.DataType.TIMESTAMP, "TIMESTAMP", "1:MILLISECONDS")
+                .build(),
+            new TableConfigBuilder(TableType.OFFLINE)
+                .setTableName("testTable")
+                .addFieldConfig(new FieldConfig("agent", FieldConfig.EncodingType.DICTIONARY,
+                    List.of(), null, null))
+                .addFieldConfig(
+                    new FieldConfig("customerId", FieldConfig.EncodingType.DICTIONARY,
+                        List.of(FieldConfig.IndexType.INVERTED), null, null))
+                .addFieldConfig(
+                    new FieldConfig("part", FieldConfig.EncodingType.RAW,
+                        List.of(FieldConfig.IndexType.TEXT), null, null))
+                .addFieldConfig(
+                    new FieldConfig("startTime", FieldConfig.EncodingType.RAW,
+                        List.of(FieldConfig.IndexType.RANGE), null, null))
+                .build())
+        .onFirstInstance(
+            new Object[]{null, "XYZ", "_zz_", 1L},
+            new Object[]{"A1", "XYZ", "_zz_", 20L}
+        )
+        .andOnSecondInstance(
+            new Object[]{"A2", "XYZ", "_zz_", 1000L},
+            new Object[]{"A3", "DEF", "_zz_", 2000L}
+        )
+        .whenQuery(
+            "set explainAskingServers=true; "
+                + "EXPLAIN PLAN FOR " + query
+        )
+        .thenResultTextIs(
+            "Operator[STRING] | Operator_Id[INT] | Parent_Id[INT]\n"
+                + "BROKER_REDUCE(sort:[startTime ASC],limit:1000) | 1 | 0\n"
+                + "COMBINE_SELECT_ORDERBY_MINMAX | 2 | 1\n"
+                + "PLAN_START(numSegmentsForThisPlan:1) | -1 | -1\n"
+                + "SELECT_PARTIAL_ORDER_BY_ASC(sortedList: (startTime), unsortedList: (), rest: (case(is_null(agent),"
+                + "'N/A',and(text_match(part,'_zz_'),is_not_null(part)),agent,''))) | 3 | 2\n"
+                + "TRANSFORM(case(is_null(agent),'N/A',and(text_match(part,'_zz_'),is_not_null(part)),agent,''), "
+                + "startTime) | 4 | 3\n"
+                + "PROJECT(agent, startTime, part) | 5 | 4\n"
+                + "DOC_ID_SET | 6 | 5\n"
+                + "FILTER_AND | 7 | 6\n"
+                + "FILTER_FULL_SCAN(operator:RANGE,predicate:startTime BETWEEN '0' AND '1000000') | 8 | 7\n"
+                + "FILTER_FULL_SCAN(operator:EQ,predicate:customerId = 'XYZ') | 9 | 7"
+        ).whenQuery(query)
+        .thenResultTextIs("val[STRING]\n"
+            + "N/A\n"
+            + "A1\n"
+            + "A2");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -101,13 +101,18 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
   private static final String SKILLS_TEXT_MV_COL_NAME = "SKILLS_TEXT_MV_COL";
   private static final String SKILLS_TEXT_MV_COL_DICT_NAME = "SKILLS_TEXT_MV_COL_DICT";
   private static final String INT_COL_NAME = "INT_COL";
+
   private static final List<String> RAW_TEXT_INDEX_COLUMNS =
       Arrays.asList(QUERY_LOG_TEXT_COL_NAME, SKILLS_TEXT_COL_NAME, SKILLS_TEXT_COL_MULTI_TERM_NAME,
           SKILLS_TEXT_NO_RAW_NAME, SKILLS_TEXT_MV_COL_NAME);
+
   private static final List<String> DICT_TEXT_INDEX_COLUMNS =
       Arrays.asList(SKILLS_TEXT_COL_DICT_NAME, SKILLS_TEXT_MV_COL_DICT_NAME);
+
   private static final int INT_BASE_VALUE = 1000;
-  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .setSchemaName(TABLE_NAME)
       .addSingleValueDimension(QUERY_LOG_TEXT_COL_NAME, FieldSpec.DataType.STRING)
       .addSingleValueDimension(SKILLS_TEXT_COL_NAME, FieldSpec.DataType.STRING)
       .addSingleValueDimension(SKILLS_TEXT_COL_DICT_NAME, FieldSpec.DataType.STRING)
@@ -115,10 +120,15 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
       .addSingleValueDimension(SKILLS_TEXT_NO_RAW_NAME, FieldSpec.DataType.STRING)
       .addMultiValueDimension(SKILLS_TEXT_MV_COL_NAME, FieldSpec.DataType.STRING)
       .addMultiValueDimension(SKILLS_TEXT_MV_COL_DICT_NAME, FieldSpec.DataType.STRING)
-      .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();
-  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-      .setNoDictionaryColumns(RAW_TEXT_INDEX_COLUMNS).setInvertedIndexColumns(DICT_TEXT_INDEX_COLUMNS)
-      .setFieldConfigList(createFieldConfigs()).build();
+      .addMetric(INT_COL_NAME, FieldSpec.DataType.INT)
+      .build();
+
+  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName(TABLE_NAME)
+      .setNoDictionaryColumns(RAW_TEXT_INDEX_COLUMNS)
+      .setInvertedIndexColumns(DICT_TEXT_INDEX_COLUMNS)
+      .setFieldConfigList(createFieldConfigs())
+      .build();
 
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -273,7 +273,6 @@ public class PinotOperatorTable implements SqlOperatorTable {
    */
   private static final List<SqlOperator> PINOT_OPERATORS = List.of(
       // Placeholder for special predicates
-      new PinotSqlFunction("TEXT_MATCH", ReturnTypes.BOOLEAN, OperandTypes.CHARACTER_CHARACTER),
       new PinotSqlFunction("TEXT_CONTAINS", ReturnTypes.BOOLEAN, OperandTypes.CHARACTER_CHARACTER),
       new PinotSqlFunction("JSON_MATCH", ReturnTypes.BOOLEAN, OperandTypes.CHARACTER_CHARACTER),
       new PinotSqlFunction("VECTOR_SIMILARITY", ReturnTypes.BOOLEAN,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -298,6 +298,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     List<Object[]> testCases = new ArrayList<>();
     // Missing index
     testCases.add(new Object[]{"SELECT col1 FROM a WHERE textMatch(col1, 'f') LIMIT 10", "without text index"});
+    testCases.add(new Object[]{"SELECT col1, textMatch(col1, 'f') FROM a LIMIT 10", "without text index"});
 
     // Query hint with dynamic broadcast pipeline breaker should return error upstream
     testCases.add(new Object[]{


### PR DESCRIPTION
PR adds text_match() transform function, making it possible to use function outside WHERe clause, e.g. in SELECT.
Example:

- expression in SELECT list
```sql
select id, skills, TEXT_MATCH(skills, 'sewing') as match 
from testTable 
order by id 
```
- option within CASE expression
```sql
SELECT 
 ( 
   case 
     when agent is null then 'N/A' 
     when TEXT_MATCH(part, '_zz_') AND part IS NOT NULL then agent 
     else '' 
   end 
 ) as val 
FROM testTable 
 WHERE startTime BETWEEN 0 AND 1000000 
  AND customerId = 'XYZ'  
ORDER BY startTime ASC 
LIMIT 1000
```

Note: text_match() as transform function still requires first argument to be text-indexed column and second argument - a string literal. This means it won't work on e.g. concatenation of two string columns or a column and string literal. 