### PR TITLE
Add configs to customize http client/request timeouts and improve peer download reliability 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1255,6 +1255,25 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   /**
+   * Download a file.
+   *
+   * @param uri URI
+   * @param dest File destination
+   * @param authProvider auth provider
+   * @param httpHeaders http headers
+   * @param connectionRequestTimeoutMs Connection request timeout in milliseconds
+   * @param socketTimeoutMs Socket timeout in milliseconds
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public int downloadFile(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders,
+      int connectionRequestTimeoutMs, int socketTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    return _httpClient.downloadFile(uri, connectionRequestTimeoutMs, socketTimeoutMs, dest, authProvider, httpHeaders);
+  }
+
+  /**
    * Download and untar a file in a streamed way with rate limit
    *
    * @param uri URI
@@ -1271,6 +1290,26 @@ public class FileUploadDownloadClient implements AutoCloseable {
       long maxStreamRateInByte)
       throws IOException, HttpErrorStatusException {
     return _httpClient.downloadUntarFileStreamed(uri, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, dest, authProvider,
+        httpHeaders, maxStreamRateInByte);
+  }
+
+  /**
+   * Download and untar a file in a streamed way with rate limit
+   *
+   * @param uri URI
+   * @param dest File destination
+   * @param authProvider auth token
+   * @param httpHeaders http headers
+   * @param maxStreamRateInByte limit the rate to write download-untar stream to disk, in bytes
+   *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public File downloadUntarFileStreamed(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders,
+      long maxStreamRateInByte, int connectionRequestTimeoutMs, int socketTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    return _httpClient.downloadUntarFileStreamed(uri, connectionRequestTimeoutMs, socketTimeoutMs, dest, authProvider,
         httpHeaders, maxStreamRateInByte);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
@@ -29,15 +29,19 @@ public class HttpClientConfig {
   protected static final String MAX_CONNS_CONFIG_NAME = "http.client.maxConnTotal";
   protected static final String MAX_CONNS_PER_ROUTE_CONFIG_NAME = "http.client.maxConnPerRoute";
   protected static final String DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME = "http.client.disableDefaultUserAgent";
+  protected static final String CONNECTION_TIMEOUT = "http.client.connectionTimeoutMs";
 
   private final int _maxConnTotal;
   private final int _maxConnPerRoute;
   private final boolean _disableDefaultUserAgent;
+  private final int _connectionTimeoutMs;
 
-  private HttpClientConfig(int maxConnTotal, int maxConnPerRoute, boolean disableDefaultUserAgent) {
+  private HttpClientConfig(int maxConnTotal, int maxConnPerRoute, boolean disableDefaultUserAgent,
+      int connectionTimeout) {
     _maxConnTotal = maxConnTotal;
     _maxConnPerRoute = maxConnPerRoute;
     _disableDefaultUserAgent = disableDefaultUserAgent;
+    _connectionTimeoutMs = connectionTimeout;
   }
 
   public int getMaxConnTotal() {
@@ -50,6 +54,10 @@ public class HttpClientConfig {
 
   public boolean isDisableDefaultUserAgent() {
     return _disableDefaultUserAgent;
+  }
+
+  public int getConnectionTimeoutMs() {
+    return _connectionTimeoutMs;
   }
 
   /**
@@ -68,6 +76,10 @@ public class HttpClientConfig {
     if (StringUtils.isNotEmpty(maxConnsPerRoute)) {
       builder.withMaxConnsPerRoute(Integer.parseInt(maxConnsPerRoute));
     }
+    String connectionTimeout = pinotConfiguration.getProperty(CONNECTION_TIMEOUT);
+    if (StringUtils.isNotEmpty(connectionTimeout)) {
+      builder.withConnectionTimeoutMs(Integer.parseInt(connectionTimeout));
+    }
     boolean disableDefaultUserAgent = pinotConfiguration.getProperty(DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME, false);
     builder.withDisableDefaultUserAgent(disableDefaultUserAgent);
     return builder;
@@ -81,6 +93,7 @@ public class HttpClientConfig {
     private int _maxConns = -1;
     private int _maxConnsPerRoute = -1;
     private boolean _disableDefaultUserAgent = false;
+    private int _connectionTimeoutMs = -1;
 
     private Builder() {
     }
@@ -100,8 +113,13 @@ public class HttpClientConfig {
       return this;
     }
 
+    public Builder withConnectionTimeoutMs(int connectionTimeout) {
+      _connectionTimeoutMs = connectionTimeout;
+      return this;
+    }
+
     public HttpClientConfig build() {
-      return new HttpClientConfig(_maxConns, _maxConnsPerRoute, _disableDefaultUserAgent);
+      return new HttpClientConfig(_maxConns, _maxConnsPerRoute, _disableDefaultUserAgent, _connectionTimeoutMs);
     }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
@@ -32,15 +32,18 @@ public class HttpClientConfigTest {
     pinotConfiguration.setProperty(HttpClientConfig.MAX_CONNS_CONFIG_NAME, "123");
     pinotConfiguration.setProperty(HttpClientConfig.MAX_CONNS_PER_ROUTE_CONFIG_NAME, "11");
     pinotConfiguration.setProperty(HttpClientConfig.DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME, "true");
+    pinotConfiguration.setProperty(HttpClientConfig.CONNECTION_TIMEOUT, "30000");
     HttpClientConfig httpClientConfig = HttpClientConfig.newBuilder(pinotConfiguration).build();
     Assert.assertEquals(123, httpClientConfig.getMaxConnTotal());
     Assert.assertEquals(11, httpClientConfig.getMaxConnPerRoute());
+    Assert.assertEquals(30000, httpClientConfig.getConnectionTimeoutMs());
     Assert.assertTrue(httpClientConfig.isDisableDefaultUserAgent());
 
     // Ensure default builder uses negative values
     HttpClientConfig defaultConfig = HttpClientConfig.newBuilder(new PinotConfiguration()).build();
     Assert.assertTrue(defaultConfig.getMaxConnTotal() < 0, "default value should be < 0");
     Assert.assertTrue(defaultConfig.getMaxConnPerRoute() < 0, "default value should be < 0");
+    Assert.assertTrue(defaultConfig.getConnectionTimeoutMs() < 0, "default value should be < 0");
     Assert.assertFalse(defaultConfig.isDisableDefaultUserAgent(), "Default user agent should be enabled by default");
   }
 }


### PR DESCRIPTION
Makes http request/client timeouts configurable, primarily meant for peer download. We have found peer downloads often fail while waiting for a connection from the pool. Retry means the peer download loses its spot in the queue, it's better to wait for a connection longer in many cases. Example stack trace:

```
org.apache.hc.core5.http.ConnectionRequestTimeoutException: Timeout deadline: 180000 MILLISECONDS, actual: 180001 MILLISECONDS at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.acquireEndpoint(InternalExecRuntime.java:120) at 
<...>
org.apache.pinot.common.utils.http.HttpClient.downloadFile(HttpClient.java:403) at 
<...>
```

new configs are:
```
pinot.server.segment.fetcher.http.request.connectionRequestTimeoutMs=12345  // time to wait for free connection from the pool
pinot.server.segment.fetcher.http.request.socketTimeoutMs=12345 // time to wait for segment to download
pinot.server.segment.fetcher.http.client.connectionTimeoutMs=12345 // time to wait to establish connection
```
the current/default timeout settings/behavior is unchanged 