### PR TITLE
Cancel subqueries after reduction

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TestFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TestFunctions.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+
+/**
+ * A number of functions used for testing, e.g. crashes during query compilation or processing.
+ * They're not meant for production use.
+ */
+public class TestFunctions {
+
+  private static volatile boolean _enabled = false;
+
+  public static void enable() {
+    _enabled = true;
+  }
+
+  public static void disable() {
+    _enabled = false;
+  }
+
+  /*
+   * If 'ignored' is a column reference, calcite shouldn't evaluate expression at compile time
+   * and replace with a constant.
+   * */
+  @ScalarFunction
+  public long throwError(int ignored) {
+    if (_enabled) {
+      throw new RuntimeException("The sky is falling!");
+    }
+
+    return 0L;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TestFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TestFunctions.java
@@ -22,7 +22,7 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
 /**
- * A number of functions used for testing, e.g. crashes during query compilation or processing.
+ * A number  of functions used for testing, e.g. crashes during query compilation or processing.
  * They're not meant for production use.
  */
 public class TestFunctions {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ExplainIntegrationTestTrait.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ExplainIntegrationTestTrait.java
@@ -105,9 +105,15 @@ public interface ExplainIntegrationTestTrait {
   default void explainAskingServers(@Language("sql") String query, String expected) {
     try {
       JsonNode jsonNode = postQuery("set explainAskingServers=true; explain plan for " + query);
-      JsonNode plan = jsonNode.get("resultTable").get("rows").get(0).get(1);
+      JsonNode resultTable = jsonNode.get("resultTable");
 
-      Assert.assertEquals(plan.asText(), expected);
+      if (resultTable != null) {
+        JsonNode plan = resultTable.get("rows").get(0).get(1);
+        Assert.assertEquals(plan.asText(), expected);
+      } else {
+        String error = ITestUtils.toErrorString(jsonNode);
+        Assert.assertEquals(error, expected);
+      }
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByEnableTrimOptionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByEnableTrimOptionIntegrationTest.java
@@ -206,8 +206,8 @@ public class GroupByEnableTrimOptionIntegrationTest extends BaseClusterIntegrati
     JsonNode result = postV2Query(sql);
     JsonNode plan = postV2Query(option + " set explainAskingServers=true; explain plan for " + query);
 
-    Assert.assertEquals(GroupByOptionsIntegrationTest.toResultStr(result), expectedResult);
-    Assert.assertEquals(GroupByOptionsIntegrationTest.toExplainStr(plan), expectedPlan);
+    Assert.assertEquals(ITestUtils.toResultStr(result), expectedResult);
+    Assert.assertEquals(ITestUtils.toExplainStr(plan), expectedPlan);
   }
 
   private JsonNode postV2Query(String query)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ITestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ITestUtils.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.jetbrains.annotations.NotNull;
+
+
+public class ITestUtils {
+
+  static final String RESULT_TABLE = "resultTable";
+
+  private ITestUtils() {
+  }
+
+  public static @NotNull String toExplainStr(JsonNode mainNode) {
+    if (mainNode == null) {
+      return "null";
+    }
+    JsonNode node = mainNode.get(RESULT_TABLE);
+    if (node == null) {
+      return ITestUtils.toErrorString(mainNode);
+    }
+    return toExplainString(node);
+  }
+
+  public static String toExplainString(JsonNode node) {
+    return node.get("rows").get(0).get(1).textValue();
+  }
+
+  public static @NotNull String toResultStr(JsonNode mainNode) {
+    if (mainNode == null) {
+      return "null";
+    }
+    JsonNode node = mainNode.get(RESULT_TABLE);
+    if (node == null) {
+      return toErrorString(mainNode);
+    }
+    return toString(node);
+  }
+
+  public static String toErrorString(JsonNode topNode) {
+    JsonNode node = topNode.get("exceptions");
+    JsonNode jsonNode = node.get(0);
+    if (jsonNode != null) {
+      return jsonNode.get("message").textValue();
+    }
+    return "";
+  }
+
+  public static String toString(JsonNode node) {
+    StringBuilder buf = new StringBuilder();
+    ArrayNode columnNames = (ArrayNode) node.get("dataSchema").get("columnNames");
+    ArrayNode columnTypes = (ArrayNode) node.get("dataSchema").get("columnDataTypes");
+    ArrayNode rows = (ArrayNode) node.get("rows");
+
+    for (int i = 0; i < columnNames.size(); i++) {
+      JsonNode name = columnNames.get(i);
+      JsonNode type = columnTypes.get(i);
+
+      if (i > 0) {
+        buf.append(",\t");
+      }
+
+      buf.append(name).append('[').append(type).append(']');
+    }
+
+    for (int i = 0; i < rows.size(); i++) {
+      ArrayNode row = (ArrayNode) rows.get(i);
+
+      buf.append('\n');
+      for (int j = 0; j < row.size(); j++) {
+        if (j > 0) {
+          buf.append(",\t");
+        }
+
+        buf.append(row.get(j));
+      }
+    }
+
+    return buf.toString();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryFailureIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryFailureIntegrationTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.function.scalar.TestFunctions;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.integration.tests.ClusterIntegrationTestUtils.getBrokerQueryApiUrl;
+
+
+/*
+ * This test verifies that cancel is being called on queries sent by the broker if exception occurs in any operator.
+ */
+public class QueryFailureIntegrationTest extends BaseClusterIntegrationTestSet implements ExplainIntegrationTestTrait {
+
+  static final int FILES_NO = 2;
+  static final int RECORDS_NO = 5;
+  static final String I_COL = "i";
+  static final int SERVERS_NO = 2;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    startZk();
+    startController();
+    startServers(SERVERS_NO);
+    startBroker();
+
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(DEFAULT_SCHEMA_NAME)
+        .addSingleValueDimension(I_COL, FieldSpec.DataType.INT)
+        .build();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    List<File> avroFiles = createAvroFile(_tempDir);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(DEFAULT_TABLE_NAME, _tarDir);
+
+    setUseMultiStageQueryEngine(true);
+    TestUtils.waitForCondition(() -> getCurrentCountStarResult(DEFAULT_TABLE_NAME) == FILES_NO * RECORDS_NO, 100L,
+        60_000,
+        "Failed to load  documents", true, Duration.ofMillis(60_000 / 10));
+
+    Map<String, List<String>> map = getTableServersToSegmentsMap(getTableName(), TableType.OFFLINE);
+    // make sure segments are split between multiple servers
+    org.testng.Assert.assertEquals(map.size(), SERVERS_NO);
+
+    TestFunctions.enable();
+  }
+
+  @Test
+  public void testCancellationOnMaxRowsInJoinError()
+      throws Exception {
+    // query should fail in subquery on maxRowsInJoin limit and the other 'sleepy' query should get cancelled
+    JsonNode result = postQuery("set maxRowsInJoin=2; "
+        + "select * from "
+        + "(select sum(t1.i+t2.i) "
+        + "from mytable t1 "
+        + "join mytable t2 on t1.i!=t2.i "
+        + "group by t1.i, t2.i) "
+        + "union all "
+        + "select sum(sleep(i+1000)) "
+        + "from mytable ");
+    Assert.assertTrue(
+        ITestUtils.toResultStr(result).contains(
+            "245=Cannot build in memory right table for join operator"));
+  }
+
+  @Test
+  public void testCancellationOnNumGroupsLimitError()
+      throws Exception {
+
+    // query should fail in subquery on num groups limit and the other 'sleepy' query should get cancelled
+    JsonNode result = postQuery(
+        "set errorOnNumGroupsLimit=true; set numGroupsLimit=1; "
+            + "select * from "
+            + "(select count(*) "
+            + "from mytable "
+            + "group by i) "
+            + "union all "
+            + "select sum(sleep(i+1000)) "
+            + "from mytable ");
+
+    String resultStr = ITestUtils.toResultStr(result);
+    Assert.assertTrue(resultStr, resultStr.contains("NUM_GROUPS_LIMIT has been reached at AggregateOperator"));
+  }
+
+  @Test
+  public void testCancellationOnFunctionCallError()
+      throws Exception {
+    // trigger exception only in thread processing of first segment
+    String query =
+        "select i, sum(case when i = 0 then throwError(i) else sleep(i+1000) end) "
+            + " from mytable "
+            + " group by i";
+
+    JsonNode result = postQuery(query);
+
+    Assert.assertTrue(
+        ITestUtils.toResultStr(result)
+            .contains(
+                "Caught exception while invoking method: public long org.apache.pinot.common.function.scalar"
+                    + ".TestFunctions.throwError(int) with arguments: [0]"));
+  }
+
+  public JsonNode postQuery(String query)
+      throws Exception {
+    return postQuery(query, getBrokerQueryApiUrl(getBrokerBaseApiUrl(), true), null,
+        getExtraQueryProperties());
+  }
+
+  protected TableConfig createOfflineTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(getTableName())
+        .setNumReplicas(getNumReplicas())
+        .setBrokerTenant(getBrokerTenant())
+        .build();
+  }
+
+  // for debug only
+  protected Properties getPinotConnectionProperties() {
+    Properties properties = new Properties();
+    properties.put("timeoutMs", "3600000");
+    properties.put("brokerReadTimeoutMs", "3600000");
+    properties.put("brokerConnectTimeoutMs", "3600000");
+    properties.putAll(getExtraQueryProperties());
+    return properties;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(DEFAULT_TABLE_NAME);
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+
+    FileUtils.deleteDirectory(_tempDir);
+
+    TestFunctions.disable();
+  }
+
+  public static List<File> createAvroFile(File tempDir)
+      throws IOException {
+
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+    avroSchema.setFields(ImmutableList.of(
+        new org.apache.avro.Schema.Field(I_COL,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT), null, null)));
+
+    List<File> files = new ArrayList<>();
+    for (int file = 0; file < FILES_NO; file++) {
+      File avroFile = new File(tempDir, "data_" + file + ".avro");
+      try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+        fileWriter.create(avroSchema, avroFile);
+
+        for (int docId = 0; docId < RECORDS_NO; docId++) {
+          GenericData.Record record = new GenericData.Record(avroSchema);
+          record.put(I_COL, file);
+          fileWriter.append(record);
+        }
+        files.add(avroFile);
+      }
+    }
+    return files;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -230,12 +230,10 @@ public class AggregateOperator extends MultiStageOperator {
       } else {
         TransferableBlock dataBlock = new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
         if (_groupByExecutor.isNumGroupsLimitReached()) {
+          _input.earlyTerminate();
+          _statMap.merge(StatKey.NUM_GROUPS_LIMIT_REACHED, true);
           if (_errorOnNumGroupsLimit) {
-            _input.earlyTerminate();
             throw new RuntimeException("NUM_GROUPS_LIMIT has been reached at " + _operatorId);
-          } else {
-            _statMap.merge(StatKey.NUM_GROUPS_LIMIT_REACHED, true);
-            _input.earlyTerminate();
           }
         }
         return dataBlock;
@@ -447,7 +445,8 @@ public class AggregateOperator extends MultiStageOperator {
         return true;
       }
     },
-    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN);
+    NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    EARLY_TERMINATED(StatMap.Type.BOOLEAN);
     //@formatter:on
 
     private final StatMap.Type _type;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -88,7 +88,8 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
 
   @Override
   protected void earlyTerminate() {
-    _isEarlyTerminated = true;
+    super.earlyTerminate();
+    _statMap.merge(StatKey.EARLY_TERMINATED, true);
     _multiConsumer.earlyTerminate();
   }
 
@@ -231,7 +232,17 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     /**
      * How long (in CPU time) it took to wait for the messages to be offered to downstream operator.
      */
-    UPSTREAM_WAIT_MS(StatMap.Type.LONG);
+    UPSTREAM_WAIT_MS(StatMap.Type.LONG),
+    /**
+     * This shouldn't be actually here, but we need it to be sure that we detect early termination in all cases.
+     *
+     * Usually early termination should be marked on the operartor that actually terminates early, but in some cases
+     * (like {@link MultiStageOperator#sampleAndCheckInterruption()} we are just early terminating the child operators
+     * without marking the operator itself as early terminated or failing accordingly).
+     *
+     * By capturing the early termination here, we can ensure that the operator is marked as early terminated.
+     */
+    EARLY_TERMINATED(StatMap.Type.BOOLEAN);
     //@formatter:on
 
     private final StatMap.Type _type;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -165,9 +165,6 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     if (_executionFuture == null) {
       _executionFuture = startExecution();
     }
-    if (_isEarlyTerminated) {
-      return constructMetadataBlock();
-    }
     BaseResultsBlock resultsBlock =
         _blockingQueue.poll(_context.getDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     if (resultsBlock == null) {
@@ -339,7 +336,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
       if (exceptions != null) {
         throw new RuntimeException("Received exception block: " + exceptions);
       }
-      if (_isEarlyTerminated || resultsBlock == LAST_RESULTS_BLOCK) {
+      if (resultsBlock == LAST_RESULTS_BLOCK) {
         break;
       } else if (!(resultsBlock instanceof ExplainV2ResultBlock)) {
         throw new IllegalArgumentException("Expected ExplainV2ResultBlock, got: " + resultsBlock.getClass().getName());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -73,7 +73,7 @@ public class LiteralValueOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    if (!_isLiteralBlockReturned && !_isEarlyTerminated && !_literalRows.isEmpty()) {
+    if (!_isLiteralBlockReturned && !_literalRows.isEmpty()) {
       _isLiteralBlockReturned = true;
       return constructBlock();
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -51,13 +51,6 @@ public class MailboxReceiveOperator extends BaseMailboxReceiveOperator {
   @Override
   protected TransferableBlock getNextBlock() {
     TransferableBlock block = _multiConsumer.readBlockBlocking();
-    // When early termination flag is set, caller is expecting an EOS block to be returned, however since the 2 stages
-    // between sending/receiving mailbox are setting early termination flag asynchronously, there's chances that the
-    // next block pulled out of the ReceivingMailbox to be an already buffered normal data block. This requires the
-    // MailboxReceiveOperator to continue pulling and dropping data block until an EOS block is observed.
-    while (_isEarlyTerminated && !block.isEndOfStreamBlock()) {
-      block = _multiConsumer.readBlockBlocking();
-    }
     if (block.isSuccessfulEndOfStreamBlock()) {
       updateEosBlock(block, _statMap);
     } else if (block.isDataBlock()) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -174,6 +174,7 @@ public class SortOperator extends MultiStageOperator {
                   _context.getId());
             }
             // setting operator to be early terminated and awaits EOS block next.
+            _statMap.merge(StatKey.LIMIT_REACHED, true);
             earlyTerminate();
           }
         }
@@ -201,7 +202,8 @@ public class SortOperator extends MultiStageOperator {
       public boolean includeDefaultInJson() {
         return true;
       }
-    };
+    },
+    LIMIT_REACHED(StatMap.Type.BOOLEAN);
     //@formatter:on
 
     private final StatMap.Type _type;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java
@@ -343,7 +343,7 @@ public class MultiStageQueryStats {
    * The final stats for the stage are obtained in the execution root (usually the broker) by
    * {@link Closed#merge(StageStats) merging} the partial views from all OpChains.
    */
-  public abstract static class StageStats {
+  public abstract static class StageStats implements Iterable<Entry> {
 
     /**
      * The types of the operators in the stage.
@@ -427,6 +427,24 @@ public class MultiStageQueryStats {
       while (typeIterator.hasNext()) {
         consumer.accept(typeIterator.next(), statIterator.next());
       }
+    }
+
+    @Override
+    public Iterator<Entry> iterator() {
+      return new Iterator<>() {
+        final Iterator<MultiStageOperator.Type> _typeIterator = _operatorTypes.iterator();
+        final Iterator<StatMap<?>> _statIterator = _operatorStats.iterator();
+
+        @Override
+        public boolean hasNext() {
+          return _typeIterator.hasNext();
+        }
+
+        @Override
+        public Entry next() {
+          return new Entry(_typeIterator.next(), _statIterator.next());
+        }
+      };
     }
 
     public JsonNode asJson() {
@@ -648,6 +666,24 @@ public class MultiStageQueryStats {
     }
 
     public MultiStageQueryStats build() {
+      return _stats;
+    }
+  }
+
+  public static class Entry {
+    private final MultiStageOperator.Type _type;
+    private final StatMap<?> _stats;
+
+    public Entry(MultiStageOperator.Type type, StatMap<?> stats) {
+      _type = type;
+      _stats = stats;
+    }
+
+    public MultiStageOperator.Type getType() {
+      return _type;
+    }
+
+    public StatMap<?> getStats() {
       return _stats;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -145,10 +145,8 @@ public class QueryDispatcher {
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
       return runReducer(requestId, dispatchableSubPlan, timeoutMs, queryOptions, _mailboxService);
-    } catch (Throwable e) {
-      // TODO: Consider always cancel when it returns (early terminate)
+    } finally {
       cancel(requestId, servers);
-      throw e;
     }
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Error in subquery triggers early termination propagation, stats checked, and broker cancels remaining subqueries\.

```mermaid
flowchart TD
  N0["Operator detects error #38; sets limit stat #40;F2#41;"]:::stAdded
  N1["Operator calls earlyTerminate on input #40;F2#41;"]:::stAdded
  N2["Child earlyTerminate sets EARLY#95;TERMINATED stat #40;F3#44; F7#41;"]:::stAdded
  N3["QueryResult includes operator stats via iterator #40;F11#44; F12#41;"]:::stAdded
  N4["QueryResult#46;isEarlyTerminated#40;#41; checks entries #40;F12#41;"]:::stAdded
  N5["Operator type#39;s isEarlyTerminated returns true #40;F8#41;"]:::stAdded
  N6["QueryDispatcher cancels subqueries if early terminated #40;F12#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java)
- F3: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java)
- F7: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java)
- F8: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java)
- F11: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStats.java)
- F12: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher\.java — [before](https://github.com/apache/pinot/blob/d195edf414153b10e642140eead016edd3fd974d/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java) · [after](https://github.com/apache/pinot/blob/1dfd445a8260271a97f8b4cc359c1393a132ebba/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQxOTVlZGY0MTQxNTNiMTBlNjQyMTQwZWVhZDAxNmVkZDNmZDk3NGQiLCJjb250ZXh0X2hhc2giOiJjNzM0MmI4N2ZkMWU1OGY3ODNiYjhjMzM2MzU4YzI0M2RmZGIyOGJlNDVhODllZGI4NzA2MDllZjZjNmFiZjQyIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDE2MTcyLCJoZWFkX3NoYSI6IjFkZmQ0NDVhODI2MDI3MWE5N2Y4YjRjYzM1OWMxMzkzYTEzMmViYmEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4YjJkNWI2ZDllZTk4MGVlODAwNGQ0NGVkYjBjMGUzMmFkNWY3ZGIwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 9d8fc8f4369ef81f3a75c7d00f82abf765ec418d99f63a4c6813b7747d873786 -->
<!-- pinot-pr-flow:end -->

This PR checks that subqueries are cancelled when error reaches MSQE request handler.