### PR TITLE
Fix memory leak in QueryDispatcher

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -146,7 +146,13 @@ public class QueryDispatcher {
     Set<QueryServerInstance> servers = new HashSet<>();
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
-      return runReducer(requestId, dispatchableSubPlan, timeoutMs, queryOptions, _mailboxService);
+      try {
+        return runReducer(requestId, dispatchableSubPlan, timeoutMs, queryOptions, _mailboxService);
+      } finally {
+        if (isQueryCancellationEnabled()) {
+          _serversByQuery.remove(requestId);
+        }
+      }
     } catch (Throwable e) {
       // TODO: Consider always cancel when it returns (early terminate)
       cancel(requestId, servers);


### PR DESCRIPTION
- https://github.com/apache/pinot/commit/f1509f8a4339181d8540abd5e9f66e2d25bb67d3 introduced a `Map<Long, Set<QueryServerInstance>> _serversByQuery` in `QueryDispatcher` that tracks the set of servers that a query has been dispatched to.
- However, entries in this map are only cleared for failed or cancelled queries and the map isn't updated for successful queries. 
- This is a critical memory leak in brokers with query cancellation enabled as this map will grow indefinitely.
- This patch fixes the issue by clearing the map entries for successful queries as well.