### PR TITLE
Nit: Fix Error Message Typo

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -133,7 +133,7 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
       }
     }
     throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". "
-        + "Valid types are: " + errroMessageFor(quickStarts));
+        + "Valid types are: " + errorMessageFor(quickStarts));
   }
 
   @Override
@@ -145,7 +145,7 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
       Set<Class<? extends QuickStartBase>> quickStarts = allQuickStarts();
 
       throw new UnsupportedOperationException("No QuickStart type provided. "
-          + "Valid types are: " + errroMessageFor(quickStarts));
+          + "Valid types are: " + errorMessageFor(quickStarts));
     }
 
     QuickStartBase quickstart = selectQuickStart(_type);
@@ -170,7 +170,7 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     return true;
   }
 
-  private static List<String> errroMessageFor(Set<Class<? extends QuickStartBase>> quickStarts)
+  private static List<String> errorMessageFor(Set<Class<? extends QuickStartBase>> quickStarts)
       throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
     List<String> validTypes = new ArrayList<>();
     for (Class<? extends QuickStartBase> quickStart : quickStarts) {


### PR DESCRIPTION
- Nit
- Renames `errroMessageFor` function within `QuickstartCommand.java` to `errorMessageFor`