### PR TITLE
Close `ChunkReaderContext` to improve projection/scan based filter memory for raw columns

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
@@ -47,4 +47,11 @@ public interface BlockDocIdIterator {
    * @see {https://github.com/RoaringBitmap/RoaringBitmap/pull/243#issuecomment-381278304}
    */
   int OPTIMAL_ITERATOR_BATCH_SIZE = 256;
+
+  /**
+   * Close resources if applicable.
+   */
+  default void close() {
+    // do nothing by default
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
@@ -25,7 +25,7 @@ import org.apache.pinot.segment.spi.Constants;
  * The interface <code>BlockDocIdIterator</code> represents the iterator for <code>BlockDocIdSet</code>. The document
  * ids returned from the iterator should be in ascending order.
  */
-public interface BlockDocIdIterator {
+public interface BlockDocIdIterator extends AutoCloseable {
 
   /**
    * Returns the next matching document id, or {@link Constants#EOF} if there is no more matching documents.

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockDocIdIterator.java
@@ -51,6 +51,7 @@ public interface BlockDocIdIterator extends AutoCloseable {
   /**
    * Close resources if applicable.
    */
+  @Override
   default void close() {
     // do nothing by default
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -34,7 +34,7 @@ import org.apache.pinot.spi.data.FieldSpec;
  * to prevent garbage collection.
  */
 @SuppressWarnings("Duplicates")
-public class DataBlockCache {
+public class DataBlockCache implements AutoCloseable {
   private final DataFetcher _dataFetcher;
 
   // Mark whether data have been fetched, need to be cleared in initNewBlock()
@@ -410,6 +410,7 @@ public class DataBlockCache {
   /**
    * Close the data block cache and release all resources.
    */
+  @Override
   public void close() {
     _dataFetcher.close();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -406,4 +406,11 @@ public class DataBlockCache {
   public void addDataSource(String fullColumnKeyName, DataSource keyDataSource) {
     _dataFetcher.addDataSource(fullColumnKeyName, keyDataSource);
   }
+
+  /**
+   * Close the data block cache and release all resources.
+   */
+  public void close() {
+    _dataFetcher.close();
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -45,7 +45,7 @@ import org.apache.pinot.spi.utils.MapUtils;
  * and garbage collection.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class DataFetcher {
+public class DataFetcher implements AutoCloseable {
   // Thread local (reusable) buffer for single-valued column dictionary Ids
   private static final ThreadLocal<int[]> THREAD_LOCAL_DICT_IDS =
       ThreadLocal.withInitial(() -> new int[DocIdSetPlanNode.MAX_DOC_PER_CALL]);
@@ -598,6 +598,7 @@ public class DataFetcher {
   /**
    * Close the DataFetcher and release all resources (specifically, the ForwardIndexReaderContext off-heap buffers).
    */
+  @Override
   public void close() {
     try {
       for (ColumnValueReader columnValueReader : _columnValueReaderMap.values()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.common;
 
 import com.google.common.base.Preconditions;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -586,8 +585,7 @@ public class DataFetcher implements AutoCloseable {
     }
 
     @Override
-    public void close()
-        throws IOException {
+    public void close() {
       if (_readerContext != null) {
         _readerContext.close();
       }
@@ -599,17 +597,8 @@ public class DataFetcher implements AutoCloseable {
    */
   @Override
   public void close() {
-    boolean failedToCloseAll = false;
     for (ColumnValueReader columnValueReader : _columnValueReaderMap.values()) {
-      try {
         columnValueReader.close();
-      } catch (IOException e) {
-        failedToCloseAll = true;
-      }
-    }
-
-    if (failedToCloseAll) {
-      throw new RuntimeException("Failed to close the DataFetcher and release all query resources");
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -594,4 +594,17 @@ public class DataFetcher {
       }
     }
   }
+
+  /**
+   * Close the DataFetcher and release all resources (specifically, the ForwardIndexReaderContext off-heap buffers).
+   */
+  public void close() {
+    try {
+      for (ColumnValueReader columnValueReader : _columnValueReaderMap.values()) {
+        columnValueReader.close();
+      }
+    } catch (IOException e) {
+      // do nothing
+    }
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -598,7 +598,7 @@ public class DataFetcher implements AutoCloseable {
   @Override
   public void close() {
     for (ColumnValueReader columnValueReader : _columnValueReaderMap.values()) {
-        columnValueReader.close();
+      columnValueReader.close();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -35,7 +35,7 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.trace.Tracing;
 
 
-public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
+public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> implements AutoCloseable {
   private static final String EXPLAIN_NAME = "PROJECT";
 
   private final Map<String, DataSource> _dataSourceMap;
@@ -70,6 +70,7 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
     assert _docIdSetOperator != null;
     DocIdSetBlock docIdSetBlock = _docIdSetOperator.nextBlock();
     if (docIdSetBlock == null) {
+      _dataBlockCache.close();
       return null;
     } else {
       Tracing.activeRecording().setNumChildren(_dataSourceMap.size());
@@ -115,5 +116,10 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
   @Override
   public ExecutionStatistics getExecutionStatistics() {
     return _docIdSetOperator != null ? _docIdSetOperator.getExecutionStatistics() : new ExecutionStatistics(0, 0, 0, 0);
+  }
+
+  @Override
+  public void close() {
+    _dataBlockCache.close();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
@@ -59,6 +59,7 @@ public final class AndDocIdIterator implements BlockDocIdIterator {
           index = 0;
         }
       } else {
+        closeIterators();
         return Constants.EOF;
       }
     }
@@ -70,5 +71,13 @@ public final class AndDocIdIterator implements BlockDocIdIterator {
   public int advance(int targetDocId) {
     _nextDocId = targetDocId;
     return next();
+  }
+
+  private void closeIterators() {
+    for (BlockDocIdIterator it : _docIdIterators) {
+      if (it instanceof ScanBasedDocIdIterator) {
+        ((ScanBasedDocIdIterator) it).close();
+      }
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
@@ -75,9 +75,7 @@ public final class AndDocIdIterator implements BlockDocIdIterator {
 
   private void closeIterators() {
     for (BlockDocIdIterator it : _docIdIterators) {
-      if (it instanceof ScanBasedDocIdIterator) {
-        ((ScanBasedDocIdIterator) it).close();
-      }
+      it.close();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -38,7 +38,6 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   private final PredicateEvaluator _predicateEvaluator;
   private final ForwardIndexReader _reader;
-  // TODO: Figure out a way to close the reader context
   private final ForwardIndexReaderContext _readerContext;
   private final int _numDocs;
   private final int _maxNumValuesPerMVEntry;
@@ -69,6 +68,7 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
         return nextDocId;
       }
     }
+    close();
     return Constants.EOF;
   }
 
@@ -249,6 +249,17 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       int length = _reader.getBytesMV(docId, _buffer, _readerContext);
       _numEntriesScanned += length;
       return _predicateEvaluator.applyMV(_buffer, length);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (_readerContext != null) {
+        _readerContext.close();
+      }
+    } catch (Exception e) {
+      // Ignore
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -254,12 +254,8 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   @Override
   public void close() {
-    try {
-      if (_readerContext != null) {
-        _readerContext.close();
-      }
-    } catch (Exception e) {
-      // Ignore
+    if (_readerContext != null) {
+      _readerContext.close();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/OrDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/OrDocIdIterator.java
@@ -118,9 +118,7 @@ public final class OrDocIdIterator implements BlockDocIdIterator {
     while (i < _numNotExhaustedIterators) {
       if (_nextDocIds[i] == Constants.EOF) {
         // Close the exhausted iterator
-        if (_docIdIterators[i] instanceof ScanBasedDocIdIterator) {
-          ((ScanBasedDocIdIterator) _docIdIterators[i]).close();
-        }
+        _docIdIterators[i].close();
 
         // Need to check the new iterator moved to this index, so do not increase the index
         _numNotExhaustedIterators--;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/OrDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/OrDocIdIterator.java
@@ -117,6 +117,11 @@ public final class OrDocIdIterator implements BlockDocIdIterator {
     int i = 0;
     while (i < _numNotExhaustedIterators) {
       if (_nextDocIds[i] == Constants.EOF) {
+        // Close the exhausted iterator
+        if (_docIdIterators[i] instanceof ScanBasedDocIdIterator) {
+          ((ScanBasedDocIdIterator) _docIdIterators[i]).close();
+        }
+
         // Need to check the new iterator moved to this index, so do not increase the index
         _numNotExhaustedIterators--;
         _docIdIterators[i] = _docIdIterators[_numNotExhaustedIterators];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -317,12 +317,8 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   @Override
   public void close() {
-    try {
-      if (_readerContext != null) {
-        _readerContext.close();
-      }
-    } catch (Exception e) {
-      // Ignore
+    if (_readerContext != null) {
+      _readerContext.close();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -38,8 +38,6 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private final PredicateEvaluator _predicateEvaluator;
   private final ForwardIndexReader _reader;
-  // TODO: Figure out a way to close the reader context
-  //       ChunkReaderContext should be closed explicitly to release the off-heap buffer
   private final ForwardIndexReaderContext _readerContext;
   private final int _numDocs;
   private final ValueMatcher _valueMatcher;
@@ -91,6 +89,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
       _firstMismatch = batchSize;
       _cursor = 0;
       if (_firstMismatch == 0) {
+        close();
         return Constants.EOF;
       }
     }
@@ -108,6 +107,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
         return nextDocId;
       }
     }
+    close();
     return Constants.EOF;
   }
 
@@ -138,6 +138,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
       }
       _numEntriesScanned += limit;
     }
+    close();
     return result.get();
   }
 
@@ -311,6 +312,17 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
     @Override
     public boolean doesValueMatch(int docId) {
       return _predicateEvaluator.applySV(_reader.getBytes(docId, _readerContext));
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (_readerContext != null) {
+        _readerContext.close();
+      }
+    } catch (Exception e) {
+      // Ignore
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -57,9 +57,15 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   /**
    * Returns the estimated (effective) cardinality of the underlying data source
    */
-
   default float getEstimatedCardinality(boolean isAndDocIdSet) {
     //default N/A behavior so that it always get picked in the end
     return isAndDocIdSet ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
+  }
+
+  /**
+   * Close resources if applicable.
+   */
+  default void close() {
+    // do nothing by default
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -39,7 +39,8 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc);
 
   /**
-   * Applies AND operation to the given bitmap of document ids, returns a bitmap of the matching document ids.
+   * Applies AND operation to the given bitmap of document ids, returns a bitmap of the matching document ids. This
+   * method is expected to be called only once, as resources are released after the first call.
    */
   default MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds) {
     if (docIds.isEmpty()) {
@@ -60,12 +61,5 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   default float getEstimatedCardinality(boolean isAndDocIdSet) {
     //default N/A behavior so that it always get picked in the end
     return isAndDocIdSet ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
-  }
-
-  /**
-   * Close resources if applicable.
-   */
-  default void close() {
-    // do nothing by default
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -80,9 +80,10 @@ public class ProjectPlanNode implements PlanNode {
     DocIdSetOperator docIdSetOperator =
         _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_segmentContext, _queryContext, _maxDocsPerCall,
             _filterOperator).run() : null;
-    ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
-    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
-        : projectionOperator;
+    try (ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator)) {
+      return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
+          : projectionOperator;
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -80,10 +80,11 @@ public class ProjectPlanNode implements PlanNode {
     DocIdSetOperator docIdSetOperator =
         _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_segmentContext, _queryContext, _maxDocsPerCall,
             _filterOperator).run() : null;
-    try (ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator)) {
-      return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
-          : projectionOperator;
-    }
+
+    // TODO: figure out a way to close this operator, as it may hold reader context
+    ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
+    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
+        : projectionOperator;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
@@ -81,13 +81,14 @@ public class StarTreeProjectPlanNode implements PlanNode {
         new StarTreeDocIdSetPlanNode(_queryContext, _starTreeV2, _predicateEvaluatorsMap, groupByColumns).run();
     Map<String, DataSource> dataSourceMap = new HashMap<>(HashUtil.getHashMapCapacity(projectionColumns.size()));
     projectionColumns.forEach(column -> dataSourceMap.put(column, _starTreeV2.getDataSource(column)));
-    try (ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator)) {
-      // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
-      //       - They are all columns (not functions or constants), where no transform is required
-      //       - We never call TransformOperator.getResultColumnContext() on them
-      return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator,
-          Arrays.asList(_groupByExpressions)) : projectionOperator;
-    }
+
+    // TODO: figure out a way to close this operator, as it may hold reader context
+    ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
+    // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
+    //       - They are all columns (not functions or constants), where no transform is required
+    //       - We never call TransformOperator.getResultColumnContext() on them
+    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator,
+        Arrays.asList(_groupByExpressions)) : projectionOperator;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
@@ -81,12 +81,13 @@ public class StarTreeProjectPlanNode implements PlanNode {
         new StarTreeDocIdSetPlanNode(_queryContext, _starTreeV2, _predicateEvaluatorsMap, groupByColumns).run();
     Map<String, DataSource> dataSourceMap = new HashMap<>(HashUtil.getHashMapCapacity(projectionColumns.size()));
     projectionColumns.forEach(column -> dataSourceMap.put(column, _starTreeV2.getDataSource(column)));
-    ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
-    // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
-    //       - They are all columns (not functions or constants), where no transform is required
-    //       - We never call TransformOperator.getResultColumnContext() on them
-    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator,
-        Arrays.asList(_groupByExpressions)) : projectionOperator;
+    try (ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator)) {
+      // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
+      //       - They are all columns (not functions or constants), where no transform is required
+      //       - We never call TransformOperator.getResultColumnContext() on them
+      return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator,
+          Arrays.asList(_groupByExpressions)) : projectionOperator;
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/CLPForwardIndexReaderV1.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/CLPForwardIndexReaderV1.java
@@ -203,8 +203,7 @@ public class CLPForwardIndexReaderV1 implements ForwardIndexReader<CLPForwardInd
     }
 
     @Override
-    public void close()
-        throws IOException {
+    public void close() {
       if (_dictVarsReaderContext != null) {
         _dictVarsReaderContext.close();
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/CLPForwardIndexReaderV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/CLPForwardIndexReaderV2.java
@@ -241,8 +241,7 @@ public class CLPForwardIndexReaderV2 implements ForwardIndexReader<CLPForwardInd
     }
 
     @Override
-    public void close()
-        throws IOException {
+    public void close() {
       if (null != _logTypeIdReaderContext) {
         _logTypeIdReaderContext.close();
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
@@ -43,6 +43,7 @@ public class ChunkReaderContext implements ForwardIndexReaderContext {
   private int _chunkId;
 
   private List<ForwardIndexReader.ByteRange> _ranges;
+  private boolean _closed;
 
   public ChunkReaderContext(int maxChunkSize) {
     _chunkBuffer = ByteBuffer.allocateDirect(maxChunkSize);
@@ -52,6 +53,10 @@ public class ChunkReaderContext implements ForwardIndexReaderContext {
 
   @Override
   public void close() {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
     CleanerUtil.cleanQuietly(_chunkBuffer);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.segment.index.readers.forward;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,11 +51,8 @@ public class ChunkReaderContext implements ForwardIndexReaderContext {
   }
 
   @Override
-  public void close()
-      throws IOException {
-    if (CleanerUtil.UNMAP_SUPPORTED) {
-      CleanerUtil.getCleaner().freeBuffer(_chunkBuffer);
-    }
+  public void close() {
+    CleanerUtil.cleanQuietly(_chunkBuffer);
   }
 
   public ByteBuffer getChunkBuffer() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -375,7 +375,7 @@ public class VarByteChunkForwardIndexReaderV4
 
   private static final class CompressedReaderContext extends ReaderContext {
 
-    private ByteBuffer _decompressedBuffer;
+    private final ByteBuffer _decompressedBuffer;
     private final ChunkDecompressor _chunkDecompressor;
     private final ChunkCompressionType _chunkCompressionType;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -334,7 +334,6 @@ public class VarByteChunkForwardIndexReaderV4
   private static final class UncompressedReaderContext extends ReaderContext {
 
     private ByteBuffer _chunk;
-    private List<ByteRange> _ranges;
 
     UncompressedReaderContext(PinotDataBuffer metadata, PinotDataBuffer chunks, long chunkStartOffset) {
       super(chunks, metadata, chunkStartOffset);
@@ -376,7 +375,7 @@ public class VarByteChunkForwardIndexReaderV4
 
   private static final class CompressedReaderContext extends ReaderContext {
 
-    private final ByteBuffer _decompressedBuffer;
+    private ByteBuffer _decompressedBuffer;
     private final ChunkDecompressor _chunkDecompressor;
     private final ChunkCompressionType _chunkCompressionType;
 
@@ -445,6 +444,7 @@ public class VarByteChunkForwardIndexReaderV4
     @Override
     public void close() {
       CleanerUtil.cleanQuietly(_decompressedBuffer);
+      _decompressedBuffer = null;
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -378,6 +378,7 @@ public class VarByteChunkForwardIndexReaderV4
     private final ByteBuffer _decompressedBuffer;
     private final ChunkDecompressor _chunkDecompressor;
     private final ChunkCompressionType _chunkCompressionType;
+    private boolean _closed;
 
     CompressedReaderContext(PinotDataBuffer metadata, PinotDataBuffer chunks, long chunkStartOffset,
         ChunkDecompressor chunkDecompressor, ChunkCompressionType chunkCompressionType, int targetChunkSize) {
@@ -443,6 +444,10 @@ public class VarByteChunkForwardIndexReaderV4
 
     @Override
     public void close() {
+      if (_closed) {
+        return;
+      }
+      _closed = true;
       CleanerUtil.cleanQuietly(_decompressedBuffer);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -444,7 +444,6 @@ public class VarByteChunkForwardIndexReaderV4
     @Override
     public void close() {
       CleanerUtil.cleanQuietly(_decompressedBuffer);
-      _decompressedBuffer = null;
     }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
@@ -28,4 +28,7 @@ import java.io.Closeable;
  * inside the context in order to accelerate the following reads.
  */
 public interface ForwardIndexReaderContext extends Closeable {
+
+  @Override
+  void close();
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
@@ -18,16 +18,13 @@
  */
 package org.apache.pinot.segment.spi.index.reader;
 
-import java.io.Closeable;
-
-
 /**
  * Interface for the context of the forward index reader.
  * <p>The forward index reader itself is always stateless because it needs to be accessed by multiple threads. The
  * context can be passed when reading the values from the forward index reader so that reader can store some states
  * inside the context in order to accelerate the following reads.
  */
-public interface ForwardIndexReaderContext extends Closeable {
+public interface ForwardIndexReaderContext extends AutoCloseable {
 
   @Override
   void close();


### PR DESCRIPTION
Closes `ChunkReaderContext` in `ProjectionOperator` and scan based iterators to reduce direct buffer usage. Lightly tested in a local staging cluster - will add some more query shapes soon.

For the simple query: `select lower(message_logtype) from table where lower(message_logtype) = 'asdf'` we see up to 80GB direct buffer memory usage, which can take 10s of minutes to be collected. e.g., per host metrics:
<img width="768" alt="image" src="https://github.com/user-attachments/assets/812751fb-af33-4ef4-87cf-4b8b052af5a3" />

With the patch, the same query creates no discernable spike in direct buffer usage (query executed at 17:43):
<img width="768" alt="image" src="https://github.com/user-attachments/assets/a0863f15-54b3-415a-8bbc-31cb4a4fd215" />


