### PR TITLE
Update FailureDetector recovery logic to not break if only one query engine is being used

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
@@ -166,22 +166,30 @@ public class GrpcBrokerRequestHandler extends BaseSingleStageBrokerRequestHandle
   /**
    * Check if a server that was previously detected as unhealthy is now healthy.
    */
-  private boolean retryUnhealthyServer(String instanceId) {
+  private FailureDetector.ServerState retryUnhealthyServer(String instanceId) {
     LOGGER.info("Checking gRPC connection to unhealthy server: {}", instanceId);
     ServerInstance serverInstance = _routingManager.getEnabledServerInstanceMap().get(instanceId);
     if (serverInstance == null) {
       LOGGER.info("Failed to find enabled server: {} in routing manager, skipping the retry", instanceId);
-      return false;
+      return FailureDetector.ServerState.UNHEALTHY;
     }
 
     String hostnamePort = _streamingQueryClient._instanceIdToHostnamePortMap.get(instanceId);
-    ServerGrpcQueryClient client = _streamingQueryClient._grpcQueryClientMap.get(hostnamePort);
-
-    if (client == null) {
-      LOGGER.warn("No GrpcQueryClient found for server with instanceId: {}", instanceId);
-      return false;
+    // Could occur if the cluster is only serving multi-stage queries
+    if (hostnamePort == null) {
+      LOGGER.debug("No GrpcQueryClient found for server with instanceId: {}", instanceId);
+      return FailureDetector.ServerState.UNKNOWN;
     }
 
-    return client.getChannel().getState(true) == ConnectivityState.READY;
+    ServerGrpcQueryClient client = _streamingQueryClient._grpcQueryClientMap.get(hostnamePort);
+
+    ConnectivityState connectivityState = client.getChannel().getState(true);
+    if (connectivityState == ConnectivityState.READY) {
+      LOGGER.info("Successfully connected to server: {}", instanceId);
+      return FailureDetector.ServerState.HEALTHY;
+    } else {
+      LOGGER.info("Still can't connect to server: {}, current state: {}", instanceId, connectivityState);
+      return FailureDetector.ServerState.UNHEALTHY;
+    }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -551,12 +551,12 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   /**
    * Check if a server that was previously detected as unhealthy is now healthy.
    */
-  public boolean retryUnhealthyServer(String instanceId) {
+  public FailureDetector.ServerState retryUnhealthyServer(String instanceId) {
     LOGGER.info("Checking gRPC connection to unhealthy server: {}", instanceId);
     ServerInstance serverInstance = _routingManager.getEnabledServerInstanceMap().get(instanceId);
     if (serverInstance == null) {
       LOGGER.info("Failed to find enabled server: {} in routing manager, skipping the retry", instanceId);
-      return false;
+      return FailureDetector.ServerState.UNHEALTHY;
     }
 
     return _queryDispatcher.checkConnectivityToInstance(instanceId);

--- a/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/FailureDetector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/FailureDetector.java
@@ -45,9 +45,11 @@ public interface FailureDetector {
 
   /**
    * Registers a function that will be periodically called to retry unhealthy servers. The function is called with the
-   * instanceId of the unhealthy server and should return true if the server is now healthy, false otherwise.
+   * instanceId of the unhealthy server and should return {@link ServerState#HEALTHY} if the server is now healthy,
+   * {@link ServerState#UNHEALTHY} if the server is still unhealthy, and {@link ServerState#UNKNOWN} if the retrier
+   * does not know about this server.
    */
-  void registerUnhealthyServerRetrier(Function<String, Boolean> unhealthyServerRetrier);
+  void registerUnhealthyServerRetrier(Function<String, ServerState> unhealthyServerRetrier);
 
   /**
    * Registers a consumer that will be called with the instanceId of a server that is detected as healthy.
@@ -83,4 +85,10 @@ public interface FailureDetector {
    * Stops the failure detector.
    */
   void stop();
+
+  enum ServerState {
+    HEALTHY,
+    UNHEALTHY,
+    UNKNOWN
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/NoOpFailureDetector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/failuredetector/NoOpFailureDetector.java
@@ -35,7 +35,7 @@ public class NoOpFailureDetector implements FailureDetector {
   }
 
   @Override
-  public void registerUnhealthyServerRetrier(Function<String, Boolean> unhealthyServerRetrier) {
+  public void registerUnhealthyServerRetrier(Function<String, ServerState> unhealthyServerRetrier) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -169,6 +169,14 @@ public class QueryRouter {
     asyncQueryResponse.markQueryFailed(serverRoutingInstance, e);
   }
 
+  public boolean hasChannel(ServerInstance serverInstance) {
+    if (_serverChannelsTls != null) {
+      return _serverChannelsTls.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
+    } else {
+      return _serverChannels.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+    }
+  }
+
   /**
    * Connects to the given server, returns {@code true} if the server is successfully connected.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -133,6 +133,10 @@ public class ServerChannels {
         .sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes, timeoutMs);
   }
 
+  public boolean hasChannel(ServerRoutingInstance serverRoutingInstance) {
+    return _serverToChannelMap.containsKey(serverRoutingInstance);
+  }
+
   public void connect(ServerRoutingInstance serverRoutingInstance)
       throws InterruptedException, TimeoutException {
     _serverToChannelMap.computeIfAbsent(serverRoutingInstance, ServerChannel::new).connect();


### PR DESCRIPTION
- After https://github.com/apache/pinot/pull/15005, the failure detector recovery mechanism relied on each handler reporting the server as healthy to be safe.
- However, in use cases where only one query engine is being used, the server channels for the other engine would never have been established. The v1 Netty handler created the channel in the retry process in case only v2 queries were being used whereas the v2 gRPC channel wasn't created if only v1 queries were being used and the server would never be marked as healthy again until the end of the retry period.
- Both of these behaviors are incorrect - we only want to retry the channels we've already established through queries. This patch fixes the retry mechanism by introducing a new `FailureDetector#ServerState` that can be healthy, unhealthy or unknown. The server will be marked as healthy again only if none of the retry handlers return unhealthy.