### PR TITLE
Fix stale host / port bug for failure detector

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -559,6 +559,6 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       return FailureDetector.ServerState.UNHEALTHY;
     }
 
-    return _queryDispatcher.checkConnectivityToInstance(instanceId);
+    return _queryDispatcher.checkConnectivityToInstance(serverInstance);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -55,6 +55,7 @@ import org.apache.pinot.common.response.PinotBrokerTimeSeriesResponse;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
 import org.apache.pinot.core.util.trace.TracedThreadFactory;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -104,7 +105,6 @@ public class QueryDispatcher {
   private final MailboxService _mailboxService;
   private final ExecutorService _executorService;
   private final Map<String, DispatchClient> _dispatchClientMap = new ConcurrentHashMap<>();
-  private final Map<String, String> _instanceIdToHostnamePortMap = new ConcurrentHashMap<>();
   private final Map<String, TimeSeriesDispatchClient> _timeSeriesDispatchClientMap = new ConcurrentHashMap<>();
   @Nullable
   private final TlsConfig _tlsConfig;
@@ -217,22 +217,25 @@ public class QueryDispatcher {
     }
   }
 
-  public FailureDetector.ServerState checkConnectivityToInstance(String instanceId) {
-    String hostnamePort = _instanceIdToHostnamePortMap.get(instanceId);
+  public FailureDetector.ServerState checkConnectivityToInstance(ServerInstance serverInstance) {
+    String hostname = serverInstance.getHostname();
+    int port = serverInstance.getQueryServicePort();
+    String hostnamePort = String.format("%s_%d", hostname, port);
 
+    DispatchClient client = _dispatchClientMap.get(hostnamePort);
     // Could occur if the cluster is only serving single-stage queries
-    if (hostnamePort == null) {
-      LOGGER.debug("No DispatchClient found for server with instanceId: {}", instanceId);
+    if (client == null) {
+      LOGGER.debug("No DispatchClient found for server with instanceId: {}", serverInstance.getInstanceId());
       return FailureDetector.ServerState.UNKNOWN;
     }
 
-    DispatchClient client = _dispatchClientMap.get(hostnamePort);
     ConnectivityState connectivityState = client.getChannel().getState(true);
     if (connectivityState == ConnectivityState.READY) {
-      LOGGER.info("Successfully connected to server: {}", instanceId);
+      LOGGER.info("Successfully connected to server: {}", serverInstance.getInstanceId());
       return FailureDetector.ServerState.HEALTHY;
     } else {
-      LOGGER.info("Still can't connect to server: {}, current state: {}", instanceId, connectivityState);
+      LOGGER.info("Still can't connect to server: {}, current state: {}", serverInstance.getInstanceId(),
+          connectivityState);
       return FailureDetector.ServerState.UNHEALTHY;
     }
   }
@@ -444,7 +447,6 @@ public class QueryDispatcher {
     String hostname = queryServerInstance.getHostname();
     int port = queryServerInstance.getQueryServicePort();
     String hostnamePort = String.format("%s_%d", hostname, port);
-    _instanceIdToHostnamePortMap.put(queryServerInstance.getInstanceId(), hostnamePort);
     return _dispatchClientMap.computeIfAbsent(hostnamePort, k -> new DispatchClient(hostname, port, _tlsConfig));
   }
 
@@ -547,7 +549,6 @@ public class QueryDispatcher {
       dispatchClient.getChannel().shutdown();
     }
     _dispatchClientMap.clear();
-    _instanceIdToHostnamePortMap.clear();
     _mailboxService.shutdown();
     _executorService.shutdown();
   }


### PR DESCRIPTION
- The query service port for a server (used for MSE queries) can change across server restarts.
- There is currently an edge case scenario with the failure detector mechanism (See https://github.com/apache/pinot/pull/15005, https://github.com/apache/pinot/pull/8491 for background) in a scenario where there are MSE queries pre server restart that have established gRPC channels to the server host / port, and there aren't any MSE queries post server restart. Here, if an SSE query failure triggers the failure detector mechanism to mark the server as unhealthy, the server won't be marked as healthy until the retry period ends or if an MSE query is sent and a new gRPC channel is established to the server's new query service port.
- This patch fixes the issue to not use stale host / port information for the failure detector's retry mechanism.