### PR TITLE
Fix the missing getNumValuesMV() in raw forward index v4 and v5

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -200,6 +200,11 @@ public class VarByteChunkForwardIndexReaderV4
   }
 
   @Override
+  public int getNumValuesMV(int docId, ReaderContext context) {
+    return ByteBuffer.wrap(context.getValue(docId)).getInt();
+  }
+
+  @Override
   public void close()
       throws IOException {
     _chunkDecompressor.close();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV5.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV5.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.readers.forward;
 
+import java.nio.ByteBuffer;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV4;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV5;
 import org.apache.pinot.segment.local.utils.ArraySerDeUtils;
@@ -79,5 +80,16 @@ public class VarByteChunkForwardIndexReaderV5 extends VarByteChunkForwardIndexRe
   @Override
   public double[] getDoubleMV(int docId, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
     return ArraySerDeUtils.deserializeDoubleArrayWithoutLength(context.getValue(docId));
+  }
+
+  @Override
+  public int getNumValuesMV(int docId, ReaderContext context) {
+    byte[] bytes = context.getValue(docId);
+    int valueSize = getStoredType().size();
+    if (valueSize > 0) {
+      return bytes.length / valueSize;
+    } else {
+      return ByteBuffer.wrap(bytes).getInt();
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -31,21 +31,23 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.PinotBuffersAfterMethodCheckRule;
-import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV4;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueFixedByteRawIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkMVForwardIndexReader;
-import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkForwardIndexReaderV4;
+import org.apache.pinot.segment.local.segment.index.forward.ForwardIndexReaderFactory;
 import org.apache.pinot.segment.spi.V1Constants.Indexes;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class MultiValueFixedByteRawIndexCreatorTest implements PinotBuffersAfterMethodCheckRule {
@@ -57,8 +59,8 @@ public class MultiValueFixedByteRawIndexCreatorTest implements PinotBuffersAfter
   @DataProvider(name = "compressionTypes")
   public Object[][] compressionTypes() {
     return Arrays.stream(ChunkCompressionType.values())
-        .flatMap(ct -> IntStream.of(2, 4).boxed()
-            .map(writerVersion -> new Object[]{ct, writerVersion})).toArray(Object[][]::new);
+        .flatMap(ct -> IntStream.rangeClosed(2, 5).boxed().map(writerVersion -> new Object[]{ct, writerVersion}))
+        .toArray(Object[][]::new);
   }
 
   @BeforeClass
@@ -155,11 +157,6 @@ public class MultiValueFixedByteRawIndexCreatorTest implements PinotBuffersAfter
         maxElements, false, writerVersion, 1024 * 1024, 1000);
   }
 
-  public ForwardIndexReader getForwardIndexReader(PinotDataBuffer buffer, DataType dataType, int writerVersion) {
-    return writerVersion == VarByteChunkForwardIndexWriterV4.VERSION ? new VarByteChunkForwardIndexReaderV4(buffer,
-        dataType.getStoredType(), false) : new FixedByteChunkMVForwardIndexReader(buffer, dataType.getStoredType());
-  }
-
   public <T> void testMV(DataType dataType, List<T> inputs, ToIntFunction<T> sizeof, IntFunction<T> constructor,
       Injector<T> injector, Extractor<T> extractor, ChunkCompressionType compressionType, int writerVersion)
       throws IOException {
@@ -167,33 +164,33 @@ public class MultiValueFixedByteRawIndexCreatorTest implements PinotBuffersAfter
     int numDocs = inputs.size();
     int maxElements = inputs.stream().mapToInt(sizeof).max().orElseThrow(RuntimeException::new);
     File file = new File(_outputDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
-    file.delete();
-    MultiValueFixedByteRawIndexCreator creator =
-        getMultiValueFixedByteRawIndexCreator(compressionType, column, numDocs, dataType, maxElements, writerVersion);
-    inputs.forEach(input -> injector.inject(creator, input));
-    creator.close();
+    FileUtils.deleteQuietly(file);
+    try (MultiValueFixedByteRawIndexCreator creator = getMultiValueFixedByteRawIndexCreator(compressionType, column,
+        numDocs, dataType, maxElements, writerVersion)) {
+      inputs.forEach(input -> injector.inject(creator, input));
+    }
 
-    //read
-    try (final PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN,
-        "")) {
-      ForwardIndexReader reader = getForwardIndexReader(buffer, dataType, writerVersion);
-
-      final ForwardIndexReaderContext context = reader.createContext();
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
+        ForwardIndexReader reader = ForwardIndexReaderFactory.createRawIndexReader(buffer, dataType, false);
+        ForwardIndexReaderContext context = reader.createContext()) {
       T valueBuffer = constructor.apply(maxElements);
       for (int i = 0; i < numDocs; i++) {
-        Assert.assertEquals(inputs.get(i), extractor.extract(reader, context, i, valueBuffer));
+        T input = inputs.get(i);
+        assertEquals(reader.getNumValuesMV(i, context), sizeof.applyAsInt(input));
+        assertEquals(extractor.extract(reader, context, i, valueBuffer), input);
       }
 
       // Value byte range test
-      Assert.assertTrue(reader.isBufferByteRangeInfoSupported());
-      Assert.assertFalse(reader.isFixedOffsetMappingType());
-      final ForwardIndexReaderContext valueRangeContext = reader.createContext();
+      assertTrue(reader.isBufferByteRangeInfoSupported());
+      assertFalse(reader.isFixedOffsetMappingType());
       List<ForwardIndexReader.ByteRange> ranges = new ArrayList<>();
-      for (int i = 0; i < numDocs; i++) {
-        try {
-          reader.recordDocIdByteRanges(i, valueRangeContext, ranges);
-        } catch (Exception e) {
-          Assert.fail("Failed to record byte ranges for docId: " + i, e);
+      try (ForwardIndexReaderContext valueRangeContext = reader.createContext()) {
+        for (int i = 0; i < numDocs; i++) {
+          try {
+            reader.recordDocIdByteRanges(i, valueRangeContext, ranges);
+          } catch (Exception e) {
+            fail("Failed to record byte ranges for docId: " + i, e);
+          }
         }
       }
     }
@@ -208,14 +205,11 @@ public class MultiValueFixedByteRawIndexCreatorTest implements PinotBuffersAfter
   }
 
   private static List<int[]> ints(boolean isFixedMVRowLength) {
-    return IntStream.range(0, 1000)
-        .mapToObj(i -> new int[isFixedMVRowLength ? 50 : RANDOM.nextInt(50)])
-        .peek(array -> {
-          for (int i = 0; i < array.length; i++) {
-            array[i] = RANDOM.nextInt();
-          }
-        })
-        .collect(Collectors.toList());
+    return IntStream.range(0, 1000).mapToObj(i -> new int[isFixedMVRowLength ? 50 : RANDOM.nextInt(50)]).peek(array -> {
+      for (int i = 0; i < array.length; i++) {
+        array[i] = RANDOM.nextInt();
+      }
+    }).collect(Collectors.toList());
   }
 
   private static List<long[]> longs(boolean isFixedMVRowLength) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
@@ -31,7 +31,6 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.index.forward.ForwardIndexReaderFactory;
 import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
-import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
@@ -96,7 +95,8 @@ public class RawIndexCreatorTest implements PinotBuffersAfterClassCheckRule {
       .build();
   //@formatter:on
   private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
-      .setNoDictionaryColumns(SCHEMA.getDimensionNames()).build();
+      .setNoDictionaryColumns(SCHEMA.getDimensionNames())
+      .build();
   private static final Random RANDOM = new Random();
 
   private RecordReader _recordReader;
@@ -207,8 +207,9 @@ public class RawIndexCreatorTest implements PinotBuffersAfterClassCheckRule {
   public void testStringMVRawIndexCreator()
       throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(STRING_MV_COLUMN);
-    try (VarByteChunkMVForwardIndexReader rawIndexReader = new VarByteChunkMVForwardIndexReader(indexBuffer,
-        DataType.STRING); ChunkReaderContext readerContext = rawIndexReader.createContext()) {
+    try (
+        ForwardIndexReader rawIndexReader = ForwardIndexReaderFactory.createRawIndexReader(indexBuffer, DataType.STRING,
+            false); ForwardIndexReaderContext readerContext = rawIndexReader.createContext()) {
       _recordReader.rewind();
       int maxNumberOfMultiValues =
           _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(STRING_MV_COLUMN).getMaxNumberOfMultiValues();
@@ -239,9 +240,8 @@ public class RawIndexCreatorTest implements PinotBuffersAfterClassCheckRule {
   public void testBytesMVRawIndexCreator()
       throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(BYTES_MV_COLUMN);
-    try (VarByteChunkMVForwardIndexReader rawIndexReader = new VarByteChunkMVForwardIndexReader(indexBuffer,
-        DataType.BYTES);
-        ChunkReaderContext readerContext = rawIndexReader.createContext()) {
+    try (ForwardIndexReader rawIndexReader = ForwardIndexReaderFactory.createRawIndexReader(indexBuffer, DataType.BYTES,
+        false); ForwardIndexReaderContext readerContext = rawIndexReader.createContext()) {
       _recordReader.rewind();
       int maxNumberOfMultiValues =
           _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(BYTES_MV_COLUMN).getMaxNumberOfMultiValues();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -142,7 +142,6 @@ public class ForwardIndexTypeTest {
           new ForwardIndexConfig.Builder()
               .withCompressionType(ChunkCompressionType.SNAPPY)
               .withDeriveNumDocsPerChunk(false)
-              .withRawIndexWriterVersion(2)
               .build()
       );
     }
@@ -163,7 +162,6 @@ public class ForwardIndexTypeTest {
           new ForwardIndexConfig.Builder()
               .withCompressionType(ChunkCompressionType.SNAPPY)
               .withDeriveNumDocsPerChunk(false)
-              .withRawIndexWriterVersion(2)
               .build()
       );
     }


### PR DESCRIPTION
Also improve the runtime for raw index test and include test for v3 and v5