### PR TITLE
fix(ui): query settings are not passing correctly when running via cmd+enter

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -245,7 +245,14 @@ const QueryPage = () => {
     if (modifiedEnabled && event.keyCode == 220) {
       handleFormatSQL(editor.getValue());
     }
-  }
+  };
+
+  const handleQueryInterfaceKeyDownRef = React.useRef(handleQueryInterfaceKeyDown);
+
+  useEffect(() => {
+    handleQueryInterfaceKeyDownRef.current = handleQueryInterfaceKeyDown;
+  }, [handleQueryInterfaceKeyDown]);
+  
 
   const handleComment = (cm: NativeCodeMirror.Editor) => {
     const selections = cm.listSelections();
@@ -511,7 +518,9 @@ const QueryPage = () => {
                   }}
                   value={inputQuery}
                   onChange={handleOutputDataChange}
-                  onKeyDown={handleQueryInterfaceKeyDown}
+                  // Ensures the latest function is always called, preventing stale state issues due to closures.
+                  // Directly passing handleQueryInterfaceKeyDown may result in outdated state references.
+                  onKeyDown={(editor, event) => handleQueryInterfaceKeyDownRef.current(editor, event)} 
                   className={classes.codeMirror}
                   autoCursor={false}
                 />


### PR DESCRIPTION
## Issue

- Run a query without queryOptions using the `RUN QUERY` button - Works as expected, empty query options.
- Run a query with a specific timeout using the `RUN QUERY` button - Works as expected, timeoutMs added to queryOptions.
- Run a query with a specific timeout using `CMD + ENTER` - Doesn't work as expected, queryOptions is empty and should have  timeoutMs.

![oss-ui-issue-gif](https://github.com/user-attachments/assets/73d4755e-3c67-400d-b687-0788d7930b09)


## Solution
- The function triggered by Cmd + Enter to run the query was using stale state values, causing the issue.


https://github.com/user-attachments/assets/72ab545d-7692-4e6c-bab9-4a1397c94f16

