### PR TITLE
Disabled the disk utilization check periodic task in QuickStart

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -306,7 +306,7 @@ public class ControllerConf extends PinotConfiguration {
   private static final String ENABLE_RESOURCE_UTILIZATION_CHECK = "controller.enable.resource.utilization.check";
   private static final String RESOURCE_UTILIZATION_CHECKER_INITIAL_DELAY =
       "controller.resource.utilization.checker.initial.delay";
-  private static final String RESOURCE_UTILIZATION_CHECKER_FREQUENCY =
+  public static final String RESOURCE_UTILIZATION_CHECKER_FREQUENCY =
       "controller.resource.utilization.checker.frequency";
   private static final String ENABLE_BATCH_MESSAGE_MODE = "controller.enable.batch.message.mode";
   public static final String DIM_TABLE_MAX_SIZE = "controller.dimTable.maxSize";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
@@ -296,6 +297,7 @@ public class MultistageEngineQuickStart extends Quickstart {
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     configOverrides.put(CommonConstants.Broker.CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION, true);
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_QUERY_CANCELLATION, true);
+    configOverrides.put(ControllerConf.RESOURCE_UTILIZATION_CHECKER_FREQUENCY, "-1");
     return configOverrides;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -39,6 +39,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
@@ -284,7 +285,9 @@ public abstract class QuickStartBase {
 
   protected Map<String, Object> getConfigOverrides() {
     try {
-      return StringUtils.isEmpty(_configFilePath) ? ImmutableMap.of()
+      return StringUtils.isEmpty(_configFilePath) ? ImmutableMap.of(
+          // disable running the disk utilization check periodic task by default in QuickStart
+          ControllerConf.RESOURCE_UTILIZATION_CHECKER_FREQUENCY, "-1")
           : PinotConfigUtils.readConfigFromFile(_configFilePath);
     } catch (ConfigurationException e) {
       throw new RuntimeException(e);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.PinotAdministrator;
@@ -50,6 +51,7 @@ public class RealtimeQuickStart extends QuickStartBase {
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configOverrides = new HashMap<>();
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(ControllerConf.RESOURCE_UTILIZATION_CHECKER_FREQUENCY, "-1");
     return configOverrides;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tsdb.spi.PinotTimeSeriesConfiguration;
 import org.apache.pinot.tsdb.spi.series.SimpleTimeSeriesBuilderFactory;
@@ -65,6 +66,7 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
         "org.apache.pinot.tsdb.m3ql.M3TimeSeriesPlanner");
     configs.put(PinotTimeSeriesConfiguration.getSeriesBuilderFactoryConfigKey("m3ql"),
         SimpleTimeSeriesBuilderFactory.class.getName());
+    configs.put(ControllerConf.RESOURCE_UTILIZATION_CHECKER_FREQUENCY, "-1");
     return configs;
   }
 


### PR DESCRIPTION
Disabled the disk utilization check periodic task in QuickStart to not run by default. Tested by running few QuickStart apps locally.