### PR TITLE
Emits metric before Consumer gets stuck in postStopConsumedMsg Method

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -890,7 +890,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               break;
           }
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         if (_shouldStop) {
           _segmentLogger.info("Caught exception in consumer thread after stop() is invoked: {}, ignoring the exception",
               e.toString());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -897,10 +897,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         } else {
           String errorMessage = "Exception while in work";
           _segmentLogger.error(errorMessage, e);
-          postStopConsumedMsg(e.getClass().getName());
           _state = State.ERROR;
           _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
           _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 0);
+          postStopConsumedMsg(e.getClass().getName());
           return;
         }
       }


### PR DESCRIPTION
**Problem**
Encountered an issue where if PartitionConsumer runs into an Exception, The Consumer thread gets stuck in an endless loop of [postStopConsumedMsg](https://github.com/apache/pinot/blob/5f220b398cda1fde87a286492e05521d48923634/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java#L1320)

For such cases we did not receive an alert because metric is emitted after.