### PR TITLE
support to enable Map encoded custom forward index

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -821,6 +821,12 @@ public enum PinotDataType {
     @Override
     public Object convert(Object value, PinotDataType sourceType) {
       switch (sourceType) {
+        case STRING:
+          try {
+            return JsonUtils.stringToObject(value.toString(), Map.class);
+          } catch (Exception e) {
+            throw new RuntimeException("Unable to convert String to Map. Input value: " + value, e);
+          }
         case OBJECT:
         case MAP:
           if (value instanceof Map) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
@@ -3,6 +3,7 @@ package org.apache.pinot.core.operator.filter;
 import com.google.common.base.CaseFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
 import org.apache.pinot.common.request.context.predicate.InPredicate;
@@ -16,7 +17,11 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.segment.spi.index.reader.MapIndexReader;
 
 
 /**
@@ -54,10 +59,10 @@ public class MapIndexFilterOperator extends BaseFilterOperator {
 
     if (dataSource instanceof MapDataSource) {
       MapDataSource mapDS = (MapDataSource) dataSource;
-      DataSource keyDS = mapDS.getKeyDataSource(_keyName);
-      JsonIndexReader jsonIndex = keyDS.getJsonIndex();
-
-      if (jsonIndex != null) {
+      MapIndexReader mapIndexReader = mapDS.getMapIndex();
+      if (mapIndexReader != null) {
+        Map<IndexType, IndexReader> indexes = mapIndexReader.getKeyIndexes(_keyName);
+        JsonIndexReader jsonIndex = (JsonIndexReader) indexes.get(StandardIndexes.json());
         _jsonMatchPredicate = createJsonMatchPredicate();
         _jsonMatchOperator = initializeJsonMatchFilterOperator(jsonIndex, numDocs);
         _expressionFilterOperator = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
@@ -1,0 +1,194 @@
+package org.apache.pinot.core.operator.filter;
+
+import com.google.common.base.CaseFormat;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.InPredicate;
+import org.apache.pinot.common.request.context.predicate.JsonMatchPredicate;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.common.request.context.predicate.RangePredicate;
+import org.apache.pinot.core.common.BlockDocIdSet;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.ExplainAttributeBuilder;
+import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.spi.trace.FilterType;
+import org.apache.pinot.spi.trace.InvocationRecording;
+import org.apache.pinot.spi.trace.Tracing;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Filter operator for Map matching that internally uses JsonMatchFilterOperator.
+ * This operator converts map predicates to JSON predicates and delegates filtering operations
+ * to JsonMatchFilterOperator.
+ */
+public class MapIndexFilterOperator extends BaseFilterOperator {
+  private static final String EXPLAIN_NAME = "FILTER_MAP_INDEX";
+
+  private final JsonMatchFilterOperator _jsonMatchOperator;
+  private final String _columnName;
+  private final String _keyName;
+  private final Predicate _predicate;
+  private final JsonMatchPredicate _jsonMatchPredicate;
+
+  public MapIndexFilterOperator(IndexSegment indexSegment, Predicate predicate, int numDocs) {
+    super(numDocs, false);
+    _predicate = predicate;
+
+    // Get column name and key name from function arguments
+    List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
+    if (arguments.size() != 2) {
+      throw new IllegalStateException("Expected two arguments (column name and key name), found: " + arguments.size());
+    }
+
+    _columnName = arguments.get(0).getIdentifier();
+    _keyName = String.valueOf(arguments.get(1).getLiteral());
+
+    // Convert predicate to JSON format based on type
+    String jsonValue;
+    switch (predicate.getType()) {
+      case EQ:
+        jsonValue = createJsonPredicateValue(_keyName, ((EqPredicate) predicate).getValue());
+        break;
+      case IN:
+        jsonValue = createJsonArrayPredicateValue(_keyName, ((InPredicate) predicate).getValues());
+        break;
+      case RANGE:
+        RangePredicate rangePredicate = (RangePredicate) predicate;
+        jsonValue =
+            createJsonRangePredicateValue(_keyName, rangePredicate.getLowerBound(), rangePredicate.getUpperBound(),
+                rangePredicate.isLowerInclusive(), rangePredicate.isUpperInclusive());
+        break;
+      default:
+        throw new IllegalStateException("Unsupported predicate type for map index: " + predicate.getType());
+    }
+
+    // Create identifier expression for the JSON column
+    ExpressionContext jsonLhs = ExpressionContext.forIdentifier("json");
+    _jsonMatchPredicate = new JsonMatchPredicate(jsonLhs, jsonValue);
+
+    // Get JSON index and create operator
+    DataSource dataSource = indexSegment.getDataSource(_columnName);
+
+    if (dataSource instanceof MapDataSource) {
+      MapDataSource mapDS = (MapDataSource) dataSource;
+      DataSource keyDS = mapDS.getKeyDataSource(_keyName);
+      JsonIndexReader jsonIndex = keyDS.getJsonIndex();
+      if (jsonIndex == null) {
+        throw new IllegalStateException("No JSON index found for column: " + _columnName);
+      }
+      _jsonMatchOperator = new JsonMatchFilterOperator(jsonIndex, _jsonMatchPredicate, numDocs);
+    } else {
+      throw new IllegalStateException(
+          "Expected MapDataSource for column: " + _columnName + ", found: " + dataSource.getClass().getSimpleName());
+    }
+  }
+
+  private String createJsonPredicateValue(String key, String value) {
+    // Format: '"$[0].key" = ''value'''
+    // Example: JSON_MATCH(items, '"$[0].price" = ''100''')
+    //"$[1].key"='foo'
+    return String.format("\"$[0].%s\" = '%s'", key, value);
+  }
+
+  private String createJsonArrayPredicateValue(String key, List<String> values) {
+    StringBuilder valuesStr = new StringBuilder();
+    for (int i = 0; i < values.size(); i++) {
+        if (i > 0) {
+            valuesStr.append(", ");
+        }
+        valuesStr.append("''").append(values.get(i)).append("''");
+    }
+    // Format: '"$[0].key" IN (''value1'', ''value2'')'
+    return String.format("\"$[0].%s\" IN (%s)", key, valuesStr);
+  }
+
+  private String createJsonRangePredicateValue(String key, String lower, String upper, 
+                                             boolean lowerInclusive, boolean upperInclusive) {
+    StringBuilder predicate = new StringBuilder();
+    if (lower != null) {
+        predicate.append(String.format("\"$[0].%s\" %s ''%s''", 
+            key, lowerInclusive ? ">=" : ">", lower));
+    }
+    if (lower != null && upper != null) {
+        predicate.append(" AND ");
+    }
+    if (upper != null) {
+        predicate.append(String.format("\"$[0].%s\" %s ''%s''", 
+            key, upperInclusive ? "<=" : "<", upper));
+    }
+    return predicate.toString();
+  }
+
+  @Override
+  protected BlockDocIdSet getTrues() {
+    ImmutableRoaringBitmap bitmap = _jsonMatchOperator.getBitmaps().reduce();
+    record(bitmap);
+    return new BitmapDocIdSet(bitmap, _numDocs);
+  }
+
+  @Override
+  public boolean canOptimizeCount() {
+    return _jsonMatchOperator.canOptimizeCount();
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return _jsonMatchOperator.getNumMatchingDocs();
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return _jsonMatchOperator.canProduceBitmaps();
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return _jsonMatchOperator.getBitmaps();
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toExplainString() {
+    StringBuilder stringBuilder =
+        new StringBuilder(EXPLAIN_NAME).append("(column:").append(_columnName).append(",key:").append(_keyName)
+            .append(",indexLookUp:map_index").append(",operator:").append(_predicate.getType()).append(",predicate:")
+            .append(_predicate).append(",delegateTo:json_match").append(')');
+    return stringBuilder.toString();
+  }
+
+  @Override
+  protected String getExplainName() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, EXPLAIN_NAME);
+  }
+
+  @Override
+  protected void explainAttributes(ExplainAttributeBuilder attributeBuilder) {
+    super.explainAttributes(attributeBuilder);
+    attributeBuilder.putString("column", _columnName);
+    attributeBuilder.putString("key", _keyName);
+    attributeBuilder.putString("indexLookUp", "map_index");
+    attributeBuilder.putString("operator", _predicate.getType().name());
+    attributeBuilder.putString("predicate", _predicate.toString());
+    attributeBuilder.putString("delegateTo", "json_match");
+  }
+
+  private void record(ImmutableRoaringBitmap bitmap) {
+    InvocationRecording recording = Tracing.activeRecording();
+    if (recording.isEnabled()) {
+      recording.setColumnName(_columnName);
+      recording.setFilter(FilterType.INDEX, _predicate.getType().name());
+      recording.setNumDocsMatchingAfterFilter(bitmap.getCardinality());
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapIndexFilterOperator.java
@@ -51,8 +51,7 @@ public class MapIndexFilterOperator extends BaseFilterOperator {
     }
 
     _columnName = arguments.get(0).getIdentifier();
-    //FIXME keyName contains single quotes, which should be removed
-    _keyName = String.valueOf(arguments.get(1).getLiteral());
+    _keyName = cleanKey(String.valueOf(arguments.get(1).getLiteral()));
 
     // Get JSON index and create operator
     DataSource dataSource = indexSegment.getDataSource(_columnName);
@@ -113,12 +112,7 @@ public class MapIndexFilterOperator extends BaseFilterOperator {
   }
 
   private String createJsonPredicateValue(String key, String value) {
-    String cleanKey = key;
-    if (cleanKey.startsWith("'") && cleanKey.endsWith("'")) {
-      cleanKey = cleanKey.substring(1, cleanKey.length() - 1);
-    }
-
-    return String.format("%s = %s", cleanKey, value);
+    return String.format("%s = %s", key, value);
   }
 
   private String createJsonArrayPredicateValue(String key, List<String> values) {
@@ -235,5 +229,19 @@ public class MapIndexFilterOperator extends BaseFilterOperator {
     } else {
       attributeBuilder.putString("delegateTo", "expression_filter");
     }
+  }
+
+  /**
+   * Cleans the key by removing leading and trailing single quotes if present.
+   *
+   * @param key The original key string
+   * @return The cleaned key string
+   */
+  public static String cleanKey(String key) {
+    String cleanKey = key;
+    if (cleanKey.startsWith("'") && cleanKey.endsWith("'")) {
+      cleanKey = cleanKey.substring(1, cleanKey.length() - 1);
+    }
+    return cleanKey;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -105,7 +105,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToDictIdsSV(ValueBlock valueBlock) {
-    return transformToIntValuesSV(valueBlock);
+    return valueBlock.getBlockValueSet(_keyPath).getDictionaryIdsSV();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -50,13 +50,13 @@ import org.apache.pinot.core.operator.filter.VectorSimilarityFilterOperator;
 import org.apache.pinot.core.operator.filter.predicate.FSTBasedRegexpPredicateEvaluatorFactory;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.NativeMutableTextIndex;
 import org.apache.pinot.segment.local.segment.index.readers.text.NativeTextIndexReader;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
@@ -200,25 +200,10 @@ public class FilterPlanNode implements PlanNode {
    */
   private boolean canApplyMapFilter(Predicate predicate, String column) {
     // Get column name and key name from function arguments
-    //FIXME  Check for ITEM tranform function in the predicate
-    List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
-    if (arguments.size() != 2) {
-      throw new IllegalStateException("Expected two arguments (column name and key name), found: " + arguments.size());
-    }
+    FunctionContext function = predicate.getLhs().getFunction();
 
-    String columnName = arguments.get(0).getIdentifier();
-    String keyName = arguments.get(1).getIdentifier();
-
-    DataSource dataSource = _indexSegment.getDataSource(columnName);
-
-    if (dataSource instanceof MapDataSource) {
-      MapDataSource mapDS = (MapDataSource) dataSource;
-      DataSource keyDS = mapDS.getKeyDataSource(keyName);
-      //FIXME we can also get the list of keys enabled for json index from json config
-      JsonIndexReader jsonIndex = keyDS.getJsonIndex();
-      return jsonIndex != null;
-    }
-    return false;
+    // Check if the function is an ItemTransformFunction
+    return function.getFunctionName().equals(ItemTransformFunction.FUNCTION_NAME);
   }
 
   /**
@@ -268,8 +253,7 @@ public class FilterPlanNode implements PlanNode {
           } else if (canApplyH3IndexForInclusionCheck(predicate, lhs.getFunction())) {
             return new H3InclusionIndexFilterOperator(_indexSegment, _queryContext, predicate, numDocs);
           } else if (canApplyMapFilter(predicate, lhs.getIdentifier())) {
-            // FIXME can we go for all path in this method
-            return new MapIndexFilterOperator(_indexSegment, predicate, numDocs);
+            return new MapIndexFilterOperator(_indexSegment, predicate, _queryContext, numDocs);
           } else {
             // TODO: ExpressionFilterOperator does not support predicate types without PredicateEvaluator (TEXT_MATCH)
             return new ExpressionFilterOperator(_indexSegment, _queryContext, predicate, numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -192,7 +192,7 @@ public class FilterPlanNode implements PlanNode {
   }
 
   /**
-   * Map filter can be applied iff:
+   * FIXME: Map filter can be applied iff:
    * <ul>
    *   <li>Predicate </li>
    *   <li>Map has index like </li>
@@ -200,14 +200,13 @@ public class FilterPlanNode implements PlanNode {
    */
   private boolean canApplyMapFilter(Predicate predicate, String column) {
     // Get column name and key name from function arguments
+    //FIXME  Check for ITEM tranform function in the predicate
     List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
     if (arguments.size() != 2) {
       throw new IllegalStateException("Expected two arguments (column name and key name), found: " + arguments.size());
     }
 
-    // First argument is column name
     String columnName = arguments.get(0).getIdentifier();
-    // Second argument is key name
     String keyName = arguments.get(1).getIdentifier();
 
     DataSource dataSource = _indexSegment.getDataSource(columnName);
@@ -215,6 +214,7 @@ public class FilterPlanNode implements PlanNode {
     if (dataSource instanceof MapDataSource) {
       MapDataSource mapDS = (MapDataSource) dataSource;
       DataSource keyDS = mapDS.getKeyDataSource(keyName);
+      //FIXME we can also get the list of keys enabled for json index from json config
       JsonIndexReader jsonIndex = keyDS.getJsonIndex();
       return jsonIndex != null;
     }
@@ -268,6 +268,7 @@ public class FilterPlanNode implements PlanNode {
           } else if (canApplyH3IndexForInclusionCheck(predicate, lhs.getFunction())) {
             return new H3InclusionIndexFilterOperator(_indexSegment, _queryContext, predicate, numDocs);
           } else if (canApplyMapFilter(predicate, lhs.getIdentifier())) {
+            // FIXME can we go for all path in this method
             return new MapIndexFilterOperator(_indexSegment, predicate, numDocs);
           } else {
             // TODO: ExpressionFilterOperator does not support predicate types without PredicateEvaluator (TEXT_MATCH)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentSegmentCreationDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentSegmentCreationDataSource.java
@@ -42,7 +42,7 @@ public class RealtimeSegmentSegmentCreationDataSource implements SegmentCreation
 
   @Override
   public SegmentPreIndexStatsContainer gatherStats(StatsCollectorConfig statsCollectorConfig) {
-    return new RealtimeSegmentStatsContainer(_mutableSegment, _recordReader.getSortedDocIds());
+    return new RealtimeSegmentStatsContainer(_mutableSegment, _recordReader.getSortedDocIds(), statsCollectorConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.segment.local.segment.index.forward;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.CLPForwardIndexCreatorV1;
@@ -42,11 +43,19 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ForwardIndexCreatorFactory {
+  private static final String FORWARD_INDEX_CREATOR_CLASS_NAME = "forwardIndexCreatorClassName";
   private ForwardIndexCreatorFactory() {
   }
 
   public static ForwardIndexCreator createIndexCreator(IndexCreationContext context, ForwardIndexConfig indexConfig)
       throws Exception {
+    if (indexConfig.getConfigs().containsKey(FORWARD_INDEX_CREATOR_CLASS_NAME)) {
+      String className = indexConfig.getConfigs().get(FORWARD_INDEX_CREATOR_CLASS_NAME).toString();
+      //FIXME: raghav remove precondition
+      Preconditions.checkNotNull(className, "ForwardIndexCreator class name must be provided");
+      return (ForwardIndexCreator) Class.forName(className)
+          .getConstructor(IndexCreationContext.class, ForwardIndexConfig.class).newInstance(context, indexConfig);
+    }
     File indexDir = context.getIndexDir();
     FieldSpec fieldSpec = context.getFieldSpec();
     String columnName = fieldSpec.getName();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -1204,7 +1204,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       forwardIndexConfig = fieldIndexConfig.getConfig(new ForwardIndexPlugin().getIndexType());
     }
     if (forwardIndexConfig == null) {
-      forwardIndexConfig = new ForwardIndexConfig(false, null, null, null, null, null);
+      forwardIndexConfig = new ForwardIndexConfig(false, null, null, null, null, null, null);
     }
 
     return ForwardIndexCreatorFactory.createIndexCreator(indexCreationContext, forwardIndexConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
@@ -41,15 +41,12 @@ public class ImmutableMapDataSource extends BaseMapDataSource {
 
   public ImmutableMapDataSource(ColumnMetadata columnMetadata, ColumnIndexContainer columnIndexContainer) {
     super(new ImmutableMapDataSourceMetadata(columnMetadata), columnIndexContainer);
-    MapIndexReader mapIndexReader = getMapIndex();
-    if (mapIndexReader == null) {
-      // Fallback to use forward index
-      ForwardIndexReader<?> forwardIndex = getForwardIndex();
-      if (forwardIndex instanceof MapIndexReader) {
-        mapIndexReader = (MapIndexReader) forwardIndex;
-      } else {
-        mapIndexReader = new MapIndexReaderWrapper(forwardIndex, getFieldSpec());
-      }
+    MapIndexReader mapIndexReader;
+    ForwardIndexReader<?> forwardIndex = getForwardIndex();
+    if (forwardIndex instanceof MapIndexReader) {
+      mapIndexReader = (MapIndexReader) forwardIndex;
+    } else {
+      mapIndexReader = new MapIndexReaderWrapper(forwardIndex, getFieldSpec());
     }
     _mapIndexReader = mapIndexReader;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/MutableMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/MutableMapDataSource.java
@@ -55,15 +55,13 @@ public class MutableMapDataSource extends BaseMapDataSource {
             partitionFunction, partitions, minValue, maxValue, maxRowLengthInBytes),
         new ColumnIndexContainer.FromMap.Builder().withAll(mutableIndexes).build());
     _mutableIndexes = mutableIndexes;
-    MapIndexReader mapIndexReader = getMapIndex();
-    if (mapIndexReader == null) {
-      // Fallback to use forward index
-      ForwardIndexReader<?> forwardIndex = getForwardIndex();
-      if (forwardIndex instanceof MapIndexReader) {
-        mapIndexReader = (MapIndexReader) forwardIndex;
-      } else {
-        mapIndexReader = new MapIndexReaderWrapper(forwardIndex, getFieldSpec());
-      }
+    MapIndexReader mapIndexReader;
+    // Fallback to use forward index
+    ForwardIndexReader<?> forwardIndex = getForwardIndex();
+    if (forwardIndex instanceof MapIndexReader) {
+      mapIndexReader = (MapIndexReader) forwardIndex;
+    } else {
+      mapIndexReader = new MapIndexReaderWrapper(forwardIndex, getFieldSpec());
     }
     _mapIndexReader = mapIndexReader;
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -82,7 +83,7 @@ public class ForwardIndexConfig extends IndexConfig {
   }
 
   public static ForwardIndexConfig getDisabled() {
-    return new ForwardIndexConfig(true, null, null, null, null, null, null, null);
+    return new ForwardIndexConfig(true, null, null, null, null, null, null, null, null);
   }
 
   @Nullable
@@ -97,10 +98,13 @@ public class ForwardIndexConfig extends IndexConfig {
   private final ChunkCompressionType _chunkCompressionType;
   @Nullable
   private final DictIdCompressionType _dictIdCompressionType;
+  @Nullable
+  private final Map<String, Object> _configs;
 
   public ForwardIndexConfig(@Nullable Boolean disabled, @Nullable CompressionCodec compressionCodec,
       @Nullable Boolean deriveNumDocsPerChunk, @Nullable Integer rawIndexWriterVersion,
-      @Nullable String targetMaxChunkSize, @Nullable Integer targetDocsPerChunk) {
+      @Nullable String targetMaxChunkSize, @Nullable Integer targetDocsPerChunk,
+      @JsonProperty("configs") @Nullable Map<String, Object> configs) {
     super(disabled);
     _compressionCodec = compressionCodec;
     _deriveNumDocsPerChunk = Boolean.TRUE.equals(deriveNumDocsPerChunk);
@@ -110,7 +114,7 @@ public class ForwardIndexConfig extends IndexConfig {
     _targetMaxChunkSizeBytes =
         targetMaxChunkSize == null ? _defaultTargetMaxChunkSizeBytes : (int) DataSizeUtils.toBytes(targetMaxChunkSize);
     _targetDocsPerChunk = targetDocsPerChunk == null ? _defaultTargetDocsPerChunk : targetDocsPerChunk;
-
+    _configs = configs != null ? configs : new HashMap<>();
     if (compressionCodec != null) {
       switch (compressionCodec) {
         case PASS_THROUGH:
@@ -158,9 +162,10 @@ public class ForwardIndexConfig extends IndexConfig {
       @JsonProperty("deriveNumDocsPerChunk") @Nullable Boolean deriveNumDocsPerChunk,
       @JsonProperty("rawIndexWriterVersion") @Nullable Integer rawIndexWriterVersion,
       @JsonProperty("targetMaxChunkSize") @Nullable String targetMaxChunkSize,
-      @JsonProperty("targetDocsPerChunk") @Nullable Integer targetDocsPerChunk) {
+      @JsonProperty("targetDocsPerChunk") @Nullable Integer targetDocsPerChunk,
+      @JsonProperty("configs") @Nullable Map<String, Object> configs) {
     this(disabled, getActualCompressionCodec(compressionCodec, chunkCompressionType, dictIdCompressionType),
-        deriveNumDocsPerChunk, rawIndexWriterVersion, targetMaxChunkSize, targetDocsPerChunk);
+        deriveNumDocsPerChunk, rawIndexWriterVersion, targetMaxChunkSize, targetDocsPerChunk, configs);
   }
 
   public static CompressionCodec getActualCompressionCodec(@Nullable CompressionCodec compressionCodec,
@@ -234,6 +239,12 @@ public class ForwardIndexConfig extends IndexConfig {
     return _dictIdCompressionType;
   }
 
+  @JsonIgnore
+  @Nullable
+  public Map<String, Object> getConfigs() {
+    return _configs;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -264,6 +275,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private int _rawIndexWriterVersion = _defaultRawIndexWriterVersion;
     private String _targetMaxChunkSize = _defaultTargetMaxChunkSize;
     private int _targetDocsPerChunk = _defaultTargetDocsPerChunk;
+    private Map<String, Object> _configs = new HashMap<>();
 
     public Builder() {
     }
@@ -274,6 +286,7 @@ public class ForwardIndexConfig extends IndexConfig {
       _rawIndexWriterVersion = other._rawIndexWriterVersion;
       _targetMaxChunkSize = other._targetMaxChunkSize;
       _targetDocsPerChunk = other._targetDocsPerChunk;
+      _configs = other._configs;
     }
 
     public Builder withCompressionCodec(CompressionCodec compressionCodec) {
@@ -361,7 +374,7 @@ public class ForwardIndexConfig extends IndexConfig {
 
     public ForwardIndexConfig build() {
       return new ForwardIndexConfig(false, _compressionCodec, _deriveNumDocsPerChunk, _rawIndexWriterVersion,
-          _targetMaxChunkSize, _targetDocsPerChunk);
+          _targetMaxChunkSize, _targetDocsPerChunk, _configs);
     }
   }
 }


### PR DESCRIPTION
PR add  support for enabling Custom MAP encoded forwarded index creator and reader. 
Summary :

- immutable Segment Index Build Path
> Collect MapColumnPreIndexStatsCollector during gather stats phase
> Collect MAP encoded column custom metadata properties file and merge with segment metadata.properties file. 

- Immutable Segment Loader Path
> Initialize MAP column with child columns (keys)
> Collect all the key level indexes into custom MAP column IndexContainer.
> For MAP encoded columns initialize Custom Forward Index Reader with child column indexes buffer.

- Couple of MAP data column bug fixes

> Fix MAP convert for segment upload use case.
> Fix Dictionary Index reader API . 
