### PR TITLE
Extract compileRequest from BaseSingleStageRequestHandler.doHandleRequest

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -356,6 +356,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
               accessControl);
 
     if (compileResult._errorOrLiteralOnlyBrokerResponse != null) {
+      /*
+       * If the compileRequest method set the BrokerResponse field, then it is either an error response or
+       * a literal-only query. In either case, we can return the response directly.
+       */
       return compileResult._errorOrLiteralOnlyBrokerResponse;
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -315,6 +315,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
    * is successful then all member variables other than BrokerResponse will be available. If compilation is not
    * successful, then only the BrokerResponse is set. This is done to keep the current behaviour as is.
    * It became hard to keep the current behaviour if we were to throw an exception from the compileRequest method.
+   * The only exception is that a BrokerResponse is returned for a literal-only query.
    */
   private static class CompileResult {
     final PinotQuery _pinotQuery;
@@ -322,7 +323,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     final Schema _schema;
     final String _tableName;
     final String _rawTableName;
-    final BrokerResponse _errorBrokerResponse;
+    final BrokerResponse _errorOrLiteralOnlyBrokerResponse;
 
     public CompileResult(PinotQuery pinotQuery, PinotQuery serverPinotQuery, Schema schema, String tableName,
         String rawTableName) {
@@ -331,16 +332,16 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       _schema = schema;
       _tableName = tableName;
       _rawTableName = rawTableName;
-      _errorBrokerResponse = null;
+      _errorOrLiteralOnlyBrokerResponse = null;
     }
 
-    public CompileResult(BrokerResponse errorBrokerResponse) {
+    public CompileResult(BrokerResponse errorOrLiteralOnlyBrokerResponse) {
       _pinotQuery = null;
       _serverPinotQuery = null;
       _schema = null;
       _tableName = null;
       _rawTableName = null;
-      _errorBrokerResponse = errorBrokerResponse;
+      _errorOrLiteralOnlyBrokerResponse = errorOrLiteralOnlyBrokerResponse;
     }
   }
 
@@ -354,8 +355,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
           compileRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
               accessControl);
 
-    if (compileResult._errorBrokerResponse != null) {
-      return compileResult._errorBrokerResponse;
+    if (compileResult._errorOrLiteralOnlyBrokerResponse != null) {
+      return compileResult._errorOrLiteralOnlyBrokerResponse;
     }
 
     Schema schema = compileResult._schema;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -310,10 +310,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     }
   }
 
-  static class CompileResult {
+  private static class CompileResult {
     final PinotQuery _pinotQuery;
     final PinotQuery _serverPinotQuery;
-    Schema _schema;
+    final Schema _schema;
     final String _tableName;
     final String _rawTableName;
     final BrokerResponse _brokerResponse;
@@ -355,15 +355,6 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_VALIDATION_EXCEPTIONS, 1);
       requestContext.setErrorCode(QueryException.QUERY_VALIDATION_ERROR_CODE);
       return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_VALIDATION_ERROR, e));
-    } catch (BadQueryRequestException e) {
-      LOGGER.info("Caught exception while checking column names in request {}: {}, {}", requestId, query,
-          e.getMessage());
-      requestContext.setErrorCode(QueryException.UNKNOWN_COLUMN_ERROR_CODE);
-      if (compileResult != null) {
-        rawTableName = compileResult._rawTableName;
-      }
-      _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.UNKNOWN_COLUMN_EXCEPTIONS, 1);
-      return new BrokerResponseNative(QueryException.getException(QueryException.UNKNOWN_COLUMN_ERROR, e));
     }
 
     if (compileResult._brokerResponse != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -357,7 +357,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     if (compileResult._errorOrLiteralOnlyBrokerResponse != null) {
       /*
-       * If the compileRequest method set the BrokerResponse field, then it is either an error response or
+       * If the compileRequest method sets the BrokerResponse field, then it is either an error response or
        * a literal-only query. In either case, we can return the response directly.
        */
       return compileResult._errorOrLiteralOnlyBrokerResponse;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -344,18 +344,9 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       throws Exception {
     // Compile the request into PinotQuery
     long compilationStartTimeNs = System.nanoTime();
-    String rawTableName = "UNKNOWN";
-    CompileResult compileResult = null;
-    try {
-      compileResult =
+    CompileResult compileResult =
           compileRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
               accessControl);
-    } catch (DatabaseConflictException e) {
-      LOGGER.info("{}. Request {}: {}", e.getMessage(), requestId, query);
-      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_VALIDATION_EXCEPTIONS, 1);
-      requestContext.setErrorCode(QueryException.QUERY_VALIDATION_ERROR_CODE);
-      return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_VALIDATION_ERROR, e));
-    }
 
     if (compileResult._brokerResponse != null) {
       return compileResult._brokerResponse;
@@ -363,7 +354,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     Schema schema = compileResult._schema;
     String tableName = compileResult._tableName;
-    rawTableName = compileResult._rawTableName;
+    String rawTableName = compileResult._rawTableName;
     PinotQuery pinotQuery = compileResult._pinotQuery;
     PinotQuery serverPinotQuery = compileResult._serverPinotQuery;
     long compilationEndTimeNs = System.nanoTime();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -310,13 +310,19 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     }
   }
 
+  /**
+   * CompileResult holds the result of the compilation phase. Compilation may or may not be successful. If compilation
+   * is successful then all member variables other than BrokerResponse will be available. If compilation is not
+   * successful, then only the BrokerResponse is set. This is done to keep the current behaviour as is.
+   * It became hard to keep the current behaviour if we were to throw an exception from the compileRequest method.
+   */
   private static class CompileResult {
     final PinotQuery _pinotQuery;
     final PinotQuery _serverPinotQuery;
     final Schema _schema;
     final String _tableName;
     final String _rawTableName;
-    final BrokerResponse _brokerResponse;
+    final BrokerResponse _errorBrokerResponse;
 
     public CompileResult(PinotQuery pinotQuery, PinotQuery serverPinotQuery, Schema schema, String tableName,
         String rawTableName) {
@@ -325,16 +331,16 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       _schema = schema;
       _tableName = tableName;
       _rawTableName = rawTableName;
-      _brokerResponse = null;
+      _errorBrokerResponse = null;
     }
 
-    public CompileResult(BrokerResponse brokerResponse) {
+    public CompileResult(BrokerResponse errorBrokerResponse) {
       _pinotQuery = null;
       _serverPinotQuery = null;
       _schema = null;
       _tableName = null;
       _rawTableName = null;
-      _brokerResponse = brokerResponse;
+      _errorBrokerResponse = errorBrokerResponse;
     }
   }
 
@@ -348,8 +354,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
           compileRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
               accessControl);
 
-    if (compileResult._brokerResponse != null) {
-      return compileResult._brokerResponse;
+    if (compileResult._errorBrokerResponse != null) {
+      return compileResult._errorBrokerResponse;
     }
 
     Schema schema = compileResult._schema;


### PR DESCRIPTION
BaseSingleStageBrokerRequestHandler.doHandleRequest is a large function of ~600 LOC. This makes it hard to reason about the function as well as extend and reuse parts of the function. The function can be broken down into four parts:
* Compile
* Validate
* Plan (generate server request)
* Execute

This PR only extracts the code to compile the request. The o/p of compile is stored in a `CompileResult` object that the rest of the code can use. A couple of open points are:
* This PR does not try to be exactly correct about the boundaries of these parts. Eventually some code has to be moved around.
* SQL Parser & Validation errors should ideally be thrown as exceptions and then converted to `BrokerResponse`. This can be taken up in a subsequent PR.

Otherwise the code has not been changed.

This clean up is motivated by https://github.com/apache/pinot/issues/10712

Clean up of the function will help in implementing logical tables feature.