### PR TITLE
Update Doap for release 1.3.0

### DIFF
--- a/doap_Pinot.rdf
+++ b/doap_Pinot.rdf
@@ -42,9 +42,9 @@ It's perfect for user-facing real-time analytics and other analytical use cases,
     <category rdf:resource="https://projects.apache.org/category/big-data" />
     <release>
       <Version>
-        <name>1.2.0</name>
-        <created>2024-08-20</created>
-        <revision>1.2.0</revision>
+        <name>1.3.0</name>
+        <created>2025-02-17</created>
+        <revision>1.3.0</revision>
       </Version>
     </release>
     <repository>


### PR DESCRIPTION
As per the release [doc](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=107972329#CreatinganApacheRelease-Announcetotheworld), update doap with 1.3.0 release 