### PR TITLE
Retry on segment cannot build

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -68,7 +68,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false),
   IDEAL_STATE_UPDATE_FAILURE("IdealStateUpdateFailure", false),
   IDEAL_STATE_UPDATE_RETRY("IdealStateUpdateRetry", false),
-  IDEAL_STATE_UPDATE_SUCCESS("IdealStateUpdateSuccess", false);
+  IDEAL_STATE_UPDATE_SUCCESS("IdealStateUpdateSuccess", false),
+  SEGMENT_SIZE_AUTO_REDUCTION("SegmentSizeAutoReduction", false);
 
 
   private final String _brokerMeterName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -123,6 +123,7 @@ public class SegmentCompletionProtocol {
   public static final String MSG_TYPE_COMMIT_END_METADATA = "segmentCommitEndWithMetadata";
   public static final String MSG_TYPE_STOPPED_CONSUMING = "segmentStoppedConsuming";
   public static final String MSG_TYPE_EXTEND_BUILD_TIME = "extendBuildTime";
+  public static final String MSG_TYPE_CANNOT_BUILD = "segmentCannotBuild";
 
   public static final String PARAM_SEGMENT_LOCATION = "location";
   public static final String PARAM_SEGMENT_NAME = "name";
@@ -431,6 +432,12 @@ public class SegmentCompletionProtocol {
   public static class SegmentStoppedConsuming extends Request {
     public SegmentStoppedConsuming(Params params) {
       super(params, MSG_TYPE_STOPPED_CONSUMING);
+    }
+  }
+
+  public static class SegmentCannotBuildRequest extends Request {
+    public SegmentCannotBuildRequest(Params params) {
+      super(params, MSG_TYPE_CANNOT_BUILD);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -123,7 +123,7 @@ public class SegmentCompletionProtocol {
   public static final String MSG_TYPE_COMMIT_END_METADATA = "segmentCommitEndWithMetadata";
   public static final String MSG_TYPE_STOPPED_CONSUMING = "segmentStoppedConsuming";
   public static final String MSG_TYPE_EXTEND_BUILD_TIME = "extendBuildTime";
-  public static final String MSG_TYPE_CANNOT_BUILD = "segmentCannotBuild";
+  public static final String MSG_TYPE_BUILD_DETERMINISTIC_FAILURE = "segmentBuildDeterministicFailure";
 
   public static final String PARAM_SEGMENT_LOCATION = "location";
   public static final String PARAM_SEGMENT_NAME = "name";
@@ -437,7 +437,7 @@ public class SegmentCompletionProtocol {
 
   public static class SegmentCannotBuildRequest extends Request {
     public SegmentCannotBuildRequest(Params params) {
-      super(params, MSG_TYPE_CANNOT_BUILD);
+      super(params, MSG_TYPE_BUILD_DETERMINISTIC_FAILURE);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -87,6 +87,7 @@ public class TableConfigTest {
   public void testCopyConstructor() {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setContinueOnError(true);
+    ingestionConfig.setRetryOnSegmentBuildPrecheckFailure(true);
     ingestionConfig.setRowTimeValueCheck(true);
     ingestionConfig.setSegmentTimeValueCheck(false);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -298,7 +298,7 @@ public class LLCSegmentCompletionHandlers {
   }
 
   @GET
-  @Path(SegmentCompletionProtocol.MSG_TYPE_CANNOT_BUILD)
+  @Path(SegmentCompletionProtocol.MSG_TYPE_BUILD_DETERMINISTIC_FAILURE)
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_ADMIN_INFO)
   @Produces(MediaType.APPLICATION_JSON)
   public String reduceSegmentSize(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -297,6 +297,28 @@ public class LLCSegmentCompletionHandlers {
     return response;
   }
 
+  @GET
+  @Path(SegmentCompletionProtocol.MSG_TYPE_CANNOT_BUILD)
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_ADMIN_INFO)
+  @Produces(MediaType.APPLICATION_JSON)
+  public String reduceSegmentSize(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,
+      @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
+      @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows) {
+    if (instanceId == null || segmentName == null || numRows <= 0) {
+      LOGGER.error("Invalid call: segmentName={}, instanceId={}, numRowsCount={}", segmentName, instanceId,
+          numRows);
+      return SegmentCompletionProtocol.RESP_FAILED.toJsonString();
+    }
+
+    SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params()
+        .withInstanceId(instanceId)
+        .withSegmentName(segmentName)
+        .withNumRows(numRows);
+    LOGGER.info("Processing segmentStoppedConsuming: {}", requestParams);
+
+    return _segmentCompletionManager.reduceSegmentSizeAndReset(requestParams).toJsonString();
+  }
+
   /**
    * Extracts the segment file from the form into a local temporary file under file upload temporary directory.
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -186,8 +186,8 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
    * cannot build segment due to non-recoverable error.
    * In most of cases, when such request is sent, the error should be deterministic. However, due to possible data lost,
    * replicas may not hold exact same data and some of them might be able to build the segment.
-   * If the FSM _state indicates that one replica starts to commit.
-   * It means immutable segment can be created successfully, returns true.
+   * If the FSM _state indicates that one replica starts to commit, it means immutable segment can be
+   * created successfully, returns true.
    *
    * @return boolean
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -181,6 +181,21 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
         BlockingSegmentCompletionFSMState.ABORTED);
   }
 
+  /**
+   * The method is used to decide whether we should reduce segment size and reset when server reports
+   * cannot build segment due to non-recoverable error.
+   * In most of cases, when such request is sent, the error should be deterministic. However, due to possible data lost,
+   * replicas may not hold exact same data and some of them might be able to build the segment.
+   * If the FSM _state indicates that one replica starts to commit.
+   * It means immutable segment can be created successfully, returns true.
+   *
+   * @return boolean
+   */
+  public boolean isImmutableSegmentCreated() {
+    return _state.equals(BlockingSegmentCompletionFSMState.COMMITTER_UPLOADING) || _state.equals(
+        BlockingSegmentCompletionFSMState.COMMITTING) || _state.equals(BlockingSegmentCompletionFSMState.COMMITTED);
+  }
+
   /*
    * We just heard from a server that it has reached completion stage, and is reporting the offset
    * that the server is at. Since multiple servers can come in at the same time for this segment,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1095,7 +1095,7 @@ public class PinotLLCRealtimeSegmentManager {
 
   /**
    * An instance is reporting that it cannot build segment due to non-recoverable error, usually due to size too large.
-   * Reduce the segment "segment.flush.threshold.size" to its half value.
+   * Reduce the segment "segment.flush.threshold.size" to half of the current segment size target.
    */
   public void reduceSegmentSizeAndReset(LLCSegmentName llcSegmentName, int prevNumRows) {
     Preconditions.checkState(!_isStopping, "Segment manager is stopping");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
@@ -58,6 +58,18 @@ public interface SegmentCompletionFSM {
   boolean isDone();
 
   /**
+   * The method is used to decide whether we should reduce segment size and reset when server reports
+   * cannot build segment due to non-recoverable error.
+   * In most of cases, when such request is sent, the error should be deterministic. However, due to possible data lost,
+   * replicas may not hold exact same data and some of them might be able to build the segment.
+   * If the FSM _state indicates that one replica starts to commit.
+   * It means immutable segment can be created successfully, returns true.
+   *
+   * @return {@code true} if the FSM receives segment created signal, {@code false} otherwise.
+   */
+   boolean isImmutableSegmentCreated();
+
+  /**
    * Processes the event where a server indicates it has consumed up to a specified offset.
    *
    * This is typically triggered when a server finishes consuming data for a segment due

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -247,6 +247,19 @@ public class SegmentCompletionManager {
     return response;
   }
 
+  public SegmentCompletionProtocol.Response reduceSegmentSizeAndReset(
+      SegmentCompletionProtocol.Request.Params reqParams) {
+    String segmentName = reqParams.getSegmentName();
+    SegmentCompletionFSM fsm = _fsmMap.get(segmentName);
+    if (fsm != null && fsm.isImmutableSegmentCreated()) {
+      // In this case, other replica already starts committing the segment. It is a false alert.
+      LOGGER.warn("Segment {} cannot build is a false alert", segmentName);
+      return SegmentCompletionProtocol.RESP_DISCARD;
+    }
+    _segmentManager.reduceSegmentSizeAndReset(new LLCSegmentName(reqParams.getSegmentName()), reqParams.getNumRows());
+    return SegmentCompletionProtocol.RESP_PROCESSED;
+  }
+
   /**
    * This method is to be called when a server reports that it has stopped consuming a real-time segment.
    *

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -889,6 +889,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
       // Expected
     }
     try {
+      segmentManager.reduceSegmentSizeAndReset(new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS),
+          1000);
+      fail();
+    } catch (IllegalStateException e) {
+      // Expected
+    }
+    try {
       segmentManager.ensureAllPartitionsConsuming(segmentManager._tableConfig, segmentManager._streamConfigs, null);
       fail();
     } catch (IllegalStateException e) {
@@ -1384,6 +1391,28 @@ public class PinotLLCRealtimeSegmentManagerTest {
         .getNewPartitionGroupMetadataList(streamConfigs, partitionGroupConsumptionStatusList);
     partitionIds = segmentManagerSpy.getPartitionIds(streamConfigs, idealState);
     Assert.assertEquals(partitionIds.size(), 2);
+  }
+
+  @Test
+  public void testReduceSegmentSizeAndReset() {
+    // Set up a new table with 2 replicas, 5 instances, 4 partition
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager);
+    setUpNewTable(segmentManager, 2, 5, 5);
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
+        new SegmentsValidationAndRetentionConfig();
+    segmentsValidationAndRetentionConfig.setRetentionTimeUnit(TimeUnit.DAYS.toString());
+    segmentsValidationAndRetentionConfig.setRetentionTimeValue("3");
+    segmentManager._tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    String segmentName = new ArrayList<>(segmentManager._segmentZKMetadataMap.keySet()).get(0);
+
+    SegmentZKMetadata segmentZKMetadata =
+        segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentName, null);
+    int prevRowSize = segmentZKMetadata.getSizeThresholdToFlushSegment();
+    segmentManager.reduceSegmentSizeAndReset(new LLCSegmentName(segmentName), 100);
+    Assert.assertEquals(Math.min(100 / 2, prevRowSize / 2),
+        segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentName, null).getSizeThresholdToFlushSegment());
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1395,7 +1395,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
   @Test
   public void testReduceSegmentSizeAndReset() {
-    // Set up a new table with 2 replicas, 5 instances, 4 partition
+    // Set up a new table with 2 replicas, 5 instances, 4 partitions
     PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
     FakePinotLLCRealtimeSegmentManager segmentManager =
         new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -869,7 +869,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
                   // We could not build the segment. Go into error state.
                   _state = State.ERROR;
                   _segmentLogger.error("Could not build segment for {}", _segmentNameStr);
-                  if (_segmentCannotBuild) {
+                  if (_segmentCannotBuild && _tableConfig.getIngestionConfig().isRetryOnSegmentBuildPrecheckFailure()) {
                     _segmentLogger.error(
                         "Found non-recoverable segment build error for {}, from offset {} to {},"
                             + "sending notifyCannotBuild event.",

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -204,6 +204,16 @@ public class ServerSegmentCompletionProtocolHandler {
     return sendRequest(url);
   }
 
+  public SegmentCompletionProtocol.Response segmentCannotBuild(SegmentCompletionProtocol.Request.Params params) {
+    SegmentCompletionProtocol.SegmentCannotBuildRequest request =
+        new SegmentCompletionProtocol.SegmentCannotBuildRequest(params);
+    String url = createSegmentCompletionUrl(request);
+    if (url == null) {
+      return SegmentCompletionProtocol.RESP_NOT_SENT;
+    }
+    return sendRequest(url);
+  }
+
   private String createSegmentCompletionUrl(SegmentCompletionProtocol.Request request) {
     ControllerLeaderLocator leaderLocator = ControllerLeaderLocator.getInstance();
     final Pair<String, Integer> leaderHostPort = leaderLocator.getControllerLeader(_rawTableName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -1033,7 +1033,7 @@ public class RealtimeSegmentDataManagerTest {
     }
 
 
-      // TODO: Some of the tests rely on specific number of calls to the `now()` method in the SegmentDataManager.
+    // TODO: Some of the tests rely on specific number of calls to the `now()` method in the SegmentDataManager.
     // This is not a good coding practice and makes the code very fragile. This needs to be fixed.
     // Invoking now() in any part of RealtimeSegmentDataManager code will break the following tests:
     // 1. RealtimeSegmentDataManagerTest.testShouldNotSkipUnfilteredMessagesIfNotIndexedAndRowCountThresholdIsReached

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -66,6 +66,10 @@ public class IngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Configs related to skip any row which has error and continue during ingestion")
   private boolean _continueOnError;
 
+  @JsonPropertyDescription(
+      "Configs related to retry segment build on reduced size when previous build fails on Preconditions check")
+  private boolean _retryOnSegmentBuildPrecheckFailure;
+
   @JsonPropertyDescription("Configs related to validate time value for each record during ingestion")
   private boolean _rowTimeValueCheck;
 
@@ -136,6 +140,10 @@ public class IngestionConfig extends BaseJsonConfig {
     return _continueOnError;
   }
 
+  public boolean isRetryOnSegmentBuildPrecheckFailure() {
+    return _retryOnSegmentBuildPrecheckFailure;
+  }
+
   public boolean isRowTimeValueCheck() {
     return _rowTimeValueCheck;
   }
@@ -179,6 +187,10 @@ public class IngestionConfig extends BaseJsonConfig {
 
   public void setContinueOnError(boolean continueOnError) {
     _continueOnError = continueOnError;
+  }
+
+  public void setRetryOnSegmentBuildPrecheckFailure(boolean retryOnSegmentBuildPrecheckFailure) {
+    _retryOnSegmentBuildPrecheckFailure = retryOnSegmentBuildPrecheckFailure;
   }
 
   public void setRowTimeValueCheck(boolean rowTimeValueCheck) {


### PR DESCRIPTION
`ingestion` feature`
 
When mutable segments get transferred to immutable segments. There are a few preConditions check like

- 4GB SV compressed column size
- 2G MV num of elements
Those check failure would raise `IllegalStateException`, set `_state` to error and then stop there forever. This is due to the reason that Pinot is assuming such build failures are transient and would eventually be fixed by other replicas. However, in most of cases, such failures are deterministic and would fail on all replicas.

This PR will introduce a new `SegmentCannotBuildRequest` between server and controller. Once `Preconditions` check failed and there's no other replicas able to build so far. The controller would reduce the segment size by half and reset the segments.
Call out a few corner scenarios, e.g. segment has 2 replicas A and B

- "A" build failed and send `SegmentCannotBuildRequest` first, then reset segment will be sent immediately to both A and B. B would not try to build even if it may be successful in the future.
- "A" build succeed and has sent "commitStart" request. Then B build failed and send `SegmentCannotBuildRequest`. B's request would be ignored. And eventually B would get the copy from A or deepstore.

Ingestion stop issue would no longer happen. The only side effect is that user might see some latest data now but then not be able to see it later temporarily. (AS we've reset the latest immutable segments)
