### PR TITLE
Add null checks when sampling thread resource usage.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -278,8 +278,9 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
      */
     @SuppressWarnings("ConstantConditions")
     public void sampleThreadCPUTime() {
-      if (_isThreadCPUSamplingEnabled) {
-        _threadLocalEntry.get()._currentThreadCPUTimeSampleMS = getThreadResourceUsageProvider().getThreadTimeNs();
+      ThreadResourceUsageProvider provider = getThreadResourceUsageProvider();
+      if (_isThreadCPUSamplingEnabled && provider != null) {
+        _threadLocalEntry.get()._currentThreadCPUTimeSampleMS = provider.getThreadTimeNs();
       }
     }
 
@@ -289,9 +290,9 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
      */
     @SuppressWarnings("ConstantConditions")
     public void sampleThreadBytesAllocated() {
-      if (_isThreadMemorySamplingEnabled) {
-        _threadLocalEntry.get()._currentThreadMemoryAllocationSampleBytes
-            = getThreadResourceUsageProvider().getThreadAllocatedBytes();
+      ThreadResourceUsageProvider provider = getThreadResourceUsageProvider();
+      if (_isThreadMemorySamplingEnabled && provider != null) {
+        _threadLocalEntry.get()._currentThreadMemoryAllocationSampleBytes = provider.getThreadAllocatedBytes();
       }
     }
 


### PR DESCRIPTION
Issues like https://github.com/apache/pinot/issues/15045 are caused because some query execution paths are not instrumented to capture thread usage. When instrumentation is turned on NPE is caused. Since it is not possible to guarantee that all execution paths are covered, add a null check before sampling for resource usage.

Fix for #15051