### PR TITLE
Make fields protected for DefaultRebalancePreChecker

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -43,8 +43,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   public static final String NEEDS_RELOAD_STATUS = "needsReloadStatus";
   public static final String IS_MINIMIZE_DATA_MOVEMENT = "isMinimizeDataMovement";
 
-  private PinotHelixResourceManager _pinotHelixResourceManager;
-  private ExecutorService _executorService;
+  protected PinotHelixResourceManager _pinotHelixResourceManager;
+  protectedgi ExecutorService _executorService;
 
   @Override
   public void init(PinotHelixResourceManager pinotHelixResourceManager, @Nullable ExecutorService executorService) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -44,7 +44,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   public static final String IS_MINIMIZE_DATA_MOVEMENT = "isMinimizeDataMovement";
 
   protected PinotHelixResourceManager _pinotHelixResourceManager;
-  protectedgi ExecutorService _executorService;
+  protected ExecutorService _executorService;
 
   @Override
   public void init(PinotHelixResourceManager pinotHelixResourceManager, @Nullable ExecutorService executorService) {


### PR DESCRIPTION
This PR makes the `executorService` and `pinotHelixResourceManager` fields of `DefaultRebalancePreChecker` class as protected