### PR TITLE
Emits lag metric when caught up

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -287,10 +287,8 @@ public class IngestionDelayTracker {
               ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS,
               () -> getPartitionEndToEndIngestionDelayMs(partitionId));
         }
-        if (currentOffset != null && latestOffset != null) {
-          _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
-              () -> getPartitionIngestionOffsetLag(partitionId));
-        }
+        _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
+            () -> getPartitionIngestionOffsetLag(partitionId));
 
         if (currentOffset != null) {
           _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -287,6 +287,7 @@ public class IngestionDelayTracker {
               ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS,
               () -> getPartitionEndToEndIngestionDelayMs(partitionId));
         }
+
         _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
             () -> getPartitionIngestionOffsetLag(partitionId));
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -143,6 +143,10 @@ public class IngestionDelayTrackerTest {
       Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partition1), ingestionTimeMs);
     }
 
+    ingestionDelayTracker = createTracker();
+    ingestionDelayTracker.updateIngestionMetrics(segment0, partition0, 1, 1, null, null);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionOffsetLag(partition0), 0);
+
     ingestionDelayTracker.shutdown();
     Assert.assertTrue(true);
   }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Emits zero lag metric when offsets are null, ensuring gauge always updated\.

```mermaid
flowchart TD
  N0["updateIngestionMetrics called #40;F1#41;"]:::stModified
  N1["Always update offset lag gauge #40;F1#41;"]:::stModified
  N2["Gauge lambda calls getPartitionIngestionOffsetLag #40;F1#41;"]:::stModified
  N3["getPartitionIngestionOffsetLag returns 0 for null offsets #40;F2#41;"]:::stAdded
  N4["Test asserts lag #61;#61; 0 after update with null offsets #40;F2#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"invokes"| N2
  N2 -->|"returns"| N3
  N4 -->|"calls"| N0
  N4 -->|"asserts"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker\.java — [before](https://github.com/apache/pinot/blob/98dd54d52a99144d404f035f6ea77317162999ab/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java) · [after](https://github.com/apache/pinot/blob/d95774311a61599c23f5dda5e29ef92b57815b83/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java)
- F2: pinot\-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest\.java — [before](https://github.com/apache/pinot/blob/98dd54d52a99144d404f035f6ea77317162999ab/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java) · [after](https://github.com/apache/pinot/blob/d95774311a61599c23f5dda5e29ef92b57815b83/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijk4ZGQ1NGQ1MmE5OTE0NGQ0MDRmMDM1ZjZlYTc3MzE3MTYyOTk5YWIiLCJjb250ZXh0X2hhc2giOiI4YjFkYzY0ZDFlYjU4YjNkMzMwOTI5OTQxYWU5NjBhMzE4MTFmOGQ5ZjBiODEzMjgwOTU2OGU2MWEzYWUyYzUxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjg0NTM3LCJoZWFkX3NoYSI6ImQ5NTc3NDMxMWE2MTU5OWMyM2Y1ZGRhNWUyOWVmOTJiNTc4MTViODMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5OGRkNTRkNTJhOTkxNDRkNDA0ZjAzNWY2ZWE3NzMxNzE2Mjk5OWFiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature d4fcb0d10a7e8adb77f252d3796687a3ab0b2d7c72d602f197a8c2e2a3ef4392 -->
<!-- pinot-pr-flow:end -->

When Partition Consumer is caught up, Server does not emit any lag metric.
This fails some alert promQL expressions. The metric must be zero for such cases.