### PR TITLE
Fixing ordering issue in subquery for time column in GAPFILL based queries

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -57,7 +57,7 @@ abstract class BaseGapfillProcessor {
   protected final Map<Key, Object[]> _previousByGroupKey;
   protected long _count = 0;
   protected final List<ExpressionContext> _timeSeries;
-  protected final int _timeBucketColumnIndex;
+  protected int _timeBucketColumnIndex;
   protected GapfillFilterHandler _postGapfillFilterHandler = null;
   protected GapfillFilterHandler _postAggregateHavingFilterHandler = null;
   protected final int _aggregationSize;
@@ -147,6 +147,8 @@ abstract class BaseGapfillProcessor {
   public void process(BrokerResponseNative brokerResponseNative) {
     DataSchema dataSchema = brokerResponseNative.getResultTable().getDataSchema();
     replaceColumnNameWithAlias(dataSchema);
+    _timeBucketColumnIndex = getTimeBucketColumnIndexFromBrokerResponse(dataSchema);
+
     DataSchema resultTableSchema = getResultTableDataSchema(dataSchema);
     if (brokerResponseNative.getResultTable().getRows().isEmpty()) {
       brokerResponseNative.setResultTable(new ResultTable(resultTableSchema, Collections.emptyList()));
@@ -207,6 +209,27 @@ abstract class BaseGapfillProcessor {
       }
     }
     return new DataSchema(columnNames, columnDataTypes);
+  }
+
+  /**
+   * This method returns the time bucket column for broker response since for cases where gapfill contains a subquery
+   * to be evaluated (AGGREGATE_GAP_FILL and AGGREGATE_GAP_FILL_AGGREGATE), the time column may or may not the first
+   * column in the result set, hence the index of the time column in the result set needs to be determined dynamically.
+   */
+  protected int getTimeBucketColumnIndexFromBrokerResponse(DataSchema dataSchema) {
+    if (_gapfillType != GapfillUtils.GapfillType.AGGREGATE_GAP_FILL
+        && _gapfillType != GapfillUtils.GapfillType.AGGREGATE_GAP_FILL_AGGREGATE) {
+      return _timeBucketColumnIndex;
+    }
+    String timeBucketColumnName = _gapFillSelection.getFunction().getArguments().get(0).getIdentifier();
+
+    for (int i = 0; i < dataSchema.getColumnNames().length; i++) {
+      if (dataSchema.getColumnName(i).equals(timeBucketColumnName)) {
+        return i;
+      }
+    }
+
+    throw new UnsupportedOperationException("Time column not found in the result set.");
   }
 
   protected Key constructGroupKeys(Object[] row) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
@@ -835,6 +835,161 @@ public class GapfillQueriesTest extends BaseQueriesTest {
   }
 
   @Test
+  public void datetimeconvertGapfillTestGapfillOrderInSubquery() {
+    String gapfillQuery1 = "SELECT "
+        + "time_col, alias_levelId, SUM(occupied) as occupied_slots_count, time_col "
+        + "FROM ("
+        + "  SELECT "
+        + "     occupied, "
+        + "     GapFill(time_col, "
+        + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+        + "    '2021-11-07 4:00:00.000',  '2021-11-07 12:00:00.000', '1:HOURS',"
+        + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(alias_levelId, alias_lotId)),"
+        + "     alias_lotId, alias_levelId"
+        + "  FROM ("
+        + "    SELECT "
+        + "       lastWithTime(isOccupied, eventTime, 'INT') as occupied, "
+        + "       cast(lotId as varchar) as alias_lotId, "
+        + "       cast(levelId as varchar) as alias_levelId, "
+        + "       DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+        + "         '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col"
+        + "    FROM parkingData "
+        + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+        + "    GROUP BY alias_levelId, time_col, alias_lotId "
+        + "    LIMIT 200 "
+        + "  ) "
+        + "  LIMIT 200 "
+        + ") "
+        + " GROUP BY time_col, alias_levelId "
+        + " HAVING occupied_slots_count > 0"
+        + " LIMIT 200 ";
+
+    BrokerResponseNative gapfillBrokerResponse1 = getBrokerResponse(gapfillQuery1);
+
+    double[] expectedOccupiedSlotsCounts1 = new double[]{1, 2, 3, 4, 3, 2, 1};
+    ResultTable gapFillResultTable1 = gapfillBrokerResponse1.getResultTable();
+    List<Object[]> gapFillRows1 = gapFillResultTable1.getRows();
+    Assert.assertEquals(gapFillRows1.size(), expectedOccupiedSlotsCounts1.length * 2);
+    DateTimeFormatSpec dateTimeFormatter =
+        new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+    DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");
+
+    long start = dateTimeFormatter.fromFormatToMillis("2021-11-07 04:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts1.length; i += 2) {
+      String firstTimeCol = (String) gapFillRows1.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i / 2], gapFillRows1.get(i)[2]);
+      firstTimeCol = (String) gapFillRows1.get(i + 1)[0];
+      timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i / 2], gapFillRows1.get(i)[2]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+  }
+
+  @Test
+  public void datetimeconvertGapfillTestSumGapfill() {
+    String gapfillQuery1 = "SELECT "
+        + "time_col, SUM(occupied) as cnt "
+        + "FROM ("
+        + "  SELECT "
+        + "     occupied, "
+        + "     GapFill(time_col, "
+        + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+        + "    '2021-11-07 4:00:00.000',  '2021-11-07 12:00:00.000', '1:HOURS',"
+        + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(alias_levelId, alias_lotId)),"
+        + "     alias_lotId, alias_levelId"
+        + "  FROM ("
+        + "    SELECT "
+        + "       lastWithTime(isOccupied, eventTime, 'INT') as occupied, "
+        + "       cast(lotId as varchar) as alias_lotId, "
+        + "       cast(levelId as varchar) as alias_levelId, "
+        + "       DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+        + "         '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col"
+        + "    FROM parkingData "
+        + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+        + "    GROUP BY time_col, alias_levelId, alias_lotId "
+        + "    LIMIT 200 "
+        + "  ) "
+        + "  LIMIT 200 "
+        + ") "
+        + " GROUP BY time_col"
+        + " HAVING cnt > 0"
+        + " LIMIT 200";
+
+    BrokerResponseNative gapfillBrokerResponse1 = getBrokerResponse(gapfillQuery1);
+
+    double[] expectedOccupiedSlotsCounts1 = new double[]{1, 2, 2, 2, 2, 3, 3, 5};
+    ResultTable gapFillResultTable1 = gapfillBrokerResponse1.getResultTable();
+    List<Object[]> gapFillRows1 = gapFillResultTable1.getRows();
+    Assert.assertEquals(gapFillRows1.size(), expectedOccupiedSlotsCounts1.length);
+    DateTimeFormatSpec dateTimeFormatter =
+        new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+    DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");
+
+    long start = dateTimeFormatter.fromFormatToMillis("2021-11-07 04:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts1.length; i++) {
+      String firstTimeCol = (String) gapFillRows1.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i], gapFillRows1.get(i)[1]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+  }
+
+  @Test
+  public void datetimeconvertGapfillTestCountGapfill() {
+    String gapfillQuery1 = ""
+        + "SELECT "
+        + "time_col, COUNT(occupied) as cnt "
+        + "FROM ("
+        + "  SELECT "
+        + "     occupied, "
+        + "     GapFill(time_col, "
+        + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+        + "    '2021-11-07 4:00:00.000',  '2021-11-07 12:00:00.000', '1:HOURS',"
+        + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(alias_levelId, alias_lotId)),"
+        + "     alias_lotId, alias_levelId"
+        + "  FROM ("
+        + "    SELECT "
+        + "       lastWithTime(isOccupied, eventTime, 'INT') as occupied, "
+        + "       cast(lotId as varchar) as alias_lotId, "
+        + "       cast(levelId as varchar) as alias_levelId, "
+        + "       DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+        + "         '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col"
+        + "    FROM parkingData "
+        + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+        + "    GROUP BY time_col, alias_levelId, alias_lotId "
+        + "    LIMIT 200 "
+        + "  ) "
+        + "  LIMIT 200 "
+        + ") "
+        + " GROUP BY time_col"
+        + " HAVING cnt > 0"
+        + " LIMIT 200";
+
+    BrokerResponseNative gapfillBrokerResponse1 = getBrokerResponse(gapfillQuery1);
+
+    long[] expectedOccupiedSlotsCounts1 = new long[]{1, 2, 2, 2, 2, 3, 3, 3};
+    ResultTable gapFillResultTable1 = gapfillBrokerResponse1.getResultTable();
+    List<Object[]> gapFillRows1 = gapFillResultTable1.getRows();
+    Assert.assertEquals(gapFillRows1.size(), expectedOccupiedSlotsCounts1.length);
+    DateTimeFormatSpec dateTimeFormatter =
+        new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+    DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");
+
+    long start = dateTimeFormatter.fromFormatToMillis("2021-11-07 04:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts1.length; i++) {
+      String firstTimeCol = (String) gapFillRows1.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i], gapFillRows1.get(i)[1]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+  }
+
+  @Test
   public void toEpochHoursGapfillTestSelectSelect() {
     DateTimeFormatSpec dateTimeFormatter = new DateTimeFormatSpec("1:HOURS:EPOCH");
     DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");


### PR DESCRIPTION
The current GAPFILL implementation expects the time column series to always be the first column in any subquery executed before the GAPFILL operation, which is not an ideal behaviour since it breaks perfectly valid SQLs like:

```
SELECT
  occupied,
  GapFill(time_col, '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS',
    '2021-11-07 4:00:00.000',
    '2021-11-07 12:00:00.000', '1:HOURS',
    FILL(occupied, 'FILL_PREVIOUS_VALUE'),
    TIMESERIESON(alias_levelId, alias_lotId)),
  alias_lotId,
  alias_levelId
FROM
  (
    SELECT
      lastWithTime(isOccupied, eventTime, 'INT') as occupied,
      cast(lotId as varchar) as alias_lotId,
      cast(levelId as varchar) as alias_levelId,
      DATETIMECONVERT(eventTime,'1:MILLISECONDS:EPOCH',
        '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS',
        '1:HOURS') AS time_col
    FROM
      parkingData
    WHERE
      eventTime >= 1636257600000 AND eventTime <= 1636286400000
    GROUP BY
      alias_levelId, time_col,alias_lotId
    LIMIT 200
  )
LIMIT 200
```

The current implementation of `findTimeBucketColumnIndex` simply looks for the GAPFILL expression in the relevant subquery and operates on the assumption that the time bucket column is positioned in the same index as GAPFILL when GAPFILL is stripped while execution. This assumption only works for queries where GAPFILL is present in the lowest subquery and is the first to be executed. It fails for queries where a subquery is executed before GAPFILL (AGGREGATE_GAPFILL and AGGREGATE_GAPFILL_AGGREGATE).

This PR fixes this by recomputing the `timeBucketColumnIndex` for the aforementioned GAPFILL types using the broker response to identify the index of the time bucket column. It also patches the rest of the GAPFILL computation logic to remove the assumption that GAPFILL is the first column in the subquery.

### Testing

Successfully tested that the fix works in TIMESTAMP quickstart. Also added multiple unit tests to make sure each possible flow is working correctly with the fix. 
(Note: current unit tests did not have queries that trigger CountGapfillProcessor and SumAvgGapfillProcessor and this PR adds tests for those query shapes as well).
