### PR TITLE
Use instance data dir path to compute disk utilization info

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -202,4 +202,9 @@ public interface InstanceDataManager {
    * Returns consumer directory paths on the instance
    */
   List<File> getConsumerDirPaths();
+
+  /**
+   * Returns the instance data directory
+   */
+  String getInstanceDataDir();
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -199,6 +199,11 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   }
 
   @Override
+  public String getInstanceDataDir() {
+    return _instanceDataManagerConfig.getInstanceDataDir();
+  }
+
+  @Override
   public String getInstanceId() {
     return _instanceId;
   }


### PR DESCRIPTION
Changes are to use the `instanceDataDir` path to compute the disk utilization as opposed to a default path sent from the controller. The default path sent from the controller is unused as of now. The disk utilization results are also leveraged by the enhancements being made to the `rebalancer` and as a result we can not disable the `ResourceUtilizationChecker` periodic task by default.

Running the `ResourceUtilizationChecker` periodic task by default resulted in errors for the `QuickStart` apps which relied on the default path `/home/pinot/data` which maynot be available on all deployments. The changes in this PR are to rely on the `instanceDataDir` instead.

## Testing

Testing results from an internal test cluser.
```
2025/03/10 21:41:21.240 INFO [DiskUtilizationChecker] [pool-20-thread-3] Service response: {Server_pinot-server-server-0-0.pinot-pinot-server-headless.cell-q355j0-managed.svc.cluster.local_8098={
  "instanceId" : "Server_pinot-server-server-0-0.pinot-pinot-server-headless.cell-q355j0-managed.svc.cluster.local_8098",
  "path" : "/home/pinot/data/index",
  "totalSpaceBytes" : 539978293248,
  "usedSpaceBytes" : 531307618304,
  "lastUpdatedTimeInEpochMs" : 1741642881240
}}
```

Verified that the `QuickStart` apps does not throw any errors.
