### PR TITLE
[kinesis] Disabled testGetStreamNamesWithPagination on CI due to cost

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandlerIntegrationTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandlerIntegrationTest.java
@@ -112,7 +112,7 @@ public class KinesisConnectionHandlerIntegrationTest {
         "Expected to find test stream " + _testStreamName + " in list of streams: " + streams);
   }
 
-  @Test(dependsOnMethods = "testGetStreamNames")
+  @Test(dependsOnMethods = "testGetStreamNames", enabled = false)
   public void testGetStreamNamesWithPagination() {
     // Create additional test streams to test pagination
     String[] additionalStreams = new String[3];


### PR DESCRIPTION
The createStream() call in this test is incurring recurring costs in CI. The test is retained for manual use.

Note that the test only runs when AWS secrets are loaded in the env.