### PR TITLE
Skip logs for virtual columns as they are known not to be in the schema

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -68,6 +68,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -204,7 +205,11 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     for (String column : existingAllColumns) {
       if (_schema != null && !_schema.hasColumn(column)) {
         // _schema will be null only in tests
-        LOGGER.info("Column: {} of segment: {} is not in schema, skipping updating forward index", column, segmentName);
+        if (!CommonConstants.Segment.BuiltInVirtualColumn.ALL_COLUMNS.contains(column)) {
+          // Skip logs for virtual columns as they are known not to be in the schema.
+          LOGGER.info("Column: {} of segment: {} is not in schema, skipping updating forward index", column,
+              segmentName);
+        }
         continue;
       }
       boolean existingHasDict = existingDictColumns.contains(column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -205,8 +205,10 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     for (String column : existingAllColumns) {
       if (_schema != null && !_schema.hasColumn(column)) {
         // _schema will be null only in tests
-        if (!CommonConstants.Segment.BuiltInVirtualColumn.ALL_COLUMNS.contains(column)) {
-          // Skip logs for virtual columns as they are known not to be in the schema.
+        if (!CommonConstants.Segment.BuiltInVirtualColumn.ALL_VIRTUAL_COLUMNS.contains(column)) {
+          // Skip logs for virtual columns as they are known not to be in the schema in most cases. Note that virtual
+          // columns may be in the schema if it's extended by addBuiltInVirtualColumnsToSegmentSchema() method. So we
+          // just check them here to skip logs and don't skip them for cases when they are in the schema.
           LOGGER.info("Column: {} of segment: {} is not in schema, skipping updating forward index", column,
               segmentName);
         }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.config.instance.InstanceType;
@@ -1340,6 +1341,7 @@ public class CommonConstants {
       public static final String DOCID = "$docId";
       public static final String HOSTNAME = "$hostName";
       public static final String SEGMENTNAME = "$segmentName";
+      public static final Set<String> ALL_COLUMNS = Set.of(DOCID, HOSTNAME, SEGMENTNAME);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1341,7 +1341,7 @@ public class CommonConstants {
       public static final String DOCID = "$docId";
       public static final String HOSTNAME = "$hostName";
       public static final String SEGMENTNAME = "$segmentName";
-      public static final Set<String> ALL_COLUMNS = Set.of(DOCID, HOSTNAME, SEGMENTNAME);
+      public static final Set<String> ALL_VIRTUAL_COLUMNS = Set.of(DOCID, HOSTNAME, SEGMENTNAME);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.config.instance.InstanceType;
@@ -1341,7 +1340,6 @@ public class CommonConstants {
       public static final String DOCID = "$docId";
       public static final String HOSTNAME = "$hostName";
       public static final String SEGMENTNAME = "$segmentName";
-      public static final Set<String> ALL_VIRTUAL_COLUMNS = Set.of(DOCID, HOSTNAME, SEGMENTNAME);
     }
   }
 


### PR DESCRIPTION
Virtual columns are not in the schema (in most cases, unless one add them into schema), but for the INFO log here, the schema doesn't have those virtual columns and it's well known, so skip the logs for them to be less verbose