### PR TITLE
Support reading var-length type (STRING/BYTES/BIG_DECIMAL) as murmur3 32/64/128 bits hash

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
@@ -113,6 +113,18 @@ public interface BlockValSet {
    */
   byte[][] getBytesValuesSV();
 
+  default int[] get32BitsMurmur3HashValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  default long[] get64BitsMurmur3HashValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  default long[][] get128BitsMurmur3HashValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * MULTI-VALUED COLUMN APIs
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -242,6 +242,27 @@ public class DataBlockCache implements AutoCloseable {
     return bytesValues;
   }
 
+  public int[] get32BitsMurmur3HashValuesForSVColumn(String column) {
+    // TODO: This is not cached
+    int[] hashValues = new int[_length];
+    _dataFetcher.fetch32BitsMurmur3HashValues(column, _docIds, _length, hashValues);
+    return hashValues;
+  }
+
+  public long[] get64BitsMurmur3HashValuesForSVColumn(String column) {
+    // TODO: This is not cached
+    long[] hashValues = new long[_length];
+    _dataFetcher.fetch64BitsMurmur3HashValues(column, _docIds, _length, hashValues);
+    return hashValues;
+  }
+
+  public long[][] get128BitsMurmur3HashValuesForSVColumn(String column) {
+    // TODO: This is not cached
+    long[][] hashValues = new long[_length][];
+    _dataFetcher.fetch128BitsMurmur3HashValues(column, _docIds, _length, hashValues);
+    return hashValues;
+  }
+
   /**
    * MULTI-VALUED COLUMN API
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -185,6 +185,18 @@ public class DataFetcher implements AutoCloseable {
     _columnValueReaderMap.get(column).readMapValues(inDocIds, length, outValues);
   }
 
+  public void fetch32BitsMurmur3HashValues(String column, int[] inDocIds, int length, int[] outValues) {
+    _columnValueReaderMap.get(column).read32BitsMurmur3HashValues(inDocIds, length, outValues);
+  }
+
+  public void fetch64BitsMurmur3HashValues(String column, int[] inDocIds, int length, long[] outValues) {
+    _columnValueReaderMap.get(column).read64BitsMurmur3HashValues(inDocIds, length, outValues);
+  }
+
+  public void fetch128BitsMurmur3HashValues(String column, int[] inDocIds, int length, long[][] outValues) {
+    _columnValueReaderMap.get(column).read128BitsMurmur3HashValues(inDocIds, length, outValues);
+  }
+
   /**
    * MULTI-VALUED COLUMN API
    */
@@ -418,6 +430,48 @@ public class DataFetcher implements AutoCloseable {
       } else {
         for (int i = 0; i < length; i++) {
           valueBuffer[i] = MapUtils.deserializeMap(_reader.getBytes(docIds[i], readerContext));
+        }
+      }
+    }
+
+    void read32BitsMurmur3HashValues(int[] docIds, int length, int[] valueBuffer) {
+      Tracing.activeRecording().setInputDataType(_storedType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
+      if (_dictionary != null) {
+        int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
+        _dictionary.read32BitsMurmur3HashValues(dictIdBuffer, length, valueBuffer);
+      } else {
+        for (int i = 0; i < length; i++) {
+          valueBuffer[i] = _reader.get32BitsMurmur3Hash(docIds[i], readerContext);
+        }
+      }
+    }
+
+    void read64BitsMurmur3HashValues(int[] docIds, int length, long[] valueBuffer) {
+      Tracing.activeRecording().setInputDataType(_storedType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
+      if (_dictionary != null) {
+        int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
+        _dictionary.read64BitsMurmur3HashValues(dictIdBuffer, length, valueBuffer);
+      } else {
+        for (int i = 0; i < length; i++) {
+          valueBuffer[i] = _reader.get64BitsMurmur3Hash(docIds[i], readerContext);
+        }
+      }
+    }
+
+    void read128BitsMurmur3HashValues(int[] docIds, int length, long[][] valueBuffer) {
+      Tracing.activeRecording().setInputDataType(_storedType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
+      if (_dictionary != null) {
+        int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
+        _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
+        _dictionary.read128BitsMurmur3HashValues(dictIdBuffer, length, valueBuffer);
+      } else {
+        for (int i = 0; i < length; i++) {
+          valueBuffer[i] = _reader.get128BitsMurmur3Hash(docIds[i], readerContext);
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -163,6 +163,30 @@ public class ProjectionBlockValSet implements BlockValSet {
   }
 
   @Override
+  public int[] get32BitsMurmur3HashValuesSV() {
+    try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
+      recordReadValues(scope, DataType.BYTES, true);
+      return _dataBlockCache.get32BitsMurmur3HashValuesForSVColumn(_column);
+    }
+  }
+
+  @Override
+  public long[] get64BitsMurmur3HashValuesSV() {
+    try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
+      recordReadValues(scope, DataType.BYTES, true);
+      return _dataBlockCache.get64BitsMurmur3HashValuesForSVColumn(_column);
+    }
+  }
+
+  @Override
+  public long[][] get128BitsMurmur3HashValuesSV() {
+    try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
+      recordReadValues(scope, DataType.BYTES, true);
+      return _dataBlockCache.get128BitsMurmur3HashValuesForSVColumn(_column);
+    }
+  }
+
+  @Override
   public int[][] getDictionaryIdsMV() {
     try (InvocationScope scope = Tracing.getTracer().createScope(ProjectionBlockValSet.class)) {
       recordReadValues(scope, DataType.INT, false);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/TransformBlockValSet.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
+import org.apache.pinot.spi.utils.hash.MurmurHashFunctions;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -140,6 +141,39 @@ public class TransformBlockValSet implements BlockValSet {
       recordTransformValues(scope, DataType.BYTES, true);
       return _transformFunction.transformToBytesValuesSV(_valueBlock);
     }
+  }
+
+  @Override
+  public int[] get32BitsMurmur3HashValuesSV() {
+    byte[][] bytes = getBytesValuesSV();
+    int length = bytes.length;
+    int[] hashValues = new int[length];
+    for (int i = 0; i < length; i++) {
+      hashValues[i] = MurmurHashFunctions.murmurHash3X64Bit32(bytes[i], 0);
+    }
+    return hashValues;
+  }
+
+  @Override
+  public long[] get64BitsMurmur3HashValuesSV() {
+    byte[][] bytes = getBytesValuesSV();
+    int length = bytes.length;
+    long[] hashValues = new long[length];
+    for (int i = 0; i < length; i++) {
+      hashValues[i] = MurmurHashFunctions.murmurHash3X64Bit64(bytes[i], 0);
+    }
+    return hashValues;
+  }
+
+  @Override
+  public long[][] get128BitsMurmur3HashValuesSV() {
+    byte[][] bytes = getBytesValuesSV();
+    int length = bytes.length;
+    long[][] hashValues = new long[length][];
+    for (int i = 0; i < length; i++) {
+      hashValues[i] = MurmurHashFunctions.murmurHash3X64Bit128AsLongs(bytes[i], 0);
+    }
+    return hashValues;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
@@ -53,10 +53,8 @@ public final class FixedByteValueReaderWriter implements ValueReader {
     return _dataBuffer.getDouble((long) index * Double.BYTES);
   }
 
-  /**
-   * Reads the unpadded bytes into the given buffer and returns the length.
-   */
-  private int readUnpaddedBytes(int index, int numBytesPerValue, byte[] buffer) {
+  @Override
+  public int readUnpaddedBytes(int index, int numBytesPerValue, byte[] buffer) {
     // Based on the ZeroInWord algorithm: http://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
     assert buffer.length >= numBytesPerValue;
     long startOffset = (long) index * numBytesPerValue;
@@ -83,20 +81,6 @@ public final class FixedByteValueReaderWriter implements ValueReader {
       buffer[i] = b;
     }
     return i;
-  }
-
-  @Override
-  public byte[] getUnpaddedBytes(int index, int numBytesPerValue, byte[] buffer) {
-    int length = readUnpaddedBytes(index, numBytesPerValue, buffer);
-    byte[] bytes = new byte[length];
-    System.arraycopy(buffer, 0, bytes, 0, length);
-    return bytes;
-  }
-
-  @Override
-  public String getUnpaddedString(int index, int numBytesPerValue, byte[] buffer) {
-    int length = readUnpaddedBytes(index, numBytesPerValue, buffer);
-    return new String(buffer, 0, length, UTF_8);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
@@ -22,8 +22,6 @@ import java.util.List;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 
 /**
  * The value reader for var-length values (STRING and BYTES). See {@link VarLengthValueWriter} for the file layout.
@@ -89,7 +87,7 @@ public class VarLengthValueReader implements ValueReader {
   }
 
   @Override
-  public String getUnpaddedString(int index, int numBytesPerValue, byte[] buffer) {
+  public int readUnpaddedBytes(int index, int numBytesPerValue, byte[] buffer) {
     assert buffer.length >= numBytesPerValue;
 
     // Read the offset of the byte array first and then read the actual byte array.
@@ -100,7 +98,7 @@ public class VarLengthValueReader implements ValueReader {
 
     assert numBytesPerValue >= length;
     _dataBuffer.copyTo(startOffset, buffer, 0, length);
-    return new String(buffer, 0, length, UTF_8);
+    return length;
   }
 
   public void recordOffsetRanges(int index, long baseOffset, List<ForwardIndexReader.ByteRange> rangeList) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
@@ -278,6 +278,18 @@ public abstract class BaseImmutableDictionary implements Dictionary {
     return _valueReader.getBytes(dictId, _numBytesPerValue);
   }
 
+  public int get32BitsMurmur3Hash(int dictId, byte[] buffer) {
+    return _valueReader.get32BitsMurmur3Hash(dictId, _numBytesPerValue, buffer);
+  }
+
+  public long get64BitsMurmur3Hash(int dictId, byte[] buffer) {
+    return _valueReader.get64BitsMurmur3Hash(dictId, _numBytesPerValue, buffer);
+  }
+
+  public long[] get128BitsMurmur3HashValue(int dictId, byte[] buffer) {
+    return _valueReader.get128BitsMurmur3Hash(dictId, _numBytesPerValue, buffer);
+  }
+
   protected byte[] getBuffer() {
     return new byte[_numBytesPerValue];
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BigDecimalDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BigDecimalDictionary.java
@@ -97,4 +97,28 @@ public class BigDecimalDictionary extends BaseImmutableDictionary {
   public byte[] getBytesValue(int dictId) {
     return getBytes(dictId);
   }
+
+  @Override
+  public void read32BitsMurmur3HashValues(int[] dictIds, int length, int[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get32BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read64BitsMurmur3HashValues(int[] dictIds, int length, long[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get64BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read128BitsMurmur3HashValues(int[] dictIds, int length, long[][] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get128BitsMurmur3HashValue(dictIds[i], buffer);
+    }
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
@@ -104,4 +104,28 @@ public class BytesDictionary extends BaseImmutableDictionary {
   public byte[] getBytesValue(int dictId) {
     return getBytes(dictId);
   }
+
+  @Override
+  public void read32BitsMurmur3HashValues(int[] dictIds, int length, int[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get32BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read64BitsMurmur3HashValues(int[] dictIds, int length, long[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get64BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read128BitsMurmur3HashValues(int[] dictIds, int length, long[][] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get128BitsMurmur3HashValue(dictIds[i], buffer);
+    }
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/StringDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/StringDictionary.java
@@ -169,4 +169,28 @@ public class StringDictionary extends BaseImmutableDictionary {
       outValues[i] = getUnpaddedBytes(dictIds[i], buffer);
     }
   }
+
+  @Override
+  public void read32BitsMurmur3HashValues(int[] dictIds, int length, int[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get32BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read64BitsMurmur3HashValues(int[] dictIds, int length, long[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get64BitsMurmur3Hash(dictIds[i], buffer);
+    }
+  }
+
+  @Override
+  public void read128BitsMurmur3HashValues(int[] dictIds, int length, long[][] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get128BitsMurmur3HashValue(dictIds[i], buffer);
+    }
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
@@ -27,6 +27,7 @@ import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.MapUtils;
+import org.apache.pinot.spi.utils.hash.MurmurHashFunctions;
 
 
 /**
@@ -202,6 +203,18 @@ public interface Dictionary extends IndexReader {
     return new ByteArray(getBytesValue(dictId));
   }
 
+  default int get32BitsMurmur3HashValue(int dictId) {
+    return MurmurHashFunctions.murmurHash3X64Bit32(getBytesValue(dictId), 0);
+  }
+
+  default long get64BitsMurmur3HashValue(int dictId) {
+    return MurmurHashFunctions.murmurHash3X64Bit64(getBytesValue(dictId), 0);
+  }
+
+  default long[] get128BitsMurmur3HashValue(int dictId) {
+    return MurmurHashFunctions.murmurHash3X64Bit128AsLongs(getBytesValue(dictId), 0);
+  }
+
   // Batch read APIs
 
   default void readIntValues(int[] dictIds, int length, int[] outValues) {
@@ -273,6 +286,24 @@ public interface Dictionary extends IndexReader {
   default void readMapValues(int[] dictIds, int length, Map[] outValues) {
     for (int i = 0; i < length; i++) {
       outValues[i] = MapUtils.deserializeMap(getBytesValue(dictIds[i]));
+    }
+  }
+
+  default void read32BitsMurmur3HashValues(int[] dictIds, int length, int[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get32BitsMurmur3HashValue(dictIds[i]);
+    }
+  }
+
+  default void read64BitsMurmur3HashValues(int[] dictIds, int length, long[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get64BitsMurmur3HashValue(dictIds[i]);
+    }
+  }
+
+  default void read128BitsMurmur3HashValues(int[] dictIds, int length, long[][] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = get128BitsMurmur3HashValue(dictIds[i]);
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.MapUtils;
+import org.apache.pinot.spi.utils.hash.MurmurHashFunctions;
 
 
 /**
@@ -510,6 +511,18 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
     throw new UnsupportedOperationException("This ForwardIndexReader does not support MAP types. "
         + "This indicates that either the column is getting mistyped or the wrong "
         + "ForwardIndexReader is being created to read this column.");
+  }
+
+  default int get32BitsMurmur3Hash(int docId, T context) {
+    return MurmurHashFunctions.murmurHash3X64Bit32(getBytes(docId, context), 0);
+  }
+
+  default long get64BitsMurmur3Hash(int docId, T context) {
+    return MurmurHashFunctions.murmurHash3X64Bit64(getBytes(docId, context), 0);
+  }
+
+  default long[] get128BitsMurmur3Hash(int docId, T context) {
+    return MurmurHashFunctions.murmurHash3X64Bit128AsLongs(getBytes(docId, context), 0);
   }
 
   /**
@@ -995,10 +1008,10 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
 
   /**
    * Returns whether the forward index supports recording the byte ranges accessed while reading a given docId.
-   * For readers that do support this info, caller should check if the buffer is a {@link isFixedOffsetMappingType()}.
-   * If yes, the byte range mapping for a docId can be calculated using the {@link getRawDataStartOffset()} and the
-   * {@link getDocLength()} functions.
-   * if not, caller should use the {@link recordDocIdByteRanges()} function to get the list of byte ranges accessed
+   * For readers that do support this info, caller should check if the buffer is a {@link #isFixedOffsetMappingType}.
+   * If yes, the byte range mapping for a docId can be calculated using the {@link #getRawDataStartOffset} and the
+   * {@link #getDocLength} functions.
+   * if not, caller should use the {@link #recordDocIdByteRanges} function to get the list of byte ranges accessed
    * for a docId.
    */
   default boolean isBufferByteRangeInfoSupported() {


### PR DESCRIPTION
This is useful for calculating distinct count