### PR TITLE
increase test waiting time for MSE

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CancelQueryIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CancelQueryIntegrationTests.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.integration.tests;
 
+import static org.testng.Assert.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -40,8 +42,6 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
 
 
 /**
@@ -193,7 +193,9 @@ public class CancelQueryIntegrationTests extends BaseClusterIntegrationTestSet {
           fail("No exception should be thrown", e);
         }
       }
-    }, 500);
+    }, useMultiStageQueryEngine ? 5000 : 500); // TODO: horrible because we have a potential race condition for MSE,
+                                               // it will be addressed once we refactor the submit&reduce processing
+                                               // so we can track running queries more properly
 
     JsonNode result = postQuery(sqlQuery);
     // ugly: error message differs from SSQE to MSQE

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CancelQueryIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CancelQueryIntegrationTests.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import static org.testng.Assert.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -43,6 +41,7 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
 
 /**
  * Integration test that checks the query cancellation feature.


### PR DESCRIPTION
There is a test for query cancellation against a MSE that more often than not incurs into a race condition that needs some heavy refactor before can be addresed.

A first, quick attempt was made in https://github.com/apache/pinot/pull/15208 but eventually discarded until further discussion.

In the meantime, we just increase the horrible hard-coded waiting time for this test.

Some notes on the potential refactor (by @Jackie-Jiang):

> After calculating the routing, query execution is done as:
> 1. Submit the query to servers
> 2. Gather responses back
> 3. Reduce (merge) responses from servers
> When 1 fails, we should cancel the already submitted ones
> When 2 fails, we should cancel the ones not responded
> With this, we can safely start tracking query after 1 before 2
> 
> For now I'd suggest to modify the logic to separate 1 and 2+3 as separate abstract method, then change the callback to `onQuerySubmit()` which is invoked after 1. Then we need to address the above scenarios as a follow up