### PR TITLE
Return JSON instead of str in the broker debug api /debug/serverRoutingStats 

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -58,6 +58,7 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.ServerRouteInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsEntry;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
@@ -271,8 +272,8 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Server routing Stats not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public String getServerRoutingStats() {
-    return _serverRoutingStatsManager.getServerRoutingStatsStr();
+  public Map<String, ServerRoutingStatsEntry> getServerRoutingStats() {
+    return _serverRoutingStatsManager.getServerRoutingStats();
   }
 
   private long getRequestId() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -273,7 +273,11 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 500, message = "Internal server error")
   })
   public Map<String, ServerRoutingStatsEntry> getServerRoutingStats() {
-    return _serverRoutingStatsManager.getServerRoutingStats();
+    if (_serverRoutingStatsManager.isEnabled()) {
+      return _serverRoutingStatsManager.getServerRoutingStats();
+    } else {
+      throw new WebApplicationException("Server routing stats is not enabled", Response.Status.NOT_FOUND);
+    }
   }
 
   private long getRequestId() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.transport.server.routing.stats;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.common.utils.ExponentialMovingAverage;
@@ -58,10 +60,12 @@ public class ServerRoutingStatsEntry {
     _hybridScoreExponent = scoreExponent;
   }
 
+  @JsonIgnore
   public ReentrantReadWriteLock.ReadLock getServerReadLock() {
     return _serverLock.readLock();
   }
 
+  @JsonIgnore
   public ReentrantReadWriteLock.WriteLock getServerWriteLock() {
     return _serverLock.writeLock();
   }
@@ -78,6 +82,7 @@ public class ServerRoutingStatsEntry {
     return _latencyMsEMA.getAverage();
   }
 
+  @JsonProperty("hybridScore")
   public double computeHybridScore() {
     double estimatedQSize = _numInFlightRequests + _inFlighRequestsEMA.getAverage();
     return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -198,6 +198,10 @@ public class ServerRoutingStatsManager {
     }
   }
 
+  public Map<String, ServerRoutingStatsEntry> getServerRoutingStats() {
+    return _serverQueryStatsMap;
+  }
+
   /**
    * Returns ServerRoutingStatsStr for debugging/logging.
    */

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -32,10 +32,7 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 public class ServerRoutingStatsManagerTest {
@@ -71,15 +68,19 @@ public class ServerRoutingStatsManagerTest {
     ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
         _brokerMetrics);
     assertFalse(manager.isEnabled());
+    assertNull(manager.getServerRoutingStats());
     manager.init();
     assertFalse(manager.isEnabled());
+    assertNull(manager.getServerRoutingStats());
 
     // Test 2: Test enabled.
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
     manager = new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     assertFalse(manager.isEnabled());
+    assertNull(manager.getServerRoutingStats());
     manager.init();
     assertTrue(manager.isEnabled());
+    assertNotNull(manager.getServerRoutingStats());
 
     // Test 3: Shutdown and then init.
     manager.shutDown();
@@ -96,6 +97,7 @@ public class ServerRoutingStatsManagerTest {
     ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
         _brokerMetrics);
     manager.init();
+    assertNotNull(manager.getServerRoutingStats());
 
     List<Pair<String, Integer>> numInFlightReqList = manager.fetchNumInFlightRequestsForAllServers();
     assertTrue(numInFlightReqList.isEmpty());


### PR DESCRIPTION
Fix for #15017 

The o/p of the api is not easily machine readable. An example o/p is:

```
(Server=NumInFlightRequests,NumInFlightRequestsEMA,LatencyEMA,Score);Server_100.81.71.117_7050=0,6.349956168651998E-148,2.5324251579231667E-148,0.0;Server_100.81.71.117_7051=0,6.150450664351991E-147,5.482000636051586E-147,0.0;Server_100.81.71.117_7052=0,6.861196743124505E-148,2.526062961096265E-148,0.0;Server_100.81.71.117_7053=0,3.343930442767001E-147,5.466877618135145E-145,0.0
```

Instead return a json since its more easily analyzed using scripts. For example, the following json o/p of the same data:

```
{
  "Server_100.81.71.117_7050": {
    "latencyEMA": 2.6305286728948865,
    "numInFlightRequests": 10,
    "inFlightRequestsEMA": 10.83252545140485,
    "hybridScore": 23783.118690453754
  },
  "Server_100.81.71.117_7051": {
    "latencyEMA": 2.546575260838141,
    "numInFlightRequests": 10,
    "inFlightRequestsEMA": 10.832524167798587,
    "hybridScore": 23024.07539269138
  },
  "Server_100.81.71.117_7052": {
    "latencyEMA": 2.8777880660250883,
    "numInFlightRequests": 10,
    "inFlightRequestsEMA": 10.83252545140485,
    "hybridScore": 26018.638703878878
  },
  "Server_100.81.71.117_7053": {
    "latencyEMA": 1603.1813971374418,
    "numInFlightRequests": 0,
    "inFlightRequestsEMA": 18.5040581516264,
    "hybridScore": 10157424.86651867
  }
}
```

Can be processed by shell scripts to create csv files and plot them.

This change is backward-incompatible. However this is a debug API.