### PR TITLE
Add broker gauge for estimated MSE query server threads

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -52,6 +52,7 @@ import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.exception.QueryInfoException;
 import org.apache.pinot.common.failuredetector.FailureDetector;
+import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerQueryPhase;
 import org.apache.pinot.common.response.BrokerResponse;
@@ -303,6 +304,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         requestContext.setErrorCode(QueryException.EXECUTION_TIMEOUT_ERROR_CODE);
         return new BrokerResponseNative(QueryException.EXECUTION_TIMEOUT_ERROR);
       }
+      _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ESTIMATED_MSE_SERVER_THREADS,
+          _queryThrottler.currentQueryServerThreads());
     } catch (InterruptedException e) {
       LOGGER.warn("Interrupt received while waiting to execute request {}: {}", requestId, query);
       requestContext.setErrorCode(QueryException.EXECUTION_TIMEOUT_ERROR_CODE);
@@ -393,6 +396,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       return brokerResponse;
     } finally {
       _queryThrottler.release(estimatedNumQueryThreads);
+      _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ESTIMATED_MSE_SERVER_THREADS,
+          _queryThrottler.currentQueryServerThreads());
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -67,7 +67,12 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   /**
    * The queue size of ServerRoutingStatsManager main executor service.
    */
-  ROUTING_STATS_MANAGER_QUEUE_SIZE("routingStatsManagerQueueSize", true);
+  ROUTING_STATS_MANAGER_QUEUE_SIZE("routingStatsManagerQueueSize", true),
+
+  /**
+   * The estimated number of query server threads for all currently running multi-stage queries.
+   */
+  ESTIMATED_MSE_SERVER_THREADS("number", true);
 
   private final String _brokerGaugeName;
   private final String _unit;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
@@ -166,9 +166,8 @@ public class JmxMetricsIntegrationTest extends BaseClusterIntegrationTestSet {
     executorService.submit(() -> {
       while (true) {
         try {
-          postQuery(
-              "SET useMultiStageEngine=true; SELECT AirlineID, AVG(ArrDelay) FILTER (WHERE ArrDelay > 0) FROM mytable"
-                  + " GROUP BY AirlineID;");
+          postQuery("SET useMultiStageEngine=true; "
+              + "SELECT sleep(ActualElapsedTime+60000) FROM mytable WHERE ActualElapsedTime > 0 limit 1");
         } catch (Exception e) {
           LOGGER.warn("Caught exception while running query", e);
           break;


### PR DESCRIPTION
- Adds some observability for MSE's query throttling functionality (https://github.com/apache/pinot/pull/14574, https://github.com/apache/pinot/pull/14847).
- Note that this gauge metric can be used independently of the query throttling functionality - i.e., it doesn't require `pinot.beta.multistage.engine.max.server.query.threads` to be configured. It provides a per broker view of the multi-stage engine query workload.