### PR TITLE
Minion tasks should not pick up problematic consuming segments

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,18 +87,10 @@ public class PurgeTaskGenerator extends BaseTaskGenerator {
       } else {
         tableMaxNumTasks = Integer.MAX_VALUE;
       }
-      List<SegmentZKMetadata> segmentsZKMetadata = new ArrayList<>();
-      if (tableConfig.getTableType() == TableType.REALTIME) {
-        List<SegmentZKMetadata> segmentsZKMetadataAll = getSegmentsZKMetadataForTable(tableName);
-        for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadataAll) {
-          CommonConstants.Segment.Realtime.Status status = segmentZKMetadata.getStatus();
-          if (status.isCompleted()) {
-            segmentsZKMetadata.add(segmentZKMetadata);
-          }
-        }
-      } else {
-        segmentsZKMetadata = getSegmentsZKMetadataForTable(tableName);
-      }
+      List<SegmentZKMetadata> segmentsZKMetadata =
+          tableConfig.getTableType() == TableType.OFFLINE
+              ? getSegmentsZKMetadataForTable(tableName)
+              : getNonConsumingSegmentsZKMetadataForRealtimeTable(tableName);
 
       List<SegmentZKMetadata> purgedSegmentsZKMetadata = new ArrayList<>();
       List<SegmentZKMetadata> notpurgedSegmentsZKMetadata = new ArrayList<>();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -47,7 +47,6 @@ import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskGenerator.java
@@ -110,17 +110,15 @@ public class RefreshSegmentTaskGenerator extends BaseTaskGenerator {
         TaskGeneratorUtils.getRunningSegments(RefreshSegmentTask.TASK_TYPE, _clusterInfoAccessor);
 
     // Make a single ZK call to get the segments.
-    List<SegmentZKMetadata> allSegments = _clusterInfoAccessor.getSegmentsZKMetadata(tableNameWithType);
+    List<SegmentZKMetadata> allSegments =
+        tableConfig.getTableType() == TableType.OFFLINE
+            ? getSegmentsZKMetadataForTable(tableNameWithType)
+            : getNonConsumingSegmentsZKMetadataForRealtimeTable(tableNameWithType);
 
     for (SegmentZKMetadata segmentZKMetadata : allSegments) {
       // Skip if we have reached the maximum number of permissible tasks per iteration.
       if (tableNumTasks >= tableMaxNumTasks) {
         break;
-      }
-
-      // Skip consuming segments.
-      if (tableConfig.getTableType() == TableType.REALTIME && !segmentZKMetadata.getStatus().isCompleted()) {
-        continue;
       }
 
       // Skip segments for which a task is already running.


### PR DESCRIPTION
In segment commit end, Controller updates ZK in multiple steps (it does not use ZK transaction).
In one step, it updates segment ZK metadata of committing segments (set segment.status as DONE), and in the next step, it updates the consuming segment in IdealState to ONLINE.

If Controller fails in between these two steps for any reason (crash, restart, stream connection failure, ...), IdealState and SegmentZKMetadata will be out of sync. `RealtimeSegmentValidationManager` job detects this inconsistency and tries to fix it by marking IdealState as ONLINE and creating a new CONSUMING segment. However, if this segment is scheduled for purge (or any other 1:1 minion task), and purge job successfully uploads the segment, the status in SegmentZKMetadata will be updated to UPLOADED. This prevents `RealtimeSegmentValidationManager` to fix the issue.

This PR fixes this issue by making sure that the problematic segment is not scheduled for different minion tasks by detecting the problematic scenario (status in SegmentZKMetadata is UPLOADED, but IdealState is CONSUMING).

Note: MergeRollup task generator needs to be updated once this issue (https://github.com/apache/pinot/issues/15128) is fixed.