### PR TITLE
Change Pre-filter logic in MergeRollup task

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -1031,8 +1031,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
     String sqlQuery = "SELECT count(*) FROM " + tableName;
     JsonNode expectedJson = postQuery(sqlQuery);
-    long[] expectedNumBucketsToProcess100Days = {3, 2, 1, 0, 3, 2, 1, 0};
-    long[] expectedNumBucketsToProcess200Days = {0, 0, 1, 1, 0, 0, 1, 1};
+    long[] expectedNumBucketsToProcess100Days = {2, 1, 0, 0, 3, 2, 1, 0};
+    long[] expectedNumBucketsToProcess200Days = {0, 0, 2, 1, 0, 0, 1, 1};
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     int numTasks = 0;
     TaskSchedulingContext context = new TaskSchedulingContext()

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -572,22 +572,22 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
           String segmentName = segmentZKMetadata.getSegmentName();
           if (LLCSegmentName.isLLCSegment(segmentName)) {
             LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-            partitionIdToLatestCompletedSegment.compute(llcSegmentName.getPartitionGroupId(), (partId, latestSegment) -> {
+            partitionIdToLatestCompletedSegment.compute(llcSegmentName.getPartitionGroupId(), (partId, latestSegment) ->
+            {
               if (latestSegment == null) {
                 return segmentName;
               } else {
-                return new LLCSegmentName(latestSegment).getSequenceNumber() > llcSegmentName.getSequenceNumber() ?
-                        latestSegment : segmentName;
+                return new LLCSegmentName(latestSegment).getSequenceNumber() > llcSegmentName.getSequenceNumber()
+                        ? latestSegment : segmentName;
               }
             });
           }
         }
       }
       return allSegments.stream()
-              .filter(a-> ( a.getStatus().isCompleted()
-                      && !partitionIdToLatestCompletedSegment.containsValue(a.getSegmentName())
-                      ))
-              .collect(Collectors.toList());
+              .filter(a -> (a.getStatus().isCompleted()
+                        && !partitionIdToLatestCompletedSegment.containsValue(a.getSegmentName())
+              )).collect(Collectors.toList());
     } else {
       return allSegments;
     }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -162,21 +162,22 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
       LOGGER.info("Start generating task configs for table: {} for task: {}", tableNameWithType, taskType);
 
       // Get all segment metadata
-      List<SegmentZKMetadata> allSegments = getSegmentsZKMetadataForTable(tableNameWithType);
-      // Filter segments based on status
-      List<SegmentZKMetadata> preSelectedSegmentsBasedOnStatus
-          = filterSegmentsBasedOnStatus(tableConfig.getTableType(), allSegments);
+      List<SegmentZKMetadata> allSegments =
+              tableConfig.getTableType() == TableType.OFFLINE
+                      ? getSegmentsZKMetadataForTable(tableNameWithType)
+                      : filterSegmentsforRealtimeTable(
+                              getNonConsumingSegmentsZKMetadataForRealtimeTable(tableNameWithType));
 
       // Select current segment snapshot based on lineage, filter out empty segments
       SegmentLineage segmentLineage = _clusterInfoAccessor.getSegmentLineage(tableNameWithType);
       Set<String> preSelectedSegmentsBasedOnLineage = new HashSet<>();
-      for (SegmentZKMetadata segment : preSelectedSegmentsBasedOnStatus) {
+      for (SegmentZKMetadata segment : allSegments) {
         preSelectedSegmentsBasedOnLineage.add(segment.getSegmentName());
       }
       SegmentLineageUtils.filterSegmentsBasedOnLineageInPlace(preSelectedSegmentsBasedOnLineage, segmentLineage);
 
       List<SegmentZKMetadata> preSelectedSegments = new ArrayList<>();
-      for (SegmentZKMetadata segment : preSelectedSegmentsBasedOnStatus) {
+      for (SegmentZKMetadata segment : allSegments) {
         if (preSelectedSegmentsBasedOnLineage.contains(segment.getSegmentName()) && segment.getTotalDocs() > 0
             && MergeTaskUtils.allowMerge(segment)) {
           preSelectedSegments.add(segment);
@@ -544,53 +545,45 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
   }
 
   @VisibleForTesting
-  static List<SegmentZKMetadata> filterSegmentsBasedOnStatus(TableType tableType, List<SegmentZKMetadata> allSegments) {
-    if (tableType == TableType.REALTIME) {
-      // For realtime table, don't process
-      // 1. in-progress segments (Segment.Realtime.Status.IN_PROGRESS)
-      // 2. most recent sealed segments in each partition
-      // This prevents those in-progress segments and paused segments from being merged.
-      //
-      // Note that we make the following two assumptions here:
-      // 1. streaming data consumer lags are negligible
-      // 2. streaming data records are ingested mostly in chronological order (no records are ingested with delay larger
-      //    than bufferTimeMS)
-      //
-      // We don't handle the following cases intentionally because it will be either overkill or too complex
-      // 1. New partition added. If new partitions are not picked up timely, the MergeRollupTask will move watermarks
-      //    forward, and may not be able to merge some lately-created segments for those new partitions -- users should
-      //    configure pinot properly to discover new partitions timely, or they should restart pinot servers manually
-      //    for new partitions to be picked up
-      // 2. (1) no new in-progress segments are created for some partitions (2) new in-progress segments are created for
-      //    partitions, but there is no record consumed (i.e, empty in-progress segments). In those two cases,
-      //    if new records are consumed later, the MergeRollupTask may have already moved watermarks forward, and may
-      //    not be able to merge those lately-created segments -- we assume that users will have a way to backfill those
-      //    records correctly.
-      Map<Integer, String> partitionIdToLatestCompletedSegment = new HashMap<>();
-      for (SegmentZKMetadata segmentZKMetadata : allSegments) {
-        if (segmentZKMetadata.getStatus().isCompleted()) {
-          String segmentName = segmentZKMetadata.getSegmentName();
-          if (LLCSegmentName.isLLCSegment(segmentName)) {
-            LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-            partitionIdToLatestCompletedSegment.compute(llcSegmentName.getPartitionGroupId(), (partId, latestSegment) ->
-            {
-              if (latestSegment == null) {
-                return segmentName;
-              } else {
-                return new LLCSegmentName(latestSegment).getSequenceNumber() > llcSegmentName.getSequenceNumber()
-                        ? latestSegment : segmentName;
-              }
-            });
+  static List<SegmentZKMetadata> filterSegmentsforRealtimeTable(List<SegmentZKMetadata> allSegments) {
+    // For realtime table, don't process
+    // 1. in-progress segments (Segment.Realtime.Status.IN_PROGRESS), this has been taken care of in
+    //    getNonConsumingSegmentsZKMetadataForRealtimeTable()
+    // 2. most recent sealed segments in each partition, this prevents those paused segments from being merged.
+    //
+    // Note that we make the following two assumptions here:
+    // 1. streaming data consumer lags are negligible
+    // 2. streaming data records are ingested mostly in chronological order (no records are ingested with delay larger
+    //    than bufferTimeMS)
+    //
+    // We don't handle the following cases intentionally because it will be either overkill or too complex
+    // 1. New partition added. If new partitions are not picked up timely, the MergeRollupTask will move watermarks
+    //    forward, and may not be able to merge some lately-created segments for those new partitions -- users should
+    //    configure pinot properly to discover new partitions timely, or they should restart pinot servers manually
+    //    for new partitions to be picked up
+    // 2. (1) no new in-progress segments are created for some partitions (2) new in-progress segments are created for
+    //    partitions, but there is no record consumed (i.e, empty in-progress segments). In those two cases,
+    //    if new records are consumed later, the MergeRollupTask may have already moved watermarks forward, and may
+    //    not be able to merge those lately-created segments -- we assume that users will have a way to backfill those
+    //    records correctly.
+    Map<Integer, String> partitionIdToLatestCompletedSegment = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : allSegments) {
+      String segmentName = segmentZKMetadata.getSegmentName();
+      if (LLCSegmentName.isLLCSegment(segmentName)) {
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+        partitionIdToLatestCompletedSegment.compute(llcSegmentName.getPartitionGroupId(), (partId, latestSegment) -> {
+          if (latestSegment == null) {
+            return segmentName;
+          } else {
+            return new LLCSegmentName(latestSegment).getSequenceNumber() > llcSegmentName.getSequenceNumber()
+                    ? latestSegment : segmentName;
           }
-        }
+        });
       }
-      return allSegments.stream()
-              .filter(a -> (a.getStatus().isCompleted()
-                        && !partitionIdToLatestCompletedSegment.containsValue(a.getSegmentName())
-              )).collect(Collectors.toList());
-    } else {
-      return allSegments;
     }
+    return allSegments.stream()
+            .filter(a -> !partitionIdToLatestCompletedSegment.containsValue(a.getSegmentName()))
+            .collect(Collectors.toList());
   }
 
   /**

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -321,10 +321,11 @@ public class MergeRollupTaskGeneratorTest {
     MergeRollupTaskGenerator generator = new MergeRollupTaskGenerator();
     generator.init(mockClusterInfoProvide);
 
-    assertEquals(MergeRollupTaskGenerator.filterSegmentsBasedOnStatus(TableType.REALTIME,
+    List<SegmentZKMetadata> filterResult = MergeRollupTaskGenerator.filterSegmentsBasedOnStatus(TableType.REALTIME,
             Lists.newArrayList(realtimeTableSegmentMetadata1, realtimeTableSegmentMetadata2,
-                    realtimeTableSegmentMetadata3, realtimeTableSegmentMetadata4))
-            .size(), 1);
+                    realtimeTableSegmentMetadata3, realtimeTableSegmentMetadata4));
+    assertEquals(filterResult.size(), 1);
+    assertEquals(filterResult.get(0).getSegmentName(), "testTable__0__0__0");
   }
 
   private void checkPinotTaskConfig(Map<String, String> pinotTaskConfig, String segments, String mergeLevel,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -293,17 +293,17 @@ public class MergeRollupTaskGeneratorTest {
     // construct 3 following segments, among these, only 0_0 can be scheduled, others should be filtered out
     // partition 0, completed 0
     SegmentZKMetadata realtimeTableSegmentMetadata1 =
-            getSegmentZKMetadata("testTable__0__0__0", 5000, 6000, TimeUnit.MILLISECONDS,
+            getSegmentZKMetadata("testTable__0__0__20250224T0900Z", 5000, 6000, TimeUnit.MILLISECONDS,
                     null, "50000", "60000");
     realtimeTableSegmentMetadata1.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     // partition 0, completed 1
     SegmentZKMetadata realtimeTableSegmentMetadata2 =
-            getSegmentZKMetadata("testTable__0__1__1", 6000, 7000, TimeUnit.MILLISECONDS,
+            getSegmentZKMetadata("testTable__0__1__20250224T0902Z", 6000, 7000, TimeUnit.MILLISECONDS,
                     null, "60000", "70000");
     realtimeTableSegmentMetadata2.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     // partition 1, completed 0
     SegmentZKMetadata realtimeTableSegmentMetadata3 =
-            getSegmentZKMetadata("testTable__1__0__0", 5500, 6500, TimeUnit.MILLISECONDS,
+            getSegmentZKMetadata("testTable__1__0__20250224T0900Z", 5500, 6500, TimeUnit.MILLISECONDS,
                     null, "55000", "65000");
     realtimeTableSegmentMetadata3.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     when(mockClusterInfoProvide.getSegmentsZKMetadata(REALTIME_TABLE_NAME)).thenReturn(
@@ -319,7 +319,7 @@ public class MergeRollupTaskGeneratorTest {
             Lists.newArrayList(realtimeTableSegmentMetadata1, realtimeTableSegmentMetadata2,
                     realtimeTableSegmentMetadata3));
     assertEquals(filterResult.size(), 1);
-    assertEquals(filterResult.get(0).getSegmentName(), "testTable__0__0__0");
+    assertEquals(filterResult.get(0).getSegmentName(), "testTable__0__0__20250224T0900Z");
   }
 
   private void checkPinotTaskConfig(Map<String, String> pinotTaskConfig, String segments, String mergeLevel,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -299,12 +299,12 @@ public class MergeRollupTaskGeneratorTest {
     realtimeTableSegmentMetadata1.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     // partition 0, completed 1
     SegmentZKMetadata realtimeTableSegmentMetadata2 =
-            getSegmentZKMetadata("testTable__0__0__1", 6000, 7000, TimeUnit.MILLISECONDS,
+            getSegmentZKMetadata("testTable__0__1__1", 6000, 7000, TimeUnit.MILLISECONDS,
                     null, "60000", "70000");
     realtimeTableSegmentMetadata2.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     // partition 0, consuming 2
     SegmentZKMetadata realtimeTableSegmentMetadata3 =
-            getSegmentZKMetadata("testTable__0__0__2", 7000, 8000, TimeUnit.MILLISECONDS,
+            getSegmentZKMetadata("testTable__0__2__2", 7000, 8000, TimeUnit.MILLISECONDS,
                     null, "70000", "80000");
     realtimeTableSegmentMetadata3.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
     // partition 1, completed 0


### PR DESCRIPTION
# Change Pre-filter logic in MergeRollup task

Issue: #15128 

## Problem Description:
For realtime table, MergeRollup task is intended to not process segments with start time later than the earliest start time of all in progress segments, but the code is not calculating it correctly. The if condition [here](https://github.com/apache/pinot/blob/9c8ab8f397d52d185581226583ee526eb9cc7279/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java#L568-L575) is alway false because totalDocs and startTimeMs are both -1 for consuming segments. This leads to incorrectly calculate earliestStartTime to Long.MAX_VALUE.

## Changes:
Based on the following conditions:
1. BufferTime config in MergeRollup task will cover most of the cases, in which we do NOT merge the most recent segments within BufferTime
2. If one wants to merge recent segments and set BufferTime to 0, we should let them do it. But we need to make sure all consuming segments are NOT merged
3. The PauseComsuption function will seal the consuming segments and NOT create a new one. It will neither upload all metadata to ZooKeeper. If we merge it, we will lose the consuming offset. 

We decide to filter OUT the consuming segments, and the most recent completed segments for all partition, in this function.

## Tests:
Add unittest in ./pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java

The whole task generation process is tested in ./pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java

### Note:
Need to add `bugfix` label to this PR. 

