### PR TITLE
Spool intermediate stage fix

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SpoolIntegrationTest extends BaseClusterIntegrationTest
+    implements ExplainIntegrationTestTrait {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServers(2);
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create and upload segments
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(getTableName(), _tarDir);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    String property = CommonConstants.MultiStageQueryRunner.KEY_OF_MULTISTAGE_EXPLAIN_INCLUDE_SEGMENT_PLAN;
+    brokerConf.setProperty(property, "true");
+  }
+
+  @BeforeMethod
+  public void resetMultiStage() {
+    setUseMultiStageQueryEngine(true);
+  }
+
+  // Test that intermediate stages can be spooled.
+  // In this case Stage 4 is an intermediate stage whose single child is stage 5.
+  // Stage 4 is spooled and sends data to stages 3 and 7
+  @Test
+  public void intermediateSpool()
+      throws Exception {
+    JsonNode jsonNode = postQuery("SET useSpools = true;\n"
+        + "WITH group_and_sum AS (\n"
+        + "  SELECT ArrTimeBlk,\n"
+        + "    Dest,\n"
+        + "    SUM(ArrTime) AS ArrTime\n"
+        + "  FROM mytable\n"
+        + "  GROUP BY ArrTimeBlk,\n"
+        + "    Dest\n"
+        + "  limit 1000\n"
+        + "),\n"
+        + "aggregated_data AS (\n"
+        + "  SELECT\n"
+        + "    Dest,\n"
+        + "    SUM(ArrTime) AS ArrTime\n"
+        + "  FROM group_and_sum\n"
+        + "  GROUP BY\n"
+        + "    Dest\n"
+        + "),\n"
+        + "joined AS (\n"
+        + "  SELECT\n"
+        + "    s.Dest,\n"
+        + "    s.ArrTime,\n"
+        + "    (o.ArrTime) AS ArrTime2\n"
+        + "  FROM group_and_sum s\n"
+        + "  JOIN aggregated_data o\n"
+        + "  ON s.Dest = o.Dest\n"
+        + ")\n"
+        + "SELECT *\n"
+        + "FROM joined\n"
+        + "LIMIT 1");
+    JsonNode stats = jsonNode.get("stageStats");
+    DocumentContext parsed = JsonPath.parse(stats.toString());
+    List<Map<String, Object>> stage4On3 = parsed.read("$..[?(@.stage == 3)]..[?(@.stage == 4)]");
+    Assert.assertNotNull(stage4On3, "Stage 4 should be a descendant of stage 3");
+    Assert.assertEquals(stage4On3.size(), 1, "Stage 4 should only be descended from stage 3 once");
+
+    List<Map<String, Object>> stage4On7 = parsed.read("$..[?(@.stage == 7)]..[?(@.stage == 4)]");
+    Assert.assertNotNull(stage4On7, "Stage 4 should be a descendant of stage 7");
+    Assert.assertEquals(stage4On7.size(), 1, "Stage 4 should only be descended from stage 7 once");
+
+    Assert.assertEquals(stage4On3, stage4On7, "Stage 4 should be the same in both stage 3 and stage 7");
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(DEFAULT_TABLE_NAME);
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+
+    FileUtils.deleteDirectory(_tempDir);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
@@ -118,12 +118,10 @@ public class SpoolIntegrationTest extends BaseClusterIntegrationTest
     assertNoError(jsonNode);
     DocumentContext parsed = JsonPath.parse(stats.toString());
     List<Map<String, Object>> stage4On3 = parsed.read("$..[?(@.stage == 3)]..[?(@.stage == 4)]");
-    Assert.assertNotNull(stage4On3, "Stage 4 should be a descendant of stage 3");
-    Assert.assertEquals(stage4On3.size(), 1, "Stage 4 should only be descended from stage 3 once");
+    Assert.assertEquals(stage4On3.size(), 1, "Stage 4 should be descended from stage 3 exactly once");
 
     List<Map<String, Object>> stage4On7 = parsed.read("$..[?(@.stage == 7)]..[?(@.stage == 4)]");
-    Assert.assertNotNull(stage4On7, "Stage 4 should be a descendant of stage 7");
-    Assert.assertEquals(stage4On7.size(), 1, "Stage 4 should only be descended from stage 7 once");
+    Assert.assertEquals(stage4On3.size(), 1, "Stage 4 should be descended from stage 7 exactly once");
 
     Assert.assertEquals(stage4On3, stage4On7, "Stage 4 should be the same in both stage 3 and stage 7");
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
@@ -115,7 +115,7 @@ public class SpoolIntegrationTest extends BaseClusterIntegrationTest
         + "FROM joined\n"
         + "LIMIT 1");
     JsonNode stats = jsonNode.get("stageStats");
-    Assert.assertNotNull(stats, "Stage stats should be present. Please verify the query didn't fail");
+    assertNoError(jsonNode);
     DocumentContext parsed = JsonPath.parse(stats.toString());
     List<Map<String, Object>> stage4On3 = parsed.read("$..[?(@.stage == 3)]..[?(@.stage == 4)]");
     Assert.assertNotNull(stage4On3, "Stage 4 should be a descendant of stage 3");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SpoolIntegrationTest.java
@@ -115,6 +115,7 @@ public class SpoolIntegrationTest extends BaseClusterIntegrationTest
         + "FROM joined\n"
         + "LIMIT 1");
     JsonNode stats = jsonNode.get("stageStats");
+    Assert.assertNotNull(stats, "Stage stats should be present. Please verify the query didn't fail");
     DocumentContext parsed = JsonPath.parse(stats.toString());
     List<Map<String, Object>> stage4On3 = parsed.read("$..[?(@.stage == 3)]..[?(@.stage == 4)]");
     Assert.assertNotNull(stage4On3, "Stage 4 should be a descendant of stage 3");

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanFragmenter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanFragmenter.java
@@ -99,16 +99,13 @@ public class PlanFragmenter implements PlanNodeVisitor<PlanNode, PlanFragmenter.
     // Remove the old sender and its children from the plan fragment map
     _planFragmentMap.remove(oldSender);
 
-    IntList pending = new IntArrayList();
-    IntList nullableOrphans = _childPlanFragmentIdsMap.remove(oldSender);
-    if (nullableOrphans != null) {
-      pending.addAll(nullableOrphans);
-    }
-    while (!pending.isEmpty()) {
-      int orphan = pending.removeInt(pending.size() - 1);
+    IntList fragmentsToRemove = new IntArrayList();
+    fragmentsToRemove.add(oldSender);
+    while (!fragmentsToRemove.isEmpty()) {
+      int orphan = fragmentsToRemove.removeInt(fragmentsToRemove.size() - 1);
       IntList children = _childPlanFragmentIdsMap.remove(orphan);
       if (children != null) {
-        pending.addAll(children);
+        fragmentsToRemove.addAll(children);
       }
       _planFragmentMap.remove(orphan);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator.exchange;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -32,7 +33,12 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 class BroadcastExchange extends BlockExchange {
 
   protected BroadcastExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
-    super(sendingMailboxes, splitter);
+    super(sendingMailboxes, splitter, BroadcastExchange.RANDOM_INDEX_CHOOSER);
+  }
+
+  protected BroadcastExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
+      Function<List<SendingMailbox>, Integer> statsIndexChooser) {
+    super(sendingMailboxes, splitter, statsIndexChooser);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.query.runtime.operator.exchange;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.partitioning.EmptyKeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
@@ -37,9 +39,15 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 class HashExchange extends BlockExchange {
   private final KeySelector<?> _keySelector;
 
-  HashExchange(List<SendingMailbox> sendingMailboxes, KeySelector<?> keySelector, BlockSplitter splitter) {
-    super(sendingMailboxes, splitter);
+  HashExchange(List<SendingMailbox> sendingMailboxes, KeySelector<?> keySelector, BlockSplitter splitter,
+      Function<List<SendingMailbox>, Integer> statsIndexChooser) {
+    super(sendingMailboxes, splitter, statsIndexChooser);
     _keySelector = keySelector;
+  }
+
+  @VisibleForTesting
+  HashExchange(List<SendingMailbox> sendingMailboxes, KeySelector<?> keySelector, BlockSplitter splitter) {
+    this(sendingMailboxes, keySelector, splitter, RANDOM_INDEX_CHOOSER);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
@@ -38,14 +39,20 @@ class RandomExchange extends BlockExchange {
 
   private final IntFunction<Integer> _rand;
 
-  RandomExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
-    this(sendingMailboxes, RANDOM::nextInt, splitter);
+  RandomExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
+      Function<List<SendingMailbox>, Integer> statsIndexChooser) {
+    this(sendingMailboxes, RANDOM::nextInt, splitter, statsIndexChooser);
+  }
+
+  RandomExchange(List<SendingMailbox> sendingMailboxes, IntFunction<Integer> rand, BlockSplitter splitter,
+      Function<List<SendingMailbox>, Integer> statsIndexChooser) {
+    super(sendingMailboxes, splitter, statsIndexChooser);
+    _rand = rand;
   }
 
   @VisibleForTesting
   RandomExchange(List<SendingMailbox> sendingMailboxes, IntFunction<Integer> rand, BlockSplitter splitter) {
-    super(sendingMailboxes, splitter);
-    _rand = rand;
+    this(sendingMailboxes, rand, splitter, RANDOM_INDEX_CHOOSER);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pinot.query.mailbox.InMemorySendingMailbox;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
@@ -34,11 +35,16 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
  */
 class SingletonExchange extends BlockExchange {
 
-  SingletonExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
-    super(sendingMailboxes, splitter);
+  SingletonExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
+      Function<List<SendingMailbox>, Integer> statsIndexChooser) {
+    super(sendingMailboxes, splitter, statsIndexChooser);
     Preconditions.checkArgument(
         sendingMailboxes.size() == 1 && sendingMailboxes.get(0) instanceof InMemorySendingMailbox,
         "Expect single InMemorySendingMailbox for SingletonExchange");
+  }
+
+  SingletonExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
+    this(sendingMailboxes, splitter, RANDOM_INDEX_CHOOSER);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
@@ -173,7 +173,7 @@ public class BlockExchangeTest {
     }
 
     protected TestBlockExchange(List<SendingMailbox> destinations, BlockSplitter splitter) {
-      super(destinations, splitter);
+      super(destinations, splitter, BlockExchange.RANDOM_INDEX_CHOOSER);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes two errors detected when spooling intermediate stages:
1. Queries failed when spooling an intermediate stage on PlanFragment when trying to assign a fragment to the children of the pruned stage. This is solved by removing these orphan children, as it was expected.
2. On multi-senders, stats were sent randomly to different children, as we used to do in regular broadcasts. When stats are merged in `MultiStageQueryStats.mergeUpstream`, we cannot merge stats sent from an early stage. This requirement was added when spools didn't exist; therefore, we could guarantee an order in stage ids. With spools, that order is broken in the general case (a parent stage may receive data from children with smaller IDs). Instead of fixing that requirement, this PR ensures that our mailbox send operators only send stats to the smaller receiver stage. By doing that, we can still guarantee the previous constraint when merging stats because a mailbox send must always send data to its original parent.

This PR also includes a test that verifies that intermediate stages can be spooled.