### PR TITLE
Ensure SegmentDeletionManager deletes deepstore files created by BaseMultipleSegmentsConversionExecutor

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -315,10 +315,10 @@ public class SegmentDeletionManager {
       if (pinotFS.exists(compressedFileUri)) {
         return compressedFileUri;
       }
-
+      LOGGER.error("No file found for segment: {} in deepstore", segmentId);
       return null;
     } catch (Exception e) {
-      LOGGER.error("No file found for segment: {} in deepstore", segmentId);
+      LOGGER.error("Caught exception while trying to find file for segment: {} in deepstore", segmentId);
       return null;
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -288,14 +288,18 @@ public class SegmentDeletionManager {
   }
 
   /**
-   * Gets URI for segment deletion by attempting to locate the segment file in the following order:
-   * 1. Plain segment file (without extension)
-   * 2. Compressed segment file (with .tar.gz extension)
+   * Retrieves the URI for segment deletion by checking two possible segment file variants in deep store.
+   * This handles both server and minion upload scenarios:
+   * - For server uploads: searches for segment file without extension
+   * - For minion uploads (via BaseMultipleSegmentsConversionExecutor etc.): searches for segment file with .tar.gz
+   * extension
    *
-   * @param rawTableName The name of the table
-   * @param segmentId The ID of the segment to delete
-   * @return URI of the existing segment file, or null if neither variant exists or in case of filesystem errors
+   * @param rawTableName name of the table containing the segment
+   * @param segmentId name of the segment
+   * @return URI of the existing segment file if found in either format, null if segment doesn't exist in either format
+   *         or if there are filesystem access errors
    */
+  @Nullable
   private URI getFileToDeleteURI(String rawTableName, String segmentId) {
     try {
       // Create both URIs upfront

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -238,7 +238,7 @@ public class SegmentDeletionManager {
       String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
       URI fileToDeleteURI = getFileToDeleteURI(rawTableName, segmentId);
       if (fileToDeleteURI == null) {
-        LOGGER.warn("No segment file found for segment ID: {} in table: {}", segmentId, rawTableName);
+        LOGGER.warn("No segment file found for segment: {} in deep store", segmentId);
         return;
       }
       PinotFS pinotFS = PinotFSFactory.create(fileToDeleteURI.getScheme());
@@ -318,6 +318,7 @@ public class SegmentDeletionManager {
 
       return null;
     } catch (Exception e) {
+      LOGGER.error("No file found for segment: {} in deepstore", segmentId);
       return null;
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableViewsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableViewsTest.java
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
 import org.apache.helix.InstanceType;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.api.resources.TableViews;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
@@ -63,7 +64,9 @@ public class TableViewsTest extends ControllerTest {
     DEFAULT_INSTANCE.getHelixResourceManager().addTable(tableConfig);
     DEFAULT_INSTANCE.getHelixResourceManager()
         .addNewSegment(TableNameBuilder.OFFLINE.tableNameWithType(OFFLINE_TABLE_NAME),
-            SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, OFFLINE_SEGMENT_NAME), "downloadUrl");
+            SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, OFFLINE_SEGMENT_NAME),
+            getDownloadURL(DEFAULT_INSTANCE.getHelixResourceManager().getDataDir(), OFFLINE_TABLE_NAME,
+                OFFLINE_SEGMENT_NAME));
 
     // Create the hybrid table
     DEFAULT_INSTANCE.addDummySchema(HYBRID_TABLE_NAME);
@@ -166,6 +169,10 @@ public class TableViewsTest extends ControllerTest {
     return JsonUtils.stringToObject(
         sendGetRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableView(tableName, view, tableType)),
         TableViews.TableView.class);
+  }
+
+  private String getDownloadURL(String controllerDataDir, String rawTableName, String segmentId) {
+    return URIUtils.getUri(controllerDataDir, rawTableName, URIUtils.encode(segmentId)).toString();
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -50,6 +50,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -983,9 +984,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
             new EndReplaceSegmentsRequest(Arrays.asList("s9", "s6"), null)));
     // Try after new segments added to the table
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s20"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s20"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s20"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s21"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s21"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s21"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId,
         new EndReplaceSegmentsRequest(Arrays.asList("s21"), null));
     SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
@@ -1012,7 +1015,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Add 5 segments
     for (int i = 0; i < 5; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
     assertEquals(_helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false).size(), 5);
 
@@ -1057,9 +1061,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Try after new segments added to the table
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s5"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s5"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s5"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s6"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s6"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s6"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId1, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntryIds(), Collections.singleton(lineageEntryId1));
@@ -1080,7 +1086,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t1_0"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t1_0"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "merged_t1_0"));
     IdealState idealState = _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME);
     assertNotNull(idealState);
     assertTrue(idealState.getPartitionSet().contains("merged_t1_0"));
@@ -1112,7 +1119,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t2_0"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t2_0"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "merged_t2_0"));
 
     // Without force cleanup, 'startReplaceSegments' again should fail because of duplicate segments on 'segmentFrom'
     List<String> segmentsFrom4 = Arrays.asList("s1", "s2");
@@ -1140,9 +1148,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload segments again
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t3_0"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t3_0"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "merged_t3_0"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t3_1"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_t3_1"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "merged_t3_1"));
 
     // Finish the replacement
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId4, null);
@@ -1181,7 +1191,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s7"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s7"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s7"));
 
     // Start another new segment replacement with empty segmentsFrom, and check that previous lineages with empty
     // segmentsFrom are not reverted
@@ -1196,9 +1207,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Finish the replacement
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s9"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s9"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s9"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s10"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s10"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s10"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId7, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntryIds().size(), 6);
@@ -1221,7 +1234,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s11"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s11"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s11"));
 
     // Start another new segment replacement with segmentsFrom overlapping with previous lineage, and check that
     // previous lineages with overlapped segmentsFrom are reverted
@@ -1236,9 +1250,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Finish the replacement
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s13"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s13"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s13"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s14"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s14"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s14"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId9, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntryIds().size(), 8);
@@ -1286,7 +1302,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Add 3 segments
     for (int i = 0; i < 3; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
     List<String> segmentsForTable = _helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false);
     assertEquals(segmentsForTable.size(), 3);
@@ -1306,7 +1323,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Add new segments
     for (int i = 3; i < 6; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
     assertSetEquals(_helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false), "s0", "s1", "s2", "s3", "s4",
         "s5");
@@ -1342,7 +1360,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Add partial segments to indicate incomplete protocol
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s6"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s6"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s6"));
     assertEquals(_helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false).size(), 7);
     assertSetEquals(_helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, true), "s3", "s4", "s5");
 
@@ -1375,7 +1394,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Add new segments
     for (int i = 9; i < 12; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
 
     // Call end segment replacements
@@ -1396,7 +1416,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Re-upload (s9, s10, s11) to test the segment clean up from startReplaceSegments
     for (int i = 9; i < 12; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
     assertSetEquals(_helixResourceManager.getSegmentsFor(OFFLINE_TABLE_NAME, false), "s3", "s4", "s5", "s9", "s10",
         "s11");
@@ -1411,7 +1432,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     // Upload the new segments (s12, s13, s14)
     for (int i = 12; i < 15; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i), "downloadUrl");
+          SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s" + i),
+          getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s" + i));
     }
 
     // Call endReplaceSegments to start to use (s12, s13, s14)
@@ -1433,7 +1455,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s15"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s15"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s15"));
 
     // Start another new segment replacement with empty segmentsFrom, and check that previous lineages with empty
     // segmentsFrom are not reverted
@@ -1447,9 +1470,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Finish the replacement
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s17"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s17"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s17"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s18"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s18"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s18"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId6, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntry(lineageEntryId6).getSegmentsFrom(), segmentsFrom6);
@@ -1469,7 +1494,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload partial data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s19"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s19"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s19"));
 
     // Start another new segment replacement with segmentsFrom overlapping with previous lineage, and check that
     // previous lineages with overlapped segmentsFrom are reverted
@@ -1483,9 +1509,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Finish the replacement
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s21"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s21"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s21"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s22"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s22"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s22"));
 
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId8, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
@@ -1506,9 +1534,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Upload data
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s23"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s23"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s23"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s24"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s24"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s24"));
 
     // Start another new segment replacement with segmentsTo overlapping with previous lineage, and check that previous
     // lineages with overlapped segmentsTo are reverted
@@ -1526,9 +1556,11 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Finish the replacement
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s24"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s24"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s24"));
     _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s25"), "downloadUrl");
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "s25"),
+        getDownloadURL(_controllerDataDir, RAW_TABLE_NAME, "s25"));
     _helixResourceManager.endReplaceSegments(OFFLINE_TABLE_NAME, lineageEntryId10, null);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntry(lineageEntryId10).getSegmentsFrom(), segmentsFrom10);
@@ -1539,6 +1571,10 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
+  }
+
+  private String getDownloadURL(String controllerDataDir, String rawTableName, String segmentId) {
+    return URIUtils.getUri(controllerDataDir, rawTableName, URIUtils.encode(segmentId)).toString();
   }
 
   private static void assertSetEquals(Collection<String> actual, String... expected) {


### PR DESCRIPTION
## Concern

The `BaseMultipleSegmentsConversionExecutor` pushes segments on the path:

```
 File convertedSegmentTarFile = new File(convertedTarredSegmentDir,
            segmentConversionResult.getSegmentName() + TarCompressionUtils.TAR_GZ_FILE_EXTENSION);
```
This contains the extension `.tar.gz`


While the deletion manager uses the following path for deleting the old segment

`URIUtils.getUri(_dataDir, rawTableName, URIUtils.encode(segmentId));`
that lacks the extension. 


## Solution 
- Use the existing naming convention and verify if the files exists or not. 
- Use the file name with `.tar.gz` extension if the file without extension does not exist. 

## Further Improvements
- Fix the code in minion by removing the extension from the file path to which the segment is written to.