### PR TITLE
Adding perf benchmark logic for GroupIdGenerator hash map

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -126,6 +126,10 @@
               <name>pinot-BenchmarkDictionary</name>
             </program>
             <program>
+              <mainClass>org.apache.pinot.perf.BenchmarkObjectOpenHashMap</mainClass>
+              <name>pinot-BenchmarkObjectOpenHashMap</name>
+            </program>
+            <program>
               <mainClass>org.apache.pinot.perf.BenchmarkDictionaryCreation</mainClass>
               <name>pinot-BenchmarkDictionaryCreation</name>
             </program>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
@@ -36,7 +36,12 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-
+/**
+ * This benchmarks the Group ID generation logic for different types of hashmap implementations (Vanilla HashMap and
+ * Object2IntOpenHashMap) with and without reserved capacity.
+ * To run this benchmark:
+ * ./pinot/pinot-perf/target/pinot-perf-pkg/bin/pinot-BenchmarkObjectOpenHashMap.sh after building the project.
+ */
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(1)
 @Warmup(iterations = 5, time = 10)

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 10)
+@Measurement(iterations = 20, time = 10)
+@State(Scope.Benchmark)
+public class BenchmarkObjectOpenHashMap {
+  private static final int NUM_GROUPS_LIMIT = 20_000_000;
+  private static final int INVALID_ID = -1;
+  private final Object[] _values = new Object[NUM_GROUPS_LIMIT];
+
+  @Param({
+      "500000",
+      "1000000",
+      "5000000",
+      "20000000",
+  })
+  public int _cardinality;
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    for (int i = 0; i < _cardinality; i++) {
+      _values[i] = UUID.randomUUID().toString();
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int object2IntReservedOpenHashMap()
+  {
+    Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>(_cardinality + 1);
+    map.defaultReturnValue(INVALID_ID);
+    for (int j = 0; j < _cardinality; j++) {
+      getGroupId(map, _values[j]);
+    }
+    return map.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int object2IntOpenHashMap()
+  {
+    Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>();
+    map.defaultReturnValue(INVALID_ID);
+    for (int j = 0; j < _cardinality; j++) {
+      getGroupId(map, _values[j]);
+    }
+    return map.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int vanillaReservedHashMap()
+  {
+    HashMap<Object, Integer> map = new HashMap<>(_cardinality + 1);
+    for (int j = 0; j < _cardinality; j++) {
+      getGroupId(map, _values[j]);
+    }
+    return map.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int vanillaHashMap()
+  {
+    HashMap<Object, Integer> map = new HashMap<>();
+    for (int j = 0; j < _cardinality; j++) {
+      getGroupId(map, _values[j]);
+    }
+    return map.size();
+  }
+
+  private int getGroupId(HashMap<Object, Integer> map, Object value) {
+    int numGroups = map.size();
+    if (numGroups < NUM_GROUPS_LIMIT) {
+      return map.computeIfAbsent(value, k -> numGroups);
+    } else {
+      return map.getOrDefault(value, INVALID_ID);
+    }
+  }
+
+  private int getGroupId(Object2IntOpenHashMap<Object> map, Object value) {
+    int numGroups = map.size();
+    if (numGroups < NUM_GROUPS_LIMIT) {
+      return map.computeIfAbsent(value, k -> numGroups);
+    } else {
+      return map.getOrDefault(value, INVALID_ID);
+    }
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkObjectOpenHashMap.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectOpenHashMap.java
@@ -51,7 +51,7 @@ public class BenchmarkObjectOpenHashMap {
       "500000",
       "1000000",
       "5000000",
-      "20000000",
+      "20000000"
   })
   public int _cardinality;
 
@@ -65,8 +65,7 @@ public class BenchmarkObjectOpenHashMap {
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
-  public int object2IntReservedOpenHashMap()
-  {
+  public int object2IntReservedOpenHashMap() {
     Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>(_cardinality + 1);
     map.defaultReturnValue(INVALID_ID);
     for (int j = 0; j < _cardinality; j++) {
@@ -77,8 +76,7 @@ public class BenchmarkObjectOpenHashMap {
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
-  public int object2IntOpenHashMap()
-  {
+  public int object2IntOpenHashMap() {
     Object2IntOpenHashMap<Object> map = new Object2IntOpenHashMap<>();
     map.defaultReturnValue(INVALID_ID);
     for (int j = 0; j < _cardinality; j++) {
@@ -89,8 +87,7 @@ public class BenchmarkObjectOpenHashMap {
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
-  public int vanillaReservedHashMap()
-  {
+  public int vanillaReservedHashMap() {
     HashMap<Object, Integer> map = new HashMap<>(_cardinality + 1);
     for (int j = 0; j < _cardinality; j++) {
       getGroupId(map, _values[j]);
@@ -100,8 +97,7 @@ public class BenchmarkObjectOpenHashMap {
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
-  public int vanillaHashMap()
-  {
+  public int vanillaHashMap() {
     HashMap<Object, Integer> map = new HashMap<>();
     for (int j = 0; j < _cardinality; j++) {
       getGroupId(map, _values[j]);


### PR DESCRIPTION
This PR adds performance benchmarking logic to identify and measure the improvement of different strategies for hash map selection, to make a data-driven choice on the hash map used to power `GroupIdGenerator`, which has been described in the issue https://github.com/apache/pinot/issues/14685.

The results of this benchmark are:
```
Benchmark                                                 (_cardinality)  Mode  Cnt     Score     Error  Units              
BenchmarkObjectOpenHashMap.object2IntOpenHashMap                  500000  avgt   20   111.262 ±   5.448  ms/op              
BenchmarkObjectOpenHashMap.object2IntOpenHashMap                 1000000  avgt   20   299.255 ±   9.814  ms/op              
BenchmarkObjectOpenHashMap.object2IntOpenHashMap                 5000000  avgt   20  1859.503 ±  58.990  ms/op              
BenchmarkObjectOpenHashMap.object2IntOpenHashMap                20000000  avgt   20  8236.525 ± 170.751  ms/op      
        
BenchmarkObjectOpenHashMap.object2IntReservedOpenHashMap          500000  avgt   20    79.908 ±   4.715  ms/op              
BenchmarkObjectOpenHashMap.object2IntReservedOpenHashMap         1000000  avgt   20   180.827 ±  19.987  ms/op              
BenchmarkObjectOpenHashMap.object2IntReservedOpenHashMap         5000000  avgt   20  1051.368 ±  49.204  ms/op              
BenchmarkObjectOpenHashMap.object2IntReservedOpenHashMap        20000000  avgt   20  3340.668 ± 106.874  ms/op 
             
BenchmarkObjectOpenHashMap.vanillaHashMap                         500000  avgt   20   109.589 ±   2.836  ms/op              
BenchmarkObjectOpenHashMap.vanillaHashMap                        1000000  avgt   20   265.262 ±   5.215  ms/op              
BenchmarkObjectOpenHashMap.vanillaHashMap                        5000000  avgt   20  1556.399 ±  49.787  ms/op              
BenchmarkObjectOpenHashMap.vanillaHashMap                       20000000  avgt   20  6757.234 ± 314.138  ms/op     
         
BenchmarkObjectOpenHashMap.vanillaReservedHashMap                 500000  avgt   20    98.798 ±   4.344  ms/op              
BenchmarkObjectOpenHashMap.vanillaReservedHashMap                1000000  avgt   20   228.480 ±   6.570  ms/op              
BenchmarkObjectOpenHashMap.vanillaReservedHashMap                5000000  avgt   20  1067.580 ±  48.764  ms/op              
BenchmarkObjectOpenHashMap.vanillaReservedHashMap               20000000  avgt   20  4725.897 ± 284.449  ms/op    
```
which yields that the reserved hashmap performs ~2.5x better than the current unreserved hashmap, which led to the following PR: https://github.com/apache/pinot/pull/14981.