### PR TITLE
Use multiple threads to merge distinct_count result on server

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -54,7 +54,6 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -247,9 +246,9 @@ public class ObjectSerDeUtils {
         }
         throw new IllegalArgumentException(
             "Unsupported type of value: " + objectSet.first().getClass().getSimpleName());
-      } else if (value instanceof ObjectSet) {
-        ObjectSet objectSet = (ObjectSet) value;
-        if (objectSet.isEmpty() || objectSet.iterator().next() instanceof String) {
+      } else if (value instanceof Set) {
+        Set set = (Set) value;
+        if (set.isEmpty() || set.iterator().next() instanceof String) {
           return ObjectType.StringSet;
         } else {
           return ObjectType.BytesSet;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCountCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCountCombineOperator.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.combine;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Combine operator for aggregation queries.
+ */
+@SuppressWarnings({"rawtypes"})
+public class DistinctCountCombineOperator extends BaseSingleBlockCombineOperator<AggregationResultsBlock> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DistinctCountCombineOperator.class);
+  private static final String EXPLAIN_NAME = "COMBINE_DISTINCT_COUNT";
+
+  private final CountDownLatch _operatorLatch;
+  private ConcurrentHashMap.KeySetView _distinctSet;
+  private DataType _dataType;
+
+  public DistinctCountCombineOperator(List<Operator> operators, QueryContext queryContext,
+      ExecutorService executorService) {
+    super(null, operators, queryContext, executorService);
+    _operatorLatch = new CountDownLatch(_numTasks);
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected void processSegments() {
+    int operatorId;
+    while (_processingException.get() == null && (operatorId = _nextOperatorId.getAndIncrement()) < _numOperators) {
+      Operator operator = _operators.get(operatorId);
+      AggregationResultsBlock resultsBlock;
+      try {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
+        }
+        resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
+      } finally {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).release();
+        }
+      }
+      // TODO: Do not construct Set for segment result, directly add values to the concurrent set.
+      Set set = (Set) resultsBlock.getResults().get(0);
+      synchronized (this) {
+        if (_distinctSet == null) {
+          _distinctSet = ConcurrentHashMap.newKeySet(HashUtil.getHashMapCapacity(set.size()));
+          if (set instanceof IntSet) {
+            _dataType = DataType.INT;
+          } else if (set instanceof LongSet) {
+            _dataType = DataType.LONG;
+          } else if (set instanceof FloatSet) {
+            _dataType = DataType.FLOAT;
+          } else if (set instanceof DoubleSet) {
+            _dataType = DataType.DOUBLE;
+          } else {
+            Preconditions.checkState(set instanceof ObjectSet, "Unsupported set type: %s", set.getClass());
+          }
+        }
+      }
+      _distinctSet.addAll(set);
+    }
+  }
+
+  @Override
+  public void onProcessSegmentsException(Throwable t) {
+    _processingException.compareAndSet(null, t);
+  }
+
+  @Override
+  protected void onProcessSegmentsFinish() {
+    _operatorLatch.countDown();
+  }
+
+  @Override
+  public BaseResultsBlock mergeResults()
+      throws Exception {
+    long timeoutMs = _queryContext.getEndTimeMs() - System.currentTimeMillis();
+    boolean opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+    if (!opCompleted) {
+      // If this happens, the broker side should already timed out, just log the error and return
+      String errorMessage =
+          String.format("Timed out while combining distinct count results after %dms, queryContext = %s", timeoutMs,
+              _queryContext);
+      LOGGER.error(errorMessage);
+      return new ExceptionResultsBlock(new TimeoutException(errorMessage));
+    }
+
+    Throwable processingException = _processingException.get();
+    if (processingException != null) {
+      if (processingException instanceof BadQueryRequestException) {
+        return new ExceptionResultsBlock(QueryException.QUERY_VALIDATION_ERROR, processingException);
+      }
+      return new ExceptionResultsBlock(processingException);
+    }
+
+    Object result;
+    if (_queryContext.isServerReturnFinalResult() || _dataType == null) {
+      result = _distinctSet;
+    } else {
+      switch (_dataType) {
+        case INT:
+          result = new IntOpenHashSet(_distinctSet);
+          break;
+        case LONG:
+          result = new LongOpenHashSet(_distinctSet);
+          break;
+        case FLOAT:
+          result = new FloatOpenHashSet(_distinctSet);
+          break;
+        case DOUBLE:
+          result = new DoubleOpenHashSet(_distinctSet);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+    return new AggregationResultsBlock(_queryContext.getAggregationFunctions(), List.of(result), _queryContext);
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Concurrent distinct set is updated by segment results and then read to form the final distinct count result

```mermaid
flowchart TD
  N0["DistinctCountCombineOperator#46;processSegments#40;#41; updates concurrent distinct set #40;F2#41;"]:::stModified
  N1["DistinctCountCombineOperator#46;mergeResults#40;#41; reads concurrent distinct set #40;F2#41;"]:::stModified
  N0 -->|"data flow"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCountCombineOperator\.java — [after](https://github.com/apache/pinot/blob/686ae416eb9b54b8f9318a4d3aa5fdac540e6df5/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCountCombineOperator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQxOTVlZGY0MTQxNTNiMTBlNjQyMTQwZWVhZDAxNmVkZDNmZDk3NGQiLCJjb250ZXh0X2hhc2giOiI3OWU1N2I2OWEzNzM3OThkNDBkNWE4NjQxZTkxZmNlOTY4OTcxNzk2OGJjMzNmNzFlMTNmZWUzYzA0NjY2OWZiIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTU4NzIzLCJoZWFkX3NoYSI6IjY4NmFlNDE2ZWI5YjU0YjhmOTMxOGE0ZDNhYTVmZGFjNTQwZTZkZjUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkMTk1ZWRmNDE0MTUzYjEwZTY0MjE0MGVlYWQwMTZlZGQzZmQ5NzRkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c585d9698920fd1e7c17eb37b269af3c7eabddf886c2a0d82ee6bcca23fcf97e -->
<!-- pinot-pr-flow:end -->

