### PR TITLE
Fixing flaky integration test for pauseless failure scenario

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pinot.integration.tests;
 
+import java.util.List;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
 
 
@@ -52,6 +57,20 @@ public class PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
   @Test
   public void testSegmentAssignment()
       throws Exception {
+    // the setup() function only waits till all the documents have been loaded
+    // this has lead to race condition in the commit protocol and validation manager run leading to test failures
+    // checking the completion of the commit protocol i.e. segment marked COMMITTING before triggering
+    // validation manager in the tests prevents this.
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return segmentZKMetadataList.stream()
+          .filter(
+              segmentZKMetadata -> segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING)
+          .count() == NUM_REALTIME_SEGMENTS_ZK_METADATA_WITH_FAILURE;
+    }, 1000, 100000, "Some segments are still IN_PROGRESS");
+
     runValidationAndVerify();
   }
 }


### PR DESCRIPTION
Issue: https://github.com/apache/pinot/issues/15059

- The setup() function only waits till all the documents have been loaded for the pauseless table
- This has lead to race condition between the commit protocol and validation manager run leading to test failures
- Checking the completion of the commit protocol i.e. segment marked COMMITTING before triggering validation manager in the tests prevents this.

## Logs from failed tests

Commit start calls:

```
12:29:58.856 WARN [RealtimeSegmentDataManager_mytable__1__0__20250219T0659Z] [mytable__1__0__20250219T0659Z] CommitStart failed  with response {"streamPartitionMsgOffset":null,"buildTimeSec":-1,"isSplitCommitType":true,"status":"FAILED"}

12:29:59.954 WARN [RealtimeSegmentDataManager_mytable__0__0__20250219T0659Z] [mytable__0__0__20250219T0659Z] CommitStart failed  with response {"streamPartitionMsgOffset":null,"buildTimeSec":-1,"isSplitCommitType":true,"status":"FAILED"}
```

The cluster is marked ready to test even before this commit call. This commit call changes the segment ZK metadata and hence impacts the mTime for the ZK node.

mTime is used to verify whether a segment should be fixed by validation manager or not.

```
12:30:09.677 ERROR [FailureInjectingPinotLLCRealtimeSegmentManager] [main] Segment: mytable__0__0__20250219T0659Z does not exceed the max completion time: 10000ms, metadata update time: 1739948399951, current time: 1739948409676
12:30:09.677 ERROR [FailureInjectingPinotLLCRealtimeSegmentManager] [main] Segment: mytable__1__0__20250219T0659Z exceeds the max completion time: 10000ms, metadata update time: 1739948398851, current time: 1739948409676
```

`Thus mytable__1__0__20250219T0659Z` whose commit start call is first is fixed by the validation manager while `mytable__0__0__20250219T0659Z` is not. 


## Changes:
Ensure that the commit start completes before the test begins.

### Testing these changes
The test was failing in local before the changes were made. The test was run 10 times using the following command: 

`TEST_CMD='mvn test -pl pinot-integration-tests -Dtest=org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest'
`

and following is the output for the same. 


```
=====================================
Starting test run 1 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_1.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 71.93 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 1 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 2 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_2.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 77.05 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 2 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 3 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_3.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 71.38 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 3 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 4 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_4.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 73.41 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 4 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 5 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_5.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 73.47 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 5 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 6 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_6.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 70.41 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 6 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 7 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_7.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 73.63 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 7 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 8 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_8.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 86.22 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 8 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 9 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_9.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 88.46 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 9 completed successfully
=====================================
Waiting 10 seconds before next run...
=====================================
Starting test run 10 of 10
=====================================
Test output will be saved to: test_runs_20250219_141906/run_10.log
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 81.92 s -- in org.apache.pinot.integration.tests.PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
=====================================
Test run 10 completed successfully
=====================================
All test runs completed. Logs are saved in test_runs_20250219_141906/
```
