### PR TITLE
Add jute.maxBuffer in java opts as an example

### DIFF
--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -140,7 +140,7 @@ controller:
     host: pinot-controller
     port: 9000
 
-  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log"
+  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log -Djute.maxbuffer=4000000"
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-controller-log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -241,7 +241,7 @@ broker:
   securityContext: {}
   startCommand: "StartBroker"
 
-  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log"
+  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log -Djute.maxbuffer=4000000"
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-broker-log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -419,7 +419,7 @@ server:
     extraVolumes: []
     extraVolumeMounts: []
 
-  jvmOpts: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-server.log"
+  jvmOpts: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-server.log -Djute.maxbuffer=4000000"
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-server-log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -532,7 +532,7 @@ minion:
       periodSeconds: 10
 
   dataDir: /var/pinot/minion/data
-  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
+  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log -Djute.maxbuffer=4000000"
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-minion-log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -643,7 +643,7 @@ minionStateless:
       periodSeconds: 10
 
   dataDir: /var/pinot/minion/data
-  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
+  jvmOpts: "-XX:ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log -Djute.maxbuffer=4000000"
 
   log4j2ConfFile: /opt/pinot/etc/conf/pinot-minion-log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -741,6 +741,9 @@ zookeeper:
   ## Size (in MB) for the Java Heap options (Xmx and Xms)
   ## This env var is ignored if Xmx an Xms are configured via `zookeeper.jvmFlags`
   heapSize: "1024"
+
+  ## Extra JVM Flags for Zookeeper
+  jvmFlags: "-Djute.maxbuffer=4000000"
 
   persistence:
     enabled: true


### PR DESCRIPTION
We recently observed more users facing issues with znode size issue:
https://docs.pinot.apache.org/reference/troubleshooting/troubleshoot-zookeeper#adjust-zookeeper-znode-size

Hence add this jute.maxBuffer jvm flag for fast navigations.