### PR TITLE
Fixing aliased columns bug in GAPFILL based queries

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -145,7 +145,7 @@ abstract class BaseGapfillProcessor {
    * 3. Aggregate the dataset per time bucket.
    */
   public void process(BrokerResponseNative brokerResponseNative) {
-    DataSchema dataSchema = getAliasedTableDataSchema(brokerResponseNative);
+    DataSchema dataSchema = brokerResponseNative.getResultTable().getDataSchema();
     replaceColumnNameWithAlias(dataSchema);
     DataSchema resultTableSchema = getResultTableDataSchema(dataSchema);
     if (brokerResponseNative.getResultTable().getRows().isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -68,7 +68,7 @@ public class GapfillProcessor extends BaseGapfillProcessor {
    * 3. Aggregate the dataset per time bucket.
    */
   public void process(BrokerResponseNative brokerResponseNative) {
-    DataSchema dataSchema = brokerResponseNative.getResultTable().getDataSchema();
+    DataSchema dataSchema = getAliasedTableDataSchema(brokerResponseNative);
     DataSchema resultTableSchema = getResultTableDataSchema(dataSchema);
     if (brokerResponseNative.getResultTable().getRows().isEmpty()) {
       brokerResponseNative.setResultTable(new ResultTable(resultTableSchema, Collections.emptyList()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -68,7 +68,8 @@ public class GapfillProcessor extends BaseGapfillProcessor {
    * 3. Aggregate the dataset per time bucket.
    */
   public void process(BrokerResponseNative brokerResponseNative) {
-    DataSchema dataSchema = getAliasedTableDataSchema(brokerResponseNative);
+    DataSchema dataSchema = brokerResponseNative.getResultTable().getDataSchema();
+    replaceColumnNameWithAlias(dataSchema);
     DataSchema resultTableSchema = getResultTableDataSchema(dataSchema);
     if (brokerResponseNative.getResultTable().getRows().isEmpty()) {
       brokerResponseNative.setResultTable(new ResultTable(resultTableSchema, Collections.emptyList()));
@@ -97,8 +98,6 @@ public class GapfillProcessor extends BaseGapfillProcessor {
     }
 
     List<Object[]>[] timeBucketedRawRows = putRawRowsIntoTimeBucket(brokerResponseNative.getResultTable().getRows());
-
-    replaceColumnNameWithAlias(dataSchema);
 
     if (_queryContext.getAggregationFunctions() == null) {
       Map<String, Integer> sourceColumnsIndexes = new HashMap<>();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.plan.Plan;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
-import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.plan.Plan;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
@@ -784,6 +784,57 @@ public class GapfillQueriesTest extends BaseQueriesTest {
   }
 
   @Test
+  public void datetimeconvertGapfillTestAliasedColumnsInTimeserieson() {
+    String gapfillQuery1 = "SELECT "
+        + "time_col, alias_levelId, SUM(occupied) as occupied_slots_count, time_col "
+        + "FROM ("
+        + "  SELECT GapFill(time_col, "
+        + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+        + "    '2021-11-07 4:00:00.000',  '2021-11-07 12:00:00.000', '1:HOURS',"
+        + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(alias_levelId, alias_lotId)),"
+        + "     occupied, alias_lotId, alias_levelId"
+        + "  FROM ("
+        + "    SELECT DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+        + "      '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col,"
+        + "       lastWithTime(isOccupied, eventTime, 'INT') as occupied, "
+        + "       cast(lotId as varchar) as alias_lotId, "
+        + "       cast(levelId as varchar) as alias_levelId "
+        + "    FROM parkingData "
+        + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+        + "    GROUP BY time_col, alias_levelId, alias_lotId "
+        + "    LIMIT 200 "
+        + "  ) "
+        + "  LIMIT 200 "
+        + ") "
+        + " GROUP BY time_col, alias_levelId "
+        + " HAVING occupied_slots_count > 0"
+        + " LIMIT 200 ";
+
+    BrokerResponseNative gapfillBrokerResponse1 = getBrokerResponse(gapfillQuery1);
+
+    double[] expectedOccupiedSlotsCounts1 = new double[]{1, 2, 3, 4, 3, 2, 1};
+    ResultTable gapFillResultTable1 = gapfillBrokerResponse1.getResultTable();
+    List<Object[]> gapFillRows1 = gapFillResultTable1.getRows();
+    Assert.assertEquals(gapFillRows1.size(), expectedOccupiedSlotsCounts1.length * 2);
+    DateTimeFormatSpec dateTimeFormatter =
+        new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+    DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");
+
+    long start = dateTimeFormatter.fromFormatToMillis("2021-11-07 04:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts1.length; i += 2) {
+      String firstTimeCol = (String) gapFillRows1.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i / 2], gapFillRows1.get(i)[2]);
+      firstTimeCol = (String) gapFillRows1.get(i + 1)[0];
+      timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i / 2], gapFillRows1.get(i)[2]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+  }
+
+  @Test
   public void toEpochHoursGapfillTestSelectSelect() {
     DateTimeFormatSpec dateTimeFormatter = new DateTimeFormatSpec("1:HOURS:EPOCH");
     DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");


### PR DESCRIPTION
A bug exists in GAPFILL queries. Aliased columns in subqueries within GAPFILL are not correctly referenced (especially in the `TIMESERIESON()` clause), causing a `NullPointerException` to be thrown. 

This issue happens for almost all types of GAPFILL queries (`AGGREGATE_GAPFILL`, `AGGREGATE_GAPFILL_AGGREGATE`, `SELECT_GAPFILL`). 

Example query (can be reproduced on `TIMESTAMP` quickstart):
```
SELECT time_bucket,
  count(*)
from (
    SELECT GAPFILL(
        alias_created_at_timestamp,
        '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss',
        '2018-01-01 11:00:00',
        '2018-01-02 12:00:00',
        '1:HOURS',
        FILL(0, 'FILL_DEFAULT_VALUE'),
        TIMESERIESON(alias_type)
      ) as time_bucket,
      cnt,
      alias_type
    from (
        select DATETIMECONVERT(
            created_at_timestamp,
            '1:MILLISECONDS:EPOCH',
            '1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss',
            '1:HOURS'
          ) as alias_created_at_timestamp,
          cast(type as varchar) as alias_type,
          count(*) as cnt
        from githubComplexTypeEvents
        group by 1,
          2
        order by 3 desc
        limit 1000
      )
    limit 20000
  )
group by 1
```

This PR fixes the issue by correcting the incoming DataSchema with the aliased DataSchema before referencing the schema for subsequent operations.

### Testing 

Testing on Pinot quickstart for all types of GAPFILL queries, as well as added a unit test for the query shape fixed by this PR.