### PR TITLE
Add required proto for broker grpc query server and request/response objects

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BaseGrpcQueryClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BaseGrpcQueryClient.java
@@ -35,16 +35,14 @@ import javax.net.ssl.SSLException;
 import nl.altindag.ssl.SSLFactory;
 import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.config.TlsConfig;
-import org.apache.pinot.common.proto.PinotQueryServerGrpc;
-import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.common.utils.tls.PinotInsecureMode;
 import org.apache.pinot.common.utils.tls.RenewableTlsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class GrpcQueryClient implements Closeable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GrpcQueryClient.class);
+public abstract class BaseGrpcQueryClient<REQUEST, RESPONSE> implements Closeable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseGrpcQueryClient.class);
 
   // the key is the hashCode of the TlsConfig, the value is the SslContext
   // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
@@ -52,14 +50,13 @@ public class GrpcQueryClient implements Closeable {
   private static final Map<Integer, SslContext> CLIENT_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
 
   private final ManagedChannel _managedChannel;
-  private final PinotQueryServerGrpc.PinotQueryServerBlockingStub _blockingStub;
   private final int _channelShutdownTimeoutSeconds;
 
-  public GrpcQueryClient(String host, int port) {
+  public BaseGrpcQueryClient(String host, int port) {
     this(host, port, new GrpcConfig(Collections.emptyMap()));
   }
 
-  public GrpcQueryClient(String host, int port, GrpcConfig config) {
+  public BaseGrpcQueryClient(String host, int port, GrpcConfig config) {
     ManagedChannelBuilder<?> channelBuilder;
     if (config.isUsePlainText()) {
       channelBuilder = ManagedChannelBuilder
@@ -82,7 +79,6 @@ public class GrpcQueryClient implements Closeable {
     }
 
     _managedChannel = channelBuilder.build();
-    _blockingStub = PinotQueryServerGrpc.newBlockingStub(_managedChannel);
     _channelShutdownTimeoutSeconds = config.getChannelShutdownTimeoutSecond();
   }
 
@@ -108,13 +104,11 @@ public class GrpcQueryClient implements Closeable {
     });
   }
 
-  public Iterator<Server.ServerResponse> submit(Server.ServerRequest request) {
-    return _blockingStub.submit(request);
-  }
-
   public ManagedChannel getChannel() {
     return _managedChannel;
   }
+
+  abstract Iterator<RESPONSE> submit(REQUEST request);
 
   @Override
   public void close() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BrokerGrpcQueryClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BrokerGrpcQueryClient.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.grpc;
+
+import java.util.Iterator;
+import org.apache.pinot.common.config.GrpcConfig;
+import org.apache.pinot.common.proto.Broker;
+import org.apache.pinot.common.proto.PinotQueryBrokerGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class BrokerGrpcQueryClient extends BaseGrpcQueryClient<Broker.BrokerRequest, Broker.BrokerResponse> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerGrpcQueryClient.class);
+
+  private final PinotQueryBrokerGrpc.PinotQueryBrokerBlockingStub _blockingStub;
+
+  public BrokerGrpcQueryClient(String host, int port, GrpcConfig config) {
+    super(host, port, config);
+    _blockingStub = PinotQueryBrokerGrpc.newBlockingStub(getChannel());
+  }
+
+  @Override
+  Iterator<Broker.BrokerResponse> submit(Broker.BrokerRequest request) {
+    return _blockingStub.submit(request);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BrokerGrpcRequestBuilder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BrokerGrpcRequestBuilder.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.grpc;
+
+import org.apache.pinot.common.proto.Broker;
+import org.apache.pinot.spi.utils.CommonConstants.Query.Request;
+
+
+public class BrokerGrpcRequestBuilder {
+  private long _requestId;
+  private String _brokerId = "unknown";
+  private boolean _enableTrace;
+  private boolean _enableStreaming;
+  private String _sql;
+
+  public BrokerGrpcRequestBuilder setRequestId(long requestId) {
+    _requestId = requestId;
+    return this;
+  }
+
+  public BrokerGrpcRequestBuilder setBrokerId(String brokerId) {
+    _brokerId = brokerId;
+    return this;
+  }
+
+  public BrokerGrpcRequestBuilder setEnableTrace(boolean enableTrace) {
+    _enableTrace = enableTrace;
+    return this;
+  }
+
+  public BrokerGrpcRequestBuilder setEnableStreaming(boolean enableStreaming) {
+    _enableStreaming = enableStreaming;
+    return this;
+  }
+
+  public BrokerGrpcRequestBuilder setSql(String sql) {
+    _sql = sql;
+    return this;
+  }
+
+  public Broker.BrokerRequest build() {
+    return Broker.BrokerRequest.newBuilder()
+        .putMetadata(Request.MetadataKeys.REQUEST_ID, Long.toString(_requestId))
+        .putMetadata(Request.MetadataKeys.BROKER_ID, _brokerId)
+        .putMetadata(Request.MetadataKeys.ENABLE_TRACE, Boolean.toString(_enableTrace))
+        .putMetadata(Request.MetadataKeys.ENABLE_STREAMING, Boolean.toString(_enableStreaming))
+        .setSql(_sql).build();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/ServerGrpcQueryClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/ServerGrpcQueryClient.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.grpc;
+
+import java.util.Collections;
+import java.util.Iterator;
+import org.apache.pinot.common.config.GrpcConfig;
+import org.apache.pinot.common.proto.PinotQueryServerGrpc;
+import org.apache.pinot.common.proto.Server;
+
+
+public class ServerGrpcQueryClient extends BaseGrpcQueryClient<Server.ServerRequest, Server.ServerResponse> {
+  private final PinotQueryServerGrpc.PinotQueryServerBlockingStub _blockingStub;
+
+  public ServerGrpcQueryClient(String host, int port) {
+    this(host, port, new GrpcConfig(Collections.emptyMap()));
+  }
+
+  public ServerGrpcQueryClient(String host, int port, GrpcConfig config) {
+    super(host, port, config);
+    _blockingStub = PinotQueryServerGrpc.newBlockingStub(getChannel());
+  }
+
+  public Iterator<Server.ServerResponse> submit(Server.ServerRequest request) {
+    return _blockingStub.submit(request);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/ServerGrpcRequestBuilder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/ServerGrpcRequestBuilder.java
@@ -32,7 +32,7 @@ import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
 
 
-public class GrpcRequestBuilder {
+public class ServerGrpcRequestBuilder {
   private long _requestId;
   private String _brokerId = "unknown";
   private boolean _enableTrace;
@@ -42,39 +42,39 @@ public class GrpcRequestBuilder {
   private BrokerRequest _brokerRequest;
   private List<String> _segments;
 
-  public GrpcRequestBuilder setRequestId(long requestId) {
+  public ServerGrpcRequestBuilder setRequestId(long requestId) {
     _requestId = requestId;
     return this;
   }
 
-  public GrpcRequestBuilder setBrokerId(String brokerId) {
+  public ServerGrpcRequestBuilder setBrokerId(String brokerId) {
     _brokerId = brokerId;
     return this;
   }
 
-  public GrpcRequestBuilder setEnableTrace(boolean enableTrace) {
+  public ServerGrpcRequestBuilder setEnableTrace(boolean enableTrace) {
     _enableTrace = enableTrace;
     return this;
   }
 
-  public GrpcRequestBuilder setEnableStreaming(boolean enableStreaming) {
+  public ServerGrpcRequestBuilder setEnableStreaming(boolean enableStreaming) {
     _enableStreaming = enableStreaming;
     return this;
   }
 
-  public GrpcRequestBuilder setSql(String sql) {
+  public ServerGrpcRequestBuilder setSql(String sql) {
     _payloadType = Request.PayloadType.SQL;
     _sql = sql;
     return this;
   }
 
-  public GrpcRequestBuilder setBrokerRequest(BrokerRequest brokerRequest) {
+  public ServerGrpcRequestBuilder setBrokerRequest(BrokerRequest brokerRequest) {
     _payloadType = Request.PayloadType.BROKER_REQUEST;
     _brokerRequest = brokerRequest;
     return this;
   }
 
-  public GrpcRequestBuilder setSegments(List<String> segments) {
+  public ServerGrpcRequestBuilder setSegments(List<String> segments) {
     _segments = segments;
     return this;
   }

--- a/pinot-common/src/main/proto/broker.proto
+++ b/pinot-common/src/main/proto/broker.proto
@@ -1,0 +1,36 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+syntax = "proto3";
+
+package org.apache.pinot.common.proto;
+
+service PinotQueryBroker {
+  rpc Submit(BrokerRequest) returns (stream BrokerResponse);
+}
+
+message BrokerRequest {
+  map<string, string> metadata = 1;
+  string sql = 2;
+}
+
+message BrokerResponse {
+  map<string, string> metadata = 1;
+  bytes payload = 2;
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -35,8 +35,8 @@ import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
-import org.apache.pinot.common.utils.grpc.GrpcRequestBuilder;
+import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
+import org.apache.pinot.common.utils.grpc.ServerGrpcRequestBuilder;
 import org.apache.pinot.core.query.reduce.DataTableReducer;
 import org.apache.pinot.core.query.reduce.DataTableReducerContext;
 import org.apache.pinot.core.query.reduce.ResultReducerFactory;
@@ -96,19 +96,19 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
     waitForAllDocsLoaded(600_000L);
   }
 
-  public GrpcQueryClient getGrpcQueryClient() {
-    return new GrpcQueryClient("localhost", getServerGrpcPort());
+  public ServerGrpcQueryClient getGrpcQueryClient() {
+    return new ServerGrpcQueryClient("localhost", getServerGrpcPort());
   }
 
   @Test
   public void testGrpcQueryServer()
       throws Exception {
-    GrpcQueryClient queryClient = getGrpcQueryClient();
+    ServerGrpcQueryClient queryClient = getGrpcQueryClient();
     String sql = "SELECT * FROM mytable_OFFLINE LIMIT 1000000 OPTION(timeoutMs=30000)";
     BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(sql);
     List<String> segments = _helixResourceManager.getSegmentsFor("mytable_OFFLINE", true);
 
-    GrpcRequestBuilder requestBuilder = new GrpcRequestBuilder().setSegments(segments);
+    ServerGrpcRequestBuilder requestBuilder = new ServerGrpcRequestBuilder().setSegments(segments);
     testNonStreamingRequest(queryClient.submit(requestBuilder.setSql(sql).build()));
     testNonStreamingRequest(queryClient.submit(requestBuilder.setBrokerRequest(brokerRequest).build()));
 
@@ -121,9 +121,9 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
   @Test(dataProvider = "provideSqlTestCases")
   public void testQueryingGrpcServer(String sql)
       throws Exception {
-    try (GrpcQueryClient queryClient = getGrpcQueryClient()) {
+    try (ServerGrpcQueryClient queryClient = getGrpcQueryClient()) {
       List<String> segments = _helixResourceManager.getSegmentsFor("mytable_OFFLINE", true);
-      GrpcRequestBuilder requestBuilder = new GrpcRequestBuilder().setSql(sql).setSegments(segments);
+      ServerGrpcRequestBuilder requestBuilder = new ServerGrpcRequestBuilder().setSql(sql).setSegments(segments);
       DataTable dataTable = collectNonStreamingRequestResult(queryClient.submit(requestBuilder.build()));
       collectAndCompareResult(sql, queryClient.submit(requestBuilder.setEnableStreaming(true).build()), dataTable);
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
@@ -22,7 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.config.GrpcConfig;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
+import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 
@@ -47,7 +47,7 @@ public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerInt
   }
 
   @Override
-  public GrpcQueryClient getGrpcQueryClient() {
+  public ServerGrpcQueryClient getGrpcQueryClient() {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put("usePlainText", "false");
     configMap.put("tls.keystore.path", _tlsStoreJKS.getFile());
@@ -60,6 +60,6 @@ public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerInt
     PinotConfiguration brokerConfig = new PinotConfiguration(configMap);
     // This mimics how pinot broker instantiates GRPCQueryClient.
     GrpcConfig config = GrpcConfig.buildGrpcQueryConfig(brokerConfig);
-    return new GrpcQueryClient("localhost", getServerGrpcPort(), config);
+    return new ServerGrpcQueryClient("localhost", getServerGrpcPort(), config);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.config.TlsConfig;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
+import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -51,7 +51,7 @@ public class ChannelManager {
               .forAddress(k.getLeft(), k.getRight())
               .maxInboundMessageSize(
                   CommonConstants.MultiStageQueryRunner.DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES)
-              .sslContext(GrpcQueryClient.buildSslContext(_tlsConfig))
+              .sslContext(ServerGrpcQueryClient.buildSslContext(_tlsConfig))
               .build()
       );
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
-import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
+import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.query.routing.QueryServerInstance;
 
 
@@ -54,7 +54,7 @@ class DispatchClient {
     } else {
       _channel = NettyChannelBuilder
           .forAddress(host, port)
-          .sslContext(GrpcQueryClient.buildSslContext(tlsConfig))
+          .sslContext(ServerGrpcQueryClient.buildSslContext(tlsConfig))
           .build();
     }
     _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);


### PR DESCRIPTION
- Add broker grpc query endpoint and `BrokerRequest`/`BrokerResponse` proto
- Refactor existing `GrpcQueryClient` to `ServerGrpcQueryClient`
- Refactor `PinotStreamingQueryClient` to `PinotServerStreamingQueryClient`
