### PR TITLE
Improve minion observer stats to capture more granular stages of minion task execution

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -191,7 +191,7 @@ public class SegmentMapper {
         String logMessage = "Caught exception while reading data.";
         observer.accept(new MinionTaskBaseObserverStats.StatusEntry.Builder()
             .withLevel(MinionTaskBaseObserverStats.StatusEntry.LogLevel.ERROR)
-            .withStatus(logMessage + " Reason : " + e.getMessage())
+            .withStatus(logMessage + " Reason: " + e.getMessage())
             .build());
         if (!continueOnError) {
           throw new RuntimeException(logMessage, e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFileConfig;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
+import org.apache.pinot.spi.tasks.MinionTaskBaseObserverStats;
 import org.apache.pinot.spi.utils.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,10 +188,15 @@ public class SegmentMapper {
           writeRecord(transformedRow);
         }
       } catch (Exception e) {
+        String logMessage = "Caught exception while reading data.";
+        observer.accept(new MinionTaskBaseObserverStats.StatusEntry.Builder()
+            .withLevel(MinionTaskBaseObserverStats.StatusEntry.LogLevel.ERROR)
+            .withStatus(logMessage + " Reason : " + e.getMessage())
+            .build());
         if (!continueOnError) {
-          throw new RuntimeException("Caught exception while reading data", e);
+          throw new RuntimeException(logMessage, e);
         } else {
-          LOGGER.debug("Caught exception while reading data", e);
+          LOGGER.debug(logMessage, e);
           continue;
         }
       }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -160,6 +160,12 @@ public class PinotTaskProgressResource {
       }
       Map<String, MinionTaskBaseObserverStats> progressStatsMap = new HashMap<>();
       MinionEventObserver observer = MinionEventObservers.getInstance().getMinionEventObserver(subtaskName);
+      if (observer == null) {
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("MinionEventObserver does not exist for subtask: {}", subtaskName);
+        }
+        return JsonUtils.objectToString(progressStatsMap);
+      }
       MinionTaskBaseObserverStats progressStats = observer.getProgressStats();
       if (progressStats != null) {
         progressStats.setProgressLogs(null);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.event.MinionTaskState;
+import org.apache.pinot.spi.tasks.MinionTaskBaseObserverStats;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -140,6 +141,38 @@ public class PinotTaskProgressResource {
                   StringUtils.isEmpty(subtaskNames) ? "NOT_SPECIFIED" : subtaskNames,
                   StringUtils.isEmpty(subTaskState) ? "NOT_SPECIFIED" : subTaskState,
                   e.getMessage()))
+          .build());
+    }
+  }
+
+  @GET
+  @Path("/tasks/subtask/progressStats")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Get task progress stats tracked for the given subtasks")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public String getSubtaskProgressStats(
+      @ApiParam(value = "Sub task name") @QueryParam("subtaskName") String subtaskName) {
+    try {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Getting progress stats for subtask: {}", subtaskName);
+      }
+      Map<String, MinionTaskBaseObserverStats> progressStatsMap = new HashMap<>();
+      MinionEventObserver observer = MinionEventObservers.getInstance().getMinionEventObserver(subtaskName);
+      MinionTaskBaseObserverStats progressStats = observer.getProgressStats();
+      if (progressStats != null) {
+        progressStats.setProgressLogs(null);
+        progressStatsMap.put(subtaskName, progressStats);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Got subtasks progress stats: {}", progressStats);
+        }
+      }
+      return JsonUtils.objectToString(progressStatsMap);
+    } catch (Exception e) {
+      throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(
+          String.format("Failed to get task progress stats for subtask: %s due to error: %s",
+              subtaskName, e.getMessage()))
           .build());
     }
   }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
@@ -172,6 +172,9 @@ public class MinionProgressObserver extends DefaultMinionEventObserver {
     }
     String incomingStage = statusEntry.getStage();
     if (_taskProgressStats.getCurrentStage() == null) {
+      // typically incomingStage won't be null when current stage is also null as notifyTaskStart is the first
+      // that gets called during task execution.
+      // This handling is mostly for testing purpose
       _taskProgressStats.setCurrentStage(incomingStage != null ? incomingStage : MinionTaskState.UNKNOWN.name());
     }
     String currentStage = _taskProgressStats.getCurrentStage();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
@@ -68,7 +68,7 @@ public class MinionProgressObserver extends DefaultMinionEventObserver {
     MinionTaskBaseObserverStats.StatusEntry statusEntry = null;
     _taskProgressStats.setCurrentState(MinionTaskState.IN_PROGRESS.name());
     if (progress instanceof MinionTaskBaseObserverStats.StatusEntry) {
-      statusEntry= (MinionTaskBaseObserverStats.StatusEntry) progress;
+      statusEntry = (MinionTaskBaseObserverStats.StatusEntry) progress;
       progressMessage = statusEntry.getStatus();
     } else if (progress instanceof MinionTaskBaseObserverStats) {
       MinionTaskBaseObserverStats stats = (MinionTaskBaseObserverStats) progress;
@@ -77,7 +77,7 @@ public class MinionProgressObserver extends DefaultMinionEventObserver {
         statusEntry = stats.getProgressLogs().pollFirst();
         progressMessage = statusEntry != null ? statusEntry.getStatus() : null;
       }
-    } else if (progress != null){
+    } else if (progress != null) {
       progressMessage = progress.toString();
       statusEntry = new MinionTaskBaseObserverStats.StatusEntry.Builder()
           .withStatus(progressMessage)

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
@@ -187,10 +187,7 @@ public class MinionProgressObserver extends DefaultMinionEventObserver {
     }
     if (!stageTimes.containsKey(currentStage)) {
       stageTimes.put(currentStage, new MinionTaskBaseObserverStats.Timer());
-      // if end time is non-zero it indicates terminal stage in which case no need to start the timer
-      if (_taskProgressStats.getEndTimestamp() == 0) {
-        stageTimes.get(currentStage).start();
-      }
+      stageTimes.get(currentStage).start();
     }
 
     MinionTaskBaseObserverStats minionTaskObserverStats = _observerStorageManager.getTaskProgress(_taskId);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
@@ -139,7 +139,7 @@ public class MinionTaskBaseObserverStats {
     }
     MinionTaskBaseObserverStats stats = (MinionTaskBaseObserverStats) o;
     return _startTimestamp == stats.getStartTimestamp() && _endTimestamp == stats.getEndTimestamp()
-        &&_taskId.equals(stats.getTaskId()) && _currentState.equals(stats.getCurrentState())
+        && _taskId.equals(stats.getTaskId()) && _currentState.equals(stats.getCurrentState())
         && _currentStage.equals(stats.getCurrentStage());
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
@@ -151,17 +151,24 @@ public class MinionTaskBaseObserverStats {
   public static class Timer {
     private long _totalTimeMs = 0;
     private long _startTimeMs = 0;
+    private long _resumeTimeMs = 0;
 
     public void start() {
       _startTimeMs = System.currentTimeMillis();
+      _resumeTimeMs = _startTimeMs;
     }
 
     public void stop() {
-      if (_startTimeMs != 0) {
-        _totalTimeMs += System.currentTimeMillis() - _startTimeMs;
-        _startTimeMs = 0;
+      if (_resumeTimeMs != 0) {
+        _totalTimeMs += System.currentTimeMillis() - _resumeTimeMs;
+        _resumeTimeMs = 0;
       }
     }
+
+    public long getStartTimeMs() {
+      return _startTimeMs;
+    }
+
     public long getTotalTimeMs() {
       return _totalTimeMs;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
@@ -42,6 +42,8 @@ public class MinionTaskBaseObserverStats {
   protected String _currentState;
   protected long _startTimestamp;
   protected long _endTimestamp;
+  // A map to keep track of the time spent on each stage of a task execution
+  // This stat will be managed by the observer and executor should not worry about maintaining it
   protected Map<String, Timer> _stageTimes = new HashMap<>();
   protected Deque<StatusEntry> _progressLogs = new LinkedList<>();
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
@@ -21,7 +21,9 @@ package org.apache.pinot.spi.tasks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -34,8 +36,11 @@ import org.apache.pinot.spi.utils.JsonUtils;
  */
 public class MinionTaskBaseObserverStats {
   protected String _taskId;
+  protected String _currentStage;
   protected String _currentState;
   protected long _startTimestamp;
+  protected long _endTimestamp;
+  protected Map<String, Timer> _stageTimes = new HashMap<>();
   protected Deque<StatusEntry> _progressLogs = new LinkedList<>();
 
   public MinionTaskBaseObserverStats() {
@@ -44,7 +49,10 @@ public class MinionTaskBaseObserverStats {
   public MinionTaskBaseObserverStats(MinionTaskBaseObserverStats from) {
     _taskId = from.getTaskId();
     _currentState = from.getCurrentState();
+    _currentStage = from.getCurrentStage();
     _startTimestamp = from.getStartTimestamp();
+    _endTimestamp = from.getEndTimestamp();
+    _stageTimes = from.getStageTimes();
     _progressLogs = new LinkedList<>(from.getProgressLogs());
   }
 
@@ -66,12 +74,39 @@ public class MinionTaskBaseObserverStats {
     return this;
   }
 
+  public long getEndTimestamp() {
+    return _endTimestamp;
+  }
+
+  public MinionTaskBaseObserverStats setEndTimestamp(long endTimestamp) {
+    _endTimestamp = endTimestamp;
+    return this;
+  }
+
   public String getCurrentState() {
     return _currentState;
   }
 
   public MinionTaskBaseObserverStats setCurrentState(String currentState) {
     _currentState = currentState;
+    return this;
+  }
+
+  public String getCurrentStage() {
+    return _currentStage;
+  }
+
+  public MinionTaskBaseObserverStats setCurrentStage(String currentStage) {
+    _currentStage = currentStage;
+    return this;
+  }
+
+  public Map<String, Timer> getStageTimes() {
+    return _stageTimes;
+  }
+
+  public MinionTaskBaseObserverStats setStageTimes(Map<String, Timer> stageTimes) {
+    _stageTimes = stageTimes;
     return this;
   }
 
@@ -103,13 +138,33 @@ public class MinionTaskBaseObserverStats {
       return false;
     }
     MinionTaskBaseObserverStats stats = (MinionTaskBaseObserverStats) o;
-    return _startTimestamp == stats.getStartTimestamp() && _taskId.equals(stats.getTaskId())
-        && _currentState.equals(stats.getCurrentState());
+    return _startTimestamp == stats.getStartTimestamp() && _endTimestamp == stats.getEndTimestamp()
+        &&_taskId.equals(stats.getTaskId()) && _currentState.equals(stats.getCurrentState())
+        && _currentStage.equals(stats.getCurrentStage());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_taskId, _currentState, _startTimestamp);
+    return Objects.hash(_taskId, _currentStage, _currentState, _startTimestamp, _endTimestamp);
+  }
+
+  public static class Timer {
+    private long _totalTimeMs = 0;
+    private long _startTimeMs = 0;
+
+    public void start() {
+      _startTimeMs = System.currentTimeMillis();
+    }
+
+    public void stop() {
+      if (_startTimeMs != 0) {
+        _totalTimeMs += System.currentTimeMillis() - _startTimeMs;
+        _startTimeMs = 0;
+      }
+    }
+    public long getTotalTimeMs() {
+      return _totalTimeMs;
+    }
   }
 
   @JsonDeserialize(builder = StatusEntry.Builder.class)
@@ -117,11 +172,13 @@ public class MinionTaskBaseObserverStats {
     private final long _ts;
     private final LogLevel _level;
     private final String _status;
+    private String _stage;
 
-    public StatusEntry(long ts, LogLevel level, String status) {
+    private StatusEntry(long ts, LogLevel level, String status, String stage) {
       _ts = ts;
       _level = level != null ? level : LogLevel.INFO;
       _status = status;
+      _stage = stage;
     }
 
     public long getTs() {
@@ -136,14 +193,28 @@ public class MinionTaskBaseObserverStats {
       return _level;
     }
 
+    public String getStage() {
+      return _stage;
+    }
+
+    public boolean updateStage(String stage) {
+      if (_stage == null) {
+        _stage = stage;
+        return true;
+      }
+      return false;
+    }
+
     @Override
     public String toString() {
-      return "{\"ts\" : " + _ts + ", \"level\" : \"" + _level + "\", \"status\" : \"" + _status + "\"}";
+      return "{\"ts\" : " + _ts + ", \"level\" : \"" + _level + "\", \"stage\" : \"" + _stage
+          + "\", \"status\" : \"" + _status + "\"}";
     }
 
     public static class Builder {
       private long _ts;
       private LogLevel _level = LogLevel.INFO;
+      private String _stage;
       private String _status;
 
       public Builder withTs(long ts) {
@@ -156,6 +227,11 @@ public class MinionTaskBaseObserverStats {
         return this;
       }
 
+      public Builder withStage(String stage) {
+        _stage = stage;
+        return this;
+      }
+
       public Builder withStatus(String status) {
         _status = status;
         return this;
@@ -165,7 +241,7 @@ public class MinionTaskBaseObserverStats {
         if (_ts == 0) {
           _ts = System.currentTimeMillis();
         }
-        return new StatusEntry(_ts, _level, _status);
+        return new StatusEntry(_ts, _level, _status, _stage);
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStats.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.spi.tasks;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Deque;
@@ -153,6 +155,17 @@ public class MinionTaskBaseObserverStats {
     private long _startTimeMs = 0;
     private long _resumeTimeMs = 0;
 
+    public Timer() {
+    }
+
+    public Timer(@JsonProperty("totalTimeMs") long totalTimeMs,
+        @JsonProperty("startTimeMs") long startTimeMs,
+        @JsonProperty("resumeTimeMs") long resumeTimeMs) {
+      _totalTimeMs = totalTimeMs;
+      _startTimeMs = startTimeMs;
+      _resumeTimeMs = resumeTimeMs;
+    }
+
     public void start() {
       _startTimeMs = System.currentTimeMillis();
       _resumeTimeMs = _startTimeMs;
@@ -171,6 +184,11 @@ public class MinionTaskBaseObserverStats {
 
     public long getTotalTimeMs() {
       return _totalTimeMs;
+    }
+
+    @JsonIgnore
+    public long getResumeTimeMs() {
+      return _resumeTimeMs;
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStatsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/tasks/MinionTaskBaseObserverStatsTest.java
@@ -40,8 +40,12 @@ public class MinionTaskBaseObserverStatsTest {
         .setTaskId(TASK_ID)
         .setCurrentState(CURRENT_STATE)
         .setStartTimestamp(TS);
-    stats.getProgressLogs().offer(new MinionTaskBaseObserverStats.StatusEntry(
-        TS, MinionTaskBaseObserverStats.StatusEntry.LogLevel.INFO, STATUS));
+    stats.getProgressLogs().offer(new MinionTaskBaseObserverStats.StatusEntry.Builder()
+            .withTs(TS)
+            .withLevel(MinionTaskBaseObserverStats.StatusEntry.LogLevel.INFO)
+            .withStatus(STATUS)
+            .withStage("test")
+        .build());
     String statsString = getTestObjectString();
     TestObserverStats stats2 = stats.fromJsonString(statsString);
     Assert.assertEquals(stats2, stats);

--- a/pinot-spi/src/test/resources/observer_stats_test_payload.json
+++ b/pinot-spi/src/test/resources/observer_stats_test_payload.json
@@ -1,0 +1,26 @@
+{
+  "testProperty": "some test property",
+  "currentState": "IN_PROGRESS",
+  "startTimestamp": 1740407875728,
+  "endTimestamp": 1740407875728,
+  "currentStage": "testStage",
+  "stageTimes": {
+    "IN_PROGRESS": {
+      "startTimeMs": 0,
+      "totalTimeMs": 0
+    },
+    "testStage": {
+      "startTimeMs": 0,
+      "totalTimeMs": 0
+    }
+  },
+  "progressLogs": [
+    {
+      "ts": 1740407875728,
+      "stage": "test",
+      "status": "task status",
+      "level": "INFO"
+    }
+  ],
+  "taskId": "randomString"
+}


### PR DESCRIPTION
# Description

This PR 

- Adds new stats to track using `MinionProgressObserver`
- Expose minion endpoint to fetch the task progress stats


## Newly added stats

1. `_currentStage` : while the `_currentState` is limited to only hold `MinionTaskState`, we need more granular idea about which stage the minion task is currently in. This property has hold any task specific stage to give better tracking.
2. `_endTimestamp`
3. `_stageTimes` : with the new `_currentStage` property, this property stores a map of stage and its start and total time spent. This stat can help user to identify which stage is taking more time and fine tune the task configs accordingly.

These new stats are leveraged to breakdown the `SegmentProcessorFramework` observability further into map, reduce and segment generate stage.


## Endpoint to fetch the task progress stats

Path : `/tasks/subtask/progressStats`
Method : `GET`
Query params : `subtaskName`
Sample Response:
```
{
   "Task_RealtimeToOfflineSegmentsTask_d5f1d3cb-53f7-4020-9276-a672ccba6a53_1740399840094_0":{
      "currentState":"SUCCEEDED",
      "taskId":"Task_RealtimeToOfflineSegmentsTask_d5f1d3cb-53f7-4020-9276-a672ccba6a53_1740399840094_0",
      "currentStage":"SUCCEEDED",
      "endTimestamp":1740399840317,
      "startTimestamp":1740399840190,
      "stageTimes":{
         "IN_PROGRESS":{
            "startTimeMs":1740399840191,
            "totalTimeMs":59
         },
         "GENERATE_SEGMENT":{
            "startTimeMs":1740399840256,
            "totalTimeMs":61
         },
         "SUCCEEDED":{
            "startTimeMs":1740399840326,
            "totalTimeMs":0
         },
         "MAP":{
            "startTimeMs":1740399840250,
            "totalTimeMs":6
         },
         "REDUCE":{
            "startTimeMs":1740399840256,
            "totalTimeMs":0
         }
      }
   }
}
```
