### PR TITLE
Do not convert IN/NOT_IN to OR lists

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotLeftJoinToNotInClauseRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotLeftJoinToNotInClauseRule.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.pinot.calcite.sql.fun.PinotOperatorTable;
+
+
+/**
+ * Converts a left-join with literal only right side to a NOT IN clause.
+ *
+ * This is required because Calcite compiles NOT IN clause into a left-join, which is not efficient.
+ *
+ * Example query plan when reaching this rule:
+ * LogicalProject(col1=[$0])
+ *   LogicalFilter(condition=[IS NOT TRUE($3)])
+ *     LogicalJoin(condition=[=($1, $2)], joinType=[left])
+ *       LogicalProject(col1=[$0], col20=[$1])
+ *         LogicalTableScan(table=[[default, a]])
+ *       LogicalProject(ROW_VALUE=[$0], $f1=[true])
+ *         LogicalValues(tuples=[[{ _UTF-8'a1' }, { _UTF-8'a2' }, { _UTF-8'a3' }]])
+ */
+public class PinotLeftJoinToNotInClauseRule extends RelOptRule {
+  public static final PinotLeftJoinToNotInClauseRule INSTANCE =
+      new PinotLeftJoinToNotInClauseRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  public PinotLeftJoinToNotInClauseRule(RelBuilderFactory factory) {
+    super(operand(LogicalProject.class, operand(LogicalFilter.class,
+        operand(LogicalJoin.class, operand(RelNode.class, any()),
+            operand(LogicalProject.class, operand(LogicalValues.class, any()))))), factory, null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    // Match LogicalFilter with single IS NOT TRUE condition
+    LogicalFilter filter = call.rel(1);
+    RexNode filterCondition = filter.getCondition();
+    if (filterCondition.getKind() != SqlKind.IS_NOT_TRUE) {
+      return false;
+    }
+    // Match LogicalJoin with left join type and single EQUALS condition
+    LogicalJoin join = call.rel(2);
+    if (join.getJoinType() != JoinRelType.LEFT) {
+      return false;
+    }
+    RexNode joinCondition = join.getCondition();
+    if (joinCondition.getKind() != SqlKind.EQUALS) {
+      return false;
+    }
+    // Match LogicalProject with 2 columns, the first one is a reference to the LogicalValues, the second one is TRUE
+    LogicalProject project = call.rel(4);
+    List<RexNode> projects = project.getProjects();
+    if (projects.size() != 2) {
+      return false;
+    }
+    RexNode firstProject = projects.get(0);
+    if (!(firstProject instanceof RexInputRef) || ((RexInputRef) firstProject).getIndex() != 0) {
+      return false;
+    }
+    RexNode secondProject = projects.get(1);
+    if (!(secondProject instanceof RexLiteral) || !Boolean.TRUE.equals(((RexLiteral) secondProject).getValue())) {
+      return false;
+    }
+    // Match single column non-empty LogicalValues
+    LogicalValues values = call.rel(5);
+    ImmutableList<ImmutableList<RexLiteral>> tuples = values.getTuples();
+    if (tuples.isEmpty()) {
+      return false;
+    }
+    return tuples.get(0).size() == 1;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    LogicalJoin join = call.rel(2);
+    RelNode left = call.rel(3);
+    LogicalValues values = call.rel(5);
+
+    // Extract values from LogicalValues
+    ImmutableList<ImmutableList<RexLiteral>> tuples = values.getTuples();
+    List<RexNode> notInArguments = new ArrayList<>(1 + tuples.size());
+    notInArguments.add(RexInputRef.of(join.analyzeCondition().leftKeys.get(0), left.getRowType()));
+    for (List<RexLiteral> tuple : tuples) {
+      if (!tuple.isEmpty()) {
+        notInArguments.add(tuple.get(0));
+      }
+    }
+
+    // Build the NOT IN condition
+    RexBuilder rexBuilder = join.getCluster().getRexBuilder();
+    RexNode notInCondition = rexBuilder.makeCall(PinotOperatorTable.PINOT_NOT_IN, notInArguments);
+
+    // Create a LogicalFilter with the NOT IN condition
+    LogicalFilter filter = LogicalFilter.create(left, notInCondition);
+
+    // Create a LogicalProject with the NOT IN filter as the input
+    LogicalProject project = call.rel(0);
+    call.transformTo(LogicalProject.create(filter, project.getHints(), project.getProjects(), project.getRowType(),
+        project.getVariablesSet()));
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -91,7 +91,11 @@ public class PinotQueryRuleSets {
 
       // convert CASE-style filtered aggregates into true filtered aggregates
       // put it after AGGREGATE_REDUCE_FUNCTIONS where SUM is converted to SUM0
-      CoreRules.AGGREGATE_CASE_TO_FILTER
+      CoreRules.AGGREGATE_CASE_TO_FILTER,
+
+      // Convert IN and NOT IN back to their original form
+      PinotSemiJoinToInClauseRule.INSTANCE,
+      PinotLeftJoinToNotInClauseRule.INSTANCE
   );
 
   // Filter pushdown rules run using a RuleCollection since we want to push down a filter as much as possible in a

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -46,10 +46,12 @@ public class PinotRuleUtils {
   public static final RelBuilderFactory PINOT_REL_FACTORY =
       RelBuilder.proto(Contexts.of(RelFactories.DEFAULT_STRUCT, PINOT_REL_CONFIG));
 
-  public static final SqlToRelConverter.Config PINOT_SQL_TO_REL_CONFIG =
-      SqlToRelConverter.config().withHintStrategyTable(PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE)
-          .withTrimUnusedFields(true).withExpand(true).withInSubQueryThreshold(Integer.MAX_VALUE)
-          .withRelBuilderFactory(PINOT_REL_FACTORY);
+  public static final SqlToRelConverter.Config PINOT_SQL_TO_REL_CONFIG = SqlToRelConverter.config()
+      .withHintStrategyTable(PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE)
+      .withTrimUnusedFields(true)
+      .withExpand(true)
+      .withInSubQueryThreshold(0)
+      .withRelBuilderFactory(PINOT_REL_FACTORY);
 
   public static RelNode unboxRel(RelNode rel) {
     if (rel instanceof HepRelVertex) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotSemiJoinToInClauseRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotSemiJoinToInClauseRule.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.pinot.calcite.sql.fun.PinotOperatorTable;
+
+
+/**
+ * Converts a semi-join with literal only right side to an IN clause.
+ *
+ * This is required because Calcite compiles IN clause into a semi-join, which is not efficient.
+ *
+ * Example query plan when reaching this rule:
+ * LogicalJoin(condition=[=($1, $2)], joinType=[semi])
+ *   LogicalProject(col1=[$0], col2=[$1])
+ *     LogicalTableScan(table=[[default, a]])
+ *   LogicalValues(tuples=[[{ _UTF-8'a1' }, { _UTF-8'a2' }, { _UTF-8'a3' }]])
+ */
+public class PinotSemiJoinToInClauseRule extends RelOptRule {
+  public static final PinotSemiJoinToInClauseRule INSTANCE =
+      new PinotSemiJoinToInClauseRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  public PinotSemiJoinToInClauseRule(RelBuilderFactory factory) {
+    super(operand(LogicalJoin.class, operand(RelNode.class, any()), operand(LogicalValues.class, any())), factory,
+        null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    LogicalJoin join = call.rel(0);
+    if (join.getJoinType() != JoinRelType.SEMI) {
+      return false;
+    }
+    // Match single column non-empty LogicalValues
+    LogicalValues values = call.rel(2);
+    ImmutableList<ImmutableList<RexLiteral>> tuples = values.getTuples();
+    if (tuples.isEmpty()) {
+      return false;
+    }
+    return tuples.get(0).size() == 1;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    LogicalJoin join = call.rel(0);
+    RelNode left = call.rel(1);
+    LogicalValues values = call.rel(2);
+
+    // Extract values from LogicalValues
+    ImmutableList<ImmutableList<RexLiteral>> tuples = values.getTuples();
+    List<RexNode> inArguments = new ArrayList<>(1 + tuples.size());
+    inArguments.add(RexInputRef.of(join.analyzeCondition().leftKeys.get(0), left.getRowType()));
+    for (List<RexLiteral> tuple : tuples) {
+      if (!tuple.isEmpty()) {
+        inArguments.add(tuple.get(0));
+      }
+    }
+
+    // Build the IN condition
+    RexBuilder rexBuilder = join.getCluster().getRexBuilder();
+    RexNode inCondition = rexBuilder.makeCall(PinotOperatorTable.PINOT_IN, inArguments);
+
+    // Create a LogicalFilter with the IN condition
+    LogicalFilter filter = LogicalFilter.create(left, inCondition);
+    call.transformTo(filter);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -97,6 +97,13 @@ public class PinotOperatorTable implements SqlOperatorTable {
           InferTypes.FIRST_KNOWN,
           OperandTypes.MINUS_OPERATOR.or(OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.TIMESTAMP)));
 
+  // These 2 operators are not directly registered in the operator table, but are used in the custom optimization rules
+  // (see PinotSemiJoinToInClauseRule and PinotLeftJoinToNotInClauseRule) to work around the Calcite limitation of not
+  // supporting IN and NOT IN as the function call.
+  public static final PinotSqlFunction PINOT_IN = new PinotSqlFunction("IN", ReturnTypes.BOOLEAN_NULLABLE, null);
+  public static final PinotSqlFunction PINOT_NOT_IN =
+      new PinotSqlFunction("NOT_IN", ReturnTypes.BOOLEAN_NULLABLE, null);
+
   /**
    * This list includes the supported standard {@link SqlOperator}s defined in {@link SqlStdOperatorTable}.
    * NOTE: The operator order follows the same order as defined in {@link SqlStdOperatorTable} for easier search.

--- a/pinot-query-planner/src/test/resources/queries/FilterPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/FilterPlans.json
@@ -1,0 +1,114 @@
+{
+  "filter_planning_tests": {
+    "queries": [
+      {
+        "description": "Small IN clause",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 IN ('a1', 'a2', 'a3')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3')])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Large IN clause",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 IN ('a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12', 'a13', 'a14', 'a15', 'a16', 'a17', 'a18', 'a19', 'a20', 'a21', 'a22', 'a23', 'a24', 'a25', 'a26', 'a27', 'a28', 'a29', 'a30')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3', _UTF-8'a4', _UTF-8'a5', _UTF-8'a6', _UTF-8'a7', _UTF-8'a8', _UTF-8'a9', _UTF-8'a10', _UTF-8'a11', _UTF-8'a12', _UTF-8'a13', _UTF-8'a14', _UTF-8'a15', _UTF-8'a16', _UTF-8'a17', _UTF-8'a18', _UTF-8'a19', _UTF-8'a20', _UTF-8'a21', _UTF-8'a22', _UTF-8'a23', _UTF-8'a24', _UTF-8'a25', _UTF-8'a26', _UTF-8'a27', _UTF-8'a28', _UTF-8'a29', _UTF-8'a30')])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "IN clause with multiple columns",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM a WHERE col2 IN ('a1', 'a2', 'a3')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalFilter(condition=[IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3')])",
+          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "IN clause with other filters",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 IN ('a1', 'a2', 'a3') AND col3 > 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[AND(>($2, 0), IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3'))])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "IN clause with other filters",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 IN ('a1', 'a2', 'a3') OR col3 > 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[OR(>($2, 0), IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3'))])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Small NOT IN clause",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 NOT IN ('a1', 'a2', 'a3')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[NOT_IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3')])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Large NOT IN clause",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 NOT IN ('a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12', 'a13', 'a14', 'a15', 'a16', 'a17', 'a18', 'a19', 'a20', 'a21', 'a22', 'a23', 'a24', 'a25', 'a26', 'a27', 'a28', 'a29', 'a30')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[NOT_IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3', _UTF-8'a4', _UTF-8'a5', _UTF-8'a6', _UTF-8'a7', _UTF-8'a8', _UTF-8'a9', _UTF-8'a10', _UTF-8'a11', _UTF-8'a12', _UTF-8'a13', _UTF-8'a14', _UTF-8'a15', _UTF-8'a16', _UTF-8'a17', _UTF-8'a18', _UTF-8'a19', _UTF-8'a20', _UTF-8'a21', _UTF-8'a22', _UTF-8'a23', _UTF-8'a24', _UTF-8'a25', _UTF-8'a26', _UTF-8'a27', _UTF-8'a28', _UTF-8'a29', _UTF-8'a30')])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "NOT IN clause with multiple columns",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM a WHERE col2 NOT IN ('a1', 'a2', 'a3')",
+        "output": [
+          "Execution Plan",
+          "\nLogicalFilter(condition=[NOT_IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3')])",
+          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "NOT IN clause with other filters",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 NOT IN ('a1', 'a2', 'a3') AND col3 > 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[AND(>($2, 0), NOT_IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3'))])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "NOT IN clause with other filters",
+        "sql": "EXPLAIN PLAN FOR SELECT col1 FROM a WHERE col2 NOT IN ('a1', 'a2', 'a3') OR col3 > 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[OR(>($2, 0), NOT_IN($1, _UTF-8'a1', _UTF-8'a2', _UTF-8'a3'))])",
+          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      }
+    ]
+  }
+}

--- a/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
@@ -214,11 +214,11 @@
         "sql": "EXPLAIN PLAN FOR SELECT CONCAT(a.col1, '-', a.col2), MIN(a.col3) OVER() FROM a where a.col1 IN ('foo', 'bar')",
         "output": [
           "Execution Plan",
-          "\nLogicalProject($0=[$1], $1=[$2])",
+          "\nLogicalProject(EXPR$0=[$1], $1=[$2])",
           "\n  LogicalWindow(window#0=[window(aggs [MIN($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
-          "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-8'bar', _UTF-8'foo']:CHAR(3) CHARACTER SET \"UTF-8\")])",
+          "\n      LogicalProject(col3=[$2], EXPR$0=[CONCAT($0, _UTF-8'-', $1)])",
+          "\n        LogicalFilter(condition=[IN($0, _UTF-8'foo', _UTF-8'bar')])",
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]
@@ -457,7 +457,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [MIN($0), MAX($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2], $1=[LENGTH(CONCAT($0, _UTF-8' ', $1))])",
-          "\n        LogicalFilter(condition=[SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
+          "\n        LogicalFilter(condition=[NOT_IN($0, _UTF-8'foo', _UTF-8'bar', _UTF-8'baz')])",
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]
@@ -472,7 +472,7 @@
           "\n  LogicalWindow(window#0=[window(rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject($0=[LENGTH(CONCAT($0, _UTF-8' ', $1))])",
-          "\n        LogicalFilter(condition=[SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
+          "\n        LogicalFilter(condition=[NOT_IN($0, _UTF-8'foo', _UTF-8'bar', _UTF-8'baz')])",
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]
@@ -1113,7 +1113,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [MIN($1), MAX($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
-          "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
+          "\n        LogicalFilter(condition=[NOT_IN($1, _UTF-8'foo', _UTF-8'bar', _UTF-8'baz')])",
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]
@@ -1936,7 +1936,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [MIN($1), MAX($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
-          "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
+          "\n        LogicalFilter(condition=[NOT_IN($1, _UTF-8'foo', _UTF-8'bar', _UTF-8'baz')])",
           "\n          LogicalTableScan(table=[[default, a]])",
           "\n"
         ]


### PR DESCRIPTION
An attempt to fix #13617 

The idea is to:
1. Do not convert IN/NOT_IN to OR lists when converting Sql to Rel. Calcite will make it a JOIN query.
2. Convert the JOIN query back to IN/NOT_IN using a rule

It works for simple cases, but starts failing when there is another condition joined with OR (e.g. `WHERE col1 IN ('a', 'b') OR col2 > 0`). Calcite is rewriting it into a very complex expression within `SqlToRelConverter.translateIn()`, and I'm not able to find a workaround to turn it off.