### PR TITLE
Introducing MSE result holder config to minimize rehashing for high cardinality group by

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -309,6 +309,12 @@ public class QueryOptionsUtils {
   }
 
   @Nullable
+  public static Integer getMSEMaxInitialResultHolderCapacity(Map<String, String> queryOptions) {
+    String maxInitResultCap = queryOptions.get(QueryOptionKey.MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+    return maxInitResultCap != null ? Integer.parseInt(maxInitResultCap) : null;
+  }
+
+  @Nullable
   public static Integer getMinInitialIndexedTableCapacity(Map<String, String> queryOptions) {
     String minInitialIndexedTableCapacity = queryOptions.get(QueryOptionKey.MIN_INITIAL_INDEXED_TABLE_CAPACITY);
     return checkedParseIntPositive(QueryOptionKey.MIN_INITIAL_INDEXED_TABLE_CAPACITY, minInitialIndexedTableCapacity);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -310,8 +310,8 @@ public class QueryOptionsUtils {
 
   @Nullable
   public static Integer getMSEMaxInitialResultHolderCapacity(Map<String, String> queryOptions) {
-    String maxInitResultCap = queryOptions.get(QueryOptionKey.MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
-    return maxInitResultCap != null ? Integer.parseInt(maxInitResultCap) : null;
+    String maxInitialCapacity = queryOptions.get(QueryOptionKey.MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+    return checkedParseIntPositive(QueryOptionKey.MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY, maxInitialCapacity);
   }
 
   @Nullable

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -62,6 +62,7 @@ public class PinotHintOptions {
     public static final String GROUP_TRIM_SIZE = "group_trim_size";
 
     public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY = "max_initial_result_holder_capacity";
+    public static final String MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY = "mse_max_initial_result_holder_capacity";
   }
 
   public static class WindowHintOptions {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -162,7 +162,7 @@ public class QueryRunner {
 
 
     String mseMaxInitialGroupHolderCapacity =
-        config.getProperty(CommonConstants.Server.CONFIG_OF_QUERY_EXECUTOR_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+        config.getProperty(CommonConstants.Server.CONFIG_OF_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     _mseMaxInitialResultHolderCapacity =
         mseMaxInitialGroupHolderCapacity != null ? Integer.parseInt(mseMaxInitialGroupHolderCapacity) : null;
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -115,6 +115,8 @@ public class QueryRunner {
   private Integer _maxInitialResultHolderCapacity;
   @Nullable
   private Integer _minInitialIndexedTableCapacity;
+  @Nullable
+  private Integer _mseMaxInitialResultHolderCapacity;
 
   // Join overflow settings
   @Nullable
@@ -157,6 +159,12 @@ public class QueryRunner {
         config.getProperty(CommonConstants.Server.CONFIG_OF_QUERY_EXECUTOR_MIN_INITIAL_INDEXED_TABLE_CAPACITY);
     _minInitialIndexedTableCapacity =
         minInitialIndexedTableCapacityStr != null ? Integer.parseInt(minInitialIndexedTableCapacityStr) : null;
+
+
+    String mseMaxInitialGroupHolderCapacity =
+        config.getProperty(CommonConstants.Server.CONFIG_OF_QUERY_EXECUTOR_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+    _mseMaxInitialResultHolderCapacity =
+        mseMaxInitialGroupHolderCapacity != null ? Integer.parseInt(mseMaxInitialGroupHolderCapacity) : null;
 
     String maxRowsInJoinStr = config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_MAX_ROWS_IN_JOIN);
     _maxRowsInJoin = maxRowsInJoinStr != null ? Integer.parseInt(maxRowsInJoinStr) : null;
@@ -375,6 +383,15 @@ public class QueryRunner {
     if (minInitialIndexedTableCapacity != null) {
       opChainMetadata.put(QueryOptionKey.MIN_INITIAL_INDEXED_TABLE_CAPACITY,
           Integer.toString(minInitialIndexedTableCapacity));
+    }
+
+    Integer mseMaxInitialResultHolderCapacity = QueryOptionsUtils.getMSEMaxInitialResultHolderCapacity(opChainMetadata);
+    if (mseMaxInitialResultHolderCapacity == null) {
+      mseMaxInitialResultHolderCapacity = _mseMaxInitialResultHolderCapacity;
+    }
+    if (mseMaxInitialResultHolderCapacity != null) {
+      opChainMetadata.put(QueryOptionKey.MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
+          Integer.toString(mseMaxInitialResultHolderCapacity));
     }
 
     Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(opChainMetadata);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -88,11 +88,7 @@ public class MultistageGroupByExecutor {
     _leafReturnFinalResult = leafReturnFinalResult;
     _resultSchema = resultSchema;
 
-    int maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
-    Integer mseCapacity = getMSEMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
-    if (mseCapacity != null) {
-      maxInitialResultHolderCapacity = mseCapacity;
-    }
+    int maxInitialResultHolderCapacity = getResolvedMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
 
     _numGroupsLimit = getNumGroupsLimit(opChainMetadata, nodeHint);
 
@@ -130,6 +126,13 @@ public class MultistageGroupByExecutor {
     }
     Integer numGroupsLimit = QueryOptionsUtils.getNumGroupsLimit(opChainMetadata);
     return numGroupsLimit != null ? numGroupsLimit : InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT;
+  }
+
+  private int getResolvedMaxInitialResultHolderCapacity(Map<String, String> opChainMetadata,
+      @Nullable PlanNode.NodeHint nodeHint) {
+    Integer mseMaxInitialResultHolderCapacity = getMSEMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
+    return (mseMaxInitialResultHolderCapacity != null) ? mseMaxInitialResultHolderCapacity
+        : getMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
   }
 
   private int getMaxInitialResultHolderCapacity(Map<String, String> opChainMetadata,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
@@ -27,8 +27,7 @@ public class GroupIdGeneratorFactory {
 
   public static GroupIdGenerator getGroupIdGenerator(ColumnDataType[] keyTypes, int numKeyColumns,
       int numGroupsLimit, int maxInitialResultHolderCapacity) {
-    // Initial capacity is one more than expected to avoid rehashing if container is full.
-    int initialCapacity = 1 + Math.min(maxInitialResultHolderCapacity, numGroupsLimit);
+    int initialCapacity = Math.min(maxInitialResultHolderCapacity, numGroupsLimit);
     if (numKeyColumns == 1) {
       switch (keyTypes[0]) {
         case INT:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
@@ -25,24 +25,27 @@ public class GroupIdGeneratorFactory {
   private GroupIdGeneratorFactory() {
   }
 
-  public static GroupIdGenerator getGroupIdGenerator(ColumnDataType[] keyTypes, int numKeyColumns, int numGroupsLimit) {
+  public static GroupIdGenerator getGroupIdGenerator(ColumnDataType[] keyTypes, int numKeyColumns,
+      int numGroupsLimit, int maxInitialResultHolderCapacity) {
+    // Initial capacity is one more than expected to avoid rehashing if container is full.
+    int initialCapacity = 1 + Math.min(maxInitialResultHolderCapacity, numGroupsLimit);
     if (numKeyColumns == 1) {
       switch (keyTypes[0]) {
         case INT:
-          return new OneIntKeyGroupIdGenerator(numGroupsLimit);
+          return new OneIntKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         case LONG:
-          return new OneLongKeyGroupIdGenerator(numGroupsLimit);
+          return new OneLongKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         case FLOAT:
-          return new OneFloatKeyGroupIdGenerator(numGroupsLimit);
+          return new OneFloatKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         case DOUBLE:
-          return new OneDoubleKeyGroupIdGenerator(numGroupsLimit);
+          return new OneDoubleKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         default:
-          return new OneObjectKeyGroupIdGenerator(numGroupsLimit);
+          return new OneObjectKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
       }
     } else if (numKeyColumns == 2) {
-      return new TwoKeysGroupIdGenerator(keyTypes[0], keyTypes[1], numGroupsLimit);
+      return new TwoKeysGroupIdGenerator(keyTypes[0], keyTypes[1], numGroupsLimit, initialCapacity);
     } else {
-      return new MultiKeysGroupIdGenerator(keyTypes, numKeyColumns, numGroupsLimit);
+      return new MultiKeysGroupIdGenerator(keyTypes, numKeyColumns, numGroupsLimit, initialCapacity);
     }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/MultiKeysGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/MultiKeysGroupIdGenerator.java
@@ -32,8 +32,9 @@ public class MultiKeysGroupIdGenerator implements GroupIdGenerator {
   private final ValueToIdMap[] _keyToIdMaps;
   private final int _numGroupsLimit;
 
-  public MultiKeysGroupIdGenerator(ColumnDataType[] keyTypes, int numKeyColumns, int numGroupsLimit) {
-    _groupIdMap = new Object2IntOpenHashMap<>();
+  public MultiKeysGroupIdGenerator(ColumnDataType[] keyTypes, int numKeyColumns,
+      int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Object2IntOpenHashMap<>(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _keyToIdMaps = new ValueToIdMap[numKeyColumns];
     for (int i = 0; i < numKeyColumns; i++) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneDoubleKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneDoubleKeyGroupIdGenerator.java
@@ -31,8 +31,8 @@ public class OneDoubleKeyGroupIdGenerator implements GroupIdGenerator {
   private int _numGroups = 0;
   private int _nullGroupId = INVALID_ID;
 
-  public OneDoubleKeyGroupIdGenerator(int numGroupsLimit) {
-    _groupIdMap = new Double2IntOpenHashMap();
+  public OneDoubleKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Double2IntOpenHashMap(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _numGroupsLimit = numGroupsLimit;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneFloatKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneFloatKeyGroupIdGenerator.java
@@ -30,8 +30,8 @@ public class OneFloatKeyGroupIdGenerator implements GroupIdGenerator {
   private int _numGroups = 0;
   private int _nullGroupId = INVALID_ID;
 
-  public OneFloatKeyGroupIdGenerator(int numGroupsLimit) {
-    _groupIdMap = new Float2IntOpenHashMap();
+  public OneFloatKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Float2IntOpenHashMap(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _numGroupsLimit = numGroupsLimit;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneIntKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneIntKeyGroupIdGenerator.java
@@ -31,8 +31,8 @@ public class OneIntKeyGroupIdGenerator implements GroupIdGenerator {
   private int _numGroups = 0;
   private int _nullGroupId = INVALID_ID;
 
-  public OneIntKeyGroupIdGenerator(int numGroupsLimit) {
-    _groupIdMap = new Int2IntOpenHashMap();
+  public OneIntKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Int2IntOpenHashMap(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _numGroupsLimit = numGroupsLimit;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneLongKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneLongKeyGroupIdGenerator.java
@@ -31,8 +31,8 @@ public class OneLongKeyGroupIdGenerator implements GroupIdGenerator {
   private int _numGroups = 0;
   private int _nullGroupId = INVALID_ID;
 
-  public OneLongKeyGroupIdGenerator(int numGroupsLimit) {
-    _groupIdMap = new Long2IntOpenHashMap();
+  public OneLongKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Long2IntOpenHashMap(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _numGroupsLimit = numGroupsLimit;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneObjectKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneObjectKeyGroupIdGenerator.java
@@ -28,8 +28,8 @@ public class OneObjectKeyGroupIdGenerator implements GroupIdGenerator {
   private final Object2IntOpenHashMap<Object> _groupIdMap;
   private final int _numGroupsLimit;
 
-  public OneObjectKeyGroupIdGenerator(int numGroupsLimit) {
-    _groupIdMap = new Object2IntOpenHashMap<>();
+  public OneObjectKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Object2IntOpenHashMap<>(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _numGroupsLimit = numGroupsLimit;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/TwoKeysGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/TwoKeysGroupIdGenerator.java
@@ -33,8 +33,9 @@ public class TwoKeysGroupIdGenerator implements GroupIdGenerator {
   private final ValueToIdMap _secondKeyToIdMap;
   private final int _numGroupsLimit;
 
-  public TwoKeysGroupIdGenerator(ColumnDataType firstKeyType, ColumnDataType secondKeyType, int numGroupsLimit) {
-    _groupIdMap = new Long2IntOpenHashMap();
+  public TwoKeysGroupIdGenerator(ColumnDataType firstKeyType,
+      ColumnDataType secondKeyType, int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Long2IntOpenHashMap(initialCapacity);
     _groupIdMap.defaultReturnValue(INVALID_ID);
     _firstKeyToIdMap = ValueToIdMapFactory.get(firstKeyType.toDataType());
     _secondKeyToIdMap = ValueToIdMapFactory.get(secondKeyType.toDataType());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -757,7 +757,7 @@ public class CommonConstants {
         "pinot.server.query.executor.group.trim.size";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         "pinot.server.query.executor.max.init.group.holder.capacity";
-    public static final String CONFIG_OF_QUERY_EXECUTOR_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
+    public static final String CONFIG_OF_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         "pinot.server.mse.max.init.group.holder.capacity";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MIN_INITIAL_INDEXED_TABLE_CAPACITY =
         "pinot.server.query.executor.min.init.indexed.table.capacity";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -501,6 +501,7 @@ public class CommonConstants {
         public static final String NUM_GROUPS_LIMIT = "numGroupsLimit";
         public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY = "maxInitialResultHolderCapacity";
         public static final String MIN_INITIAL_INDEXED_TABLE_CAPACITY = "minInitialIndexedTableCapacity";
+        public static final String MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY = "mseMaxInitialResultHolderCapacity";
         public static final String GROUP_TRIM_THRESHOLD = "groupTrimThreshold";
         public static final String STAGE_PARALLELISM = "stageParallelism";
 
@@ -756,6 +757,8 @@ public class CommonConstants {
         "pinot.server.query.executor.group.trim.size";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         "pinot.server.query.executor.max.init.group.holder.capacity";
+    public static final String CONFIG_OF_QUERY_EXECUTOR_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
+        "pinot.server.query.executor.mse.max.init.group.holder.capacity";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MIN_INITIAL_INDEXED_TABLE_CAPACITY =
         "pinot.server.query.executor.min.init.indexed.table.capacity";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -758,7 +758,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         "pinot.server.query.executor.max.init.group.holder.capacity";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
-        "pinot.server.query.executor.mse.max.init.group.holder.capacity";
+        "pinot.server.mse.max.init.group.holder.capacity";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MIN_INITIAL_INDEXED_TABLE_CAPACITY =
         "pinot.server.query.executor.min.init.indexed.table.capacity";
 


### PR DESCRIPTION
A new configuration `pinot.server.mse.max.init.group.holder.capacity` is introduced to control the size of result holders for MSE is necessary to avoid resizing and rehashing operations in use cases where grouping is needed on high-cardinality columns (e.g., UUIDs). 
It can also be set at the query level by using the query option `mse_max_initial_result_holder_capacity`.

To preserve backward compatibility, if the aforementioned config is not set, `MultistagegroupByExecutor` will revert to the current behavior of reading the result holder size from `pinot.server.query.executor.max.init.group.holder.capacity`.

A simple query where it is necessary is 
```
SELECT
count(*)
FROM
  table_A
WHERE 
(
    user_uuid NOT IN (
      SELECT
        user_uuid
      FROM
        table_B
    )
  )
LIMIT
  100 option(useMultistageEngine=true, timeoutMs=120000, useColocatedJoin = true, maxRowsInJoin = 40000000)
```

where a group by step occurs on `user_uuid` for `table_B` before the colocated join with `table_A` which has a high cardinality.

More details in the following issue: https://github.com/apache/pinot/issues/14685