### PR TITLE
disable polyfill until we face the performance penalty

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -868,9 +868,13 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     // server returns STRING as default dataType for all columns in (some) scenarios where no rows are returned
     // this is an attempt to return more faithful information based on other sources
+    // DISABLED until we face this issue:
+    // https://github.com/apache/pinot/issues/15064
+    /*
     if (brokerResponse.getNumRowsResultSet() == 0) {
       ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
     }
+    */
 
     // Set total query processing time
     long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();
@@ -964,7 +968,9 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     // Send empty response since we don't need to evaluate either offline or realtime request.
     BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
-    ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
+    // DISABLED until we face this issue:
+    // https://github.com/apache/pinot/issues/15064
+    //ParserUtils.fillEmptyResponseSchema(brokerResponse, _tableCache, schema, database, query);
     brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
     _queryLogger.log(
         new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/EmptyResponseIntegrationTest.java
@@ -51,6 +51,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Integration test that checks data types for queries with no rows returned.
  */
+@Test(enabled = false)
 public class EmptyResponseIntegrationTest extends BaseClusterIntegrationTestSet {
   private static final int NUM_BROKERS = 1;
   private static final int NUM_SERVERS = 1;


### PR DESCRIPTION
Disable the attempt to report dataTypes on empty responses done at https://github.com/apache/pinot/pull/14836

Do not re-enable until we find a way to avoid the performance penalty reported in https://github.com/apache/pinot/issues/15064