### PR TITLE
Make KafkaConsumerFactory compatible with multi-topics ingestion

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerFactory.java
@@ -48,6 +48,6 @@ public class KafkaConsumerFactory extends StreamConsumerFactory {
   public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
     return new KafkaPartitionLevelConsumer(clientId, _streamConfig,
-        partitionGroupConsumptionStatus.getPartitionGroupId());
+        partitionGroupConsumptionStatus.getStreamPartitionGroupId());
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaConsumerFactory.java
@@ -48,6 +48,6 @@ public class KafkaConsumerFactory extends StreamConsumerFactory {
   public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
     return new KafkaPartitionLevelConsumer(clientId, _streamConfig,
-        partitionGroupConsumptionStatus.getPartitionGroupId());
+        partitionGroupConsumptionStatus.getStreamPartitionGroupId());
   }
 }


### PR DESCRIPTION
`bugfix`

The previous change on https://github.com/apache/pinot/blob/6c80b932d993027620d69a979769e9fac8e913f9/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java#L62 would not take effect if the default `KafkaConsumerFactory` is being used. The function has been override in children classes. 


