### PR TITLE
Add recommended defaults for table rebalance config, add preChecks to RebalanceTableCommand

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -608,9 +608,9 @@ public class PinotTableRestletResource {
       boolean dryRun,
       @ApiParam(value = "Whether to enable pre-checks for table, must be in dry-run mode to enable")
       @DefaultValue("false") @QueryParam("preChecks") boolean preChecks,
-      @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("false")
+      @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("true")
       @QueryParam("reassignInstances") boolean reassignInstances,
-      @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("false")
+      @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("true")
       @QueryParam("includeConsuming") boolean includeConsuming,
       @ApiParam(value = "Whether to rebalance table in bootstrap mode (regardless of minimum segment movement, "
           + "reassign all segments in a round-robin fashion as if adding new segments to an empty table)")
@@ -618,7 +618,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to allow downtime for the rebalance") @DefaultValue("false") @QueryParam("downtime")
       boolean downtime,
       @ApiParam(value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or "
-          + "maximum number of replicas allowed to be unavailable if value is negative") @DefaultValue("1")
+          + "maximum number of replicas allowed to be unavailable if value is negative") @DefaultValue("-1")
       @QueryParam("minAvailableReplicas") int minAvailableReplicas,
       @ApiParam(value = "For no-downtime rebalance, whether to enable low disk mode during rebalance. When enabled, "
           + "segments will first be offloaded from servers, then added to servers after offload is done while "

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -32,12 +32,13 @@ import org.apache.pinot.spi.config.table.TableConfig;
 public class PinotTableRebalancer extends PinotZKChanger {
   private final RebalanceConfig _rebalanceConfig = new RebalanceConfig();
 
-  public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
-      boolean includeConsuming, boolean bootstrap, boolean downtime, int minReplicasToKeepUpForNoDowntime,
-      boolean lowDiskMode, boolean bestEffort, long externalViewCheckIntervalInMs,
+  public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean preChecks,
+      boolean reassignInstances, boolean includeConsuming, boolean bootstrap, boolean downtime,
+      int minReplicasToKeepUpForNoDowntime, boolean lowDiskMode, boolean bestEffort, long externalViewCheckIntervalInMs,
       long externalViewStabilizationTimeoutInMs) {
     super(zkAddress, clusterName);
     _rebalanceConfig.setDryRun(dryRun);
+    _rebalanceConfig.setPreChecks(preChecks);
     _rebalanceConfig.setReassignInstances(reassignInstances);
     _rebalanceConfig.setIncludeConsuming(includeConsuming);
     _rebalanceConfig.setBootstrap(bootstrap);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -51,13 +51,18 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
           + " changes to the cluster, false by default)")
   private boolean _dryRun = false;
 
+  @CommandLine.Option(names = {"-preChecks"},
+      description = "Whether to enable pre-checks for table, must be in dry-run mode to enable"
+          + " changes to the cluster, false by default)")
+  private boolean _preChecks = false;
+
   @CommandLine.Option(names = {"-reassignInstances"},
-      description = "Whether to reassign instances before reassigning segments (false by default)")
-  private boolean _reassignInstances = false;
+      description = "Whether to reassign instances before reassigning segments (true by default)")
+  private boolean _reassignInstances = true;
 
   @CommandLine.Option(names = {"-includeConsuming"},
-      description = "Whether to reassign CONSUMING segments for real-time table (false by default)")
-  private boolean _includeConsuming = false;
+      description = "Whether to reassign CONSUMING segments for real-time table (true by default)")
+  private boolean _includeConsuming = true;
 
   @CommandLine.Option(names = {"-bootstrap"},
       description = "Whether to rebalance table in bootstrap mode (regardless of minimum segment movement, reassign"
@@ -70,8 +75,8 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
 
   @CommandLine.Option(names = {"-minAvailableReplicas"},
       description = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum "
-          + "number of replicas allowed to be unavailable if value is negative (1 by default)")
-  private int _minAvailableReplicas = 1;
+          + "number of replicas allowed to be unavailable if value is negative (-1 by default)")
+  private int _minAvailableReplicas = -1;
 
   @CommandLine.Option(names = {"-lowDiskMode"}, description =
       "For no-downtime rebalance, whether to enable low disk mode during rebalance. When enabled, "
@@ -104,8 +109,8 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   public boolean execute()
       throws Exception {
     PinotTableRebalancer tableRebalancer =
-        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming, _bootstrap,
-            _downtime, _minAvailableReplicas, _lowDiskMode, _bestEfforts, _externalViewCheckIntervalInMs,
+        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _preChecks, _reassignInstances, _includeConsuming,
+            _bootstrap, _downtime, _minAvailableReplicas, _lowDiskMode, _bestEfforts, _externalViewCheckIntervalInMs,
             _externalViewStabilizationTimeoutInMs);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);
     LOGGER
@@ -131,6 +136,12 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
     System.out.println(
         "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "
             + "myTable_OFFLINE -dryRun");
+    System.out.println();
+
+    System.out.println("Rebalance table in dry-run mode with pre-checks");
+    System.out.println(
+        "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "
+            + "myTable_OFFLINE -dryRun -preChecks");
     System.out.println();
 
     System.out.println("Rebalance table with instances reassigned");


### PR DESCRIPTION
This PR adds some recommended defaults for RebalanceConfig:

- reassignInstances: true
- includeConsuming: true
- minAvailableReplicas: -1 (which translates to numReplicas - 1)

It also adds `preChecks` to `RebalanceTableCommand` and updates this to have the new defaults as well

Testing:
- Validated on Swagger that the new defaults are chosen
- Ran the pinot-admin.sh command to see the newly added `-preChecks` and the defaults

cc @klsince @Jackie-Jiang @J-HowHuang @npawar 