### PR TITLE
[draft]Add a new distinctCountGlobal function

### DIFF
--- a/.mvn/.develocity/develocity-workspace-id
+++ b/.mvn/.develocity/develocity-workspace-id
@@ -1,0 +1,1 @@
+n7dqp2lp3fggxbj6jttromgy6m

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -54,7 +54,6 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -124,7 +123,7 @@ public class ObjectSerDeUtils {
     Map(8),
     IntSet(9),
     TDigest(10),
-//    DistinctTable(11),
+    //    DistinctTable(11),
     DataSketch(12),
     Geometry(13),
     RoaringBitmap(14),
@@ -247,9 +246,9 @@ public class ObjectSerDeUtils {
         }
         throw new IllegalArgumentException(
             "Unsupported type of value: " + objectSet.first().getClass().getSimpleName());
-      } else if (value instanceof ObjectSet) {
-        ObjectSet objectSet = (ObjectSet) value;
-        if (objectSet.isEmpty() || objectSet.iterator().next() instanceof String) {
+      } else if (value instanceof Set) {
+        Set set = (Set) value;
+        if (set.isEmpty() || set.iterator().next() instanceof String) {
           return ObjectType.StringSet;
         } else {
           return ObjectType.BytesSet;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationCombineOperator.java
@@ -18,12 +18,38 @@
  */
 package org.apache.pinot.core.operator.combine;
 
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.combine.merger.AggregationResultsBlockMerger;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -31,15 +57,144 @@ import org.apache.pinot.core.query.request.context.QueryContext;
  */
 @SuppressWarnings({"rawtypes"})
 public class AggregationCombineOperator extends BaseSingleBlockCombineOperator<AggregationResultsBlock> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregationCombineOperator.class);
   private static final String EXPLAIN_NAME = "COMBINE_AGGREGATE";
+
+  private final CountDownLatch _operatorLatch;
+  private ConcurrentHashMap.KeySetView _distinctSet;
+  private AggregationFunction[] _functions;
+  private DataType _dataType;
 
   public AggregationCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
     super(new AggregationResultsBlockMerger(queryContext), operators, queryContext, executorService);
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    if (aggregationFunctions != null && aggregationFunctions.length == 1
+        && aggregationFunctions[0].getType() == AggregationFunctionType.DISTINCTCOUNT) {
+      _operatorLatch = new CountDownLatch(_numTasks);
+    } else {
+      _operatorLatch = null;
+    }
   }
 
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected void processSegments() {
+    if (_operatorLatch == null) {
+      super.processSegments();
+      return;
+    }
+
+    int operatorId;
+    while (_processingException.get() == null && (operatorId = _nextOperatorId.getAndIncrement()) < _numOperators) {
+      Operator operator = _operators.get(operatorId);
+      AggregationResultsBlock resultsBlock;
+      try {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
+        }
+        resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+      } catch (RuntimeException e) {
+        throw wrapOperatorException(operator, e);
+      } finally {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).release();
+        }
+      }
+      if (resultsBlock instanceof AggregationResultsBlock) {
+        // TODO: Do not construct Set for segment result, directly add values to the concurrent set.
+        Set set = (Set) resultsBlock.getResults().get(0);
+        synchronized (this) {
+          if (_distinctSet == null) {
+            _distinctSet = ConcurrentHashMap.newKeySet(HashUtil.getHashMapCapacity(set.size()));
+            _functions = resultsBlock.getAggregationFunctions();
+            if (set instanceof IntSet) {
+              _dataType = DataType.INT;
+            } else if (set instanceof LongSet) {
+              _dataType = DataType.LONG;
+            } else if (set instanceof FloatSet) {
+              _dataType = DataType.FLOAT;
+            } else if (set instanceof DoubleSet) {
+              _dataType = DataType.DOUBLE;
+            } else {
+              Preconditions.checkState(set instanceof ObjectSet, "Unsupported set type: %s", set.getClass());
+            }
+          }
+        }
+        _distinctSet.addAll(set);
+      } else {
+        _blockingQueue.offer(resultsBlock);
+      }
+    }
+  }
+
+  @Override
+  public void onProcessSegmentsException(Throwable t) {
+    if (_operatorLatch != null) {
+      _processingException.compareAndSet(null, t);
+    } else {
+      super.onProcessSegmentsException(t);
+    }
+  }
+
+  @Override
+  protected void onProcessSegmentsFinish() {
+    if (_operatorLatch != null) {
+      _operatorLatch.countDown();
+    }
+  }
+
+  @Override
+  public BaseResultsBlock mergeResults()
+      throws Exception {
+    if (_operatorLatch == null) {
+      return super.mergeResults();
+    }
+
+    long timeoutMs = _queryContext.getEndTimeMs() - System.currentTimeMillis();
+    boolean opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+    if (!opCompleted) {
+      // If this happens, the broker side should already timed out, just log the error and return
+      String errorMessage =
+          String.format("Timed out while combining group-by order-by results after %dms, queryContext = %s", timeoutMs,
+              _queryContext);
+      LOGGER.error(errorMessage);
+      return new ExceptionResultsBlock(new TimeoutException(errorMessage));
+    }
+
+    Throwable processingException = _processingException.get();
+    if (processingException != null) {
+      if (processingException instanceof BadQueryRequestException) {
+        return new ExceptionResultsBlock(QueryException.QUERY_VALIDATION_ERROR, processingException);
+      }
+      return new ExceptionResultsBlock(processingException);
+    }
+
+    Object result;
+    if (_queryContext.isServerReturnFinalResult() || _dataType == null) {
+      result = _distinctSet;
+    } else {
+      switch (_dataType) {
+        case INT:
+          result = new IntOpenHashSet(_distinctSet);
+          break;
+        case LONG:
+          result = new LongOpenHashSet(_distinctSet);
+          break;
+        case FLOAT:
+          result = new FloatOpenHashSet(_distinctSet);
+          break;
+        case DOUBLE:
+          result = new DoubleOpenHashSet(_distinctSet);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+    return new AggregationResultsBlock(_functions, List.of(result), _queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -358,6 +358,8 @@ public class AggregationFunctionFactory {
             return new MinMaxRangeAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNT:
             return new DistinctCountAggregationFunction(arguments, nullHandlingEnabled);
+          case DISTINCTCOUNTGLOBAL:
+            return new DistinctCountGlobalAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTBITMAP:
             return new DistinctCountBitmapAggregationFunction(arguments);
           case SEGMENTPARTITIONEDDISTINCTCOUNT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
+
 /**
  * Base class for Distinct Aggregate functions that require collecting all distinct elements in a set before
  * performing the aggregate computation. This is used by DistinctSum, DistinctAvg and DistinctCount aggregation
@@ -48,7 +49,7 @@ import org.roaringbitmap.RoaringBitmap;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class BaseDistinctAggregateAggregationFunction<T extends Comparable>
     extends NullableSingleInputAggregationFunction<Set, T> {
-  private final AggregationFunctionType _functionType;
+  protected final AggregationFunctionType _functionType;
 
   protected BaseDistinctAggregateAggregationFunction(ExpressionContext expression,
       AggregationFunctionType aggregationFunctionType, boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountGlobalAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountGlobalAggregationFunction.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
+
+
+/**
+ * Aggregation function to compute the average of distinct values for an SV column
+ */
+public class DistinctCountGlobalAggregationFunction extends BaseDistinctAggregateAggregationFunction<Integer> {
+
+  private volatile Set _distinctValues;
+  private final int _initialSize;
+
+  public DistinctCountGlobalAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), AggregationFunctionType.DISTINCTCOUNTGLOBAL, nullHandlingEnabled);
+    if (arguments.size() > 1) {
+      _initialSize = arguments.get(1).getLiteral().getIntValue();
+    } else {
+      _initialSize = 1000;
+    }
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
+    initValueSetIfNeeded(aggregationResultHolder, storedType);
+    // For dictionary-encoded expression, store dictionary ids into the bitmap
+    Dictionary dictionary = blockValSet.getDictionary();
+    if (dictionary != null) {
+      int[] dictIds = blockValSet.getDictionaryIdsSV();
+      switch (storedType) {
+        case INT:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              _distinctValues.add(dictionary.getIntValue(dictIds[i]));
+            }
+          });
+          break;
+        case LONG:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              _distinctValues.add(dictionary.getLongValue(dictIds[i]));
+            }
+          });
+          break;
+        case FLOAT:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              _distinctValues.add(dictionary.getFloatValue(dictIds[i]));
+            }
+          });
+          break;
+        case DOUBLE:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              _distinctValues.add(dictionary.getDoubleValue(dictIds[i]));
+            }
+          });
+          break;
+        case STRING:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              int dictId = dictIds[i];
+              String stringValue = dictionary.getStringValue(dictId);
+              _distinctValues.add(stringValue);
+            }
+          });
+          break;
+        case BYTES:
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              _distinctValues.add(new ByteArray(dictionary.getBytesValue(dictIds[i])));
+            }
+          });
+          break;
+        default:
+          throw new IllegalStateException(
+              "Illegal data type for " + _functionType.getName() + " aggregation function: " + storedType);
+      }
+      return;
+    }
+    switch (storedType) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(intValues[i]);
+          }
+        });
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(longValues[i]);
+          }
+        });
+        break;
+      case FLOAT:
+        float[] floatValues = blockValSet.getFloatValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(floatValues[i]);
+          }
+        });
+        break;
+      case DOUBLE:
+        double[] doubleValues = blockValSet.getDoubleValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(doubleValues[i]);
+          }
+        });
+        break;
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+        //noinspection ManualArrayToCollectionCopy
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(stringValues[i]);
+          }
+        });
+        break;
+      case BYTES:
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            _distinctValues.add(new ByteArray(bytesValues[i]));
+          }
+        });
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal data type for " + _functionType.getName() + " aggregation function: " + storedType);
+    }
+  }
+
+  /**
+   * Initialize
+   */
+  protected void initValueSetIfNeeded(AggregationResultHolder aggregationResultHolder, FieldSpec.DataType valueType) {
+    if (_distinctValues == null) {
+      synchronized (this) {
+        if (_distinctValues == null) {
+          switch (valueType) {
+            case INT:
+              _distinctValues = new ConcurrentHashMap<Integer, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            case LONG:
+              _distinctValues = new ConcurrentHashMap<Long, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            case FLOAT:
+              _distinctValues = new ConcurrentHashMap<Float, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            case DOUBLE:
+              _distinctValues = new ConcurrentHashMap<Double, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            case STRING:
+              _distinctValues = new ConcurrentHashMap<String, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            case BYTES:
+              _distinctValues = new ConcurrentHashMap<ByteArray, Boolean>(_initialSize).keySet(Boolean.FALSE);
+              break;
+            default:
+              throw new IllegalStateException(
+                  "Illegal data type for DISTINCT_AGGREGATE aggregation function valueType");
+          }
+          aggregationResultHolder.setValue(_distinctValues);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    svAggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    svAggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
+  }
+
+  @Override
+  public Set merge(Set intermediateResult1, Set intermediateResult2) {
+    // Should only contains one _distinctValues
+    return _distinctValues;
+  }
+
+  @Override
+  public Set extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return _distinctValues;
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.INT;
+  }
+
+  @Override
+  public Integer extractFinalResult(Set intermediateResult) {
+    return _distinctValues.size();
+  }
+
+  @Override
+  public Integer mergeFinalResult(Integer finalResult1, Integer finalResult2) {
+    return finalResult1 + finalResult2;
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -70,6 +70,8 @@ public enum AggregationFunctionType {
    * (2) count(distinct ...) support multi-argument and will be converted into DISTINCT + COUNT
    */
   DISTINCTCOUNT("distinctCount", ReturnTypes.BIGINT, OperandTypes.ANY, SqlTypeName.OTHER, SqlTypeName.INTEGER),
+  DISTINCTCOUNTGLOBAL("distinctCountGlobal", ReturnTypes.BIGINT, OperandTypes.ANY, SqlTypeName.OTHER,
+      SqlTypeName.INTEGER),
   DISTINCTSUM("distinctSum", ReturnTypes.AGG_SUM, OperandTypes.NUMERIC, SqlTypeName.OTHER, SqlTypeName.DOUBLE),
   DISTINCTAVG("distinctAvg", ReturnTypes.DOUBLE, OperandTypes.NUMERIC, SqlTypeName.OTHER),
   DISTINCTCOUNTBITMAP("distinctCountBitmap", ReturnTypes.BIGINT, OperandTypes.ANY, SqlTypeName.OTHER,


### PR DESCRIPTION
 Add a new distinctCountGlobal function to implement a sharable ConcurrentHashMap to update distinct values to avoid many hashset merges. This is much faster for large distinct counts queries
