### PR TITLE
Set CONSUMING state priority for helix state model

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixSegmentOnlineOfflineStateModelGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixSegmentOnlineOfflineStateModelGenerator.java
@@ -97,6 +97,7 @@ public class PinotHelixSegmentOnlineOfflineStateModelGenerator {
 
     List<String> statePriorityList = new ArrayList<String>();
     statePriorityList.add(ONLINE_STATE);
+    statePriorityList.add(CONSUMING_STATE);
     statePriorityList.add(OFFLINE_STATE);
     statePriorityList.add(DROPPED_STATE);
     record.setListField(StateModelDefinitionProperty.STATE_PRIORITY_LIST.toString(), statePriorityList);
@@ -154,6 +155,8 @@ public class PinotHelixSegmentOnlineOfflineStateModelGenerator {
 
     stateTransitionPriorityList.add("ONLINE-OFFLINE");
     stateTransitionPriorityList.add("ONLINE-DROPPED");
+    stateTransitionPriorityList.add("CONSUMING-ONLINE");
+    stateTransitionPriorityList.add("CONSUMING-OFFLINE");
     stateTransitionPriorityList.add("OFFLINE-ONLINE");
     stateTransitionPriorityList.add("OFFLINE-DROPPED");
 


### PR DESCRIPTION
Set CONSUMING state priority for helix state model:
Here we make ONLINE state to be the higher priority than CONSUMING.

Why:
Usually in the normal operations this won't make any difference.
In large table restart scenario (e.g. the server restart or pre-process taking long time, say 1 hour), if the consuming segment is up early then the pinot server spent more cpu cycles on the consuming segments. 
In fact, we should let the bootstrap server/restart server to focus on the pre-process for those ONLINE segments transitions, and at the last to bring back the CONSUMING state.
Another thing worth to mention is that, during the bootstrap, the running replica could consume data and commit multiple segments already, to allow the bootstrap replica to bypass CONSUMING and directly download the segments from deep store.
