### PR TITLE
Fix LOOKUP join

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -105,8 +105,18 @@ public class WorkerManager {
       // find a single local exchange child in the leaf stage, assign workers based on the local exchange child.
       if (children.size() == 1 && isLocalExchange(children.get(0), context)) {
         DispatchablePlanMetadata childMetadata = metadataMap.get(children.get(0).getFragmentId());
-        metadata.setWorkerIdToServerInstanceMap(assignWorkersForLocalExchange(childMetadata));
+        Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = assignWorkersForLocalExchange(childMetadata);
+        metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
         metadata.setPartitionFunction(childMetadata.getPartitionFunction());
+        // Fake a segments map so that the worker can be correctly identified as leaf stage
+        // TODO: Add a query test for LOOKUP join
+        Map<String, List<String>> segmentsMap = Map.of(TableType.OFFLINE.name(), List.of());
+        Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap =
+            Maps.newHashMapWithExpectedSize(workerIdToServerInstanceMap.size());
+        for (Integer workerId : workerIdToServerInstanceMap.keySet()) {
+          workerIdToSegmentsMap.put(workerId, segmentsMap);
+        }
+        metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
       } else {
         assignWorkersToLeafFragment(fragment, context);
       }


### PR DESCRIPTION
#14893 accidentally removed the `workerIdToSegmentsMap` and broke LOOKUP join. This PR adds that back. Tested with `LookupJoinEngineQuickStart`

TODO: Add a query test for LOOKUP join