### PR TITLE
Add support for orphan segment cleanup

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -190,7 +190,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   REINGESTED_SEGMENT_UPLOADS_IN_PROGRESS("reingestedSegmentUploadsInProgress", true),
 
   // Resource utilization is within limits or not for a table
-  RESOURCE_UTILIZATION_LIMIT_EXCEEDED("ResourceUtilizationLimitExceeded", false);
+  RESOURCE_UTILIZATION_LIMIT_EXCEEDED("ResourceUtilizationLimitExceeded", false),
+
+  // The number of segments in deepstore that do not have corresponding metadata in ZooKeeper.
+  // These segments are untracked and should be considered for deletion based on retention policies.
+  UNTRACKED_SEGMENTS_COUNT("untrackedSegmentsCount", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -241,6 +241,10 @@ public class ControllerConf extends PinotConfiguration {
     public static final String TMP_SEGMENT_RETENTION_IN_SECONDS =
         "controller.realtime.segment.tmpFileRetentionInSeconds";
 
+    // Enables the deletion of untracked segments during the retention manager run.
+    // Untracked segments are those that exist in deep store but have no corresponding entry in the ZK property store.
+    public static final String ENABLE_UNTRACKED_SEGMENT_DELETION =
+        "controller.retentionManager.untrackedSegmentDeletionEnabled";
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
     public static final int DEFAULT_SPLIT_COMMIT_TMP_SEGMENT_LIFETIME_SECOND = 60 * 60; // 1 Hour.
@@ -1080,6 +1084,15 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(ControllerPeriodicTasksConf.TMP_SEGMENT_RETENTION_IN_SECONDS,
         ControllerPeriodicTasksConf.DEFAULT_SPLIT_COMMIT_TMP_SEGMENT_LIFETIME_SECOND);
   }
+
+  public boolean getUntrackedSegmentDeletionEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_UNTRACKED_SEGMENT_DELETION, false);
+  }
+
+  public void setUntrackedSegmentDeletionEnabled(boolean untrackedSegmentDeletionEnabled) {
+    setProperty(ControllerPeriodicTasksConf.ENABLE_UNTRACKED_SEGMENT_DELETION, untrackedSegmentDeletionEnabled);
+  }
+
 
   public long getPinotTaskManagerInitialDelaySeconds() {
     return getPeriodicTaskInitialDelayInSeconds();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -222,6 +222,7 @@ public class SegmentDeletionManager {
       URI segmentMetadataUri = SegmentPushUtils.generateSegmentMetadataURI(segmentFileUri.toString(), segmentId);
       if (pinotFS.exists(segmentMetadataUri)) {
         LOGGER.info("Deleting segment metadata {} from {}", segmentId, segmentMetadataUri);
+        // TODO: check if the deletion was successful and add a warning here.
         pinotFS.delete(segmentMetadataUri, true);
       }
     } catch (IOException e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -222,8 +222,9 @@ public class SegmentDeletionManager {
       URI segmentMetadataUri = SegmentPushUtils.generateSegmentMetadataURI(segmentFileUri.toString(), segmentId);
       if (pinotFS.exists(segmentMetadataUri)) {
         LOGGER.info("Deleting segment metadata {} from {}", segmentId, segmentMetadataUri);
-        // TODO: check if the deletion was successful and add a warning here.
-        pinotFS.delete(segmentMetadataUri, true);
+        if (!pinotFS.delete(segmentMetadataUri, true)) {
+          LOGGER.warn("Could not delete segment metadata: {} from: {}", segmentId, segmentMetadataUri);
+        }
       }
     } catch (IOException e) {
       LOGGER.warn("Could not delete segment metadata {} from {}", segmentId, segmentFileUri, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import javax.validation.constraints.Null;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.logging.log4j.util.Strings;
@@ -36,6 +35,7 @@ import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
@@ -58,8 +58,6 @@ import org.apache.pinot.spi.utils.retry.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.common.utils.TarCompressionUtils.TAR_COMPRESSED_FILE_EXTENSION;
-import static org.apache.pinot.common.utils.TarCompressionUtils.TAR_GZ_FILE_EXTENSION;
 
 
 /**
@@ -198,8 +196,8 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
       return null;
     }
     String segmentName = filePath.substring(filePath.lastIndexOf("/") + 1);
-    if (segmentName.endsWith(TAR_GZ_FILE_EXTENSION)) {
-      segmentName = segmentName.substring(0, segmentName.length() - TAR_GZ_FILE_EXTENSION.length());
+    if (segmentName.endsWith(TarCompressionUtils.TAR_GZ_FILE_EXTENSION)) {
+      segmentName = segmentName.substring(0, segmentName.length() - TarCompressionUtils.TAR_GZ_FILE_EXTENSION.length());
     }
     return segmentName;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -190,7 +190,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     }
     String segmentName = filePath.substring(filePath.lastIndexOf("/") + 1);
     if (segmentName.endsWith(TAR_GZ_FILE_EXTENSION)) {
-      segmentName = segmentName.substring(0, segmentName.length() - TAR_COMPRESSED_FILE_EXTENSION.length());
+      segmentName = segmentName.substring(0, segmentName.length() - TAR_GZ_FILE_EXTENSION.length());
     }
     return segmentName;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
@@ -36,12 +36,13 @@ public interface RetentionStrategy {
   boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata);
 
   /**
-   * Returns whether the segment should be purged based on end time.
+   * Determines whether a segment is eligible for purging
    *
-   * @param segmentName The name of the segment to check
-   * @param tableNameWithType Table name with type
-   * @param endTimeMs The end time of the segment in milliseconds
-   * @return Whether the segment should be purged
+   * @param tableNameWithType The table name, including its type.
+   * @param segmentName The name of the segment to evaluate.
+   * @param segmentTimeMs The segment's timestamp in milliseconds, which could be the end time from ZK metadata or
+   *                      the modification time (mTime) for the file in deep store etc.
+   * @return {@code true} if the segment should be purged; {@code false} otherwise.
    */
-  boolean isPurgeable(String segmentName, String tableNameWithType, long endTimeMs);
+  boolean isPurgeable(String tableNameWithType, String segmentName, long segmentTimeMs);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
@@ -44,5 +44,4 @@ public interface RetentionStrategy {
    * @return Whether the segment should be purged
    */
   boolean isPurgeable(String segmentName, String tableNameWithType, long endTimeMs);
-
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/RetentionStrategy.java
@@ -34,4 +34,15 @@ public interface RetentionStrategy {
    * @return Whether the segment should be purged
    */
   boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata);
-}
+
+  /**
+   * Returns whether the segment should be purged based on end time.
+   *
+   * @param segmentName The name of the segment to check
+   * @param tableNameWithType Table name with type
+   * @param endTimeMs The end time of the segment in milliseconds
+   * @return Whether the segment should be purged
+   */
+  boolean isPurgeable(String segmentName, String tableNameWithType, long endTimeMs);
+
+  }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
@@ -39,28 +39,19 @@ public class TimeRetentionStrategy implements RetentionStrategy {
 
   @Override
   public boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata) {
-    long endTimeMs = segmentZKMetadata.getEndTimeMs();
-
-    // Check that the end time is between 1971 and 2071
-    if (!TimeUtils.timeValueInValidRange(endTimeMs)) {
-      LOGGER.warn("Segment: {} of table: {} has invalid end time in millis: {}", segmentZKMetadata.getSegmentName(),
-          tableNameWithType, endTimeMs);
-      return false;
-    }
-
-    return System.currentTimeMillis() - endTimeMs > _retentionMs;
+    return isPurgeable(tableNameWithType, segmentZKMetadata.getSegmentName(), segmentZKMetadata.getEndTimeMs());
   }
 
   @Override
-  public boolean isPurgeable(String segmentName, String tableNameWithType, long endTimeMs) {
+  public boolean isPurgeable(String tableNameWithType, String segmentName, long segmentTimeMs) {
 
     // Check that the end time is between 1971 and 2071
-    if (!TimeUtils.timeValueInValidRange(endTimeMs)) {
+    if (!TimeUtils.timeValueInValidRange(segmentTimeMs)) {
       LOGGER.warn("Segment: {} of table: {} has invalid end time in millis: {}", segmentName,
-          tableNameWithType, endTimeMs);
+          tableNameWithType, segmentTimeMs);
       return false;
     }
 
-    return System.currentTimeMillis() - endTimeMs > _retentionMs;
+    return System.currentTimeMillis() - segmentTimeMs > _retentionMs;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
@@ -50,4 +50,17 @@ public class TimeRetentionStrategy implements RetentionStrategy {
 
     return System.currentTimeMillis() - endTimeMs > _retentionMs;
   }
+
+  @Override
+  public boolean isPurgeable(String segmentName, String tableNameWithType, long endTimeMs) {
+
+    // Check that the end time is between 1971 and 2071
+    if (!TimeUtils.timeValueInValidRange(endTimeMs)) {
+      LOGGER.warn("Segment: {} of table: {} has invalid end time in millis: {}", segmentName,
+          tableNameWithType, endTimeMs);
+      return false;
+    }
+
+    return System.currentTimeMillis() - endTimeMs > _retentionMs;
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -254,6 +254,7 @@ public class RetentionManagerTest {
     PinotHelixResourceManager pinotHelixResourceManager =
         setupSegmentMetadata(tableConfig, now, initialNumSegments, removedSegments);
     setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager, leadControllerManager);
+    when(pinotHelixResourceManager.getDataDir()).thenReturn(_tempDir.toString());
 
     ControllerConf conf = new ControllerConf();
     ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
@@ -286,6 +287,7 @@ public class RetentionManagerTest {
     PinotHelixResourceManager pinotHelixResourceManager =
         setupSegmentMetadataForPausedTable(tableConfig, now, removedSegments);
     setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager, leadControllerManager);
+    when(pinotHelixResourceManager.getDataDir()).thenReturn(_tempDir.toString());
 
     ControllerConf conf = new ControllerConf();
     ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -131,7 +131,8 @@ public class RetentionManagerTest {
         File segmentFile = new File(_tableDir, segmentName);
         createFileWithContent(segmentFile, "extra segment " + i + " data");
         setFileModificationTime(segmentFile, timeUnit.toMillis(pastTimeStamp));
-        if(i < untrackedSegmentsDeletionBatchSize) {
+        if (i < untrackedSegmentsDeletionBatchSize) {
+          // Add segments to the removed list till we reach untrackedSegmentsDeletionBatchSize
           removedSegments.add(segmentName);
         }
       }
@@ -148,6 +149,11 @@ public class RetentionManagerTest {
     PinotHelixResourceManager pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
 
     // Use appropriate setup based on test case
+    // In case of untrackedSegmentsDeletionBatchSize < untrackedSegmentsInDeepstoreSize, we cannot guarantee which
+    // files/ segments will be picked for deletion as there is not ordering/ sorting done before selecting
+    // untrackedSegmentsDeletionBatchSize out of untrackedSegmentsInDeepstoreSize to delete.
+    // For the case untrackedSegmentsDeletionBatchSize < untrackedSegmentsInDeepstoreSize we just check the size of the
+    // segments that will get deleted.
     if (untrackedSegmentsDeletionBatchSize >= untrackedSegmentsInDeepstoreSize) {
       // Use original setup for the case when all the segments will be included
       setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager, leadControllerManager);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -447,7 +447,7 @@ public class RetentionManagerTest {
   /**
    * Helper method to set file modification time
    */
-  private void setFileModificationTime(File file, long timestamp){
+  private void setFileModificationTime(File file, long timestamp) {
     FileTime fileTime = FileTime.fromMillis(timestamp);
     try {
       Files.setLastModifiedTime(file.toPath(), fileTime);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -56,8 +56,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class RetentionManagerTest {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -55,7 +55,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   // For more usage of this field, please refer to this design doc: https://tinyurl.com/f63ru4sb
   private String _peerSegmentDownloadScheme;
 
-  private int _untrackedSegmentsDeletionBatchSize;
+  private String _untrackedSegmentsDeletionBatchSize;
 
   /**
    * @deprecated Use {@link InstanceAssignmentConfig} instead
@@ -253,11 +253,11 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _minimizeDataMovement = minimizeDataMovement;
   }
 
-  public int getUntrackedSegmentsDeletionBatchSize() {
+  public String getUntrackedSegmentsDeletionBatchSize() {
     return _untrackedSegmentsDeletionBatchSize;
   }
 
-  public void setUntrackedSegmentsDeletionBatchSize(int untrackedSegmentsDeletionBatchSize) {
+  public void setUntrackedSegmentsDeletionBatchSize(String untrackedSegmentsDeletionBatchSize) {
     _untrackedSegmentsDeletionBatchSize = untrackedSegmentsDeletionBatchSize;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -55,6 +55,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   // For more usage of this field, please refer to this design doc: https://tinyurl.com/f63ru4sb
   private String _peerSegmentDownloadScheme;
 
+  private int _untrackedSegmentsDeletionBatchSize;
+
   /**
    * @deprecated Use {@link InstanceAssignmentConfig} instead
    */
@@ -249,5 +251,13 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   @Deprecated
   public void setMinimizeDataMovement(boolean minimizeDataMovement) {
     _minimizeDataMovement = minimizeDataMovement;
+  }
+
+  public int getUntrackedSegmentsDeletionBatchSize() {
+    return _untrackedSegmentsDeletionBatchSize;
+  }
+
+  public void setUntrackedSegmentsDeletionBatchSize(int untrackedSegmentsDeletionBatchSize) {
+    _untrackedSegmentsDeletionBatchSize = untrackedSegmentsDeletionBatchSize;
   }
 }


### PR DESCRIPTION
## Context

Followup of this PR: https://github.com/apache/pinot/pull/15048
The first PR ensured that we don't miss any segments that are created from now on. 

This PR aims to fix the orphan segments that are present in deepstore and have passed the retention time but are neither present in ZK or IdealState. 

## Scope of the PR.

The PR aims to handle two scenarios:
1. Old segments that did not get deleted from the deepstore but their SegmentZKMetadata was deleted by the retention manager. This happened due to the issue mentioned and resolved in: https://github.com/apache/pinot/pull/15048
2. The deletion by retention manager is performed as follows: 
    - Find all the segments present in the ZK ( i.e. have ZK Metadata entry)
    - Delete Segment from IS
    - Delete Segment from ZK
    - Delete Segment from deepstore
The RententionManager will not be able to delete a segment in the subsequent runs if the controller restarted etc.  between the last two steps i.e. any failure between the last two steps of the process.

## Testing

 - Unit Tests were added to ensure that segments present in deepstore that are missing in ZK are picked for deletion.
 
 ## Update

After analyzing the test results:

https://docs.google.com/document/d/1ZvNefSsRL716NspQc1f5VrRYjd9CSqocac5TIfLJWPA/edit?usp=sharing

I concluded that limiting the number of segments deleted in a single run would be beneficial. To address this, I have introduced a configurable batch size for segment deletion. (`untrackedSegmentsDeletionBatchSize` part of `SegmentsValidationAndRetentionConfig`)

### Reasons for This Change

Deletion 
- Prevent starvation of deepstore cleanup: Ensures that the RetentionManager for other tables can also delete files without delays.
- Avoid blocking API-based segment deletions:
    - Some APIs rely on the same code for deleting segments from deepstore.
    - The API will `respond` but the deletion will stay `blocked`
- Segment Lineage update function at the end does deepstore cleanup. It will not stay blocked as we just submit the request in a single threaded executor service but deepstore cleanup will stay blocked
- UpsertCompactionTaskGenerator and UpsertCompactMergeTaskGenerator also use the same code run using a single threaded executor.


```
  protected void deleteSegmentsWithDelay(String tableName, Collection<String> segmentIds,
      Long deletedSegmentsRetentionMs, long deletionDelaySeconds) {
    _executorService.schedule(new Runnable() {
      @Override
      public void run() {
        deleteSegmentFromPropertyStoreAndLocal(tableName, segmentIds, deletedSegmentsRetentionMs, deletionDelaySeconds);
      }
    }, deletionDelaySeconds, TimeUnit.SECONDS);
  }


protected synchronized void deleteSegmentFromPropertyStoreAndLocal
```


