### PR TITLE
Add a dry-run summary mode for TableRebalance which only returns a summary of the dry-run results

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -512,6 +512,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _tableSizeReader =
         new TableSizeReader(_executorService, _connectionManager, _controllerMetrics, _helixResourceManager,
             _leadControllerManager);
+    _helixResourceManager.registerTableSizeReader(_tableSizeReader);
     _storageQuotaChecker = new StorageQuotaChecker(_tableSizeReader, _controllerMetrics, _leadControllerManager,
         _helixResourceManager, _config);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -159,6 +159,7 @@ import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceContext;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.helix.core.rebalance.ZkBasedTableRebalanceObserver;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
+import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.DatabaseConfig;
 import org.apache.pinot.spi.config.instance.Instance;
@@ -241,6 +242,7 @@ public class PinotHelixResourceManager {
   private TableCache _tableCache;
   private final LineageManager _lineageManager;
   private final RebalancePreChecker _rebalancePreChecker;
+  private TableSizeReader _tableSizeReader;
 
   public PinotHelixResourceManager(String zkURL, String helixClusterName, @Nullable String dataDir,
       boolean isSingleTenantCluster, boolean enableBatchMessageMode, int deletedSegmentsRetentionInDays,
@@ -449,6 +451,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get the table size reader.
+   *
+   * @return table size reader
+   */
+  public TableSizeReader getTableSizeReader() {
+    return _tableSizeReader;
+  }
+
+/**
    * Instance related APIs
    */
 
@@ -1941,6 +1952,10 @@ public class PinotHelixResourceManager {
 
   public void registerPinotLLCRealtimeSegmentManager(PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager) {
     _pinotLLCRealtimeSegmentManager = pinotLLCRealtimeSegmentManager;
+  }
+
+  public void registerTableSizeReader(TableSizeReader tableSizeReader) {
+    _tableSizeReader = tableSizeReader;
   }
 
   private void assignInstances(TableConfig tableConfig, boolean override) {
@@ -3612,7 +3627,8 @@ public class PinotHelixResourceManager {
       tierToSegmentsMap = updateTargetTier(rebalanceJobId, tableNameWithType, tableConfig);
     }
     TableRebalancer tableRebalancer =
-        new TableRebalancer(_helixZkManager, zkBasedTableRebalanceObserver, _controllerMetrics, _rebalancePreChecker);
+        new TableRebalancer(_helixZkManager, zkBasedTableRebalanceObserver, _controllerMetrics, _rebalancePreChecker,
+            _tableSizeReader);
     return tableRebalancer.rebalance(tableConfig, rebalanceConfig, rebalanceJobId, tierToSegmentsMap);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -53,8 +53,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   }
 
   @Override
-  public Map<String, String> check(String rebalanceJobId, String tableNameWithType,
-      TableConfig tableConfig) {
+  public Map<String, String> check(String rebalanceJobId, String tableNameWithType, TableConfig tableConfig) {
     LOGGER.info("Start pre-checks for table: {} with rebalanceJobId: {}", tableNameWithType, rebalanceJobId);
 
     Map<String, String> preCheckResult = new HashMap<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -34,6 +34,11 @@ public class RebalanceConfig {
   @ApiModelProperty(example = "false")
   private boolean _dryRun = false;
 
+  // Whether to return only dry-run summary instead of full dry-run output, can only be used in dry-run mode
+  @JsonProperty("summary")
+  @ApiModelProperty(example = "false")
+  private boolean _summary = false;
+
   // Whether to perform pre-checks for rebalance. This only returns the status of each pre-check and does not fail
   // rebalance
   @JsonProperty("preChecks")
@@ -122,6 +127,14 @@ public class RebalanceConfig {
 
   public void setDryRun(boolean dryRun) {
     _dryRun = dryRun;
+  }
+
+  public boolean isSummary() {
+    return _summary;
+  }
+
+  public void setSummary(boolean summary) {
+    _summary = summary;
   }
 
   public boolean isPreChecks() {
@@ -246,10 +259,10 @@ public class RebalanceConfig {
 
   @Override
   public String toString() {
-    return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", preChecks=" + _preChecks + ", _reassignInstances="
-        + _reassignInstances + ", _includeConsuming=" + _includeConsuming + ", _bootstrap=" + _bootstrap
-        + ", _downtime=" + _downtime + ", _minAvailableReplicas=" + _minAvailableReplicas + ", _bestEfforts="
-        + _bestEfforts + ", _externalViewCheckIntervalInMs=" + _externalViewCheckIntervalInMs
+    return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", _summary=" + _summary + ", preChecks=" + _preChecks
+        + ", _reassignInstances=" + _reassignInstances + ", _includeConsuming=" + _includeConsuming + ", _bootstrap="
+        + _bootstrap + ", _downtime=" + _downtime + ", _minAvailableReplicas=" + _minAvailableReplicas
+        + ", _bestEfforts=" + _bestEfforts + ", _externalViewCheckIntervalInMs=" + _externalViewCheckIntervalInMs
         + ", _externalViewStabilizationTimeoutInMs=" + _externalViewStabilizationTimeoutInMs + ", _updateTargetTier="
         + _updateTargetTier + ", _heartbeatIntervalInMs=" + _heartbeatIntervalInMs + ", _heartbeatTimeoutInMs="
         + _heartbeatTimeoutInMs + ", _maxAttempts=" + _maxAttempts + ", _retryInitialDelayInMs="
@@ -259,6 +272,7 @@ public class RebalanceConfig {
   public static RebalanceConfig copy(RebalanceConfig cfg) {
     RebalanceConfig rc = new RebalanceConfig();
     rc._dryRun = cfg._dryRun;
+    rc._summary = cfg._summary;
     rc._preChecks = cfg._preChecks;
     rc._reassignInstances = cfg._reassignInstances;
     rc._includeConsuming = cfg._includeConsuming;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
@@ -42,6 +42,8 @@ public class RebalanceResult {
   private final String _description;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Map<String, String> _preChecksResult;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final RebalanceSummaryResult _rebalanceSummaryResult;
 
   @JsonCreator
   public RebalanceResult(@JsonProperty(value = "jobId", required = true) String jobId,
@@ -50,7 +52,8 @@ public class RebalanceResult {
       @JsonProperty("instanceAssignment") @Nullable Map<InstancePartitionsType, InstancePartitions> instanceAssignment,
       @JsonProperty("tierInstanceAssignment") @Nullable Map<String, InstancePartitions> tierInstanceAssignment,
       @JsonProperty("segmentAssignment") @Nullable Map<String, Map<String, String>> segmentAssignment,
-      @JsonProperty("preChecksResult") @Nullable Map<String, String> preChecksResult) {
+      @JsonProperty("preChecksResult") @Nullable Map<String, String> preChecksResult,
+      @JsonProperty("rebalanceSummaryResult") @Nullable RebalanceSummaryResult rebalanceSummaryResult) {
     _jobId = jobId;
     _status = status;
     _description = description;
@@ -58,6 +61,7 @@ public class RebalanceResult {
     _tierInstanceAssignment = tierInstanceAssignment;
     _segmentAssignment = segmentAssignment;
     _preChecksResult = preChecksResult;
+    _rebalanceSummaryResult = rebalanceSummaryResult;
   }
 
   @JsonProperty
@@ -93,6 +97,11 @@ public class RebalanceResult {
   @JsonProperty
   public Map<String, String> getPreChecksResult() {
     return _preChecksResult;
+  }
+
+  @JsonProperty
+  public RebalanceSummaryResult getRebalanceSummaryResult() {
+    return _rebalanceSummaryResult;
   }
 
   public enum Status {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 
@@ -138,21 +139,41 @@ public class RebalanceSummaryResult {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final RebalanceChangeInfo _numServers;
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Set<String> _serversAdded;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Set<String> _serversRemoved;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Set<String> _serversUnchanged;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Set<String> _serversGettingNewSegments;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
 
     /**
      * Constructor for ServerInfo
      * @param numServersGettingNewSegments total number of servers receiving new segments as part of this rebalance
      * @param numServers number of servers before and after this rebalance
+     * @param serversAdded set of servers getting added as part of this rebalance
+     * @param serversRemoved set of servers getting removed as part of this rebalance
+     * @param serversUnchanged set of servers existing both before and as part of this rebalance
+     * @param serversGettingNewSegments set of servers getting segments added
      * @param serverSegmentChangeInfo per server statistics for this rebalance
      */
     @JsonCreator
     public ServerInfo(@JsonProperty("numServersGettingNewSegments") int numServersGettingNewSegments,
         @JsonProperty("numServers") @Nullable RebalanceChangeInfo numServers,
+        @JsonProperty("serversAdded") @Nullable Set<String> serversAdded,
+        @JsonProperty("serversRemoved") @Nullable Set<String> serversRemoved,
+        @JsonProperty("serversUnchanged") @Nullable Set<String> serversUnchanged,
+        @JsonProperty("serversGettingNewSegments") @Nullable Set<String> serversGettingNewSegments,
         @JsonProperty("serverSegmentChangeInfo")
         @Nullable Map<String, ServerSegmentChangeInfo> serverSegmentChangeInfo) {
       _numServersGettingNewSegments = numServersGettingNewSegments;
       _numServers = numServers;
+      _serversAdded = serversAdded;
+      _serversRemoved = serversRemoved;
+      _serversUnchanged = serversUnchanged;
+      _serversGettingNewSegments = serversGettingNewSegments;
       _serverSegmentChangeInfo = serverSegmentChangeInfo;
     }
 
@@ -164,6 +185,26 @@ public class RebalanceSummaryResult {
     @JsonProperty
     public RebalanceChangeInfo getNumServers() {
       return _numServers;
+    }
+
+    @JsonProperty
+    public Set<String> getServersAdded() {
+      return _serversAdded;
+    }
+
+    @JsonProperty
+    public Set<String> getServersRemoved() {
+      return _serversRemoved;
+    }
+
+    @JsonProperty
+    public Set<String> getServersUnchanged() {
+      return _serversUnchanged;
+    }
+
+    @JsonProperty
+    public Set<String> getServersGettingNewSegments() {
+      return _serversGettingNewSegments;
     }
 
     @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -34,126 +35,249 @@ import javax.annotation.Nullable;
 public class RebalanceSummaryResult {
 
   public static class ServerSegmentChangeInfo {
-    public final int _totalNewSegments;
-    public final int _totalExistingSegments;
-    public final int _segmentsAdded;
-    public final int _segmentsDeleted;
-    public final int _segmentsUnchanged;
+    private final ServerStatus _serverStatus;
+    private final int _totalSegmentsAfterRebalance;
+    private final int _totalSegmentsBeforeRebalance;
+    private final int _segmentsAdded;
+    private final int _segmentsDeleted;
+    private final int _segmentsUnchanged;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final List<String> _tagList;
 
+    /**
+     * Constructor for ServerSegmentChangeInfo
+     * @param serverStatus server status, whether it was added, removed, or unchanged as part of this rebalance
+     * @param totalSegmentsAfterRebalance expected total segments on this server after rebalance
+     * @param totalSegmentsBeforeRebalance current number of segments on this server before rebalance
+     * @param segmentsAdded number of segments expected to be added as part of this rebalance
+     * @param segmentsDeleted number of segments expected to be deleted as part of this rebalance
+     * @param segmentsUnchanged number of segments that aren't moving from this server as part of this rebalance
+     * @param tagList server tag list
+     */
     @JsonCreator
-    public ServerSegmentChangeInfo(@JsonProperty("totalNewSegments") int totalNewSegments,
-        @JsonProperty("totalExistingSegments") int totalExistingSegments,
+    public ServerSegmentChangeInfo(@JsonProperty("serverStatus") ServerStatus serverStatus,
+        @JsonProperty("totalSegmentsAfterRebalance") int totalSegmentsAfterRebalance,
+        @JsonProperty("totalSegmentsBeforeRebalance") int totalSegmentsBeforeRebalance,
         @JsonProperty("segmentsAdded") int segmentsAdded, @JsonProperty("segmentsDeleted") int segmentsDeleted,
-        @JsonProperty("segmentsUnchanged") int segmentsUnchanged) {
-      _totalNewSegments = totalNewSegments;
-      _totalExistingSegments = totalExistingSegments;
+        @JsonProperty("segmentsUnchanged") int segmentsUnchanged,
+        @JsonProperty("tagList") @Nullable List<String> tagList) {
+      _serverStatus = serverStatus;
+      _totalSegmentsAfterRebalance = totalSegmentsAfterRebalance;
+      _totalSegmentsBeforeRebalance = totalSegmentsBeforeRebalance;
       _segmentsAdded = segmentsAdded;
       _segmentsDeleted = segmentsDeleted;
       _segmentsUnchanged = segmentsUnchanged;
+      _tagList = tagList;
+    }
+
+    @JsonProperty
+    public ServerStatus getServerStatus() {
+      return _serverStatus;
+    }
+
+    @JsonProperty
+    public int getTotalSegmentsAfterRebalance() {
+      return _totalSegmentsAfterRebalance;
+    }
+
+    @JsonProperty
+    public int getTotalSegmentsBeforeRebalance() {
+      return _totalSegmentsBeforeRebalance;
+    }
+
+    @JsonProperty
+    public int getSegmentsAdded() {
+      return _segmentsAdded;
+    }
+
+    @JsonProperty
+    public int getSegmentsDeleted() {
+      return _segmentsDeleted;
+    }
+
+    @JsonProperty
+    public int getSegmentsUnchanged() {
+      return _segmentsUnchanged;
+    }
+
+    @JsonProperty
+    public List<String> getTagList() {
+      return _tagList;
     }
   }
 
   public static class RebalanceChangeInfo {
-    public final int _existingValue;
-    public final int _newValue;
+    private final int _valueBeforeRebalance;
+    private final int _expectedValueAfterRebalance;
 
+    /**
+     * Constructor for RebalanceChangeInfo
+     * @param valueBeforeRebalance current value before rebalance
+     * @param expectedValueAfterRebalance expected value after rebalance
+     */
     @JsonCreator
-    public RebalanceChangeInfo(@JsonProperty("existingValue") int existingValue,
-        @JsonProperty("newValue") int newValue) {
-      _existingValue = existingValue;
-      _newValue = newValue;
+    public RebalanceChangeInfo(@JsonProperty("valueBeforeRebalance") int valueBeforeRebalance,
+        @JsonProperty("expectedValueAfterRebalance") int expectedValueAfterRebalance) {
+      _valueBeforeRebalance = valueBeforeRebalance;
+      _expectedValueAfterRebalance = expectedValueAfterRebalance;
+    }
+
+    @JsonProperty
+    public int getValueBeforeRebalance() {
+      return _valueBeforeRebalance;
+    }
+
+    @JsonProperty
+    public int getExpectedValueAfterRebalance() {
+      return _expectedValueAfterRebalance;
     }
   }
 
-  // TODO: Add stats about total data size to be moved and estimated calculations on how long the data move can take
-  //       during rebalance. Estimations are fine based on total table size / total number of segments
-  private final int _totalSegmentsToBeMoved;
-  private final int _numServersGettingNewSegments;
-  private final long _estimatedAverageSegmentSizeInBytes;
-  private final long _totalEstimatedDataToBeMovedInBytes;
-  private final double _totalEstimatedTimeToMoveDataInSecs;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final RebalanceChangeInfo _numServers;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final RebalanceChangeInfo _replicationFactor;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final RebalanceChangeInfo _numUniqueSegments;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final RebalanceChangeInfo _numTotalSegments;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
+  public static class ServerInfo {
+    private final int _numServersGettingNewSegments;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final RebalanceChangeInfo _numServers;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
 
+    /**
+     * Constructor for ServerInfo
+     * @param numServersGettingNewSegments total number of servers receiving new segments as part of this rebalance
+     * @param numServers number of servers before and after this rebalance
+     * @param serverSegmentChangeInfo per server statistics for this rebalance
+     */
+    @JsonCreator
+    public ServerInfo(@JsonProperty("numServersGettingNewSegments") int numServersGettingNewSegments,
+        @JsonProperty("numServers") @Nullable RebalanceChangeInfo numServers,
+        @JsonProperty("serverSegmentChangeInfo")
+        @Nullable Map<String, ServerSegmentChangeInfo> serverSegmentChangeInfo) {
+      _numServersGettingNewSegments = numServersGettingNewSegments;
+      _numServers = numServers;
+      _serverSegmentChangeInfo = serverSegmentChangeInfo;
+    }
+
+    @JsonProperty
+    public int getNumServersGettingNewSegments() {
+      return _numServersGettingNewSegments;
+    }
+
+    @JsonProperty
+    public RebalanceChangeInfo getNumServers() {
+      return _numServers;
+    }
+
+    @JsonProperty
+    public Map<String, ServerSegmentChangeInfo> getServerSegmentChangeInfo() {
+      return _serverSegmentChangeInfo;
+    }
+  }
+
+  public static class SegmentInfo {
+    private final int _totalSegmentsToBeMoved;
+    private final long _estimatedAverageSegmentSizeInBytes;
+    private final long _totalEstimatedDataToBeMovedInBytes;
+    private final double _totalEstimatedTimeToMoveDataInSecs;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final RebalanceChangeInfo _replicationFactor;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final RebalanceChangeInfo _numSegmentsInSingleReplica;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final RebalanceChangeInfo _numSegmentsAcrossAllReplicas;
+
+    /**
+     * Constructor for SegmentInfo
+     * @param totalSegmentsToBeMoved total number of segments to be moved as part of this rebalance
+     * @param estimatedAverageSegmentSizeInBytes estimated average size of segments in bytes
+     * @param totalEstimatedDataToBeMovedInBytes total estimated amount of data to be moved as part of this rebalance
+     * @param totalEstimatedTimeToMoveDataInSecs total estimated time to move the segments as part of this rebalance
+     * @param replicationFactor replication factor before and after this rebalance
+     * @param numSegmentsInSingleReplica number of segments in single replica before and after this rebalance
+     * @param numSegmentsAcrossAllReplicas total number of segments across all replicas before and after this rebalance
+     */
+    @JsonCreator
+    public SegmentInfo(@JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
+        @JsonProperty("estimatedAverageSegmentSizeInBytes") long estimatedAverageSegmentSizeInBytes,
+        @JsonProperty("totalEstimatedDataToBeMovedInBytes") long totalEstimatedDataToBeMovedInBytes,
+        @JsonProperty("totalEstimatedTimeToMoveDataInSecs") double totalEstimatedTimeToMoveDataInSecs,
+        @JsonProperty("replicationFactor") @Nullable RebalanceChangeInfo replicationFactor,
+        @JsonProperty("numSegmentsInSingleReplica") @Nullable RebalanceChangeInfo numSegmentsInSingleReplica,
+        @JsonProperty("numSegmentsAcrossAllReplicas") @Nullable RebalanceChangeInfo numSegmentsAcrossAllReplicas) {
+      _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+      _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
+      _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
+      _totalEstimatedTimeToMoveDataInSecs = totalEstimatedTimeToMoveDataInSecs;
+      _replicationFactor = replicationFactor;
+      _numSegmentsInSingleReplica = numSegmentsInSingleReplica;
+      _numSegmentsAcrossAllReplicas = numSegmentsAcrossAllReplicas;
+    }
+
+    @JsonProperty
+    public int getTotalSegmentsToBeMoved() {
+      return _totalSegmentsToBeMoved;
+    }
+
+    @JsonProperty
+    public long getEstimatedAverageSegmentSizeInBytes() {
+      return _estimatedAverageSegmentSizeInBytes;
+    }
+
+    @JsonProperty
+    public long getTotalEstimatedDataToBeMovedInBytes() {
+      return _totalEstimatedDataToBeMovedInBytes;
+    }
+
+    @JsonProperty
+    public double getTotalEstimatedTimeToMoveDataInSecs() {
+      return _totalEstimatedTimeToMoveDataInSecs;
+    }
+
+    @JsonProperty
+    public RebalanceChangeInfo getReplicationFactor() {
+      return _replicationFactor;
+    }
+
+    @JsonProperty
+    public RebalanceChangeInfo getNumSegmentsInSingleReplica() {
+      return _numSegmentsInSingleReplica;
+    }
+
+    @JsonProperty
+    public RebalanceChangeInfo getNumSegmentsAcrossAllReplicas() {
+      return _numSegmentsAcrossAllReplicas;
+    }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final ServerInfo _serverInfo;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final SegmentInfo _segmentInfo;
+
+  /**
+   * Constructor for RebalanceSummaryResult
+   * @param serverInfo server related summary information
+   * @param segmentInfo segment related summary information
+   */
   @JsonCreator
-  public RebalanceSummaryResult(
-      @JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
-      @JsonProperty("numServersGettingNewSegments") int numServersGettingNewSegments,
-      @JsonProperty("estimatedAverageSegmentSizeInBytes") long estimatedAverageSegmentSizeInBytes,
-      @JsonProperty("totalEstimatedDataToBeMovedInBytes") long totalEstimatedDataToBeMovedInBytes,
-      @JsonProperty("totalEstimatedTimeToMoveDataInSecs") double totalEstimatedTimeToMoveDataInSecs,
-      @JsonProperty("numServers") @Nullable RebalanceChangeInfo numServers,
-      @JsonProperty("replicationFactor") @Nullable RebalanceChangeInfo replicationFactor,
-      @JsonProperty("numUniqueSegments") @Nullable RebalanceChangeInfo numUniqueSegments,
-      @JsonProperty("numTotalSegments") @Nullable RebalanceChangeInfo numTotalSegments,
-      @JsonProperty("serverSegmentChangeInfo") @Nullable Map<String, ServerSegmentChangeInfo> serverSegmentChangeInfo) {
-    _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
-    _numServersGettingNewSegments = numServersGettingNewSegments;
-    _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
-    _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
-    _totalEstimatedTimeToMoveDataInSecs = totalEstimatedTimeToMoveDataInSecs;
-    _numServers = numServers;
-    _replicationFactor = replicationFactor;
-    _numUniqueSegments = numUniqueSegments;
-    _numTotalSegments = numTotalSegments;
-    _serverSegmentChangeInfo = serverSegmentChangeInfo;
+  public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
+      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo) {
+    _serverInfo = serverInfo;
+    _segmentInfo = segmentInfo;
   }
 
   @JsonProperty
-  public int getTotalSegmentsToBeMoved() {
-    return _totalSegmentsToBeMoved;
+  public ServerInfo getServerInfo() {
+    return _serverInfo;
   }
 
   @JsonProperty
-  public int getNumServersGettingNewSegments() {
-    return _numServersGettingNewSegments;
+  public SegmentInfo getSegmentInfo() {
+    return _segmentInfo;
   }
 
-  @JsonProperty
-  public long getEstimatedAverageSegmentSizeInBytes() {
-    return _estimatedAverageSegmentSizeInBytes;
-  }
-
-  @JsonProperty
-  public long getTotalEstimatedDataToBeMovedInBytes() {
-    return _totalEstimatedDataToBeMovedInBytes;
-  }
-
-  @JsonProperty
-  public double getTotalEstimatedTimeToMoveDataInSecs() {
-    return _totalEstimatedTimeToMoveDataInSecs;
-  }
-
-  @JsonProperty
-  public RebalanceChangeInfo getNumServers() {
-    return _numServers;
-  }
-
-  @JsonProperty
-  public RebalanceChangeInfo getReplicationFactor() {
-    return _replicationFactor;
-  }
-
-  @JsonProperty
-  public RebalanceChangeInfo getNumUniqueSegments() {
-    return _numUniqueSegments;
-  }
-
-  @JsonProperty
-  public RebalanceChangeInfo getNumTotalSegments() {
-    return _numTotalSegments;
-  }
-
-  @JsonProperty
-  public Map<String, ServerSegmentChangeInfo> getServerSegmentChangeInfo() {
-    return _serverSegmentChangeInfo;
+  public enum ServerStatus {
+    // ADDED if the server is newly added as part of rebalance;
+    // REMOVED if the server is removed as part of rebalance;
+    // UNCHANGED if the server status is unchanged as part of rebalance;
+    ADDED, REMOVED, UNCHANGED
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+/**
+ * Holds the summary data of the rebalance result
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RebalanceSummaryResult {
+
+  public static class ServerSegmentChangeInfo {
+    public final int _totalNewSegments;
+    public final int _totalExistingSegments;
+    public final int _segmentsAdded;
+    public final int _segmentsDeleted;
+    public final int _segmentsUnchanged;
+
+    @JsonCreator
+    public ServerSegmentChangeInfo(@JsonProperty("totalNewSegments") int totalNewSegments,
+        @JsonProperty("totalExistingSegments") int totalExistingSegments,
+        @JsonProperty("segmentsAdded") int segmentsAdded, @JsonProperty("segmentsDeleted") int segmentsDeleted,
+        @JsonProperty("segmentsUnchanged") int segmentsUnchanged) {
+      _totalNewSegments = totalNewSegments;
+      _totalExistingSegments = totalExistingSegments;
+      _segmentsAdded = segmentsAdded;
+      _segmentsDeleted = segmentsDeleted;
+      _segmentsUnchanged = segmentsUnchanged;
+    }
+  }
+
+  public static class RebalanceChangeInfo {
+    public final int _existingValue;
+    public final int _newValue;
+
+    @JsonCreator
+    public RebalanceChangeInfo(@JsonProperty("existingValue") int existingValue,
+        @JsonProperty("newValue") int newValue) {
+      _existingValue = existingValue;
+      _newValue = newValue;
+    }
+  }
+
+  // TODO: Add stats about total data size to be moved and estimated calculations on how long the data move can take
+  //       during rebalance. Estimations are fine based on total table size / total number of segments
+  private int _totalSegmentsToBeMoved;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RebalanceChangeInfo _numServers;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RebalanceChangeInfo _replicationFactor;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RebalanceChangeInfo _numUniqueSegments;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RebalanceChangeInfo _numTotalSegments;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
+
+  @JsonCreator
+  public RebalanceSummaryResult(
+      @JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
+      @JsonProperty("numServers") @Nullable RebalanceChangeInfo numServers,
+      @JsonProperty("replicationFactor") @Nullable RebalanceChangeInfo replicationFactor,
+      @JsonProperty("numUniqueSegments") @Nullable RebalanceChangeInfo numUniqueSegments,
+      @JsonProperty("numTotalSegments") @Nullable RebalanceChangeInfo numTotalSegments,
+      @JsonProperty("serverSegmentChangeInfo") @Nullable Map<String, ServerSegmentChangeInfo> serverSegmentChangeInfo) {
+    _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+    _numServers = numServers;
+    _replicationFactor = replicationFactor;
+    _numUniqueSegments = numUniqueSegments;
+    _numTotalSegments = numTotalSegments;
+    _serverSegmentChangeInfo = serverSegmentChangeInfo;
+  }
+
+  @JsonProperty
+  public int getTotalSegmentsToBeMoved() {
+    return _totalSegmentsToBeMoved;
+  }
+
+  @JsonProperty
+  public RebalanceChangeInfo getNumServers() {
+    return _numServers;
+  }
+
+  @JsonProperty
+  public RebalanceChangeInfo getReplicationFactor() {
+    return _replicationFactor;
+  }
+
+  @JsonProperty
+  public RebalanceChangeInfo getNumUniqueSegments() {
+    return _numUniqueSegments;
+  }
+
+  @JsonProperty
+  public RebalanceChangeInfo getNumTotalSegments() {
+    return _numTotalSegments;
+  }
+
+  @JsonProperty
+  public Map<String, ServerSegmentChangeInfo> getServerSegmentChangeInfo() {
+    return _serverSegmentChangeInfo;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -173,10 +173,11 @@ public class RebalanceSummaryResult {
   }
 
   public static class SegmentInfo {
+    // TODO: Add a metric to estimate the total time it will take to rebalance
     private final int _totalSegmentsToBeMoved;
+    private final int _maxSegmentsAddedToASingleServer;
     private final long _estimatedAverageSegmentSizeInBytes;
     private final long _totalEstimatedDataToBeMovedInBytes;
-    private final double _totalEstimatedTimeToMoveDataInSecs;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final RebalanceChangeInfo _replicationFactor;
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -187,25 +188,25 @@ public class RebalanceSummaryResult {
     /**
      * Constructor for SegmentInfo
      * @param totalSegmentsToBeMoved total number of segments to be moved as part of this rebalance
+     * @param maxSegmentsAddedToASingleServer maximum segments added to a single server as part of this rebalance
      * @param estimatedAverageSegmentSizeInBytes estimated average size of segments in bytes
      * @param totalEstimatedDataToBeMovedInBytes total estimated amount of data to be moved as part of this rebalance
-     * @param totalEstimatedTimeToMoveDataInSecs total estimated time to move the segments as part of this rebalance
      * @param replicationFactor replication factor before and after this rebalance
      * @param numSegmentsInSingleReplica number of segments in single replica before and after this rebalance
      * @param numSegmentsAcrossAllReplicas total number of segments across all replicas before and after this rebalance
      */
     @JsonCreator
     public SegmentInfo(@JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
+        @JsonProperty("maxSegmentsAddedToASingleServer") int maxSegmentsAddedToASingleServer,
         @JsonProperty("estimatedAverageSegmentSizeInBytes") long estimatedAverageSegmentSizeInBytes,
         @JsonProperty("totalEstimatedDataToBeMovedInBytes") long totalEstimatedDataToBeMovedInBytes,
-        @JsonProperty("totalEstimatedTimeToMoveDataInSecs") double totalEstimatedTimeToMoveDataInSecs,
         @JsonProperty("replicationFactor") @Nullable RebalanceChangeInfo replicationFactor,
         @JsonProperty("numSegmentsInSingleReplica") @Nullable RebalanceChangeInfo numSegmentsInSingleReplica,
         @JsonProperty("numSegmentsAcrossAllReplicas") @Nullable RebalanceChangeInfo numSegmentsAcrossAllReplicas) {
       _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+      _maxSegmentsAddedToASingleServer = maxSegmentsAddedToASingleServer;
       _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
       _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
-      _totalEstimatedTimeToMoveDataInSecs = totalEstimatedTimeToMoveDataInSecs;
       _replicationFactor = replicationFactor;
       _numSegmentsInSingleReplica = numSegmentsInSingleReplica;
       _numSegmentsAcrossAllReplicas = numSegmentsAcrossAllReplicas;
@@ -217,6 +218,11 @@ public class RebalanceSummaryResult {
     }
 
     @JsonProperty
+    public int getMaxSegmentsAddedToASingleServer() {
+      return _maxSegmentsAddedToASingleServer;
+    }
+
+    @JsonProperty
     public long getEstimatedAverageSegmentSizeInBytes() {
       return _estimatedAverageSegmentSizeInBytes;
     }
@@ -224,11 +230,6 @@ public class RebalanceSummaryResult {
     @JsonProperty
     public long getTotalEstimatedDataToBeMovedInBytes() {
       return _totalEstimatedDataToBeMovedInBytes;
-    }
-
-    @JsonProperty
-    public double getTotalEstimatedTimeToMoveDataInSecs() {
-      return _totalEstimatedTimeToMoveDataInSecs;
     }
 
     @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -35,6 +35,33 @@ import javax.annotation.Nullable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RebalanceSummaryResult {
 
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final ServerInfo _serverInfo;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final SegmentInfo _segmentInfo;
+
+  /**
+   * Constructor for RebalanceSummaryResult
+   * @param serverInfo server related summary information
+   * @param segmentInfo segment related summary information
+   */
+  @JsonCreator
+  public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
+      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo) {
+    _serverInfo = serverInfo;
+    _segmentInfo = segmentInfo;
+  }
+
+  @JsonProperty
+  public ServerInfo getServerInfo() {
+    return _serverInfo;
+  }
+
+  @JsonProperty
+  public SegmentInfo getSegmentInfo() {
+    return _segmentInfo;
+  }
+
   public static class ServerSegmentChangeInfo {
     private final ServerStatus _serverStatus;
     private final int _totalSegmentsAfterRebalance;
@@ -287,33 +314,6 @@ public class RebalanceSummaryResult {
     public RebalanceChangeInfo getNumSegmentsAcrossAllReplicas() {
       return _numSegmentsAcrossAllReplicas;
     }
-  }
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final ServerInfo _serverInfo;
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final SegmentInfo _segmentInfo;
-
-  /**
-   * Constructor for RebalanceSummaryResult
-   * @param serverInfo server related summary information
-   * @param segmentInfo segment related summary information
-   */
-  @JsonCreator
-  public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
-      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo) {
-    _serverInfo = serverInfo;
-    _segmentInfo = segmentInfo;
-  }
-
-  @JsonProperty
-  public ServerInfo getServerInfo() {
-    return _serverInfo;
-  }
-
-  @JsonProperty
-  public SegmentInfo getSegmentInfo() {
-    return _segmentInfo;
   }
 
   public enum ServerStatus {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -67,27 +67,39 @@ public class RebalanceSummaryResult {
 
   // TODO: Add stats about total data size to be moved and estimated calculations on how long the data move can take
   //       during rebalance. Estimations are fine based on total table size / total number of segments
-  private int _totalSegmentsToBeMoved;
+  private final int _totalSegmentsToBeMoved;
+  private final int _numServersGettingNewSegments;
+  private final long _estimatedAverageSegmentSizeInBytes;
+  private final long _totalEstimatedDataToBeMovedInBytes;
+  private final double _totalEstimatedTimeToMoveDataInSecs;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private RebalanceChangeInfo _numServers;
+  private final RebalanceChangeInfo _numServers;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private RebalanceChangeInfo _replicationFactor;
+  private final RebalanceChangeInfo _replicationFactor;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private RebalanceChangeInfo _numUniqueSegments;
+  private final RebalanceChangeInfo _numUniqueSegments;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private RebalanceChangeInfo _numTotalSegments;
+  private final RebalanceChangeInfo _numTotalSegments;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
+  private final Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
 
   @JsonCreator
   public RebalanceSummaryResult(
       @JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
+      @JsonProperty("numServersGettingNewSegments") int numServersGettingNewSegments,
+      @JsonProperty("estimatedAverageSegmentSizeInBytes") long estimatedAverageSegmentSizeInBytes,
+      @JsonProperty("totalEstimatedDataToBeMovedInBytes") long totalEstimatedDataToBeMovedInBytes,
+      @JsonProperty("totalEstimatedTimeToMoveDataInSecs") double totalEstimatedTimeToMoveDataInSecs,
       @JsonProperty("numServers") @Nullable RebalanceChangeInfo numServers,
       @JsonProperty("replicationFactor") @Nullable RebalanceChangeInfo replicationFactor,
       @JsonProperty("numUniqueSegments") @Nullable RebalanceChangeInfo numUniqueSegments,
       @JsonProperty("numTotalSegments") @Nullable RebalanceChangeInfo numTotalSegments,
       @JsonProperty("serverSegmentChangeInfo") @Nullable Map<String, ServerSegmentChangeInfo> serverSegmentChangeInfo) {
     _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+    _numServersGettingNewSegments = numServersGettingNewSegments;
+    _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
+    _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
+    _totalEstimatedTimeToMoveDataInSecs = totalEstimatedTimeToMoveDataInSecs;
     _numServers = numServers;
     _replicationFactor = replicationFactor;
     _numUniqueSegments = numUniqueSegments;
@@ -98,6 +110,26 @@ public class RebalanceSummaryResult {
   @JsonProperty
   public int getTotalSegmentsToBeMoved() {
     return _totalSegmentsToBeMoved;
+  }
+
+  @JsonProperty
+  public int getNumServersGettingNewSegments() {
+    return _numServersGettingNewSegments;
+  }
+
+  @JsonProperty
+  public long getEstimatedAverageSegmentSizeInBytes() {
+    return _estimatedAverageSegmentSizeInBytes;
+  }
+
+  @JsonProperty
+  public long getTotalEstimatedDataToBeMovedInBytes() {
+    return _totalEstimatedDataToBeMovedInBytes;
+  }
+
+  @JsonProperty
+  public double getTotalEstimatedTimeToMoveDataInSecs() {
+    return _totalEstimatedTimeToMoveDataInSecs;
   }
 
   @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
@@ -71,8 +71,8 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
         if (result.getStatus() == RebalanceResult.Status.DONE) {
           rebalanceResult.put(table, new RebalanceResult(result.getJobId(), RebalanceResult.Status.IN_PROGRESS,
               "In progress, check controller task status for the", result.getInstanceAssignment(),
-              result.getTierInstanceAssignment(), result.getSegmentAssignment(), result.getRebalanceSummaryResult(),
-              result.getPreChecksResult()));
+              result.getTierInstanceAssignment(), result.getSegmentAssignment(), result.getPreChecksResult(),
+              result.getRebalanceSummaryResult()));
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
@@ -60,7 +60,7 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
                 false));
       } catch (TableNotFoundException exception) {
         rebalanceResult.put(table, new RebalanceResult(null, RebalanceResult.Status.FAILED, exception.getMessage(),
-            null, null, null, null));
+            null, null, null, null, null));
       }
     });
     if (config.isDryRun()) {
@@ -71,7 +71,8 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
         if (result.getStatus() == RebalanceResult.Status.DONE) {
           rebalanceResult.put(table, new RebalanceResult(result.getJobId(), RebalanceResult.Status.IN_PROGRESS,
               "In progress, check controller task status for the", result.getInstanceAssignment(),
-              result.getTierInstanceAssignment(), result.getSegmentAssignment(), result.getPreChecksResult()));
+              result.getTierInstanceAssignment(), result.getSegmentAssignment(), result.getRebalanceSummaryResult(),
+              result.getPreChecksResult()));
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -36,7 +36,7 @@ public class TenantRebalanceResult {
       _rebalanceTableResults = new HashMap<>();
       rebalanceTableResults.forEach((table, result) -> {
         _rebalanceTableResults.put(table, new RebalanceResult(result.getJobId(), result.getStatus(),
-            result.getDescription(), null, null, null, null));
+            result.getDescription(), null, null, null, null, null));
       });
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -93,7 +93,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker();
     preChecker.init(_helixResourceManager, Executors.newFixedThreadPool(10));
-    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager, null, null, preChecker);
+    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager, null, null, preChecker,
+        _helixResourceManager.getTableSizeReader());
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
 
@@ -177,6 +178,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNull(rebalanceResult.getSegmentAssignment());
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 3);
 
     Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> serverSegmentChangeInfoMap =
         rebalanceResult.getRebalanceSummaryResult().getServerSegmentChangeInfo();
@@ -394,6 +396,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     // Without instances reassignment, the rebalance should return status NO_OP, and the existing instance partitions
     // should be used
@@ -417,6 +420,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     // With instances reassignment, the rebalance should return status DONE, the existing instance partitions should be
     // removed, and the default instance partitions should be used
@@ -461,6 +465,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 15);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 3);
 
     // Rebalance with downtime should succeed
     rebalanceConfig = new RebalanceConfig();
@@ -553,6 +558,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     // Run actual table rebalance
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -583,6 +589,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     // rebalance is NOOP and no change in assignment caused by new instances
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -615,6 +622,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 15);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 9);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 6);
 
     // rebalance should change assignment
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -688,6 +696,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
@@ -714,6 +723,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 0);
 
     // rebalance is NOOP and no change in assignment caused by new instances
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -740,6 +750,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 30);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
     assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServersGettingNewSegments(), 6);
 
     // rebalance should change assignment
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -100,6 +100,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Rebalance should fail without creating the table
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+    assertNull(rebalanceResult.getRebalanceSummaryResult());
+
+    // Rebalance with dry-run summary should fail without creating the table
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+    assertNull(rebalanceResult.getRebalanceSummaryResult());
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);
@@ -113,6 +122,24 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     }
     Map<String, Map<String, String>> oldSegmentAssignment =
         _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
+
+    // Rebalance with dry-run summary should return NO_OP status
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+
+    // Dry-run mode should not change the IdealState
+    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+        oldSegmentAssignment);
 
     // Rebalance should return NO_OP status
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -137,8 +164,50 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       addFakeServerInstanceToAutoJoinHelixCluster(SERVER_INSTANCE_ID_PREFIX + (numServers + i), true);
     }
 
+    // Rebalance in dry-run summary mode with added servers
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 14);
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+
+    Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> serverSegmentChangeInfoMap =
+        rebalanceResult.getRebalanceSummaryResult().getServerSegmentChangeInfo();
+    assertNotNull(serverSegmentChangeInfoMap);
+    for (int i = 0; i < numServers; i++) {
+      // Original servers should be losing some segments
+      String newServer = SERVER_INSTANCE_ID_PREFIX + i;
+      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+      assertTrue(serverSegmentChange._segmentsDeleted > 0);
+      assertTrue(serverSegmentChange._segmentsUnchanged > 0);
+      assertTrue(serverSegmentChange._totalExistingSegments > 0);
+      assertTrue(serverSegmentChange._totalNewSegments > 0);
+      assertEquals(serverSegmentChange._segmentsAdded, 0);
+    }
+    for (int i = 0; i < numServersToAdd; i++) {
+      // New servers should only get new segments
+      String newServer = SERVER_INSTANCE_ID_PREFIX + (numServers + i);
+      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+      assertTrue(serverSegmentChange._segmentsAdded > 0);
+      assertEquals(serverSegmentChange._totalExistingSegments, 0);
+      assertEquals(serverSegmentChange._totalNewSegments, serverSegmentChange._segmentsAdded);
+      assertEquals(serverSegmentChange._segmentsDeleted, 0);
+      assertEquals(serverSegmentChange._segmentsUnchanged, 0);
+    }
+
+    // Dry-run mode should not change the IdealState
+    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+        oldSegmentAssignment);
+
     // Rebalance in dry-run mode
-    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setDryRun(true);
     rebalanceConfig.setPreChecks(true);
     rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
@@ -186,6 +255,21 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
         oldSegmentAssignment);
 
+    // Rebalance dry-run summary with 3 min available replicas should not be impacted since actual rebalance does not
+    // occur
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceConfig.setMinAvailableReplicas(3);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+
     // Rebalance with 3 min available replicas should fail as the table only have 3 replicas
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setMinAvailableReplicas(3);
@@ -218,6 +302,38 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new InstanceAssignmentConfig(tagPoolConfig, null, replicaGroupPartitionConfig, null, false)));
     _helixResourceManager.updateTableConfig(tableConfig);
 
+    // Try dry-run summary mode
+    // No need to reassign instances because instances should be automatically assigned when updating the table config
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 11);
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+
+    serverSegmentChangeInfoMap = rebalanceResult.getRebalanceSummaryResult().getServerSegmentChangeInfo();
+    assertNotNull(serverSegmentChangeInfoMap);
+    for (int i = 0; i < numServers + numServersToAdd; i++) {
+      String newServer = SERVER_INSTANCE_ID_PREFIX + i;
+      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+      assertEquals(serverSegmentChange._totalNewSegments, 5);
+      // Ensure not all segments moved
+      assertTrue(serverSegmentChange._segmentsUnchanged > 0);
+      // Ensure all segments has something assigned prior to rebalance
+      assertTrue(serverSegmentChange._totalExistingSegments > 0);
+    }
+
+    // Dry-run mode should not change the IdealState
+    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+        newSegmentAssignment);
+
+    // Try actual rebalance
     // No need to reassign instances because instances should be automatically assigned when updating the table config
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
@@ -264,12 +380,43 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     tableConfig.setInstanceAssignmentConfigMap(null);
     _helixResourceManager.updateTableConfig(tableConfig);
 
+    // Try dry-run summary mode without reassignment to ensure that existing instance partitions are used
+    // no movement should occur
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
+
     // Without instances reassignment, the rebalance should return status NO_OP, and the existing instance partitions
     // should be used
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     assertEquals(rebalanceResult.getInstanceAssignment(), instanceAssignment);
     assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
+
+    // Try dry-run summary mode with reassignment
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceConfig.setReassignInstances(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    // No move expected since already balanced
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
 
     // With instances reassignment, the rebalance should return status DONE, the existing instance partitions should be
     // removed, and the default instance partitions should be used
@@ -300,6 +447,21 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
           TagNameUtils.getOfflineTagForTenant(null));
     }
 
+    // Try dry-run summary mode
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceConfig.setDowntime(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 15);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+
     // Rebalance with downtime should succeed
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setDowntime(true);
@@ -326,6 +488,16 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         assertFalse(instanceStateMap.containsKey(SERVER_INSTANCE_ID_PREFIX + (numServers + j)));
       }
     }
+
+    // Try summary mode without dry-run set
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+    assertNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
 
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
   }
@@ -367,7 +539,23 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         _helixResourceManager.getTableIdealState(OFFLINE_TIERED_TABLE_NAME).getRecord().getMapFields();
 
     TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
+
+    // Try dry-run summary mode
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+
+    // Run actual table rebalance
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -381,6 +569,20 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       addFakeServerInstanceToAutoJoinHelixCluster(TIER_B_NAME + "_" + SERVER_INSTANCE_ID_PREFIX + i, false);
     }
     _helixResourceManager.createServerTenant(new Tenant(TenantRole.SERVER, TIER_B_NAME, 3, 3, 0));
+
+    // Try dry-run summary mode, should be no-op
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
 
     // rebalance is NOOP and no change in assignment caused by new instances
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -399,6 +601,20 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new TierConfig(TIER_FIXED_NAME, TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, fixedTierSegments,
             TierFactory.PINOT_SERVER_STORAGE_TYPE, NO_TIER_NAME + "_OFFLINE", null, null)));
     _helixResourceManager.updateTableConfig(tableConfig);
+
+    // Try dry-run summary mode, some moves should occur
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 15);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 9);
 
     // rebalance should change assignment
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -458,7 +674,22 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         _helixResourceManager.getTableIdealState(OFFLINE_TIERED_TABLE_NAME).getRecord().getMapFields();
 
     TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
+
+    // Try dry-run summary mode
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -469,6 +700,21 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
           "replicaAssignment" + TIER_A_NAME + "_" + SERVER_INSTANCE_ID_PREFIX + i, false);
     }
     _helixResourceManager.createServerTenant(new Tenant(TenantRole.SERVER, "replicaAssignment" + TIER_A_NAME, 6, 6, 0));
+
+    // Try dry-run summary mode
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 3);
+
     // rebalance is NOOP and no change in assignment caused by new instances
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
@@ -480,6 +726,20 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new TierConfig(TIER_A_NAME, TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "0d", null,
             TierFactory.PINOT_SERVER_STORAGE_TYPE, "replicaAssignment" + TIER_A_NAME + "_OFFLINE", null, null)));
     _helixResourceManager.updateTableConfig(tableConfig);
+
+    // Try dry-run summary mode
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 30);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 3);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
 
     // rebalance should change assignment
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
@@ -503,6 +763,20 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     tableConfig.setInstanceAssignmentConfigMap(Collections.singletonMap(TIER_A_NAME,
         new InstanceAssignmentConfig(tagPoolConfig, null, replicaGroupPartitionConfig, null, false)));
     _helixResourceManager.updateTableConfig(tableConfig);
+
+    // Try dry-run summary mode
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(true);
+    rebalanceConfig.setSummary(true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+    assertNull(rebalanceResult.getInstanceAssignment());
+    assertNull(rebalanceResult.getTierInstanceAssignment());
+    assertNull(rebalanceResult.getSegmentAssignment());
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getTotalSegmentsToBeMoved(), 13);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._existingValue, 6);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getNumServers()._newValue, 6);
 
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -4136,6 +4136,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       assertTrue(summaryResult.getSegmentInfo().getEstimatedAverageSegmentSizeInBytes() > 0L,
           "Avg segment size expected to be > 0 but found to be 0");
     }
+    assertEquals(summaryResult.getServerInfo().getNumServersGettingNewSegments(),
+        summaryResult.getServerInfo().getServersGettingNewSegments().size());
     if (existingNumServers != newNumServers) {
       assertTrue(summaryResult.getServerInfo().getNumServersGettingNewSegments() > 0,
           "Expected number of servers should be > 0");
@@ -4189,10 +4191,13 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         numServersRemoved + numServersUnchanged);
     Assert.assertEquals(summaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(),
         numServersAdded + numServersUnchanged);
+
+    assertEquals(numServersAdded, summaryResult.getServerInfo().getServersAdded().size());
+    assertEquals(numServersRemoved, summaryResult.getServerInfo().getServersRemoved().size());
+    assertEquals(numServersUnchanged, summaryResult.getServerInfo().getServersUnchanged().size());
   }
 
-  protected void waitForRebalanceToComplete(RebalanceResult rebalanceResult, long timeoutMs)
-      throws Exception {
+  protected void waitForRebalanceToComplete(RebalanceResult rebalanceResult, long timeoutMs) {
     String jobId = rebalanceResult.getJobId();
     if (rebalanceResult.getStatus() != RebalanceResult.Status.IN_PROGRESS) {
       return;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -296,7 +296,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     _executorService = Executors.newFixedThreadPool(10);
     preChecker.init(_helixResourceManager, _executorService);
     _tableRebalancer = new TableRebalancer(_resourceManager.getHelixZkManager(), null, null, preChecker,
-    _resourceManager.getTableSizeReader());
+        _resourceManager.getTableSizeReader());
   }
 
   private void reloadAllSegments(String testQuery, boolean forceDownload, long numTotalDocs)
@@ -4151,14 +4151,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
           summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved()
               * summaryResult.getSegmentInfo().getEstimatedAverageSegmentSizeInBytes(),
           "Estimated data to be moved in bytes doesn't match");
-      assertTrue(summaryResult.getSegmentInfo().getTotalEstimatedTimeToMoveDataInSecs() > 0.0D,
-          "Estimated time to move segments should be more than 0.0 seconds");
+      assertTrue(summaryResult.getSegmentInfo().getMaxSegmentsAddedToASingleServer() > 0,
+          "Estimated max number of segments to move in a single server should be > 0");
     } else {
       assertEquals(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0, "Segments to be moved should be 0");
       assertEquals(summaryResult.getSegmentInfo().getTotalEstimatedDataToBeMovedInBytes(), 0L,
           "Estimated data to be moved in bytes should be 0");
-      assertEquals(summaryResult.getSegmentInfo().getTotalEstimatedTimeToMoveDataInSecs(), 0.0D,
-          "Estimated time to move segments should be 0.0D");
+      assertEquals(summaryResult.getSegmentInfo().getMaxSegmentsAddedToASingleServer(), 0,
+          "Estimated max number of segments to move in a single server should be 0");
     }
 
     // Validate server status stats with numServers information


### PR DESCRIPTION
This PR adds a `summary` option to the TableRebalance API which is meant to be used with `dryRun`. If `summary` is set to `true` a summary of the dry-run is returned rather than the full dry-run. This summary gives some stats about changes that will occur during the rebalance, such as:

- Total number of segments to be moved
- Unique and total number of segments
- Replication factor
- Number of servers
- Server map to segment add/remove/unchanged information
- Average segment size
- Number of servers getting segments added
- Total data size being moved (calculated based on average segment size - based on TableSize)
- An estimate of how long the move can take (based on estimates to download and process each segment) - we should decide on a good throughput estimate as part of this PR review (left a TODO where the code is relevant)

Today the dry-run output can be very large, and can be difficult to make sense of in terms of the changes occurring. It can also be difficult to display the full output. For now `summary` is not appended to `dryRun` without `summary` enabled, but this can be added if it makes sense to add a summary even for the usual result return.

Note: This PR will have conflicts with https://github.com/apache/pinot/pull/15029 and will need to be rebased once that is merged.

Sample JSON summary [NOTE - please see later comments for updated summary based on review comments]:
```
{
  "totalSegmentsToBeMoved" : 6,
  "numServersGettingNewSegments" : 1,
  "estimatedAverageSegmentSizeInBytes" : 1690546,
  "totalEstimatedDataToBeMovedInBytes" : 10143276,
  "totalEstimatedTimeToMoveDataInSecs" : 0.09673381805419921,
  "numServers" : {
    "_existingValue" : 1,
    "_newValue" : 2
  },
  "replicationFactor" : {
    "_existingValue" : 1,
    "_newValue" : 1
  },
  "numUniqueSegments" : {
    "_existingValue" : 12,
    "_newValue" : 12
  },
  "numTotalSegments" : {
    "_existingValue" : 12,
    "_newValue" : 12
  },
  "serverSegmentChangeInfo" : {
    "Server_localhost_22004" : {
      "_totalNewSegments" : 6,
      "_totalExistingSegments" : 0,
      "_segmentsAdded" : 6,
      "_segmentsDeleted" : 0,
      "_segmentsUnchanged" : 0
    },
    "Server_localhost_22001" : {
      "_totalNewSegments" : 6,
      "_totalExistingSegments" : 12,
      "_segmentsAdded" : 0,
      "_segmentsDeleted" : 6,
      "_segmentsUnchanged" : 6
    }
  }
}
```

cc @Jackie-Jiang @klsince @deepthi912 @npawar 