### PR TITLE
Ensure group by result holder capacity even for empty groups in MultistageGroupByExecutor

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -344,6 +344,9 @@ public class MultistageGroupByExecutor {
         // compliant results. However, if the query option to skip empty groups is set, we avoid this step for
         // improved performance.
         generateGroupByKeys(block);
+        for (int i = 0; i < _aggFunctions.length; i++) {
+          _aggregateResultHolders[i].ensureCapacity(_groupIdGenerator.getNumGroups());
+        }
       }
     }
   }


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/15121.
- The group by result holders need to have entries for all group keys generated, even for empty groups (i.e., group keys that don't have any matching rows based on the aggregation filter).