### PR TITLE
apache#15162 - Bug Fix Segments going into BAD state for Dedup Tables with metadataTTL 

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -283,8 +283,13 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
       return;
     }
     try {
-      if (skipSegmentOutOfTTL(segment, false)) {
-        return;
+      // segment.getSegmentMetadata().getColumnMetadataMap() will be null when offloading a temporary segment data
+      // manager created in BaseTableDataManager.addSegment which caused replicas to go into ERROR state when
+      // metadataTTL is set
+      if (segment.getSegmentMetadata() != null && segment.getSegmentMetadata().getColumnMetadataMap() != null) {
+        if (skipSegmentOutOfTTL(segment, false)) {
+          return;
+        }
       }
       try (DedupUtils.DedupRecordInfoReader dedupRecordInfoReader = new DedupUtils.DedupRecordInfoReader(segment,
           _primaryKeyColumns, _dedupTimeColumn)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -284,7 +284,7 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
     }
     try {
       // segment.getSegmentMetadata().getColumnMetadataMap() will be null when offloading a temporary segment data
-      // manager created in BaseTableDataManager.addSegment which caused replicas to go into ERROR state when
+      // manager created in BaseTableDataManager.addSegment which caused replicas to go into BAD state when
       // metadataTTL is set
       if (segment.getSegmentMetadata() != null && segment.getSegmentMetadata().getColumnMetadataMap() != null) {
         if (skipSegmentOutOfTTL(segment, false)) {


### PR DESCRIPTION
**Context:**
https://apache-pinot.slack.com/archives/C011C9JHN7R/p1740757158048619
Noticed segments going into BAD state when metadataTTL is set for dedup tables and Replication > 1

`[RealtimeSegmentDataManager_leaderboard_entries__0__1__20250228T1528Z] [leaderboard_entries__0__1__20250228T1528Z] Caught exception in consumer thread after stop() is invoked: java.lang.RuntimeException: Caught exception while removing segment: leaderboard_entries__0__1__20250228T1528Z of table: leaderboard_entries_REALTIME from ConcurrentMapPartitionDedupMetadataManager, ignoring the exception`

**Root Cause:**
segment.getSegmentMetadata().getColumnMetadataMap() is null when offloading oldSegmentManager for which segmentMetadata is like below:

`{"segmentName":"githubEvents__1__5__20250303T1928Z","schemaName":"githubEvents","crc":-9223372036854775808,"creationTimeMillis":1741030112009,"creationTimeReadable":"2025-03-03T19:28:32:009 UTC","timeColumn":null,"timeUnit":null,"timeGranularitySec":null,"startTimeMillis":null,"startTimeReadable":null,"endTimeMillis":null,"endTimeReadable":null,"segmentVersion":null,"creatorName":null,"totalDocs":0,"custom":{},"startOffset":null,"endOffset":null} `

**Before Fix:**
![image](https://github.com/user-attachments/assets/51cc61a7-51c4-4ab3-921d-7db1b43a165e)

**After Fix:**
![image](https://github.com/user-attachments/assets/081a3d8e-a89d-4a06-86f3-ee2449c44cae)

