### PR TITLE
Fix build sempahore deadlock

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -70,7 +70,7 @@ public class RealtimeSegmentConverter {
     }
   }
 
-  public void build(@Nullable SegmentVersion segmentVersion,@Nullable ServerMetrics serverMetrics)
+  public void build(@Nullable SegmentVersion segmentVersion, @Nullable ServerMetrics serverMetrics)
       throws Exception {
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(_tableConfig, _dataSchema, true);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -70,7 +70,7 @@ public class RealtimeSegmentConverter {
     }
   }
 
-  public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics)
+  public void build(@Nullable SegmentVersion segmentVersion,@Nullable ServerMetrics serverMetrics)
       throws Exception {
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(_tableConfig, _dataSchema, true);
 
@@ -116,7 +116,7 @@ public class RealtimeSegmentConverter {
       }
     }
 
-    if (segmentPartitionConfig != null) {
+    if (segmentPartitionConfig != null && serverMetrics != null) {
       Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
       for (String columnName : columnPartitionMap.keySet()) {
         int numPartitions = driver.getSegmentStats().getColumnProfileFor(columnName).getPartitions().size();


### PR DESCRIPTION
# Issue
Deadlock while performing reingestion in the DR for pauseless.

## Details
- Reingestion of `ERROR` segments while fixing pauseless tables acquires segBuildSemaphore
- The segBuildSemaphore was not released
- This was causing threads to indefinitely wait to build segments. 
- Helix state transitions rely on segment lock. 
    - Segment lock is also attained in `RealtimeSegmentDataManager` before building the segment.
    - Thus, the state transitions also got blocked hogging all the helix state transition threads.
- This paused ingestion for normal tables as well. 

### Thread dump


The consuming thread has held the lock for the segment (`0x00000005a17a31f8`) and is waiting for the segment build semaphore
```
"upsertMeetupRsvp_pauseless_oss_2__0__55__20250219T1525Z" #17211 [1385] daemon prio=5 os_prio=0 cpu=18301.93ms elapsed=54546.51s tid=0x00007fc52bc7d810 nid=1385 waiting on condition  [0x00007fc4590fc000]  java.lang.Thread.State: TIMED_WAITING (parking) at jdk.internal.misc.Unsafe.park(java.base@21.0.6/Native Method) - parking to wait for  <0x0000000578b63e08> (a java.util.concurrent.Semaphore$FairSync) at java.util.concurrent.locks.LockSupport.parkNanos(java.base@21.0.6/LockSupport.java:269) at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.6/AbstractQueuedSynchronizer.java:756) at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(java.base@21.0.6/AbstractQueuedSynchronizer.java:1126) at java.util.concurrent.Semaphore.tryAcquire(java.base@21.0.6/Semaphore.java:415) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.buildSegmentInternal(RealtimeSegmentDataManager.java:1120) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.buildSegmentForCommit(RealtimeSegmentDataManager.java:976) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager$PartitionConsumer.run(RealtimeSegmentDataManager.java:870) at java.lang.Thread.runWith(java.base@21.0.6/Thread.java:1596) at java.lang.Thread.run(java.base@21.0.6/Thread.java:1583)  Locked ownable synchronizers: - <0x00000005a17a31f8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
```

The helix state transition thread is waiting on the segment lock (`0x00000005a17a31f8`):

```
"HelixTaskExecutor-message_handle_thread_0" #149 [157] daemon prio=5 os_prio=0 cpu=290275.55ms elapsed=64755.50s tid=0x00007fc507d5b810 nid=157 waiting on condition  [0x00007fc506c7c000]  java.lang.Thread.State: WAITING (parking) at jdk.internal.misc.Unsafe.park(java.base@21.0.6/Native Method) - parking to wait for  <0x00000005a17a31f8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync) at java.util.concurrent.locks.LockSupport.park(java.base@21.0.6/LockSupport.java:221) at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.6/AbstractQueuedSynchronizer.java:754) at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.6/AbstractQueuedSynchronizer.java:990) at java.util.concurrent.locks.ReentrantLock$Sync.lock(java.base@21.0.6/ReentrantLock.java:153) at java.util.concurrent.locks.ReentrantLock.lock(java.base@21.0.6/ReentrantLock.java:322) at org.apache.pinot.core.data.manager.BaseTableDataManager.addOnlineSegment(BaseTableDataManager.java:333)  Locked ownable synchronizers: - <0x0000000582d475d8> (a java.util.concurrent.ThreadPoolExecutor$Worker)
```

## Fix
- Release the semaphore in the finally block

## Testing the changes

Improved the changes by getting `10 segments` to be in error state instead of `1`. The number of parallel builds allowed are `4`. The test fails with the previous code while runs successfully with the updated changes.
```
java.lang.AssertionError: Failed to meet condition in 100000ms, error message: Some segments are still in ERROR state after resetSegments()

	at org.testng.Assert.fail(Assert.java:111)
	at org.apache.pinot.util.TestUtils.waitForCondition(TestUtils.java:113)
	at org.apache.pinot.util.TestUtils.waitForCondition(TestUtils.java:90)
	at org.apache.pinot.integration.tests.PauselessRealtimeIngestionSegmentCommitFailureTest.testSegmentAssignment(PauselessRealtimeIngestionSegmentCommitFailureTest.java:185)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:687)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:230)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:63)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:995)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:203)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:154)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:134)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at org.testng.TestRunner.privateRun(TestRunner.java:741)
	at org.testng.TestRunner.run(TestRunner.java:616)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:421)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:413)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:373)
	at org.testng.SuiteRunner.run(SuiteRunner.java:312)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1274)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1208)
	at org.testng.TestNG.runSuites(TestNG.java:1112)
	at org.testng.TestNG.run(TestNG.java:1079)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:65)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
```

The test passes after the changes. 



# Additional Changes
- Allow passing null as server metrics while building the segment. 
- This is useful for re-ingesting segments where we don't want to pollute the existing server metrics that are used for grafana dashboards


