### PR TITLE
Enhance rebalance pre-checks to provide more information in status returned

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -81,7 +81,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     if (_executorService == null) {
       LOGGER.warn("Executor service is null, skipping needsReload check for table: {} rebalanceJobId: {}",
           tableNameWithType, rebalanceJobId);
-      return RebalancePreCheckerResult.error("Could not determine needReload status, run manually");
+      return RebalancePreCheckerResult.error("Could not determine needReload status, run needReload API manually");
     }
     try (PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager()) {
       TableMetadataReader metadataReader = new TableMetadataReader(_executorService, connectionManager,
@@ -103,7 +103,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     }
 
     return needsReload == null
-        ? RebalancePreCheckerResult.error("Could not determine needReload status, run manually")
+        ? RebalancePreCheckerResult.error("Could not determine needReload status, run needReload API manually")
         : !needsReload ? RebalancePreCheckerResult.pass("No need to reload")
             : RebalancePreCheckerResult.warning("Reload needed prior to running rebalance");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -81,7 +81,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     if (_executorService == null) {
       LOGGER.warn("Executor service is null, skipping needsReload check for table: {} rebalanceJobId: {}",
           tableNameWithType, rebalanceJobId);
-      return RebalancePreCheckerResult.warning("Could not determine needReload status, run manually");
+      return RebalancePreCheckerResult.error("Could not determine needReload status, run manually");
     }
     try (PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager()) {
       TableMetadataReader metadataReader = new TableMetadataReader(_executorService, connectionManager,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
@@ -27,5 +27,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 
 public interface RebalancePreChecker {
   void init(PinotHelixResourceManager pinotHelixResourceManager, @Nullable ExecutorService executorService);
-  Map<String, String> check(String rebalanceJobId, String tableNameWithType, TableConfig tableConfig);
+  Map<String, RebalancePreCheckerResult> check(String rebalanceJobId, String tableNameWithType,
+      TableConfig tableConfig);
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
@@ -49,6 +49,18 @@ public class RebalancePreCheckerResult {
     _message = message;
   }
 
+  public static RebalancePreCheckerResult pass(@Nullable String message) {
+    return new RebalancePreCheckerResult(PreCheckStatus.PASS, message);
+  }
+
+  public static RebalancePreCheckerResult warning(@Nullable String message) {
+    return new RebalancePreCheckerResult(PreCheckStatus.WARNING, message);
+  }
+
+  public static RebalancePreCheckerResult error(@Nullable String message) {
+    return new RebalancePreCheckerResult(PreCheckStatus.ERROR, message);
+  }
+
   @JsonProperty
   public PreCheckStatus getPreCheckStatus() {
     return _preCheckStatus;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
@@ -53,8 +53,8 @@ public class RebalancePreCheckerResult {
     return new RebalancePreCheckerResult(PreCheckStatus.PASS, message);
   }
 
-  public static RebalancePreCheckerResult warning(@Nullable String message) {
-    return new RebalancePreCheckerResult(PreCheckStatus.WARNING, message);
+  public static RebalancePreCheckerResult warn(@Nullable String message) {
+    return new RebalancePreCheckerResult(PreCheckStatus.WARN, message);
   }
 
   public static RebalancePreCheckerResult error(@Nullable String message) {
@@ -73,8 +73,8 @@ public class RebalancePreCheckerResult {
 
   public enum PreCheckStatus {
     // PASS if the pre-check status is considered safe for rebalance;
-    // WARNING if the pre-check status is a warning and should be double-checked for rebalance;
+    // WARN if the pre-check status is a warning and should be double-checked for rebalance;
     // ERROR if the pre-check status has failed and should be addressed prior to rebalance;
-    PASS, WARNING, ERROR
+    PASS, WARN, ERROR
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreCheckerResult.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+
+
+/**
+ * Holds the pre-check result for each pre-check performed as part of RebalancePreChecker
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RebalancePreCheckerResult {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final PreCheckStatus _preCheckStatus;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String _message;
+
+  /**
+   * Constructor for RebalancePreCheckerResult
+   * @param preCheckStatus server related summary information
+   * @param message segment related summary information
+   */
+  @JsonCreator
+  public RebalancePreCheckerResult(@JsonProperty("preCheckStatus") PreCheckStatus preCheckStatus,
+      @JsonProperty("message") @Nullable String message) {
+    _preCheckStatus = preCheckStatus;
+    _message = message;
+  }
+
+  @JsonProperty
+  public PreCheckStatus getPreCheckStatus() {
+    return _preCheckStatus;
+  }
+
+  @JsonProperty
+  public String getMessage() {
+    return _message;
+  }
+
+  public enum PreCheckStatus {
+    // PASS if the pre-check status is considered safe for rebalance;
+    // WARNING if the pre-check status is a warning and should be double-checked for rebalance;
+    // ERROR if the pre-check status has failed and should be addressed prior to rebalance;
+    PASS, WARNING, ERROR
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
@@ -41,7 +41,7 @@ public class RebalanceResult {
   private final Map<String, Map<String, String>> _segmentAssignment;
   private final String _description;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final Map<String, String> _preChecksResult;
+  private final Map<String, RebalancePreCheckerResult> _preChecksResult;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final RebalanceSummaryResult _rebalanceSummaryResult;
 
@@ -52,7 +52,7 @@ public class RebalanceResult {
       @JsonProperty("instanceAssignment") @Nullable Map<InstancePartitionsType, InstancePartitions> instanceAssignment,
       @JsonProperty("tierInstanceAssignment") @Nullable Map<String, InstancePartitions> tierInstanceAssignment,
       @JsonProperty("segmentAssignment") @Nullable Map<String, Map<String, String>> segmentAssignment,
-      @JsonProperty("preChecksResult") @Nullable Map<String, String> preChecksResult,
+      @JsonProperty("preChecksResult") @Nullable Map<String, RebalancePreCheckerResult> preChecksResult,
       @JsonProperty("rebalanceSummaryResult") @Nullable RebalanceSummaryResult rebalanceSummaryResult) {
     _jobId = jobId;
     _status = status;
@@ -95,7 +95,7 @@ public class RebalanceResult {
   }
 
   @JsonProperty
-  public Map<String, String> getPreChecksResult() {
+  public Map<String, RebalancePreCheckerResult> getPreChecksResult() {
     return _preChecksResult;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -219,7 +219,7 @@ public class TableRebalancer {
         externalViewCheckIntervalInMs, externalViewStabilizationTimeoutInMs, minimizeDataMovement);
 
     // Perform pre-checks if enabled
-    Map<String, String> preChecksResult = null;
+    Map<String, RebalancePreCheckerResult> preChecksResult = null;
     if (preChecks) {
       if (!dryRun) {
         // Dry-run must be enabled to run pre-checks

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -217,17 +217,21 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     rebalanceConfig.setPreChecks(true);
     rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    Map<String, String> preCheckResult = rebalanceResult.getPreChecksResult();
+    Map<String, RebalancePreCheckerResult> preCheckResult = rebalanceResult.getPreChecksResult();
     assertNotNull(preCheckResult);
     assertEquals(preCheckResult.size(), 2);
     assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS));
     assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
     // Sending request to servers should fail for all, so needsPreprocess should be set to "error" to indicate that a
     // manual check is needed
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS),
-        "WARNING: could not determine needReload status, run manually");
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT),
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement");
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
+        RebalancePreCheckerResult.PreCheckStatus.ERROR);
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
+        "Could not determine needReload status, run manually");
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),
+        "Instance assignment not allowed, no need for minimizeDataMovement");
 
     // All servers should be assigned to the table
     instanceAssignment = rebalanceResult.getInstanceAssignment();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -224,8 +224,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
     // Sending request to servers should fail for all, so needsPreprocess should be set to "error" to indicate that a
     // manual check is needed
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS), "error");
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT), "false");
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS),
+        "WARNING: could not determine needReload status, run manually");
+    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT),
+        "PASS: instance assignment not allowed, no need for minimizeDataMovement");
 
     // All servers should be assigned to the table
     instanceAssignment = rebalanceResult.getInstanceAssignment();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -227,7 +227,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
         RebalancePreCheckerResult.PreCheckStatus.ERROR);
     assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
-        "Could not determine needReload status, run manually");
+        "Could not determine needReload status, run needReload API manually");
     assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
         RebalancePreCheckerResult.PreCheckStatus.PASS);
     assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -70,6 +70,7 @@ import org.apache.pinot.controller.api.resources.ServerRebalanceJobStatusRespons
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.rebalance.DefaultRebalancePreChecker;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfig;
+import org.apache.pinot.controller.helix.core.rebalance.RebalancePreCheckerResult;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceSummaryResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
@@ -823,14 +824,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     rebalanceConfig.setPreChecks(true);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement",
-        "PASS: no need to reload");
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "No need to reload",
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
 
     // Enable minimizeDataMovement
     tableConfig.setInstanceAssignmentConfigMap(createInstanceAssignmentConfigMap(true));
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: minimizeDataMovement is enabled", "PASS: no need to reload");
+        "minimizeDataMovement is enabled", RebalancePreCheckerResult.PreCheckStatus.PASS,
+        "No need to reload", RebalancePreCheckerResult.PreCheckStatus.PASS);
 
     // Undo minimizeDataMovement, update the table config to add a column to bloom filter
     tableConfig.getIndexingConfig().getBloomFilterColumns().add("Quarter");
@@ -838,16 +841,18 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement",
-        "WARNING: reload needed prior to running rebalance");
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
+        RebalancePreCheckerResult.PreCheckStatus.WARNING);
 
     // Undo tableConfig change
     tableConfig.getIndexingConfig().getBloomFilterColumns().remove("Quarter");
     updateTableConfig(tableConfig);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement",
-        "PASS: no need to reload");
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "No need to reload",
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
 
     // Add a schema change
     Schema schema = createSchema();
@@ -855,22 +860,24 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateSchema(schema);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement",
-        "WARNING: reload needed prior to running rebalance");
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
+        RebalancePreCheckerResult.PreCheckStatus.WARNING);
 
     // Keep schema change and update table config to add minimizeDataMovement
     tableConfig.setInstanceAssignmentConfigMap(createInstanceAssignmentConfigMap(true));
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "PASS: minimizeDataMovement is enabled",
-        "WARNING: reload needed prior to running rebalance");
+        "minimizeDataMovement is enabled", RebalancePreCheckerResult.PreCheckStatus.PASS,
+        "Reload needed prior to running rebalance", RebalancePreCheckerResult.PreCheckStatus.WARNING);
 
     // Keep schema change and update table config to add instance config map with minimizeDataMovement = false
     tableConfig.setInstanceAssignmentConfigMap(createInstanceAssignmentConfigMap(false));
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
-        "WARNING: minimizeDataMovement is not enabled but instance assignment is allowed",
-        "WARNING: reload needed prior to running rebalance");
+        "minimizeDataMovement is not enabled but instance assignment is allowed",
+        RebalancePreCheckerResult.PreCheckStatus.WARNING, "Reload needed prior to running rebalance",
+        RebalancePreCheckerResult.PreCheckStatus.WARNING);
 
     // Add a new server (to force change in instance assignment) and enable reassignInstances
     BaseServerStarter serverStarter1 = startOneServer(NUM_SERVERS);
@@ -878,8 +885,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     tableConfig.setInstanceAssignmentConfigMap(null);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.DONE,
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement",
-        "WARNING: reload needed prior to running rebalance");
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
+        RebalancePreCheckerResult.PreCheckStatus.WARNING);
 
     // Disable dry-run
     rebalanceConfig.setDryRun(false);
@@ -894,16 +902,22 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   private void checkRebalancePreCheckStatus(RebalanceResult rebalanceResult, RebalanceResult.Status expectedStatus,
-      String expectedMinimizeDataMovement, String expectedNeedsReloadStatus) {
+      String expectedMinimizeDataMovement, RebalancePreCheckerResult.PreCheckStatus expectedMinimizeDataMovementStatus,
+      String expectedNeedsReloadMessage, RebalancePreCheckerResult.PreCheckStatus expectedNeedsReloadStatus) {
     assertEquals(rebalanceResult.getStatus(), expectedStatus);
-    Map<String, String> preChecksResult = rebalanceResult.getPreChecksResult();
+    Map<String, RebalancePreCheckerResult> preChecksResult = rebalanceResult.getPreChecksResult();
     assertNotNull(preChecksResult);
     assertEquals(preChecksResult.size(), 2);
     assertTrue(preChecksResult.containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
     assertTrue(preChecksResult.containsKey(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS));
-    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT),
+    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
+        expectedMinimizeDataMovementStatus);
+    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),
         expectedMinimizeDataMovement);
-    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS), expectedNeedsReloadStatus);
+    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
+        expectedNeedsReloadStatus);
+    assertEquals(preChecksResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
+        expectedNeedsReloadMessage);
   }
 
   private Map<String, InstanceAssignmentConfig> createInstanceAssignmentConfigMap(boolean minimizeDataMovement) {
@@ -4179,10 +4193,17 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertNotNull(rebalanceResult.getPreChecksResult());
     assertTrue(rebalanceResult.getPreChecksResult().containsKey(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS));
     assertTrue(rebalanceResult.getPreChecksResult().containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
-    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS),
-        "PASS: no need to reload");
-    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT),
-        "PASS: instance assignment not allowed, no need for minimizeDataMovement");
+    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
+        "No need to reload");
+    assertEquals(rebalanceResult.getPreChecksResult().get(
+            DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
+    assertEquals(rebalanceResult.getPreChecksResult().get(
+        DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),
+        "Instance assignment not allowed, no need for minimizeDataMovement");
+    assertEquals(rebalanceResult.getPreChecksResult().get(
+            DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
   }
 
   private void checkRebalanceDryRunSummary(RebalanceResult rebalanceResult, RebalanceResult.Status expectedStatus,

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -843,7 +843,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
         "Instance assignment not allowed, no need for minimizeDataMovement",
         RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
-        RebalancePreCheckerResult.PreCheckStatus.WARNING);
+        RebalancePreCheckerResult.PreCheckStatus.WARN);
 
     // Undo tableConfig change
     tableConfig.getIndexingConfig().getBloomFilterColumns().remove("Quarter");
@@ -862,22 +862,22 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
         "Instance assignment not allowed, no need for minimizeDataMovement",
         RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
-        RebalancePreCheckerResult.PreCheckStatus.WARNING);
+        RebalancePreCheckerResult.PreCheckStatus.WARN);
 
     // Keep schema change and update table config to add minimizeDataMovement
     tableConfig.setInstanceAssignmentConfigMap(createInstanceAssignmentConfigMap(true));
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
         "minimizeDataMovement is enabled", RebalancePreCheckerResult.PreCheckStatus.PASS,
-        "Reload needed prior to running rebalance", RebalancePreCheckerResult.PreCheckStatus.WARNING);
+        "Reload needed prior to running rebalance", RebalancePreCheckerResult.PreCheckStatus.WARN);
 
     // Keep schema change and update table config to add instance config map with minimizeDataMovement = false
     tableConfig.setInstanceAssignmentConfigMap(createInstanceAssignmentConfigMap(false));
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.NO_OP,
         "minimizeDataMovement is not enabled but instance assignment is allowed",
-        RebalancePreCheckerResult.PreCheckStatus.WARNING, "Reload needed prior to running rebalance",
-        RebalancePreCheckerResult.PreCheckStatus.WARNING);
+        RebalancePreCheckerResult.PreCheckStatus.WARN, "Reload needed prior to running rebalance",
+        RebalancePreCheckerResult.PreCheckStatus.WARN);
 
     // Add a new server (to force change in instance assignment) and enable reassignInstances
     BaseServerStarter serverStarter1 = startOneServer(NUM_SERVERS);
@@ -887,7 +887,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.DONE,
         "Instance assignment not allowed, no need for minimizeDataMovement",
         RebalancePreCheckerResult.PreCheckStatus.PASS, "Reload needed prior to running rebalance",
-        RebalancePreCheckerResult.PreCheckStatus.WARNING);
+        RebalancePreCheckerResult.PreCheckStatus.WARN);
 
     // Disable dry-run
     rebalanceConfig.setDryRun(false);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -32,14 +32,13 @@ import org.apache.pinot.spi.config.table.TableConfig;
 public class PinotTableRebalancer extends PinotZKChanger {
   private final RebalanceConfig _rebalanceConfig = new RebalanceConfig();
 
-  public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean preChecks,
-      boolean reassignInstances, boolean includeConsuming,
-      RebalanceConfig.MinimizeDataMovementOptions minimizeDataMovement, boolean bootstrap, boolean downtime,
-      int minReplicasToKeepUpForNoDowntime, boolean lowDiskMode, boolean bestEffort, long externalViewCheckIntervalInMs,
+  public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
+      boolean includeConsuming, RebalanceConfig.MinimizeDataMovementOptions minimizeDataMovement,
+      boolean bootstrap, boolean downtime, int minReplicasToKeepUpForNoDowntime, boolean lowDiskMode,
+      boolean bestEffort, long externalViewCheckIntervalInMs,
       long externalViewStabilizationTimeoutInMs) {
     super(zkAddress, clusterName);
     _rebalanceConfig.setDryRun(dryRun);
-    _rebalanceConfig.setPreChecks(preChecks);
     _rebalanceConfig.setReassignInstances(reassignInstances);
     _rebalanceConfig.setIncludeConsuming(includeConsuming);
     _rebalanceConfig.setMinimizeDataMovement(minimizeDataMovement);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -51,11 +51,6 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
           + " changes to the cluster, false by default)")
   private boolean _dryRun = false;
 
-  @CommandLine.Option(names = {"-preChecks"},
-      description = "Whether to enable pre-checks for table, must be in dry-run mode to enable"
-          + " changes to the cluster, false by default)")
-  private boolean _preChecks = false;
-
   @CommandLine.Option(names = {"-reassignInstances"},
       description = "Whether to reassign instances before reassigning segments (true by default)")
   private boolean _reassignInstances = true;
@@ -113,8 +108,10 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   @Override
   public boolean execute()
       throws Exception {
+    // TODO: Add pre-checks option to this command. This needs the PinotHelixResourceManager to be wired in to use
+    //       the default pre-checker
     PinotTableRebalancer tableRebalancer =
-        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _preChecks, _reassignInstances, _includeConsuming,
+        new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming,
             _minimizeDataMovement, _bootstrap, _downtime, _minAvailableReplicas, _lowDiskMode, _bestEfforts,
             _externalViewCheckIntervalInMs, _externalViewStabilizationTimeoutInMs);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -140,12 +140,6 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
             + "myTable_OFFLINE -dryRun");
     System.out.println();
 
-    System.out.println("Rebalance table in dry-run mode with pre-checks");
-    System.out.println(
-        "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "
-            + "myTable_OFFLINE -dryRun -preChecks");
-    System.out.println();
-
     System.out.println("Rebalance table with instances reassigned");
     System.out.println(
         "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "


### PR DESCRIPTION
Today some of the rebalance pre-checks just return a simple status, e.g.:

```
  "preChecksResult": {
    "isMinimizeDataMovement": "true",
    "needsReloadStatus": "true"
  }
```

It is hard to figure out from the above if that is indeed an issue and some action should be taken, or whether it can be ignored. This PR enhances the returned status for the above two pre-checks. Now the return will look like:

Replica-group based that needs reload but has minimizeDataMovement enabled:
```
  "preChecksResult": {
    "isMinimizeDataMovement": "PASS: minimizeDataMovement is enabled",
    "needsReloadStatus": "WARNING: reload needed prior to running rebalance"
  }
```

Replica-group based that doesn't need reload but doesn't have minimizeDataMovement enabled:
```
  "preChecksResult": {
    "isMinimizeDataMovement": "WARNING: minimizeDataMovement is not enabled but instance assignment is allowed",
    "needsReloadStatus": "PASS: no need to reload"
  }
```

Balanced assignment based that does not need reload:
```
  "preChecksResult": {
    "isMinimizeDataMovement": "PASS: instance assignment not allowed, no need for minimizeDataMovement",
    "needsReloadStatus": "PASS: no need to reload"
  }
```

ERROR during fetching reload status:
```
  "preChecksResult": {
    "isMinimizeDataMovement": "PASS: instance assignment not allowed, no need for minimizeDataMovement",
    "needsReloadStatus": "WARNING: could not determine needReload status, run manually"
  }
```

cc @klsince @npawar @J-HowHuang @Jackie-Jiang 