### PR TITLE
add metric for multstiage num groups limit reached

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -378,6 +378,14 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
       fillOldBrokerResponseStats(brokerResponse, queryResults.getQueryStats(), dispatchableSubPlan);
 
+      // Track number of queries with number of groups limit reached
+      for (String table : tableNames) {
+        if (brokerResponse.isNumGroupsLimitReached()) {
+          _brokerMetrics.addMeteredTableValue(table, BrokerMeter.BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED,
+              1);
+        }
+      }
+
       // Set total query processing time
       // TODO: Currently we don't emit metric for QUERY_TOTAL_TIME_MS
       long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();


### PR DESCRIPTION
We're realizing a lot of the existing metric in single stage
1. are missing multistage
2. don't quite make sense with multiple tables

This increments the `BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED` metric for all tables in a v2 engine query when hit. It's not exactly accurate, but the alternative today is you don't actually know this is happening except from the client side.