### PR TITLE
Eliminate object type check during aggregate ser/de

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -76,6 +76,7 @@ import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.datasketches.tuple.aninteger.IntegerSummaryDeserializer;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.core.query.aggregation.utils.exprminmax.ExprMinMaxObject;
 import org.apache.pinot.core.query.utils.idset.IdSet;
@@ -176,6 +177,10 @@ public class ObjectSerDeUtils {
       return _value;
     }
 
+    /**
+     * @deprecated Avoid using this method because it is very inefficient.
+     */
+    @Deprecated
     public static ObjectType getObjectType(Object value) {
       if (value instanceof String) {
         return ObjectType.String;
@@ -330,6 +335,7 @@ public class ObjectSerDeUtils {
     T deserialize(ByteBuffer byteBuffer);
   }
 
+  @Deprecated
   public static final ObjectSerDe<String> STRING_SER_DE = new ObjectSerDe<String>() {
 
     @Override
@@ -350,6 +356,7 @@ public class ObjectSerDeUtils {
     }
   };
 
+  @Deprecated
   public static final ObjectSerDe<Long> LONG_SER_DE = new ObjectSerDe<Long>() {
 
     @Override
@@ -368,6 +375,7 @@ public class ObjectSerDeUtils {
     }
   };
 
+  @Deprecated
   public static final ObjectSerDe<Double> DOUBLE_SER_DE = new ObjectSerDe<Double>() {
 
     @Override
@@ -812,6 +820,7 @@ public class ObjectSerDeUtils {
     }
   };
 
+  @Deprecated
   public static final ObjectSerDe<Map<Object, Object>> MAP_SER_DE = new ObjectSerDe<Map<Object, Object>>() {
 
     @Override
@@ -1229,10 +1238,7 @@ public class ObjectSerDeUtils {
 
     @Override
     public byte[] serialize(RoaringBitmap bitmap) {
-      byte[] bytes = new byte[bitmap.serializedSizeInBytes()];
-      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
-      bitmap.serialize(byteBuffer);
-      return bytes;
+      return RoaringBitmapUtils.serialize(bitmap);
     }
 
     @Override
@@ -1242,13 +1248,7 @@ public class ObjectSerDeUtils {
 
     @Override
     public RoaringBitmap deserialize(ByteBuffer byteBuffer) {
-      RoaringBitmap bitmap = new RoaringBitmap();
-      try {
-        bitmap.deserialize(byteBuffer);
-      } catch (IOException e) {
-        throw new RuntimeException("Caught exception while deserializing RoaringBitmap", e);
-      }
-      return bitmap;
+      return RoaringBitmapUtils.deserialize(byteBuffer);
     }
   };
 
@@ -1282,10 +1282,11 @@ public class ObjectSerDeUtils {
     }
   };
 
-  public static final ObjectSerDe<List<Object>> LIST_SER_DE = new ObjectSerDe<List<Object>>() {
+  @Deprecated
+  public static final ObjectSerDe<List> LIST_SER_DE = new ObjectSerDe<>() {
 
     @Override
-    public byte[] serialize(List<Object> list) {
+    public byte[] serialize(List list) {
       int size = list.size();
 
       // Directly return the size (0) for empty list
@@ -1813,10 +1814,6 @@ public class ObjectSerDeUtils {
     return SER_DES[objectTypeValue].serialize(value);
   }
 
-  /**
-   * @deprecated Use each individual SER_DE class instead.
-   */
-  @Deprecated
   public static <T> T deserialize(CustomObject customObject) {
     return (T) SER_DES[customObject.getType()].deserialize(customObject.getBuffer());
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -119,15 +118,9 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   /**
    * Serializes the intermediate result into a custom object. This method should be implemented if the intermediate
    * result type is OBJECT.
-   *
-   * TODO: Override this method in the aggregation functions that return OBJECT type intermediate results to reduce the
-   *       overhead of instanceof checks in the default implementation.
    */
   default SerializedIntermediateResult serializeIntermediateResult(IntermediateResult intermediateResult) {
-    assert getIntermediateResultColumnType() == ColumnDataType.OBJECT;
-    int type = ObjectSerDeUtils.ObjectType.getObjectType(intermediateResult).getValue();
-    byte[] bytes = ObjectSerDeUtils.serialize(intermediateResult, type);
-    return new SerializedIntermediateResult(type, bytes);
+    throw new UnsupportedOperationException("Cannot serialize intermediate result for function: " + getType());
   }
 
   /**
@@ -154,13 +147,9 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   /**
    * Deserializes the intermediate result from the custom object. This method should be implemented if the intermediate
    * result type is OBJECT.
-   *
-   * TODO: Override this method in the aggregation functions that return OBJECT type intermediate results to not rely
-   *       on the type to decouple this from ObjectSerDeUtils.
    */
   default IntermediateResult deserializeIntermediateResult(CustomObject customObject) {
-    assert getIntermediateResultColumnType() == ColumnDataType.OBJECT;
-    return ObjectSerDeUtils.deserialize(customObject);
+    throw new UnsupportedOperationException("Cannot deserialize intermediate result for function: " + getType());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -203,13 +203,13 @@ public class AvgAggregationFunction extends NullableSingleInputAggregationFuncti
 
   @Override
   public SerializedIntermediateResult serializeIntermediateResult(AvgPair avgPair) {
-    // ObjectSerDeUtils.ObjectType.AvgPair.getValue() == 4
-    return new SerializedIntermediateResult(4, avgPair.toBytes());
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.AvgPair.getValue(),
+        ObjectSerDeUtils.AVG_PAIR_SER_DE.serialize(avgPair));
   }
 
   @Override
   public AvgPair deserializeIntermediateResult(CustomObject customObject) {
-    return AvgPair.fromByteBuffer(customObject.getBuffer());
+    return ObjectSerDeUtils.AVG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -22,9 +22,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -173,13 +175,24 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
   }
 
   @Override
-  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.OBJECT;
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
   }
 
   @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.DOUBLE;
+  public SerializedIntermediateResult serializeIntermediateResult(CovarianceTuple covarianceTuple) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.CovarianceTuple.getValue(),
+        ObjectSerDeUtils.COVARIANCE_TUPLE_OBJECT_SER_DE.serialize(covarianceTuple));
+  }
+
+  @Override
+  public CovarianceTuple deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.COVARIANCE_TUPLE_OBJECT_SER_DE.deserialize(customObject.getBuffer());
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
@@ -20,10 +20,12 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -317,6 +319,17 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(RoaringBitmap roaringBitmap) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.RoaringBitmap.getValue(),
+        ObjectSerDeUtils.ROARING_BITMAP_SER_DE.serialize(roaringBitmap));
+  }
+
+  @Override
+  public RoaringBitmap deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.ROARING_BITMAP_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -24,9 +24,11 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.datasketches.cpc.CpcSketch;
 import org.apache.datasketches.memory.Memory;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -401,6 +403,17 @@ public class DistinctCountCPCSketchAggregationFunction
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(CpcSketchAccumulator cpcSketchAccumulator) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.CpcSketchAccumulator.getValue(),
+        ObjectSerDeUtils.DATA_SKETCH_CPC_ACCUMULATOR_SER_DE.serialize(cpcSketchAccumulator));
+  }
+
+  @Override
+  public CpcSketchAccumulator deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DATA_SKETCH_CPC_ACCUMULATOR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -352,6 +353,17 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(HyperLogLog hyperLogLog) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.HyperLogLog.getValue(),
+        ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog));
+  }
+
+  @Override
+  public HyperLogLog deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -365,6 +366,17 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(HyperLogLogPlus hyperLogLogPlus) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.HyperLogLogPlus.getValue(),
+        ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.serialize(hyperLogLogPlus));
+  }
+
+  @Override
+  public HyperLogLogPlus deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -100,6 +101,16 @@ public class DistinctCountRawHLLAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return _distinctCountHLLAggregationFunction.getIntermediateResultColumnType();
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(HyperLogLog hyperLogLog) {
+    return _distinctCountHLLAggregationFunction.serializeIntermediateResult(hyperLogLog);
+  }
+
+  @Override
+  public HyperLogLog deserializeIntermediateResult(CustomObject customObject) {
+    return _distinctCountHLLAggregationFunction.deserializeIntermediateResult(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -101,6 +102,16 @@ public class DistinctCountRawHLLPlusAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return _distinctCountHLLPlusAggregationFunction.getIntermediateResultColumnType();
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(HyperLogLogPlus hyperLogLogPlus) {
+    return _distinctCountHLLPlusAggregationFunction.serializeIntermediateResult(hyperLogLogPlus);
+  }
+
+  @Override
+  public HyperLogLogPlus deserializeIntermediateResult(CustomObject customObject) {
+    return _distinctCountHLLPlusAggregationFunction.deserializeIntermediateResult(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
@@ -22,6 +22,7 @@ import com.dynatrace.hash4j.distinctcount.UltraLogLog;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -348,6 +349,17 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(UltraLogLog ultraLogLog) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.UltraLogLog.getValue(),
+        ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.serialize(ultraLogLog));
+  }
+
+  @Override
+  public UltraLogLog deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -167,6 +168,17 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(HyperLogLog hyperLogLog) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.HyperLogLog.getValue(),
+        ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hyperLogLog));
+  }
+
+  @Override
+  public HyperLogLog deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'DOUBLE')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Double> doubleLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleLongPair.getValue(),
+        ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE.serialize((DoubleLongPair) doubleLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Double> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'FLOAT')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Float> floatLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FloatLongPair.getValue(),
+        ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE.serialize((FloatLongPair) floatLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Float> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -107,6 +108,17 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
     } else {
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'INT')";
     }
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Integer> intLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.IntLongPair.getValue(),
+        ObjectSerDeUtils.INT_LONG_PAIR_SER_DE.serialize((IntLongPair) intLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Integer> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.INT_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'LONG')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Long> longLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.LongLongPair.getValue(),
+        ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE.serialize((LongLongPair) longLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Long> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'STRING')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<String> stringLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.StringLongPair.getValue(),
+        ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE.serialize((StringLongPair) stringLongPair));
+  }
+
+  @Override
+  public ValueLongPair<String> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
@@ -20,9 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -142,13 +144,24 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
   }
 
   @Override
-  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.OBJECT;
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
   }
 
   @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.DOUBLE;
+  public SerializedIntermediateResult serializeIntermediateResult(PinotFourthMoment pinotFourthMoment) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.PinotFourthMoment.getValue(),
+        ObjectSerDeUtils.PINOT_FOURTH_MOMENT_OBJECT_SER_DE.serialize(pinotFourthMoment));
+  }
+
+  @Override
+  public PinotFourthMoment deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.PINOT_FOURTH_MOMENT_OBJECT_SER_DE.deserialize(customObject.getBuffer());
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.frequencies.LongsSketch;
 import org.apache.datasketches.memory.Memory;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -248,6 +250,17 @@ public class FrequentLongsSketchAggregationFunction
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(LongsSketch longsSketch) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FrequentLongsSketch.getValue(),
+        ObjectSerDeUtils.FREQUENT_LONGS_SKETCH_SER_DE.serialize(longsSketch));
+  }
+
+  @Override
+  public LongsSketch deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FREQUENT_LONGS_SKETCH_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
@@ -25,9 +25,11 @@ import java.util.Map;
 import org.apache.datasketches.common.ArrayOfStringsSerDe;
 import org.apache.datasketches.frequencies.ItemsSketch;
 import org.apache.datasketches.memory.Memory;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -232,6 +234,17 @@ public class FrequentStringsSketchAggregationFunction
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ItemsSketch<String> stringItemsSketch) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FrequentStringsSketch.getValue(),
+        ObjectSerDeUtils.FREQUENT_STRINGS_SKETCH_SER_DE.serialize(stringItemsSketch));
+  }
+
+  @Override
+  public ItemsSketch<String> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FREQUENT_STRINGS_SKETCH_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -22,9 +22,11 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -216,6 +218,17 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(DoubleArrayList doubles) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleArrayList.getValue(),
+        ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.serialize(doubles));
+  }
+
+  @Override
+  public DoubleArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -471,6 +473,17 @@ public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(IdSet idSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.IdSet.getValue(),
+        ObjectSerDeUtils.ID_SET_SER_DE.serialize(idSet));
+  }
+
+  @Override
+  public IdSet deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.ID_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -29,9 +29,11 @@ import org.apache.datasketches.tuple.Sketches;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.datasketches.tuple.aninteger.IntegerSummaryDeserializer;
 import org.apache.datasketches.tuple.aninteger.IntegerSummarySetOperations;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -261,6 +263,17 @@ public class IntegerTupleSketchAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(TupleIntSketchAccumulator tupleIntSketchAccumulator) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.TupleIntSketchAccumulator.getValue(),
+        ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_ACCUMULATOR_SER_DE.serialize(tupleIntSketchAccumulator));
+  }
+
+  @Override
+  public TupleIntSketchAccumulator deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_ACCUMULATOR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'DOUBLE')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Double> doubleLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleLongPair.getValue(),
+        ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE.serialize((DoubleLongPair) doubleLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Double> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'FLOAT')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Float> floatLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FloatLongPair.getValue(),
+        ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE.serialize((FloatLongPair) floatLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Float> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -107,6 +108,17 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
     } else {
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'INT')";
     }
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Integer> intLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.IntLongPair.getValue(),
+        ObjectSerDeUtils.INT_LONG_PAIR_SER_DE.serialize((IntLongPair) intLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Integer> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.INT_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'LONG')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<Long> longLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.LongLongPair.getValue(),
+        ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE.serialize((LongLongPair) longLongPair));
+  }
+
+  @Override
+  public ValueLongPair<Long> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -98,6 +99,17 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'STRING')";
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ValueLongPair<String> stringLongPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.StringLongPair.getValue(),
+        ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE.serialize((StringLongPair) stringLongPair));
+  }
+
+  @Override
+  public ValueLongPair<String> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -195,6 +196,17 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(MinMaxRangePair minMaxRangePair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.MinMaxRangePair.getValue(),
+        ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.serialize(minMaxRangePair));
+  }
+
+  @Override
+  public MinMaxRangePair deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
@@ -34,9 +34,11 @@ import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -490,6 +492,32 @@ public class ModeAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(Map<? extends Number, Long> longMap) {
+    if (longMap instanceof Int2LongMap) {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.Int2LongMap.getValue(),
+          ObjectSerDeUtils.INT_2_LONG_MAP_SER_DE.serialize((Int2LongMap) longMap));
+    } else if (longMap instanceof Long2LongMap) {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.Long2LongMap.getValue(),
+          ObjectSerDeUtils.LONG_2_LONG_MAP_SER_DE.serialize((Long2LongMap) longMap));
+    } else if (longMap instanceof Float2LongMap) {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.Float2LongMap.getValue(),
+          ObjectSerDeUtils.FLOAT_2_LONG_MAP_SER_DE.serialize((Float2LongMap) longMap));
+    } else if (longMap instanceof Double2LongMap) {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.Double2LongMap.getValue(),
+          ObjectSerDeUtils.DOUBLE_2_LONG_MAP_SER_DE.serialize((Double2LongMap) longMap));
+    } else {
+      throw new IllegalStateException(
+          "Illegal data type for Intermediate Result of MODE aggregation function: " + longMap.getClass()
+              .getSimpleName());
+    }
+  }
+
+  @Override
+  public Map<? extends Number, Long> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.deserialize(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
@@ -22,9 +22,11 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -423,6 +425,17 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ExprMinMaxObject exprMinMaxObject) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.ExprMinMaxObject.getValue(),
+        ObjectSerDeUtils.ARG_MIN_MAX_OBJECT_SER_DE.serialize(exprMinMaxObject));
+  }
+
+  @Override
+  public ExprMinMaxObject deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.ARG_MIN_MAX_OBJECT_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -21,9 +21,11 @@ package org.apache.pinot.core.query.aggregation.function;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -144,6 +146,17 @@ public class PercentileAggregationFunction extends NullableSingleInputAggregatio
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(DoubleArrayList doubleArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleArrayList.getValue(),
+        ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.serialize(doubleArrayList));
+  }
+
+  @Override
+  public DoubleArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -208,6 +209,17 @@ public class PercentileEstAggregationFunction extends NullableSingleInputAggrega
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(QuantileDigest quantileDigest) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.QuantileDigest.getValue(),
+        ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.serialize(quantileDigest));
+  }
+
+  @Override
+  public QuantileDigest deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.datasketches.memory.Memory;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -241,6 +243,17 @@ public class PercentileKLLAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(KllDoublesSketch kllDoublesSketch) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.KllDataSketch.getValue(),
+        ObjectSerDeUtils.KLL_SKETCH_SER_DE.serialize(kllDoublesSketch));
+  }
+
+  @Override
+  public KllDoublesSketch deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.KLL_SKETCH_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -115,6 +116,16 @@ public class PercentileRawEstAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return _percentileEstAggregationFunction.getIntermediateResultColumnType();
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(QuantileDigest quantileDigest) {
+    return _percentileEstAggregationFunction.serializeIntermediateResult(quantileDigest);
+  }
+
+  @Override
+  public QuantileDigest deserializeIntermediateResult(CustomObject customObject) {
+    return _percentileEstAggregationFunction.deserializeIntermediateResult(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -127,6 +128,16 @@ public class PercentileRawTDigestAggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return _percentileTDigestAggregationFunction.getIntermediateResultColumnType();
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(TDigest tDigest) {
+    return _percentileTDigestAggregationFunction.serializeIntermediateResult(tDigest);
+  }
+
+  @Override
+  public TDigest deserializeIntermediateResult(CustomObject customObject) {
+    return _percentileTDigestAggregationFunction.deserializeIntermediateResult(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -26,9 +26,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -292,6 +294,22 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(Object o) {
+    if (o instanceof TDigest) {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.TDigest.getValue(),
+          ObjectSerDeUtils.TDIGEST_SER_DE.serialize((TDigest) o));
+    } else {
+      return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleArrayList.getValue(),
+          ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.serialize((DoubleArrayList) o));
+    }
+  }
+
+  @Override
+  public Object deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.deserialize(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -230,6 +231,17 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(TDigest tDigest) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.TDigest.getValue(),
+        ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest));
+  }
+
+  @Override
+  public TDigest deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
@@ -20,9 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -112,6 +114,17 @@ public class StUnionAggregationFunction extends BaseSingleInputAggregationFuncti
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(Geometry geometry) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.Geometry.getValue(),
+        ObjectSerDeUtils.GEOMETRY_SER_DE.serialize(geometry));
+  }
+
+  @Override
+  public Geometry deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.GEOMETRY_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
@@ -24,9 +24,11 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -346,7 +348,19 @@ public class SumPrecisionAggregationFunction extends NullableSingleInputAggregat
 
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
+    // TODO: Revisit if we should change this to BIG_DECIMAL
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(BigDecimal bigDecimal) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.BigDecimal.getValue(),
+        ObjectSerDeUtils.BIGDECIMAL_SER_DE.serialize(bigDecimal));
+  }
+
+  @Override
+  public BigDecimal deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.BIGDECIMAL_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
@@ -20,9 +20,11 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -170,6 +172,17 @@ public class VarianceAggregationFunction extends NullableSingleInputAggregationF
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
     return DataSchema.ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(VarianceTuple varianceTuple) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.VarianceTuple.getValue(),
+        ObjectSerDeUtils.VARIANCE_TUPLE_OBJECT_SER_DE.serialize(varianceTuple));
+  }
+
+  @Override
+  public VarianceTuple deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.VARIANCE_TUPLE_OBJECT_SER_DE.deserialize(customObject.getBuffer());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctDoubleFunction.java
@@ -19,14 +19,17 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
-public class ArrayAggDistinctDoubleFunction extends BaseArrayAggDoubleFunction<DoubleOpenHashSet> {
+public class ArrayAggDistinctDoubleFunction extends BaseArrayAggDoubleFunction<DoubleSet> {
   public ArrayAggDistinctDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, nullHandlingEnabled);
   }
@@ -54,5 +57,16 @@ public class ArrayAggDistinctDoubleFunction extends BaseArrayAggDoubleFunction<D
       resultHolder.setValueForKey(groupKey, valueSet);
     }
     valueSet.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(DoubleSet doubleOpenHashSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleSet.getValue(),
+        ObjectSerDeUtils.DOUBLE_SET_SER_DE.serialize(doubleOpenHashSet));
+  }
+
+  @Override
+  public DoubleSet deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctFloatFunction.java
@@ -19,14 +19,17 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatSet;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
-public class ArrayAggDistinctFloatFunction extends BaseArrayAggFloatFunction<FloatOpenHashSet> {
+public class ArrayAggDistinctFloatFunction extends BaseArrayAggFloatFunction<FloatSet> {
   public ArrayAggDistinctFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, nullHandlingEnabled);
   }
@@ -54,5 +57,16 @@ public class ArrayAggDistinctFloatFunction extends BaseArrayAggFloatFunction<Flo
       resultHolder.setValueForKey(groupKey, valueSet);
     }
     valueSet.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(FloatSet floatSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FloatSet.getValue(),
+        ObjectSerDeUtils.FLOAT_SET_SER_DE.serialize(floatSet));
+  }
+
+  @Override
+  public FloatSet deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FLOAT_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
@@ -19,15 +19,18 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public class ArrayAggDistinctIntFunction extends BaseArrayAggIntFunction<IntOpenHashSet> {
+public class ArrayAggDistinctIntFunction extends BaseArrayAggIntFunction<IntSet> {
   public ArrayAggDistinctIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
@@ -56,5 +59,16 @@ public class ArrayAggDistinctIntFunction extends BaseArrayAggIntFunction<IntOpen
       resultHolder.setValueForKey(groupKey, valueSet);
     }
     valueSet.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(IntSet intSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.IntSet.getValue(),
+        ObjectSerDeUtils.INT_SET_SER_DE.serialize(intSet));
+  }
+
+  @Override
+  public IntSet deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.INT_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
@@ -19,15 +19,18 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongOpenHashSet> {
+public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongSet> {
   public ArrayAggDistinctLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
       boolean nullHandlingEnabled) {
     super(expression, dataType, nullHandlingEnabled);
@@ -56,5 +59,16 @@ public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongO
       resultHolder.setValueForKey(groupKey, valueSet);
     }
     valueSet.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(LongSet longSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.LongSet.getValue(),
+        ObjectSerDeUtils.LONG_SET_SER_DE.serialize(longSet));
+  }
+
+  @Override
+  public LongSet deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.LONG_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
@@ -19,15 +19,18 @@
 package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.util.Arrays;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
 
-public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<ObjectOpenHashSet<String>> {
+public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<ObjectSet<String>> {
   public ArrayAggDistinctStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, nullHandlingEnabled);
   }
@@ -50,5 +53,16 @@ public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<O
       resultHolder.setValueForKey(groupKey, valueSet);
     }
     valueSet.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ObjectSet<String> stringSet) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.StringSet.getValue(),
+        ObjectSerDeUtils.STRING_SET_SER_DE.serialize(stringSet));
+  }
+
+  @Override
+  public ObjectSet<String> deserializeIntermediateResult(CustomObject customObject) {
+    return (ObjectSet<String>) ObjectSerDeUtils.STRING_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDoubleFunction.java
@@ -20,8 +20,10 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
@@ -54,5 +56,16 @@ public class ArrayAggDoubleFunction extends BaseArrayAggDoubleFunction<DoubleArr
       resultHolder.setValueForKey(groupKey, valueArray);
     }
     valueArray.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(DoubleArrayList doubleArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.DoubleArrayList.getValue(),
+        ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.serialize(doubleArrayList));
+  }
+
+  @Override
+  public DoubleArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.DOUBLE_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
@@ -20,8 +20,10 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
@@ -54,5 +56,16 @@ public class ArrayAggFloatFunction extends BaseArrayAggFloatFunction<FloatArrayL
       resultHolder.setValueForKey(groupKey, valueArray);
     }
     valueArray.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(FloatArrayList floatArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FloatArrayList.getValue(),
+        ObjectSerDeUtils.FLOAT_ARRAY_LIST_SER_DE.serialize(floatArrayList));
+  }
+
+  @Override
+  public FloatArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FLOAT_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
@@ -20,8 +20,10 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -55,5 +57,16 @@ public class ArrayAggIntFunction extends BaseArrayAggIntFunction<IntArrayList> {
       resultHolder.setValueForKey(groupKey, valueArray);
     }
     valueArray.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(IntArrayList intArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.IntArrayList.getValue(),
+        ObjectSerDeUtils.INT_ARRAY_LIST_SER_DE.serialize(intArrayList));
+  }
+
+  @Override
+  public IntArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.INT_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
@@ -20,8 +20,10 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -55,5 +57,16 @@ public class ArrayAggLongFunction extends BaseArrayAggLongFunction<LongArrayList
       resultHolder.setValueForKey(groupKey, valueArray);
     }
     valueArray.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(LongArrayList longArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.LongArrayList.getValue(),
+        ObjectSerDeUtils.LONG_ARRAY_LIST_SER_DE.serialize(longArrayList));
+  }
+
+  @Override
+  public LongArrayList deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.LONG_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
@@ -21,8 +21,10 @@ package org.apache.pinot.core.query.aggregation.function.array;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
@@ -50,5 +52,17 @@ public class ArrayAggStringFunction extends BaseArrayAggStringFunction<ObjectArr
       resultHolder.setValueForKey(groupKey, valueArray);
     }
     valueArray.add(value);
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ObjectArrayList<String> stringArrayList) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.StringArrayList.getValue(),
+        ObjectSerDeUtils.STRING_ARRAY_LIST_SER_DE.serialize(stringArrayList));
+  }
+
+  @Override
+  public ObjectArrayList<String> deserializeIntermediateResult(CustomObject customObject) {
+    //noinspection unchecked
+    return ObjectSerDeUtils.STRING_ARRAY_LIST_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.doubles.AbstractDoubleCollection;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleCollection;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
@@ -27,7 +27,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public abstract class BaseArrayAggDoubleFunction<I extends AbstractDoubleCollection>
+public abstract class BaseArrayAggDoubleFunction<I extends DoubleCollection>
     extends BaseArrayAggFunction<I, DoubleArrayList> {
   public BaseArrayAggDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, FieldSpec.DataType.DOUBLE, nullHandlingEnabled);
@@ -77,10 +77,10 @@ public abstract class BaseArrayAggDoubleFunction<I extends AbstractDoubleCollect
   }
 
   @Override
-  public DoubleArrayList extractFinalResult(I doubleArrayList) {
-    if (doubleArrayList == null) {
+  public DoubleArrayList extractFinalResult(I doubles) {
+    if (doubles == null) {
       return new DoubleArrayList();
     }
-    return new DoubleArrayList(doubleArrayList);
+    return new DoubleArrayList(doubles);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.floats.AbstractFloatCollection;
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.floats.FloatCollection;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
@@ -27,7 +27,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public abstract class BaseArrayAggFloatFunction<I extends AbstractFloatCollection>
+public abstract class BaseArrayAggFloatFunction<I extends FloatCollection>
     extends BaseArrayAggFunction<I, FloatArrayList> {
   public BaseArrayAggFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, FieldSpec.DataType.FLOAT, nullHandlingEnabled);
@@ -77,10 +77,10 @@ public abstract class BaseArrayAggFloatFunction<I extends AbstractFloatCollectio
   }
 
   @Override
-  public FloatArrayList extractFinalResult(I floatArrayList) {
-    if (floatArrayList == null) {
+  public FloatArrayList extractFinalResult(I floats) {
+    if (floats == null) {
       return new FloatArrayList();
     }
-    return new FloatArrayList(floatArrayList);
+    return new FloatArrayList(floats);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.ints.AbstractIntCollection;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
@@ -27,7 +27,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public abstract class BaseArrayAggIntFunction<I extends AbstractIntCollection>
+public abstract class BaseArrayAggIntFunction<I extends IntCollection>
     extends BaseArrayAggFunction<I, IntArrayList> {
   public BaseArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
       boolean nullHandlingEnabled) {
@@ -78,10 +78,10 @@ public abstract class BaseArrayAggIntFunction<I extends AbstractIntCollection>
   }
 
   @Override
-  public IntArrayList extractFinalResult(I intArrayList) {
-    if (intArrayList == null) {
+  public IntArrayList extractFinalResult(I ints) {
+    if (ints == null) {
       return new IntArrayList();
     }
-    return new IntArrayList(intArrayList);
+    return new IntArrayList(ints);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.longs.AbstractLongCollection;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongCollection;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
@@ -27,7 +27,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public abstract class BaseArrayAggLongFunction<I extends AbstractLongCollection>
+public abstract class BaseArrayAggLongFunction<I extends LongCollection>
     extends BaseArrayAggFunction<I, LongArrayList> {
   public BaseArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
       boolean nullHandlingEnabled) {
@@ -78,10 +78,10 @@ public abstract class BaseArrayAggLongFunction<I extends AbstractLongCollection>
   }
 
   @Override
-  public LongArrayList extractFinalResult(I arrayList) {
-    if (arrayList == null) {
+  public LongArrayList extractFinalResult(I longs) {
+    if (longs == null) {
       return new LongArrayList();
     }
-    return new LongArrayList(arrayList);
+    return new LongArrayList(longs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectIterators;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -28,7 +28,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
-public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollection<String>>
+public abstract class BaseArrayAggStringFunction<I extends ObjectCollection<String>>
     extends BaseArrayAggFunction<I, ObjectArrayList<String>> {
   public BaseArrayAggStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression, FieldSpec.DataType.STRING, nullHandlingEnabled);
@@ -78,13 +78,13 @@ public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollect
   }
 
   @Override
-  public ObjectArrayList<String> extractFinalResult(I stringArrayList) {
-    if (stringArrayList == null) {
+  public ObjectArrayList<String> extractFinalResult(I strings) {
+    if (strings == null) {
       return new ObjectArrayList<>();
     }
     // NOTE: Wrap a String[] to work around the bug of ObjectArrayList constructor creating Object[] internally.
-    String[] stringArray = new String[stringArrayList.size()];
-    ObjectIterators.unwrap(stringArrayList.iterator(), stringArray);
+    String[] stringArray = new String[strings.size()];
+    ObjectIterators.unwrap(strings.iterator(), stringArray);
     return ObjectArrayList.wrap(stringArray);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggDistinctFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggDistinctFunction.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
-import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
+import it.unimi.dsi.fastutil.objects.ObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 
@@ -36,7 +38,7 @@ public class ListAggDistinctFunction extends ListAggFunction {
   }
 
   @Override
-  protected AbstractObjectCollection<String> getObjectCollection(AggregationResultHolder aggregationResultHolder) {
+  protected ObjectLinkedOpenHashSet<String> getObjectCollection(AggregationResultHolder aggregationResultHolder) {
     ObjectLinkedOpenHashSet<String> valueSet = aggregationResultHolder.getResult();
     if (valueSet == null) {
       valueSet = new ObjectLinkedOpenHashSet<>();
@@ -46,7 +48,7 @@ public class ListAggDistinctFunction extends ListAggFunction {
   }
 
   @Override
-  protected AbstractObjectCollection<String> getObjectCollection(GroupByResultHolder groupByResultHolder,
+  protected ObjectLinkedOpenHashSet<String> getObjectCollection(GroupByResultHolder groupByResultHolder,
       int groupKey) {
     ObjectLinkedOpenHashSet<String> valueSet = groupByResultHolder.getResult(groupKey);
     if (valueSet == null) {
@@ -54,5 +56,16 @@ public class ListAggDistinctFunction extends ListAggFunction {
       groupByResultHolder.setValueForKey(groupKey, valueSet);
     }
     return valueSet;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(ObjectCollection<String> strings) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.OrderedStringSet.getValue(),
+        ObjectSerDeUtils.ORDERED_STRING_SET_SER_DE.serialize((ObjectLinkedOpenHashSet<String>) strings));
+  }
+
+  @Override
+  public ObjectLinkedOpenHashSet<String> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.ORDERED_STRING_SET_SER_DE.deserialize(customObject.getBuffer());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -158,6 +160,19 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
   @Override
   public ColumnDataType getIntermediateResultColumnType() {
     return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(I i) {
+    // TODO: Improve the ser/de logic
+    int type = ObjectSerDeUtils.ObjectType.getObjectType(i).getValue();
+    byte[] bytes = ObjectSerDeUtils.serialize(i, type);
+    return new SerializedIntermediateResult(type, bytes);
+  }
+
+  @Override
+  public I deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.deserialize(customObject);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
@@ -25,9 +25,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.stream.Collectors;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -235,8 +237,19 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
   }
 
   @Override
-  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.OBJECT;
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(PriorityQueue<FunnelStepEvent> funnelStepEvents) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.FunnelStepEventAccumulator.getValue(),
+        ObjectSerDeUtils.FUNNEL_STEP_EVENT_ACCUMULATOR_SER_DE.serialize(funnelStepEvents));
+  }
+
+  @Override
+  public PriorityQueue<FunnelStepEvent> deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.FUNNEL_STEP_EVENT_ACCUMULATOR_SER_DE.deserialize(customObject.getBuffer());
   }
 
   /**


### PR DESCRIPTION
Add intermediate result ser/de logic for each individual aggregate function to avoid the object type check in `ObjectSerDeUtils.getObjectType()`