### PR TITLE
[multistage] Replace LogicalTableScan with PinotLogicalTableScan

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineExplainIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineExplainIntegrationTest.java
@@ -163,7 +163,7 @@ public class MultiStageEngineExplainIntegrationTest extends BaseClusterIntegrati
     explainLogical("SELECT 1 FROM mytable",
         "Execution Plan\n"
             + "LogicalProject(EXPR$0=[1])\n"
-            + "  LogicalTableScan(table=[[default, mytable]])\n");
+            + "  PinotLogicalTableScan(table=[[default, mytable]])\n");
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3485,7 +3485,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         + "      PinotLogicalAggregate(group=[{0}], agg#0=[COUNT($1)], aggType=[FINAL])\n"
         + "        PinotLogicalExchange(distribution=[hash[0]])\n"
         + "          PinotLogicalAggregate(group=[{17}], agg#0=[COUNT()], aggType=[LEAF])\n"
-        + "            LogicalTableScan(table=[[default, mytable]])\n");
+        + "            PinotLogicalTableScan(table=[[default, mytable]])\n");
     assertEquals(response1Json.get("rows").get(0).get(2).asText(), "Rule Execution Times\n"
         + "Rule: AggregateProjectMergeRule -> Time:*\n"
         + "Rule: Project -> Time:*\n"
@@ -3512,7 +3512,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "Execution Plan\n"
             + "LogicalProject\\(.*\\)\n"
             + "  LogicalFilter\\(condition=\\[<\\(.*, 0\\)]\\)\n"
-            + "    LogicalTableScan\\(table=\\[\\[default, mytable]]\\)\n"
+            + "    PinotLogicalTableScan\\(table=\\[\\[default, mytable]]\\)\n"
     ).matcher(response2Json.get("rows").get(0).get(1).asText()).find());
     assertEquals(response2Json.get("rows").get(0).get(2).asText(),
         "Rule Execution Times\n"

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalTableScan.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalTableScan.java
@@ -37,7 +37,8 @@ public class PinotLogicalTableScan extends TableScan {
     super(cluster, traitSet, hints, table);
   }
 
-  @Override public RelNode withHints(List<RelHint> hintList) {
+  @Override
+  public RelNode withHints(List<RelHint> hintList) {
     return new PinotLogicalTableScan(getCluster(), traitSet, hintList, table);
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalTableScan.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/logical/PinotLogicalTableScan.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.logical;
+
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+
+
+/**
+ * Same as {@link org.apache.calcite.rel.logical.LogicalTableScan}, except that it doesn't drop provided traits
+ * in the {@link #copy} method.
+ */
+public class PinotLogicalTableScan extends TableScan {
+  protected PinotLogicalTableScan(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints, RelOptTable table) {
+    super(cluster, traitSet, hints, table);
+  }
+
+  @Override public RelNode withHints(List<RelHint> hintList) {
+    return new PinotLogicalTableScan(getCluster(), traitSet, hintList, table);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    assert inputs.isEmpty();
+    return new PinotLogicalTableScan(getCluster(), traitSet, hints, table);
+  }
+
+  public static PinotLogicalTableScan create(LogicalTableScan logicalTableScan) {
+    return new PinotLogicalTableScan(logicalTableScan.getCluster(), logicalTableScan.getTraitSet(),
+        logicalTableScan.getHints(), logicalTableScan.getTable());
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotImplicitTableHintRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotImplicitTableHintRule.java
@@ -25,9 +25,9 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.hint.RelHint;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.calcite.rel.logical.PinotLogicalTableScan;
 import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.immutables.value.Value;
@@ -47,7 +47,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
 
   public static PinotImplicitTableHintRule withWorkerManager(WorkerManager workerManager) {
     return new PinotImplicitTableHintRule(ImmutablePinotImplicitTableHintRule.Config.builder()
-        .operandSupplier(b0 -> b0.operand(LogicalTableScan.class).anyInputs())
+        .operandSupplier(b0 -> b0.operand(PinotLogicalTableScan.class).anyInputs())
         .workerManager(workerManager)
         .build()
     );
@@ -55,7 +55,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
 
   @Override
   public boolean matches(RelOptRuleCall call) {
-    LogicalTableScan tableScan = call.rel(0);
+    PinotLogicalTableScan tableScan = call.rel(0);
 
     // we don't want to apply this rule if the explicit hint is complete
     return !isHintComplete(getTableOptionHint(tableScan));
@@ -63,7 +63,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
 
   @Override
   public void onMatch(RelOptRuleCall call) {
-    LogicalTableScan tableScan = call.rel(0);
+    PinotLogicalTableScan tableScan = call.rel(0);
 
     String tableName = RelToPlanNodeConverter.getTableNameFromTableScan(tableScan);
     @Nullable
@@ -97,14 +97,14 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
    * Get the table option hint from the table scan, if any.
    */
   @Nullable
-  private static RelHint getTableOptionHint(LogicalTableScan tableScan) {
+  private static RelHint getTableOptionHint(PinotLogicalTableScan tableScan) {
     return PinotHintStrategyTable.getHint(tableScan, PinotHintOptions.TABLE_HINT_OPTIONS);
   }
 
   /**
    * Returns a new node which is a copy of the given table scan with the new table options hint.
    */
-  private static RelNode withNewTableOptions(LogicalTableScan tableScan, TableOptions tableOptions) {
+  private static RelNode withNewTableOptions(PinotLogicalTableScan tableScan, TableOptions tableOptions) {
     ArrayList<RelHint> newHints = new ArrayList<>(tableScan.getHints());
 
     newHints.removeIf(relHint -> relHint.hintName.equals(PinotHintOptions.TABLE_HINT_OPTIONS));
@@ -130,7 +130,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
    * Any explicit hint will override the implicit hint obtained from the table partition info.
    */
   private static TableOptions calculateTableOptions(
-      @Nullable RelHint relHint, TableOptions implicitTableOptions, LogicalTableScan tableScan) {
+      @Nullable RelHint relHint, TableOptions implicitTableOptions, PinotLogicalTableScan tableScan) {
     if (relHint == null) {
       return implicitTableOptions;
     }
@@ -150,7 +150,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
   /**
    * Returns a table options hint with the partition key overridden by the hint, if any.
    */
-  private static ImmutableTableOptions overridePartitionKey(ImmutableTableOptions base, LogicalTableScan tableScan,
+  private static ImmutableTableOptions overridePartitionKey(ImmutableTableOptions base, PinotLogicalTableScan tableScan,
       Map<String, String> kvOptions) {
     String partitionKey = kvOptions.get(kvOptions.get(PinotHintOptions.TableHintOptions.PARTITION_KEY));
     if (partitionKey == null || partitionKey.equals(base.getPartitionKey())) {
@@ -163,8 +163,8 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
   /**
    * Returns a table options hint with the partition function overridden by the hint, if any.
    */
-  private static ImmutableTableOptions overridePartitionFunction(ImmutableTableOptions base, LogicalTableScan tableScan,
-      Map<String, String> kvOptions) {
+  private static ImmutableTableOptions overridePartitionFunction(ImmutableTableOptions base,
+      PinotLogicalTableScan tableScan, Map<String, String> kvOptions) {
     String partitionFunction = kvOptions.get(kvOptions.get(PinotHintOptions.TableHintOptions.PARTITION_FUNCTION));
     if (partitionFunction == null || partitionFunction.equals(base.getPartitionFunction())) {
       return base;
@@ -178,7 +178,7 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
    * Returns a table options hint with the partition parallelism overridden by the hint, if any.
    */
   private static ImmutableTableOptions overridePartitionParallelism(ImmutableTableOptions base,
-      LogicalTableScan tableScan, Map<String, String> kvOptions) {
+      PinotLogicalTableScan tableScan, Map<String, String> kvOptions) {
     String partitionParallelismStr = kvOptions.get(PinotHintOptions.TableHintOptions.PARTITION_PARALLELISM);
     if (partitionParallelismStr == null) {
       return base;
@@ -197,8 +197,8 @@ public class PinotImplicitTableHintRule extends RelRule<RelRule.Config> {
   /**
    * Returns a table options hint with the partition size overridden by the hint, if any.
    */
-  private static ImmutableTableOptions overridePartitionSize(ImmutableTableOptions base, LogicalTableScan tableScan,
-      Map<String, String> kvOptions) {
+  private static ImmutableTableOptions overridePartitionSize(ImmutableTableOptions base,
+      PinotLogicalTableScan tableScan, Map<String, String> kvOptions) {
     String partitionSizeStr = kvOptions.get(PinotHintOptions.TableHintOptions.PARTITION_SIZE);
     if (partitionSizeStr == null) {
       return base;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -150,7 +150,8 @@ public class PinotQueryRuleSets {
       PinotExchangeEliminationRule.INSTANCE,
 
       // Evaluate the Literal filter nodes
-      CoreRules.FILTER_REDUCE_EXPRESSIONS
+      CoreRules.FILTER_REDUCE_EXPRESSIONS,
+      PinotTableScanConverterRule.INSTANCE
   );
   //@formatter:on
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
@@ -21,6 +21,7 @@ package org.apache.pinot.calcite.rel.rules;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -35,7 +36,6 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.mapping.IntPair;
@@ -46,6 +46,7 @@ import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalAggregate;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
+import org.apache.pinot.calcite.rel.logical.PinotLogicalTableScan;
 import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.slf4j.Logger;
@@ -95,9 +96,9 @@ public class PinotRelDistributionTraitRule extends RelOptRule {
       return new LogicalJoin(join.getCluster(), clusterTraitSet.plus(trait), join.getLeft(), join.getRight(),
           join.getCondition(), join.getVariablesSet(), join.getJoinType(), join.isSemiJoinDone(),
           ImmutableList.copyOf(join.getSystemFieldList()));
-    } else if (relNode instanceof LogicalTableScan) {
-      LogicalTableScan tableScan = (LogicalTableScan) relNode;
-      return new LogicalTableScan(tableScan.getCluster(), clusterTraitSet.plus(trait), tableScan.getTable());
+    } else if (relNode instanceof PinotLogicalTableScan) {
+      PinotLogicalTableScan tableScan = (PinotLogicalTableScan) relNode;
+      return tableScan.copy(clusterTraitSet.plus(trait), Collections.emptyList());
     } else {
       return relNode.copy(clusterTraitSet.plus(trait), relNode.getInputs());
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotTableScanConverterRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotTableScanConverterRule.java
@@ -1,0 +1,28 @@
+package org.apache.pinot.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.pinot.calcite.rel.logical.PinotLogicalTableScan;
+
+
+public class PinotTableScanConverterRule extends RelOptRule {
+  public static final PinotTableScanConverterRule INSTANCE =
+      new PinotTableScanConverterRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  public PinotTableScanConverterRule(RelBuilderFactory factory) {
+    super(operand(TableScan.class, none()), factory, null);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    TableScan tableScan = call.rel(0);
+    if (tableScan instanceof LogicalTableScan) {
+      call.transformTo(PinotLogicalTableScan.create(call.rel(0)));
+    } else if (!(tableScan instanceof PinotLogicalTableScan)) {
+      throw new IllegalStateException("Unknown table scan in PinotTableScanConverterRule: " + tableScan.getClass());
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotTableScanConverterRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotTableScanConverterRule.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.calcite.rel.rules;
 
 import org.apache.calcite.plan.RelOptRule;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -41,7 +41,6 @@ import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.logical.LogicalWindow;
 import org.apache.calcite.rel.type.RelDataType;
@@ -56,6 +55,7 @@ import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalAggregate;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalExchange;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalSortExchange;
+import org.apache.pinot.calcite.rel.logical.PinotLogicalTableScan;
 import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
 import org.apache.pinot.calcite.rel.rules.PinotRuleUtils;
 import org.apache.pinot.common.config.provider.TableCache;
@@ -107,8 +107,8 @@ public final class RelToPlanNodeConverter {
    */
   public PlanNode toPlanNode(RelNode node) {
     PlanNode result;
-    if (node instanceof LogicalTableScan) {
-      result = convertLogicalTableScan((LogicalTableScan) node);
+    if (node instanceof PinotLogicalTableScan) {
+      result = convertPinotLogicalTableScan((PinotLogicalTableScan) node);
     } else if (node instanceof LogicalProject) {
       result = convertLogicalProject((LogicalProject) node);
     } else if (node instanceof LogicalFilter) {
@@ -289,7 +289,7 @@ public final class RelToPlanNodeConverter {
         convertInputs(node.getInputs()), RexExpressionUtils.fromRexNode(node.getCondition()));
   }
 
-  private TableScanNode convertLogicalTableScan(LogicalTableScan node) {
+  private TableScanNode convertPinotLogicalTableScan(PinotLogicalTableScan node) {
     String tableName = _tableCache.getActualTableName(getTableNameFromTableScan(node));
     List<RelDataTypeField> fields = node.getRowType().getFieldList();
     List<String> columns = new ArrayList<>(fields.size());

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -90,7 +90,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         + "    PinotLogicalExchange(distribution=[hash])\n"
         + "      PinotLogicalAggregate(group=[{}], agg#0=[COUNT() FILTER $0], agg#1=[COUNT()], aggType=[LEAF])\n"
         + "        LogicalProject($f1=[=($0, _UTF-8'a')])\n"
-        + "          LogicalTableScan(table=[[default, a]])\n");
+        + "          PinotLogicalTableScan(table=[[default, a]])\n");
     //@formatter:on
   }
 
@@ -592,13 +592,13 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
             + "  \"rels\": [\n"
             + "    {\n"
             + "      \"id\": \"0\",\n"
-            + "      \"relOp\": \"LogicalTableScan\",\n"
+            + "      \"relOp\": \"org.apache.pinot.calcite.rel.logical.PinotLogicalTableScan\",\n"
             + "      \"table\": [\n"
             + "        \"default\",\n"
             + "        \"a\"\n"
             + "      ],\n"
             + "      \"inputs\": [],\n"
-            + "      \"type\": \"LogicalTableScan\"\n"
+            + "      \"type\": \"PinotLogicalTableScan\"\n"
             + "    },\n"
             + "    {\n"
             + "      \"id\": \"1\",\n"
@@ -626,7 +626,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
             + "digraph {\n"
             + "\"PinotLogicalExchange\\n\" -> \"PinotLogicalAggregat\\ne\\n\" [label=\"0\"]\n"
             + "\"PinotLogicalAggregat\\ne\\n\" -> \"PinotLogicalExchange\\n\" [label=\"0\"]\n"
-            + "\"LogicalTableScan\\n\" -> \"PinotLogicalAggregat\\ne\\n\" [label=\"0\"]\n"
+            + "\"PinotLogicalTableSca\\nn\\n\" -> \"PinotLogicalAggregat\\ne\\n\" [label=\"0\"]\n"
             + "}\n"
         },
         new Object[]{"EXPLAIN PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
@@ -635,10 +635,10 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
             + "  LogicalJoin(condition=[=($0, $1)], joinType=[inner])\n"
             + "    PinotLogicalExchange(distribution=[hash[0]])\n"
             + "      LogicalProject(col1=[$0])\n"
-            + "        LogicalTableScan(table=[[default, a]])\n"
+            + "        PinotLogicalTableScan(table=[[default, a]])\n"
             + "    PinotLogicalExchange(distribution=[hash[0]])\n"
             + "      LogicalProject(col1=[$0], col3=[$2])\n"
-            + "        LogicalTableScan(table=[[default, b]])\n"
+            + "        PinotLogicalTableScan(table=[[default, b]])\n"
         },
     };
     //@formatter:on

--- a/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
@@ -13,13 +13,13 @@
           "\n        LogicalJoin(condition=[>=($0, $2)], joinType=[inner])",
           "\n          PinotLogicalExchange(distribution=[random])",
           "\n            LogicalProject(col3=[$2], col4=[$3])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n          PinotLogicalExchange(distribution=[broadcast])",
           "\n            LogicalProject(EXPR$0=[CAST(/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)):DECIMAL(1000, 0)])",
           "\n              PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)], aggType=[FINAL])",
           "\n                PinotLogicalExchange(distribution=[hash])",
           "\n                  PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($3)], agg#1=[COUNT()], aggType=[LEAF])",
-          "\n                    LogicalTableScan(table=[[default, a]])",
+          "\n                    PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -33,7 +33,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($3)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -47,7 +47,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($3)], agg#1=[COUNT()], agg#2=[MAX($3)], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -61,7 +61,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -74,7 +74,7 @@
           "\n  PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)], aggType=[FINAL])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -88,7 +88,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -102,7 +102,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -116,7 +116,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -130,7 +130,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'pink floyd'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -148,13 +148,13 @@
           "\n            PinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)], aggType=[DIRECT])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                LogicalProject(col2=[$1], col3=[$2], $f2=[50])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1, 2]])",
           "\n          LogicalProject(col2=[$0], sum_of_runs=[$1], $f2=[50])",
           "\n            PinotLogicalAggregate(group=[{0}], agg#0=[PERCENTILE($1, 50)], aggType=[DIRECT])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                LogicalProject(col2=[$1], col3=[$2], $f2=[50])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
@@ -6,7 +6,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT * FROM d",
         "output": [
           "Execution Plan",
-          "\nLogicalTableScan(table=[[default, d]])",
+          "\nPinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -18,7 +18,7 @@
           "\nLogicalSort(offset=[0], fetch=[0])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[0])",
-          "\n      LogicalTableScan(table=[[default, d]])",
+          "\n      PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -30,7 +30,7 @@
           "\nLogicalSort(offset=[0], fetch=[0])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[0])",
-          "\n      LogicalTableScan(table=[[default, d]])",
+          "\n      PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -41,7 +41,7 @@
           "Execution Plan",
           "\nLogicalProject(col1=[$0], EXPR$1=[+($2, $6)])",
           "\n  LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -52,7 +52,7 @@
           "Execution Plan",
           "\nLogicalProject(col1=[$0], colsum=[+($2, $6)])",
           "\n  LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -65,7 +65,7 @@
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(EXPR$0=[DATETRUNC(_UTF-8'DAY', $6)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -78,7 +78,7 @@
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(day=[DATETRUNC(_UTF-8'DAY', $6)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -92,7 +92,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n        LogicalProject($f0=[CAST(CASE(>($2, 10), _UTF-8'1':VARCHAR CHARACTER SET \"UTF-8\", >($2, 20), _UTF-8'2':VARCHAR CHARACTER SET \"UTF-8\", >($2, 30), _UTF-8'3':VARCHAR CHARACTER SET \"UTF-8\", >($2, 40), _UTF-8'4':VARCHAR CHARACTER SET \"UTF-8\", >($2, 50), _UTF-8'5':VARCHAR CHARACTER SET \"UTF-8\", _UTF-8'0':VARCHAR CHARACTER SET \"UTF-8\")):DECIMAL(1000, 500) NOT NULL])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -106,7 +106,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[LEAF])",
           "\n        LogicalProject(EXPR$1=[ARRAY_TO_MV($6)], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, e]])",
+          "\n          PinotLogicalTableScan(table=[[default, e]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/GroupByPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/GroupByPlans.json
@@ -9,7 +9,7 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -22,7 +22,7 @@
           "\n  PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], agg#1=[COUNT($2)], agg#2=[MAX($3)], agg#3=[MIN($4)], aggType=[FINAL])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[COUNT()], agg#2=[MAX($2)], agg#3=[MIN($2)], aggType=[LEAF])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -35,7 +35,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -49,7 +49,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], aggType=[LEAF])",
           "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -63,7 +63,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($0, _UTF-8'a'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -78,7 +78,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], agg#1=[$SUM0($2)], agg#2=[MAX($2)], agg#3=[MIN($2)], aggType=[LEAF])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -93,7 +93,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], agg#1=[$SUM0($2)], agg#2=[MAX($2)], agg#3=[MIN($2)], aggType=[LEAF])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -105,7 +105,7 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -118,7 +118,7 @@
           "\n  PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], agg#1=[COUNT()], aggType=[DIRECT])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -131,7 +131,7 @@
           "\n  PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], agg#1=[COUNT()], agg#2=[MAX($1)], agg#3=[MIN($1)], aggType=[DIRECT])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -144,7 +144,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0], col3=[$2])",
           "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -157,7 +157,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0], col3=[$2])",
           "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -171,7 +171,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0])",
           "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -185,7 +185,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($0, _UTF-8'a'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -200,7 +200,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0], col3=[$2])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -215,7 +215,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0], col3=[$2])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -230,7 +230,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0], col3=[$2])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -246,7 +246,7 @@
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{0}], agg#0=[DISTINCTCOUNT($1)], aggType=[LEAF], leafReturnFinalResult=[true])",
           "\n            LogicalFilter(condition=[>=($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -262,7 +262,7 @@
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{0}], agg#0=[DISTINCTCOUNT($1)], aggType=[LEAF], leafReturnFinalResult=[true], collations=[[1 DESC]], limit=[10])",
           "\n            LogicalFilter(condition=[>=($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -279,7 +279,7 @@
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            PinotLogicalAggregate(group=[{0}], agg#0=[DISTINCTCOUNT($1)], aggType=[LEAF], collations=[[1 DESC]], limit=[10])",
           "\n              LogicalFilter(condition=[>=($2, 0)])",
-          "\n                LogicalTableScan(table=[[default, a]])",
+          "\n                PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -295,7 +295,7 @@
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 1}], aggType=[LEAF], collations=[[]], limit=[10])",
           "\n            LogicalFilter(condition=[>=($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -12,10 +12,10 @@
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], ts=[$6])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -30,10 +30,10 @@
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], ts=[$6])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -44,9 +44,9 @@
           "Execution Plan",
           "\nLogicalJoin(condition=[=($0, $9)], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
-          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[1]])",
-          "\n    LogicalTableScan(table=[[default, b]])",
+          "\n    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -58,9 +58,9 @@
           "\nLogicalJoin(condition=[=($0, $9)], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalFilter(condition=[>=($2, 0)])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[1]])",
-          "\n    LogicalTableScan(table=[[default, b]])",
+          "\n    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -72,9 +72,9 @@
           "\nLogicalJoin(condition=[AND(=($0, $9), >($2, $10))], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalFilter(condition=[>=($2, 0)])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[1]])",
-          "\n    LogicalTableScan(table=[[default, b]])",
+          "\n    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -85,9 +85,9 @@
           "Execution Plan",
           "\nLogicalJoin(condition=[AND(=($0, $8), =($1, $9))], joinType=[inner])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n    LogicalTableScan(table=[[default, b]])",
+          "\n    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -101,11 +101,11 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], ts=[$6])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[<($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -122,11 +122,11 @@
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0])",
           "\n              LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n                LogicalTableScan(table=[[default, a]])",
+          "\n                PinotLogicalTableScan(table=[[default, a]])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col2=[$1], col3=[$2])",
           "\n              LogicalFilter(condition=[<($2, 0)])",
-          "\n                LogicalTableScan(table=[[default, b]])",
+          "\n                PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -139,10 +139,10 @@
           "\n  LogicalJoin(condition=[AND(=($0, $3), =($1, $4))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], ts=[$6])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], ts=[$6])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -158,10 +158,10 @@
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n            LogicalFilter(condition=[>=($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -177,10 +177,10 @@
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n            LogicalFilter(condition=[>=($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -194,11 +194,11 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[_UTF-8'bar', _UTF-8'foo']:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'alice':VARCHAR(7) CHARACTER SET \"UTF-8\"), (_UTF-8'alice':VARCHAR(7) CHARACTER SET \"UTF-8\".._UTF-8'charlie':VARCHAR(7) CHARACTER SET \"UTF-8\"), (_UTF-8'charlie':VARCHAR(7) CHARACTER SET \"UTF-8\"..+∞)]:VARCHAR(7) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -212,11 +212,11 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[_UTF-8'bar', _UTF-8'foo']:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'alice':VARCHAR(7) CHARACTER SET \"UTF-8\"), (_UTF-8'alice':VARCHAR(7) CHARACTER SET \"UTF-8\".._UTF-8'charlie':VARCHAR(7) CHARACTER SET \"UTF-8\"), (_UTF-8'charlie':VARCHAR(7) CHARACTER SET \"UTF-8\"..+∞)]:VARCHAR(7) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -228,10 +228,10 @@
           "\nLogicalProject(col1=[$0], col2=[$1])",
           "\n  LogicalJoin(condition=[=($2, $3)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -244,10 +244,10 @@
           "\n  LogicalJoin(condition=[=($2, $3)], joinType=[semi])",
           "\n    PinotLogicalExchange(distribution=[hash[2]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -259,12 +259,12 @@
           "\nLogicalProject(col1=[$0], col2=[$1])",
           "\n  LogicalJoin(condition=[=($2, $3)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -276,12 +276,12 @@
           "\nLogicalProject(col1=[$0], col2=[$1])",
           "\n  LogicalJoin(condition=[=($2, $3)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -295,10 +295,10 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col3=[$2], col6=[$5])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -312,12 +312,12 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col3=[$2], col6=[$5])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                LogicalTableScan(table=[[default, b]])",
+          "\n                PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -335,19 +335,19 @@
           "\n            PinotLogicalExchange(distribution=[hash[2]])",
           "\n              LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n                LogicalFilter(condition=[=($1, _UTF-8'test')])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              LogicalProject(col3=[$2])",
           "\n                LogicalFilter(condition=[=($0, _UTF-8'foo')])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col3=[$2])",
           "\n            LogicalFilter(condition=[=($0, _UTF-8'bar')])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col3=[$2])",
           "\n        LogicalFilter(condition=[=($0, _UTF-8'foobar')])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -370,14 +370,14 @@
           "\n                      PinotLogicalExchange(distribution=[hash[3]])",
           "\n                        LogicalProject(col1=[$0], col2=[$1], col3=[$2], col30=[$2])",
           "\n                          LogicalFilter(condition=[=($1, _UTF-8'test')])",
-          "\n                            LogicalTableScan(table=[[default, a]])",
+          "\n                            PinotLogicalTableScan(table=[[default, a]])",
           "\n                      PinotLogicalExchange(distribution=[hash[0]])",
           "\n                        PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
           "\n                          PinotLogicalExchange(distribution=[hash[0]])",
           "\n                            PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                              LogicalProject(col3=[$2], $f1=[true])",
           "\n                                LogicalFilter(condition=[=($0, _UTF-8'foo')])",
-          "\n                                  LogicalTableScan(table=[[default, b]])",
+          "\n                                  PinotLogicalTableScan(table=[[default, b]])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                LogicalProject(col3=[$0], $f1=[$1])",
           "\n                  PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
@@ -385,7 +385,7 @@
           "\n                      PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                        LogicalProject(col3=[$2], $f1=[true])",
           "\n                          LogicalFilter(condition=[=($0, _UTF-8'bar')])",
-          "\n                            LogicalTableScan(table=[[default, b]])",
+          "\n                            PinotLogicalTableScan(table=[[default, b]])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col3=[$0], $f1=[$1])",
           "\n          PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
@@ -393,7 +393,7 @@
           "\n              PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                LogicalProject(col3=[$2], $f1=[true])",
           "\n                  LogicalFilter(condition=[=($0, _UTF-8'foobar')])",
-          "\n                    LogicalTableScan(table=[[default, b]])",
+          "\n                    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -406,13 +406,13 @@
           "\n  LogicalJoin(condition=[AND(=($0, $3), =($1, $4), >($2, $5))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col4=[$3])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[*(0.5:DECIMAL(2, 1), $2)])",
           "\n        PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -425,13 +425,13 @@
           "\n  LogicalJoin(condition=[AND(=($0, $3), =($1, $4), >($2, $5))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col4=[$3])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n            LogicalProject(col1=[$0], col2=[$1], $f0=[*(0.5:DECIMAL(2, 1), $2)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -444,14 +444,14 @@
           "\n  LogicalJoin(condition=[AND(=($0, $3), =($1, $4), >($2, $5))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col4=[$3])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[CAST(/($2, $3)):DECIMAL(12, 1) NOT NULL])",
           "\n        PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT($3)], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n              LogicalProject(col1=[$0], col2=[$1], $f0=[*(0.5:DECIMAL(2, 1), $2)])",
-          "\n                LogicalTableScan(table=[[default, b]])",
+          "\n                PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -464,13 +464,13 @@
           "\n  LogicalJoin(condition=[AND(=($0, $3), =($1, $4), >($2, $5))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col4=[$3])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[*(0.5:DECIMAL(2, 1), /(CAST($2):DOUBLE NOT NULL, $3))])",
           "\n        PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT($3)], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            PinotLogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -483,12 +483,12 @@
           "\n  LogicalJoin(condition=[=($1, $2)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -504,10 +504,10 @@
           "\n        LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], ts=[$6])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -519,19 +519,19 @@
           "\nLogicalJoin(condition=[=($2, $8)], joinType=[semi])",
           "\n  LogicalJoin(condition=[=($1, $8)], joinType=[semi])",
           "\n    LogicalJoin(condition=[=($1, $8)], joinType=[semi])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n        LogicalProject(col1=[$0])",
           "\n          LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[>($2, 100)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n  PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n    LogicalProject(col3=[$2])",
           "\n      LogicalFilter(condition=[<($2, 100)])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -547,15 +547,15 @@
           "\n        LogicalProject(col3=[$1])",
           "\n          LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n            LogicalProject(col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n              LogicalProject(col1=[$0])",
           "\n                LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col3=[$2])",
           "\n            LogicalFilter(condition=[<($2, 100)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -573,15 +573,15 @@
           "\n            LogicalProject(col1=[$0], col3=[$2])",
           "\n              LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n                LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n                PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n                  LogicalProject(col1=[$0])",
           "\n                    LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n                      LogicalTableScan(table=[[default, a]])",
+          "\n                      PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n              LogicalProject(col3=[$2])",
           "\n                LogicalFilter(condition=[<($2, 100)])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -593,15 +593,15 @@
           "\nLogicalJoin(condition=[=($2, $8)], joinType=[semi])",
           "\n  LogicalJoin(condition=[=($0, $8)], joinType=[semi])",
           "\n    LogicalFilter(condition=[<($2, 100)])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n    LogicalProject(col3=[$2])",
           "\n      LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -629,7 +629,7 @@
           "\n                                PinotLogicalExchange(distribution=[hash[1]])",
           "\n                                  LogicalProject(col3=[$2], col30=[$2])",
           "\n                                    LogicalFilter(condition=[AND(=($0, _UTF-8'foo'), =($1, _UTF-8'xylo'), =($3, 12), NOT($4))])",
-          "\n                                      LogicalTableScan(table=[[default, a]])",
+          "\n                                      PinotLogicalTableScan(table=[[default, a]])",
           "\n                                PinotLogicalExchange(distribution=[hash[0]])",
           "\n                                  LogicalProject(col3=[$0], $f1=[$1])",
           "\n                                    PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
@@ -637,7 +637,7 @@
           "\n                                        PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                                          LogicalProject(col3=[$2], $f1=[true])",
           "\n                                            LogicalFilter(condition=[=($0, _UTF-8'foo')])",
-          "\n                                              LogicalTableScan(table=[[default, b]])",
+          "\n                                              PinotLogicalTableScan(table=[[default, b]])",
           "\n                        PinotLogicalExchange(distribution=[hash[0]])",
           "\n                          LogicalProject(col3=[$0], $f1=[$1])",
           "\n                            PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
@@ -645,7 +645,7 @@
           "\n                                PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                                  LogicalProject(col3=[$2], $f1=[true])",
           "\n                                    LogicalFilter(condition=[=($0, _UTF-8'bar')])",
-          "\n                                      LogicalTableScan(table=[[default, b]])",
+          "\n                                      PinotLogicalTableScan(table=[[default, b]])",
           "\n                PinotLogicalExchange(distribution=[hash[0]])",
           "\n                  LogicalProject(col3=[$0], $f1=[$1])",
           "\n                    PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[FINAL])",
@@ -653,11 +653,11 @@
           "\n                        PinotLogicalAggregate(group=[{0}], agg#0=[MIN($1)], aggType=[LEAF])",
           "\n                          LogicalProject(col3=[$2], $f1=[true])",
           "\n                            LogicalFilter(condition=[=($0, _UTF-8'foobar')])",
-          "\n                              LogicalTableScan(table=[[default, b]])",
+          "\n                              PinotLogicalTableScan(table=[[default, b]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col3=[$2])",
           "\n            LogicalFilter(condition=[=($0, _UTF-8'fork')])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       }
@@ -674,9 +674,9 @@
           "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -690,9 +690,9 @@
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -705,9 +705,9 @@
           "\n  LogicalJoin(condition=[AND(=($0, $1), =($2, _UTF-8'foo'))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -720,9 +720,9 @@
           "\n  LogicalJoin(condition=[AND(=($0, $1), =($2, _UTF-8'foo'))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -735,9 +735,9 @@
           "\n  LogicalJoin(condition=[AND(=($0, $1), =($1, _UTF-8'foo'))], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -750,9 +750,9 @@
           "\n  LogicalJoin(condition=[=($1, $2)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       }
@@ -769,10 +769,10 @@
           "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -786,11 +786,11 @@
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[=($1, _UTF-8'bar')])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -803,10 +803,10 @@
           "\n  LogicalJoin(condition=[=($1, $3)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast])",
           "\n      LogicalProject(col2=[$1], $f8=[UPPER($0)])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       }
@@ -823,10 +823,10 @@
           "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -840,11 +840,11 @@
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[=($1, _UTF-8'foo')])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[=($1, _UTF-8'bar')])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -857,10 +857,10 @@
           "\n  LogicalJoin(condition=[=($1, $3)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col1=[$0], $f8=[UPPER($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[single])",
           "\n      LogicalProject(col2=[$1], $f8=[UPPER($0)])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
@@ -16,7 +16,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[30], EXPR$1=[11])",
-          "\n  LogicalTableScan(table=[[default, d]])",
+          "\n  PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -26,7 +26,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[1997-02-01 00:00:00])",
-          "\n  LogicalTableScan(table=[[default, d]])",
+          "\n  PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -36,7 +36,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[854755200000:BIGINT])",
-          "\n  LogicalTableScan(table=[[default, d]])",
+          "\n  PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -46,7 +46,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[TIMESTAMPDIFF(FLAG(DAY), CAST($6):TIMESTAMP(0) NOT NULL, CAST(854755200000:BIGINT):TIMESTAMP(0) NOT NULL)])",
-          "\n  LogicalTableScan(table=[[default, d]])",
+          "\n  PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -56,7 +56,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalFilter(condition=[=(CAST($6):TIMESTAMP(0) NOT NULL, 2019-01-01 00:00:00)])",
-          "\n  LogicalTableScan(table=[[default, d]])",
+          "\n  PinotLogicalTableScan(table=[[default, d]])",
           "\n"
         ]
       },
@@ -66,7 +66,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(day=[854755200000:BIGINT])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -76,7 +76,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalFilter(condition=[=(DATETRUNC(_UTF-8'MONTH', $6), 1546300800000)])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -86,7 +86,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[_UTF-8'MONTH'])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -96,7 +96,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[_UTF-8'month 1':VARCHAR CHARACTER SET \"UTF-8\"])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -106,7 +106,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[_UTF-8'nth':VARCHAR CHARACTER SET \"UTF-8\"])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -116,7 +116,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[_UTF-8'NTH':VARCHAR CHARACTER SET \"UTF-8\"])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -126,7 +126,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[599041711439609855:BIGINT])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -136,7 +136,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[X'8040340000000000004024000000000000':VARBINARY])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -146,7 +146,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[1.3416951966757335E7:DOUBLE])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -156,7 +156,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[12345678901234567890123456789.1234567890123456789:DECIMAL(1000, 0)])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -166,7 +166,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[14:BIGINT])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -176,7 +176,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[15:BIGINT])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -186,7 +186,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[ARRAY(1, 2, 3)])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -206,7 +206,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[ARRAY(0.1:DECIMAL(2, 1), 0.2:DECIMAL(2, 1), 0.3:DECIMAL(2, 1))])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -226,7 +226,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[ARRAY(_UTF-8'a', _UTF-8'b', _UTF-8'c')])",
-          "\n  LogicalTableScan(table=[[default, a]])",
+          "\n  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -249,7 +249,7 @@
           "\n  PinotLogicalExchange(distribution=[hash])",
           "\n    PinotLogicalAggregate(group=[{}], agg#0=[COUNT()], aggType=[LEAF])",
           "\n      LogicalFilter(condition=[>(CAST($0):BIGINT NOT NULL, 14)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },

--- a/pinot-query-planner/src/test/resources/queries/OrderByPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/OrderByPlans.json
@@ -9,7 +9,7 @@
           "\nLogicalSort(sort0=[$0], dir0=[ASC])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalProject(col1=[$0])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -21,7 +21,7 @@
           "\nLogicalSort(sort0=[$0], dir0=[ASC])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalProject(value1=[$0])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -33,7 +33,7 @@
           "\nLogicalSort(sort0=[$0], dir0=[ASC], offset=[0], fetch=[10])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalSort(sort0=[$0], dir0=[ASC], fetch=[10])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -45,7 +45,7 @@
           "\nLogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], offset=[0], fetch=[10])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0, 1 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[10])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -57,7 +57,7 @@
           "\nLogicalSort(offset=[0], fetch=[10000000])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10000000])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -68,7 +68,7 @@
           "Execution Plan",
           "\nLogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[10000000])",
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0, 1 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
-          "\n    LogicalTableScan(table=[[default, b]])",
+          "\n    PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -82,7 +82,7 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -96,7 +96,7 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -110,7 +110,7 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -124,7 +124,7 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
@@ -32,11 +32,11 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col1=[$0])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
           "\n          LogicalFilter(condition=[<($2, 0)])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -47,11 +47,11 @@
           "Execution Plan",
           "\nLogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n  LogicalProject(col1=[$0], col2=[$1])",
-          "\n    LogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n    LogicalProject(col2=[$1])",
           "\n      LogicalFilter(condition=[>($2, 0)])",
-          "\n        LogicalTableScan(table=[[default, b]])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -63,15 +63,15 @@
           "\nLogicalJoin(condition=[=($1, $2)], joinType=[semi])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col2=[$1])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n  PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n    LogicalProject(col1=[$0])",
           "\n      LogicalFilter(condition=[>($2, 0)])",
-          "\n        LogicalTableScan(table=[[default, c]])",
+          "\n        PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       },
@@ -86,15 +86,15 @@
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalJoin(condition=[=($0, $3)], joinType=[semi])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n          PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n            LogicalProject(col2=[$1])",
           "\n              LogicalFilter(condition=[>($2, 0)])",
-          "\n                LogicalTableScan(table=[[default, b]])",
+          "\n                PinotLogicalTableScan(table=[[default, b]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, c]])",
+          "\n              PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       },
@@ -106,11 +106,11 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col2=[$1])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -124,11 +124,11 @@
           "\n    PinotLogicalAggregate(group=[{1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($0, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col2=[$1])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -142,7 +142,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>=($2, 0), =($0, _UTF-8'a'))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -157,7 +157,7 @@
           "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalProject(col2=[$1], col3=[$2], $f2=[CAST($0):DECIMAL(1000, 500) NOT NULL])",
           "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -169,7 +169,7 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], agg#1=[$SUM0($1)], agg#2=[$SUM0($2)], aggType=[DIRECT])",
           "\n  LogicalProject(col2=[$1], col3=[$2], $f2=[CAST($0):DECIMAL(1000, 500) NOT NULL])",
           "\n    LogicalFilter(condition=[AND(>=($2, 0), =($1, _UTF-8'a'))])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       }
@@ -186,11 +186,11 @@
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -202,7 +202,7 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    PinotLogicalAggregate(group=[{1}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -214,7 +214,7 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -229,11 +229,11 @@
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -248,11 +248,11 @@
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -267,11 +267,11 @@
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -285,11 +285,11 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -301,11 +301,11 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -319,13 +319,13 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              PinotLogicalAggregate(group=[{0}], aggType=[LEAF])",
           "\n                LogicalFilter(condition=[>($2, 0)])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -337,11 +337,11 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0]], relExchangeType=[PIPELINE_BREAKER])",
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[DIRECT])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -355,11 +355,11 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -373,11 +373,11 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -391,7 +391,7 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($1, 1)])",
@@ -399,7 +399,7 @@
           "\n                PinotLogicalExchange(distribution=[hash[0]])",
           "\n                  PinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], aggType=[LEAF])",
           "\n                    LogicalFilter(condition=[>($2, 0)])",
-          "\n                      LogicalTableScan(table=[[default, b]])",
+          "\n                      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -415,11 +415,11 @@
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[COUNT()], aggType=[LEAF])",
           "\n          LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n              LogicalProject(col1=[$0])",
           "\n                LogicalFilter(condition=[>($2, 0)])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -435,11 +435,11 @@
           "\n        PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
           "\n          LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n              LogicalProject(col1=[$0])",
           "\n                LogicalFilter(condition=[>($2, 0)])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -451,11 +451,11 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -467,11 +467,11 @@
           "\nPinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col2=[$1], col3=[$2])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n    PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n      LogicalProject(col1=[$0])",
           "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -485,11 +485,11 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], agg#1=[COUNT()], aggType=[DIRECT])",
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -503,11 +503,11 @@
           "\n    PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])",
           "\n      LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -520,11 +520,11 @@
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalJoin(condition=[=($0, $1)], joinType=[semi])",
           "\n      LogicalProject(col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n        LogicalProject(col1=[$0])",
           "\n          LogicalFilter(condition=[>($2, 0)])",
-          "\n            LogicalTableScan(table=[[default, b]])",
+          "\n            PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -538,11 +538,11 @@
           "\n    LogicalProject(col1=[$0], col3=[$2])",
           "\n      LogicalJoin(condition=[=($1, $3)], joinType=[semi])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n        PinotLogicalExchange(distribution=[broadcast], relExchangeType=[PIPELINE_BREAKER])",
           "\n          LogicalProject(col1=[$0])",
           "\n            LogicalFilter(condition=[>($2, 0)])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/SetOpPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/SetOpPlans.json
@@ -9,10 +9,10 @@
           "\nLogicalUnion(all=[true])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, b]])",
+          "\n      PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -26,13 +26,13 @@
           "\n    LogicalUnion(all=[true])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, c]])",
+          "\n      PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       },
@@ -49,13 +49,13 @@
           "\n          LogicalUnion(all=[true])",
           "\n            PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n              LogicalProject(col1=[$0], col2=[$1])",
-          "\n                LogicalTableScan(table=[[default, a]])",
+          "\n                PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n              LogicalProject(col1=[$0], col2=[$1])",
-          "\n                LogicalTableScan(table=[[default, b]])",
+          "\n                PinotLogicalTableScan(table=[[default, b]])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, c]])",
+          "\n            PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       },
@@ -69,13 +69,13 @@
           "\n    LogicalIntersect(all=[false])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, c]])",
+          "\n      PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       },
@@ -89,13 +89,13 @@
           "\n    LogicalMinus(all=[false])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n      PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n        LogicalProject(col1=[$0], col2=[$1])",
-          "\n          LogicalTableScan(table=[[default, b]])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
           "\n  PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[default, c]])",
+          "\n      PinotLogicalTableScan(table=[[default, c]])",
           "\n"
         ]
       }

--- a/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
@@ -10,7 +10,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -23,7 +23,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [COUNT()])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(winLiteral=[0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -37,7 +37,7 @@
           "\n    LogicalWindow(window#0=[window(aggs [COUNT()])])",
           "\n      PinotLogicalExchange(distribution=[hash])",
           "\n        LogicalProject(winLiteral=[0])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -50,7 +50,7 @@
           "\n  LogicalWindow(window#0=[window(rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(winLiteral=[0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -63,7 +63,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -75,7 +75,7 @@
           "\nLogicalWindow(window#0=[window(rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n  PinotLogicalExchange(distribution=[hash])",
           "\n    LogicalProject(col1=[$0])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -89,7 +89,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -103,7 +103,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -118,7 +118,7 @@
           "\n      LogicalWindow(window#0=[window(aggs [SUM($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -133,7 +133,7 @@
           "\n      LogicalWindow(window#0=[window(rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n        PinotLogicalExchange(distribution=[hash])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -149,7 +149,7 @@
           "\n        LogicalWindow(window#0=[window(aggs [SUM($1)])])",
           "\n          PinotLogicalExchange(distribution=[hash])",
           "\n            LogicalProject(col1=[$0], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -165,7 +165,7 @@
           "\n        LogicalWindow(window#0=[window(aggs [SUM($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -178,7 +178,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -192,7 +192,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[>($2, 10)])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -205,7 +205,7 @@
           "\n  PinotLogicalExchange(distribution=[hash])",
           "\n    LogicalProject(col1=[$0])",
           "\n      LogicalFilter(condition=[>($2, 10)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -219,7 +219,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-8'bar', _UTF-8'foo']:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -234,7 +234,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -249,7 +249,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -264,7 +264,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -280,7 +280,7 @@
           "\n        PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -298,7 +298,7 @@
           "\n            PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -316,7 +316,7 @@
           "\n            PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -329,7 +329,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($1), COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -342,7 +342,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -356,7 +356,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -370,7 +370,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($0), MIN($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -385,7 +385,7 @@
           "\n      LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
           "\n        PinotLogicalExchange(distribution=[hash])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -401,7 +401,7 @@
           "\n        LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
           "\n          PinotLogicalExchange(distribution=[hash])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -417,7 +417,7 @@
           "\n        LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
           "\n          PinotLogicalExchange(distribution=[hash])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -430,7 +430,7 @@
           "\n  LogicalWindow(window#0=[window(aggs [SUM($0), MAX($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -444,7 +444,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[>($2, 100)])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -458,7 +458,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject(col3=[$2], $1=[LENGTH(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -473,7 +473,7 @@
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalProject($0=[LENGTH(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -488,7 +488,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -503,7 +503,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -518,7 +518,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -534,7 +534,7 @@
           "\n        PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -552,7 +552,7 @@
           "\n            PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -565,7 +565,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -578,7 +578,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -592,7 +592,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -605,7 +605,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -618,7 +618,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -632,7 +632,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -646,7 +646,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [MAX($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -661,7 +661,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} aggs [MIN($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -677,7 +677,7 @@
           "\n        LogicalWindow(window#0=[window(partition {1} aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -693,7 +693,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} aggs [MIN($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -709,7 +709,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -722,7 +722,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} aggs [COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -735,7 +735,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col3=[$2], $1=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -749,7 +749,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -763,7 +763,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -776,7 +776,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} aggs [SUM($0), COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -789,7 +789,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject($0=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -804,7 +804,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -819,7 +819,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -834,7 +834,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -849,7 +849,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -865,7 +865,7 @@
           "\n        PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -883,7 +883,7 @@
           "\n            PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -896,7 +896,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -910,7 +910,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -923,7 +923,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -936,7 +936,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -950,7 +950,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -965,7 +965,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), MAX($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -981,7 +981,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -997,7 +997,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), MAX($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1012,7 +1012,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), MAX($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1027,7 +1027,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), COUNT($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1043,7 +1043,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER(), ROW_NUMBER()])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1058,7 +1058,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), SUM($2), COUNT($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1073,7 +1073,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} aggs [SUM($2), COUNT($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1086,7 +1086,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} aggs [SUM($1), MAX($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1100,7 +1100,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1114,7 +1114,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1127,7 +1127,7 @@
           "\n  LogicalWindow(window#0=[window(partition {2} aggs [SUM($1), COUNT($1), COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[2]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1142,7 +1142,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1157,7 +1157,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1172,7 +1172,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{2}], agg#0=[$SUM0($2)], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1188,7 +1188,7 @@
           "\n        PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1206,7 +1206,7 @@
           "\n            PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
           "\n              PinotLogicalExchange(distribution=[hash[0]])",
           "\n                PinotLogicalAggregate(group=[{2}], aggType=[LEAF])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1219,7 +1219,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [SUM($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1232,7 +1232,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1246,7 +1246,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [SUM($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1259,7 +1259,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1272,7 +1272,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1 DESC] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1285,7 +1285,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1300,7 +1300,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1315,7 +1315,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] aggs [RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1330,7 +1330,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1345,7 +1345,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] aggs [DENSE_RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1360,7 +1360,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1375,7 +1375,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] aggs [RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1390,7 +1390,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1] aggs [DENSE_RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1403,7 +1403,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1417,7 +1417,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1431,7 +1431,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1444,7 +1444,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [MAX($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1459,7 +1459,7 @@
           "\n      LogicalWindow(window#0=[window(order by [0 DESC] aggs [MIN($2)])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1475,7 +1475,7 @@
           "\n        LogicalWindow(window#0=[window(order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1491,7 +1491,7 @@
           "\n        LogicalWindow(window#0=[window(order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1507,7 +1507,7 @@
           "\n        LogicalWindow(window#0=[window(order by [1] aggs [RANK()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1523,7 +1523,7 @@
           "\n        LogicalWindow(window#0=[window(order by [0 DESC] aggs [MIN($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1539,7 +1539,7 @@
           "\n        LogicalWindow(window#0=[window(order by [0 DESC] aggs [DENSE_RANK()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1552,7 +1552,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1565,7 +1565,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col3=[$2], $1=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1579,7 +1579,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1592,7 +1592,7 @@
           "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n    LogicalProject(col2=[$1])",
           "\n      LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1606,7 +1606,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1620,7 +1620,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], $1=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1634,7 +1634,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], $1=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1647,7 +1647,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [SUM($0), COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1660,7 +1660,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject($0=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1673,7 +1673,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject($0=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1686,7 +1686,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1699,7 +1699,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [RANK(), DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1713,7 +1713,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1726,7 +1726,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1739,7 +1739,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [DENSE_RANK(), RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1752,7 +1752,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1765,7 +1765,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [DENSE_RANK(), MIN($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1778,7 +1778,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [COUNT($1), MIN($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1791,7 +1791,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [COUNT($1), RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1806,7 +1806,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1, 0 DESC] aggs [SUM($2), COUNT($2)])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1, 0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1821,7 +1821,7 @@
           "\n      LogicalWindow(window#0=[window(order by [1, 0 DESC] aggs [RANK(), SUM($2), COUNT($2)])])",
           "\n        PinotLogicalSortExchange(distribution=[hash], collation=[[1, 0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1837,7 +1837,7 @@
           "\n        LogicalWindow(window#0=[window(order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1853,7 +1853,7 @@
           "\n        LogicalWindow(window#0=[window(order by [1, 0 DESC] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[1, 0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1869,7 +1869,7 @@
           "\n        LogicalWindow(window#0=[window(order by [1, 0 DESC] aggs [DENSE_RANK(), RANK()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash], collation=[[1, 0 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1882,7 +1882,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [SUM($1), MAX($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1896,7 +1896,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], $1=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1909,7 +1909,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] aggs [DENSE_RANK(), RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col2=[$1], $1=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1923,7 +1923,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1937,7 +1937,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1951,7 +1951,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], $1=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1964,7 +1964,7 @@
           "\n  LogicalWindow(window#0=[window(order by [2] aggs [SUM($1), COUNT($1), COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1977,7 +1977,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1] aggs [DENSE_RANK(), COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], $1=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -1990,7 +1990,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2003,7 +2003,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2017,7 +2017,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2031,7 +2031,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2044,7 +2044,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2057,7 +2057,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2070,7 +2070,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2083,7 +2083,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2097,7 +2097,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2110,7 +2110,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [MAX($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2125,7 +2125,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} order by [0] aggs [MIN($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2140,7 +2140,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} order by [0] aggs [DENSE_RANK()])])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2156,7 +2156,7 @@
           "\n        LogicalWindow(window#0=[window(partition {1} order by [1] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2172,7 +2172,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [0] aggs [MIN($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2188,7 +2188,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2204,7 +2204,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [0] aggs [RANK()])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2217,7 +2217,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2231,7 +2231,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2244,7 +2244,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col2=[$1])",
           "\n      LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2257,7 +2257,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col2=[$1])",
           "\n      LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2271,7 +2271,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2285,7 +2285,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], $1=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2298,7 +2298,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1] aggs [SUM($0), COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2311,7 +2311,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject($0=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2324,7 +2324,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1 DESC] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2337,7 +2337,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1 DESC] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2350,7 +2350,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1 ASC-nulls-first] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2363,7 +2363,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [1 DESC-nulls-last] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalExchange(distribution=[hash[1]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2376,7 +2376,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2389,7 +2389,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [DENSE_RANK(), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2403,7 +2403,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2416,7 +2416,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2428,7 +2428,7 @@
           "\nLogicalWindow(window#0=[window(partition {0} order by [0] aggs [RANK(), DENSE_RANK()])])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0])",
-          "\n      LogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2441,7 +2441,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2454,7 +2454,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2467,7 +2467,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [COUNT($1), DENSE_RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2482,7 +2482,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} order by [1, 0] aggs [SUM($2), COUNT($2)])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2497,7 +2497,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} order by [1, 0] aggs [DENSE_RANK(), RANK()])])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2513,7 +2513,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2529,7 +2529,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0, 1} order by [1, 0] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2545,7 +2545,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0, 1} order by [1, 0] aggs [RANK(), DENSE_RANK()])])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2558,7 +2558,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1), MAX($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col2=[$1], col3=[$2], $2=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2572,7 +2572,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2585,7 +2585,7 @@
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalProject(col1=[$0])",
           "\n      LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2599,7 +2599,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2613,7 +2613,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2626,7 +2626,7 @@
           "\n  LogicalWindow(window#0=[window(partition {2} order by [2] aggs [SUM($1), COUNT($1), COUNT($0)])])",
           "\n    PinotLogicalExchange(distribution=[hash[2]])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2640,7 +2640,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject($0=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2653,7 +2653,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0] aggs [RANK(), DENSE_RANK()])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject($0=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2666,7 +2666,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0 DESC] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2679,7 +2679,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0 ASC-nulls-first] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2692,7 +2692,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [0 DESC-nulls-last] aggs [SUM($1), COUNT($1), MIN($1)])])",
           "\n    PinotLogicalExchange(distribution=[hash[0]])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2705,7 +2705,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2718,7 +2718,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2731,7 +2731,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2744,7 +2744,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2757,7 +2757,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2770,7 +2770,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2783,7 +2783,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2796,7 +2796,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2809,7 +2809,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [MAX($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2824,7 +2824,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} order by [1] aggs [MIN($2)])])",
           "\n        PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2839,7 +2839,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} order by [1] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2854,7 +2854,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0} order by [1] aggs [RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2870,7 +2870,7 @@
           "\n        LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2886,7 +2886,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [1] aggs [MIN($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2902,7 +2902,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [1] aggs [DENSE_RANK()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2915,7 +2915,7 @@
           "\n  LogicalWindow(window#0=[window(partition {2} order by [0] aggs [COUNT($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[2]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2], $3=[SUBSTR($0, 0, 2)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2929,7 +2929,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2943,7 +2943,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[SEARCH($2, Sarg[(10..500]])])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2957,7 +2957,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2], $3=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2971,7 +2971,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], $2=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2985,7 +2985,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], $2=[CONCAT($0, _UTF-8'-', $1)])",
           "\n        LogicalFilter(condition=[OR(SEARCH($0, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\"), >=($2, 42))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -2998,7 +2998,7 @@
           "\n  LogicalWindow(window#0=[window(partition {2} order by [1] aggs [SUM($0), COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[2]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col3=[$2], $1=[REVERSE($1)], $2=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3011,7 +3011,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject($0=[REVERSE($1)], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3024,7 +3024,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject($0=[REVERSE($1)], $1=[CONCAT($0, _UTF-8'-', $1)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3037,7 +3037,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [2] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3050,7 +3050,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [MAX($1), DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3064,7 +3064,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [2] aggs [MAX($2), COUNT($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3077,7 +3077,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [SUM($2), COUNT($2), MIN($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3090,7 +3090,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [DENSE_RANK(), RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3103,7 +3103,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [SUM($2), COUNT($2), MIN($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3116,7 +3116,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [COUNT($2), MIN($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3129,7 +3129,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [COUNT($2), DENSE_RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3144,7 +3144,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} order by [2, 0] aggs [SUM($2), COUNT($2)])])",
           "\n        PinotLogicalSortExchange(distribution=[hash[0, 1]], collation=[[2, 0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3159,7 +3159,7 @@
           "\n      LogicalWindow(window#0=[window(partition {0, 1} order by [2, 0] aggs [RANK(), DENSE_RANK()])])",
           "\n        PinotLogicalSortExchange(distribution=[hash[0, 1]], collation=[[2, 0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3175,7 +3175,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0} order by [1] aggs [SUM($2), COUNT($2), MIN($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3191,7 +3191,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0, 1} order by [2, 0] aggs [SUM($2), COUNT($2)])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[0, 1]], collation=[[2, 0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3207,7 +3207,7 @@
           "\n        LogicalWindow(window#0=[window(partition {0, 1} order by [2, 0] aggs [DENSE_RANK(), RANK()])])",
           "\n          PinotLogicalSortExchange(distribution=[hash[0, 1]], collation=[[2, 0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n            LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3220,7 +3220,7 @@
           "\n  LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), MAX($2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[1]], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2], $3=[REVERSE($0)])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3234,7 +3234,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3248,7 +3248,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3262,7 +3262,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1])",
           "\n        LogicalFilter(condition=[AND(>($2, 42), SEARCH($0, Sarg[_UTF-8'chewbacca':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'vader':VARCHAR(9) CHARACTER SET \"UTF-8\", _UTF-8'yoda':VARCHAR(9) CHARACTER SET \"UTF-8\"]:VARCHAR(9) CHARACTER SET \"UTF-8\"))])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3276,7 +3276,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2], $3=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3290,7 +3290,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], $2=[REVERSE(CONCAT($0, _UTF-8' ', $1))])",
           "\n        LogicalFilter(condition=[SEARCH($1, Sarg[(-∞.._UTF-8'bar'), (_UTF-8'bar'.._UTF-8'baz'), (_UTF-8'baz'.._UTF-8'foo'), (_UTF-8'foo'..+∞)]:CHAR(3) CHARACTER SET \"UTF-8\")])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3303,7 +3303,7 @@
           "\n  LogicalWindow(window#0=[window(partition {3} order by [2] aggs [SUM($1), COUNT($1), COUNT($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[3]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2], $2=[CONCAT($0, _UTF-8'-', $1)], $3=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3316,7 +3316,7 @@
           "\n  LogicalWindow(window#0=[window(partition {2} order by [1] aggs [SUM($0), COUNT($0), RANK()])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[2]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col3=[$2], $1=[CONCAT($0, _UTF-8'-', $1)], $2=[REVERSE(CONCAT($0, _UTF-8'-', $1))])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3332,10 +3332,10 @@
           "\n        LogicalJoin(condition=[=($0, $3)], joinType=[inner])",
           "\n          PinotLogicalExchange(distribution=[hash[0]])",
           "\n            LogicalProject(col1=[$0], col3=[$2])",
-          "\n              LogicalTableScan(table=[[default, a]])",
+          "\n              PinotLogicalTableScan(table=[[default, a]])",
           "\n          PinotLogicalExchange(distribution=[hash[1]])",
           "\n            LogicalProject(col1=[$0], col2=[$1])",
-          "\n              LogicalTableScan(table=[[default, b]])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -3350,7 +3350,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], agg#0=[COUNT()], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3365,7 +3365,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], agg#0=[COUNT()], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3380,7 +3380,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], agg#0=[COUNT()], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3395,7 +3395,7 @@
           "\n      PinotLogicalAggregate(group=[{0, 1}], agg#0=[COUNT($2)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n          PinotLogicalAggregate(group=[{0, 2}], agg#0=[COUNT()], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3409,7 +3409,7 @@
           "\n    LogicalWindow(window#0=[window(partition {1} order by [2] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n      PinotLogicalSortExchange(distribution=[hash[1]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3423,7 +3423,7 @@
           "\n    LogicalWindow(window#0=[window(partition {1} order by [2] aggs [RANK(), DENSE_RANK()])])",
           "\n      PinotLogicalSortExchange(distribution=[hash[1]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3437,7 +3437,7 @@
           "\n    LogicalWindow(window#0=[window(partition {0} order by [1 DESC] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
           "\n      PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1 DESC]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n        LogicalProject(col2=[$1], col3=[$2])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3452,7 +3452,7 @@
           "\n      PinotLogicalAggregate(group=[{0}], agg#0=[COUNT($1)], aggType=[FINAL])",
           "\n        PinotLogicalExchange(distribution=[hash[0]])",
           "\n          PinotLogicalAggregate(group=[{0}], agg#0=[COUNT()], aggType=[LEAF])",
-          "\n            LogicalTableScan(table=[[default, a]])",
+          "\n            PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3470,11 +3470,11 @@
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n                LogicalFilter(condition=[>($2, 100)])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              LogicalProject(col2=[$1])",
           "\n                LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-8'brandon sanderson':VARCHAR(17) CHARACTER SET \"UTF-8\", _UTF-8'douglas adams':VARCHAR(17) CHARACTER SET \"UTF-8\"]:VARCHAR(17) CHARACTER SET \"UTF-8\")])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -3492,11 +3492,11 @@
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n                LogicalFilter(condition=[>($2, 100)])",
-          "\n                  LogicalTableScan(table=[[default, a]])",
+          "\n                  PinotLogicalTableScan(table=[[default, a]])",
           "\n            PinotLogicalExchange(distribution=[hash[0]])",
           "\n              LogicalProject(col2=[$1])",
           "\n                LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-8'brandon sanderson':VARCHAR(17) CHARACTER SET \"UTF-8\", _UTF-8'douglas adams':VARCHAR(17) CHARACTER SET \"UTF-8\"]:VARCHAR(17) CHARACTER SET \"UTF-8\")])",
-          "\n                  LogicalTableScan(table=[[default, b]])",
+          "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },
@@ -3509,7 +3509,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [2] aggs [LAG($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3522,7 +3522,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [2] aggs [LEAD($1, 2)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[2]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3536,7 +3536,7 @@
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalFilter(condition=[>=($2, 0)])",
-          "\n          LogicalTableScan(table=[[default, a]])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3549,7 +3549,7 @@
           "\n  LogicalWindow(window#0=[window(order by [0] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [MIN($0)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3562,7 +3562,7 @@
           "\n  LogicalWindow(window#0=[window(order by [1, 0] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [MIN($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[1, 0]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3575,7 +3575,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] range between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING aggs [FIRST_VALUE($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },
@@ -3589,7 +3589,7 @@
           "\n  LogicalWindow(window#0=[window(partition {0} order by [1] aggs [LAST_VALUE($1)])])",
           "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
-          "\n        LogicalTableScan(table=[[default, a]])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n"
         ]
       },


### PR DESCRIPTION
`LogicalTableScan` drops traits in the `copy` method, and the copy method is used often during calcite planning to copy the `RelNode` in a type agnostic manner.

Hence introducing a new node for this.