### PR TITLE
Fix GET /queries broker API UnsupportedOperationException bug

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.requesthandler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -133,8 +134,8 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public Map<Long, String> getRunningQueries() {
-    // Both engines share the same request Id generator, so the query will have unique ids across the two engines.
-    Map<Long, String> queries = _singleStageBrokerRequestHandler.getRunningQueries();
+    // Both engines share the same request ID generator, so the query will have unique IDs across the two engines.
+    Map<Long, String> queries = new HashMap<>(_singleStageBrokerRequestHandler.getRunningQueries());
     if (_multiStageBrokerRequestHandler != null) {
       queries.putAll(_multiStageBrokerRequestHandler.getRunningQueries());
     }


### PR DESCRIPTION
- This method was updated in https://github.com/apache/pinot/pull/14823 which introduced a new cancellation mechanism.
- A small bug was introduced here as well wherein calls to `GET /queries` failed with an `UnsupportedOperationException` error because we're trying to update an unmodifiable map. 