### PR TITLE
Enhance early termination handling in LeafStageTransferableBlockOperator and OpChainSchedulerService

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -49,10 +49,9 @@ public class OpChainSchedulerService {
     Future<?> scheduledFuture = _executorService.submit(new TraceRunnable() {
       @Override
       public void runJob() {
-        boolean isFinished = false;
         TransferableBlock returnedErrorBlock = null;
         Throwable thrown = null;
-        try {
+        try (OpChain closeMe = operatorChain) {
           ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
           Tracing.ThreadAccountantOps.setupWorker(operatorChain.getId().getStageId(),
               ThreadExecutionContext.TaskType.MSE, threadResourceUsageProvider,
@@ -62,7 +61,6 @@ public class OpChainSchedulerService {
           while (!result.isEndOfStreamBlock()) {
             result = operatorChain.getRoot().nextBlock();
           }
-          isFinished = true;
           if (result.isErrorBlock()) {
             returnedErrorBlock = result;
             LOGGER.error("({}): Completed erroneously {} {}", operatorChain, result.getQueryStats(),
@@ -80,8 +78,6 @@ public class OpChainSchedulerService {
               thrown = new RuntimeException("Error block " + returnedErrorBlock.getExceptions());
             }
             operatorChain.cancel(thrown);
-          } else if (isFinished) {
-            operatorChain.close();
           }
           Tracing.ThreadAccountantOps.clear();
         }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -51,6 +51,8 @@ public class OpChainSchedulerService {
       public void runJob() {
         TransferableBlock returnedErrorBlock = null;
         Throwable thrown = null;
+        // try-with-resources to ensure that the operator chain is closed
+        // TODO: Change the code so we ownership is expressed in the code in a better way
         try (OpChain closeMe = operatorChain) {
           ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
           Tracing.ThreadAccountantOps.setupWorker(operatorChain.getId().getStageId(),


### PR DESCRIPTION
We detected that `cancel` and `earlyTerminate` methods were not actually interrupting SSE threads. Specifically, in `LeafStageTransferableBlockOperatorTest`, newly added tests `cancelMethodInterruptsSseTasks` and `earlyTerminateMethodInterruptsSseTasks` would fail in master.

This, combined by the fact that the OpChain (and therefore their MSE operators) were not closed when error blocks are received, means that SSE threads were not interrupted when there were some errors.

For example, imagine the following query (that can be ran in `ColocatedJoinEngineQuickStart`):
```sql
select * 
from userGroups as g1 
cross join (
  select * 
  from userAttributes as a1
  cross join userAttributes as a2
)
limit 10
```

This query will always fail because the inner cross join exceeds the max number of rows in a join. But in master, the leaf stage that scans `userGroups` will not be canceled and will run until:
1. All blocks are read
2. Timeout is detected

In the same situation in this PR, the leaf stage will be canceled in the following situations:
1. The leaf stage produces at least one block, which is sent downstream. When it reaches the send mailbox, it notifies the early terminate, which, in the new code, actually interrupts the SSE threads.
2. Timeout is detected 

We can improve this mechanism further. Specifically, upstream (aka parent stages) could send a message to the upstream (children stages) indicating that the computation has been aborted. This would improve the cancellation process, especially when the leaf stage executes expensive work like sorting or grouping without ST indexes. However, it would require applying changes in the worker protocol. IMHO, what we should do is rethink this protocol and use reactive streams instead. To me, it looks like we are trying to reinvent the wheel here, trying to make a partial implementation of reactive streams that is not good enough.

Another thing to notice is that we have 3 termination methods in MseOperators: cancel, earlyTerminate and close. They are not documented, and their semantic differences are not clear. That is another part of the code we need to re-examine. Again, to me, it looks like we are trying to reinvent the wheel here, and reactive streams are the actual semantics we would need to use.