### PR TITLE
Idea for supporting minion scaling based on tasks

### DIFF
--- a/helm/pinot/README.md
+++ b/helm/pinot/README.md
@@ -19,6 +19,41 @@
 
 -->
 
+# Apache Pinot Helm Chart
+
+This Helm Chart helps you deploy Apache Pinot on Kubernetes.
+
+## Features
+
+- Deploy complete Pinot cluster (Controller, Broker, Server, Minion)
+- Support for auto-scaling Pinot Minions based on task queue size
+- Configurable resource limits and node affinity
+- ZooKeeper integration
+- Customizable configuration
+
+## Auto-scaling Pinot Minions
+
+Pinot now supports auto-scaling minions based on task queue size. For detailed documentation, see:
+- [Minion Auto-scaling Documentation](docs/minion-autoscaling.md)
+
+To enable auto-scaling, add the following to your values.yaml:
+
+```yaml
+minionStateless:
+  enabled: true
+  
+  # Auto-scaling configuration
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    # Task queue based autoscaling
+    taskQueueMetric:
+      enabled: true
+      # Target value is tasks per minion - e.g., 5 means scale to have ~5 tasks per minion
+      targetValue: 5
+```
+
 # Pinot Quickstart on Kubernetes with Helm
 
 ## Prerequisite

--- a/helm/pinot/docs/minion-autoscaling.md
+++ b/helm/pinot/docs/minion-autoscaling.md
@@ -1,0 +1,200 @@
+# Pinot Minion Auto-scaling
+
+This guide explains how to set up auto-scaling for Pinot Minions based on task queue size.
+
+## Overview
+
+Pinot Minions execute various tasks, such as segment merging, reindexing, or purging. As the number of tasks increases, you may need to scale the number of minion instances to handle the load efficiently. This guide demonstrates how to implement auto-scaling for minions based on the number of pending tasks.
+
+## Approaches to Auto-scaling
+
+There are two main approaches to auto-scaling Pinot Minions:
+
+1. **Kubernetes-based auto-scaling**: Using Horizontal Pod Autoscaler (HPA) with custom metrics
+2. **Custom auto-scaling**: Implementing your own scaling logic using the Pinot API
+
+## Prerequisites
+
+- Kubernetes cluster with Helm installed
+- Prometheus for metrics collection
+- Prometheus Adapter for custom metrics in Kubernetes
+
+## Enabling Metrics
+
+The Pinot controller emits metrics about the task queue size that can be used for auto-scaling:
+
+- `pinot_controller_TOTAL_PENDING_MINION_TASKS`: Total number of pending tasks across all task types
+- `pinot_controller_PENDING_MINION_TASKS_PER_TYPE`: Number of pending tasks per task type
+
+## Option 1: Kubernetes HPA with Custom Metrics
+
+### Step 1: Deploy Prometheus and Prometheus Adapter
+
+If you don't already have Prometheus and Prometheus Adapter installed, deploy them:
+
+```bash
+# Add Prometheus Helm repo
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+# Install Prometheus
+helm install prometheus prometheus-community/prometheus
+
+# Install Prometheus Adapter
+helm install prometheus-adapter prometheus-community/prometheus-adapter -f prometheus-adapter-values.yaml
+```
+
+Create a `prometheus-adapter-values.yaml` file that includes rules for exposing Pinot task metrics:
+
+```yaml
+rules:
+  default: false
+  custom:
+    - seriesQuery: 'pinot_controller_TOTAL_PENDING_MINION_TASKS'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: "^pinot_controller_TOTAL_PENDING_MINION_TASKS"
+        as: "pinot_pending_tasks"
+      metricsQuery: sum(<<.Series>>)
+```
+
+### Step 2: Enable Auto-scaling in Pinot Helm Chart
+
+Update your Pinot Helm values to enable auto-scaling for minion stateless:
+
+```yaml
+minionStateless:
+  enabled: true
+  replicaCount: 1
+  
+  # Enable auto-scaling
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    # CPU-based autoscaling (optional)
+    cpuTargetPercentage: 80
+    # Task queue based autoscaling (recommended)
+    taskQueueMetric:
+      enabled: true
+      metricName: "pinot_pending_tasks"
+      # Target value is tasks per minion - e.g., 5 means scale to have ~5 tasks per minion
+      targetValue: 5
+```
+
+Deploy or upgrade Pinot with these settings:
+
+```bash
+helm upgrade --install pinot pinot/pinot -f values.yaml
+```
+
+### Step 3: Verify Auto-scaling Works
+
+Generate some tasks and observe the HPA in action:
+
+```bash
+# Monitor the HPA
+kubectl get hpa -w
+
+# Check scaling decisions
+kubectl describe hpa pinot-minion-stateless
+```
+
+## Option 2: Custom Auto-scaling with Pinot API
+
+For more complex scaling logic, you can use the Pinot API to implement your own auto-scaling mechanism.
+
+### Step 1: Get Task Counts from Pinot API
+
+The Pinot controller exposes endpoints to get task counts:
+
+```bash
+# Get overall task counts
+curl http://pinot-controller-external:9000/minions/taskcount
+
+# Get task counts for a specific task type
+curl http://pinot-controller-external:9000/minions/taskcount/SegmentGenerationAndPushTask
+```
+
+### Step 2: Implement a Custom Scaler
+
+Create a script or service that:
+
+1. Periodically polls the task count API
+2. Makes scaling decisions based on the number of tasks
+3. Updates the number of minion replicas through the Kubernetes API
+
+Example Python script:
+
+```python
+import requests
+import kubernetes
+from kubernetes import client, config
+import time
+import math
+
+# Configure Kubernetes client
+config.load_kube_config()
+apps_v1_api = client.AppsV1Api()
+
+# Pinot controller endpoint
+PINOT_CONTROLLER = "http://pinot-controller-external:9000"
+
+# Scaling parameters
+MIN_REPLICAS = 1
+MAX_REPLICAS = 10
+TARGET_TASKS_PER_MINION = 5
+NAMESPACE = "default"
+DEPLOYMENT_NAME = "pinot-minion-stateless"
+
+while True:
+    try:
+        # Get task count
+        response = requests.get(f"{PINOT_CONTROLLER}/minions/taskcount")
+        data = response.json()
+        
+        total_pending_tasks = data.get("totalPendingTasks", 0)
+        current_minions = data.get("totalMinionInstances", 1)
+        
+        # Calculate desired number of minions
+        desired_replicas = math.ceil(total_pending_tasks / TARGET_TASKS_PER_MINION)
+        desired_replicas = max(MIN_REPLICAS, min(desired_replicas, MAX_REPLICAS))
+        
+        # Only scale if change is needed
+        if desired_replicas != current_minions:
+            print(f"Scaling minions from {current_minions} to {desired_replicas}")
+            
+            # Update the deployment
+            apps_v1_api.patch_namespaced_deployment_scale(
+                name=DEPLOYMENT_NAME,
+                namespace=NAMESPACE,
+                body={"spec": {"replicas": desired_replicas}}
+            )
+    
+    except Exception as e:
+        print(f"Error: {e}")
+    
+    # Wait before checking again
+    time.sleep(60)
+```
+
+## Tips for Efficient Auto-scaling
+
+1. **Set appropriate scaling thresholds**: Too aggressive scaling can cause thrashing, while too conservative scaling might not provide enough resources.
+
+2. **Consider task-specific scaling**: Different task types may have different resource requirements. You might want to scale minions for specific task types separately.
+
+3. **Add scale-down delay**: To prevent rapid scale-down after task completion, add a stabilization window (implemented in the HPA definition).
+
+4. **Monitor performance**: Keep track of task execution times and adjust scaling parameters as needed.
+
+5. **Resource efficiency**: If you're frequently running tasks, consider keeping a minimum number of minions ready to reduce startup latency.
+
+## Conclusion
+
+Auto-scaling Pinot Minions based on task queue size helps ensure that your system can handle varying workloads efficiently. By using either Kubernetes HPA with custom metrics or a custom scaling solution, you can optimize resource usage while maintaining good performance.

--- a/helm/pinot/templates/minion-stateless/hpa.yaml
+++ b/helm/pinot/templates/minion-stateless/hpa.yaml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if and .Values.minionStateless.enabled .Values.minionStateless.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "pinot.minionStateless.fullname" . }}
+  namespace: {{ include "pinot.namespace" . }}
+  labels:
+    {{- include "pinot.minionStatelessLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "pinot.minionStateless.fullname" . }}
+  minReplicas: {{ .Values.minionStateless.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.minionStateless.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.minionStateless.autoscaling.cpuTargetPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.minionStateless.autoscaling.cpuTargetPercentage }}
+  {{- end }}
+  {{- if .Values.minionStateless.autoscaling.memoryTargetPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.minionStateless.autoscaling.memoryTargetPercentage }}
+  {{- end }}
+  {{- if .Values.minionStateless.autoscaling.taskQueueMetric.enabled }}
+  - type: External
+    external:
+      metric:
+        name: {{ .Values.minionStateless.autoscaling.taskQueueMetric.metricName | default "pinot_controller_TOTAL_PENDING_MINION_TASKS" }}
+        selector:
+          matchLabels:
+            {{- toYaml .Values.minionStateless.autoscaling.taskQueueMetric.selectorLabels | nindent 12 }}
+      target:
+        type: AverageValue
+        averageValue: {{ .Values.minionStateless.autoscaling.taskQueueMetric.targetValue }}
+  {{- end }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.minionStateless.autoscaling.scaleUpStabilizationWindowSeconds | default 0 }}
+      policies:
+      - type: Percent
+        value: {{ .Values.minionStateless.autoscaling.scaleUpPercentValue | default 100 }}
+        periodSeconds: {{ .Values.minionStateless.autoscaling.scaleUpPeriodSeconds | default 15 }}
+      - type: Pods
+        value: {{ .Values.minionStateless.autoscaling.scaleUpPodsValue | default 4 }}
+        periodSeconds: {{ .Values.minionStateless.autoscaling.scaleUpPeriodSeconds | default 15 }}
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.minionStateless.autoscaling.scaleDownStabilizationWindowSeconds | default 300 }}
+      policies:
+      - type: Percent
+        value: {{ .Values.minionStateless.autoscaling.scaleDownPercentValue | default 100 }}
+        periodSeconds: {{ .Values.minionStateless.autoscaling.scaleDownPeriodSeconds | default 15 }}
+      selectPolicy: Max
+{{- end }}

--- a/helm/pinot/templates/minion-stateless/test-hpa.yaml
+++ b/helm/pinot/templates/minion-stateless/test-hpa.yaml
@@ -1,0 +1,50 @@
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: RELEASE-NAME-minion-stateless
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: RELEASE-NAME-minion-stateless
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: External
+    external:
+      metric:
+        name: pinot_controller_TOTAL_PENDING_MINION_TASKS
+        selector:
+          matchLabels:
+            instance: pinot-controller
+      target:
+        type: AverageValue
+        averageValue: 5
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15
+      - type: Pods
+        value: 4
+        periodSeconds: 15
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 25
+        periodSeconds: 15
+      selectPolicy: Max

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -697,6 +697,33 @@ minionStateless:
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 
+  # Auto-scaling configuration for minion stateless
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    # CPU-based autoscaling (optional)
+    cpuTargetPercentage: 80
+    # Memory-based autoscaling (optional)
+    memoryTargetPercentage: 80
+    # Task queue based autoscaling (recommended)
+    taskQueueMetric:
+      enabled: true
+      # The Prometheus metric name for pending tasks
+      metricName: "pinot_controller_TOTAL_PENDING_MINION_TASKS"
+      # Labels to select the specific metric
+      selectorLabels: {}
+      # Target value is tasks per minion - e.g., 5 means scale to have ~5 tasks per minion
+      targetValue: 5
+    # Fine-tuning autoscaling behavior
+    scaleUpStabilizationWindowSeconds: 0
+    scaleUpPercentValue: 100
+    scaleUpPodsValue: 4
+    scaleUpPeriodSeconds: 15
+    scaleDownStabilizationWindowSeconds: 300
+    scaleDownPercentValue: 25
+    scaleDownPeriodSeconds: 15
+
   # Extra configs will be appended to pinot-minion.conf file
   extra:
     configs: |-

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -190,7 +190,13 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   REINGESTED_SEGMENT_UPLOADS_IN_PROGRESS("reingestedSegmentUploadsInProgress", true),
 
   // Resource utilization is within limits or not for a table
-  RESOURCE_UTILIZATION_LIMIT_EXCEEDED("ResourceUtilizationLimitExceeded", false);
+  RESOURCE_UTILIZATION_LIMIT_EXCEEDED("ResourceUtilizationLimitExceeded", false),
+
+  // Total number of pending minion tasks across all task types
+  TOTAL_PENDING_MINION_TASKS("Tasks", true),
+
+  // Number of pending minion tasks per task type
+  PENDING_MINION_TASKS_PER_TYPE("Tasks", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionResource.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.task.TaskState;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.Authorize;
+import org.apache.pinot.core.auth.TargetType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+/**
+ * Endpoints for managing Pinot minions
+ */
+@Api(tags = Constants.TASK_TAG, authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
+    @Authorization(value = DATABASE)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        key = SWAGGER_AUTHORIZATION_KEY,
+        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
+    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
+        description = "Database context passed through http header. If no context is provided 'default' database "
+            + "context will be considered.")}))
+@Path("/minions")
+public class PinotMinionResource {
+  public static final Logger LOGGER = LoggerFactory.getLogger(PinotMinionResource.class);
+
+  @Inject
+  PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @Inject
+  PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+
+  @Inject
+  PinotTaskManager _pinotTaskManager;
+
+  @GET
+  @Path("/instances")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("List all minion instances")
+  public Set<String> getMinionInstances() {
+    return _pinotHelixResourceManager.getAllInstancesForMinion();
+  }
+
+  @GET
+  @Path("/instances/tagged")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("List all minion instances with a tag")
+  public Map<String, Set<String>> getTaggedMinionInstances(
+      @ApiParam(value = "Tag name (e.g. DefaultTenant_OFFLINE)") @QueryParam("tag") @DefaultValue("") String tag) {
+    if (tag.isEmpty()) {
+      return _pinotHelixResourceManager.getMinionInstancesWithTags();
+    } else {
+      return Map.of(tag, _pinotHelixResourceManager.getInstancesWithTag(tag));
+    }
+  }
+
+  @GET
+  @Path("/taskcount")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Get the count of pending minion tasks")
+  public Map<String, Object> getPendingTaskCount() {
+    Map<String, Object> taskCounts = new HashMap<>();
+    
+    // Get total pending task count across all task types
+    int totalPendingTasks = _pinotTaskManager.getTotalPendingTaskCount();
+    taskCounts.put("totalPendingTasks", totalPendingTasks);
+    
+    // Get pending task count per task type
+    Map<String, Integer> pendingTasksByType = new HashMap<>();
+    for (String taskType : _pinotHelixTaskResourceManager.getTaskTypes()) {
+      int pendingCount = _pinotTaskManager.getPendingTaskCount(taskType);
+      pendingTasksByType.put(taskType, pendingCount);
+    }
+    taskCounts.put("pendingTasksByType", pendingTasksByType);
+    
+    // Calculate scaling metrics
+    int totalMinionInstances = _pinotHelixResourceManager.getAllInstancesForMinion().size();
+    taskCounts.put("totalMinionInstances", totalMinionInstances);
+    
+    // Tasks per minion - used for autoscaling decisions
+    double tasksPerMinion = totalMinionInstances > 0 ? (double) totalPendingTasks / totalMinionInstances : 0;
+    taskCounts.put("tasksPerMinion", tasksPerMinion);
+    
+    return taskCounts;
+  }
+
+  @GET
+  @Path("/taskcount/{taskType}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Get the count of pending minion tasks for a specific task type")
+  public Map<String, Object> getPendingTaskCountByType(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
+    Map<String, Object> taskTypeCount = new HashMap<>();
+    
+    int pendingCount = _pinotTaskManager.getPendingTaskCount(taskType);
+    taskTypeCount.put("pendingTasks", pendingCount);
+    
+    // Get total tasks for this task type (all states)
+    Map<String, TaskState> taskStates = _pinotHelixTaskResourceManager.getTaskStates(taskType);
+    taskTypeCount.put("totalTasks", taskStates.size());
+    
+    // Count by state
+    Map<TaskState, Integer> countByState = new HashMap<>();
+    for (TaskState state : taskStates.values()) {
+      countByState.put(state, countByState.getOrDefault(state, 0) + 1);
+    }
+    taskTypeCount.put("taskStateCount", countByState);
+    
+    // Calculate scaling metrics
+    // Find minions with the appropriate tag for this task type
+    Set<String> minionInstances = _pinotHelixResourceManager.getInstancesWithTag(
+        _pinotHelixTaskResourceManager.getTaskQueueTag(taskType));
+    taskTypeCount.put("availableMinionInstances", minionInstances.size());
+    
+    // Tasks per minion - used for autoscaling decisions
+    double tasksPerMinion = minionInstances.size() > 0 ? (double) pendingCount / minionInstances.size() : 0;
+    taskTypeCount.put("tasksPerMinion", tasksPerMinion);
+    
+    return taskTypeCount;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotMinionResourceIntegrationTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotMinionResourceIntegrationTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+
+@Test(groups = "integration")
+public class PinotMinionResourceIntegrationTest extends ControllerTest {
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String TASK_TYPE = MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    startZk();
+    startController();
+    
+    // Add fake instances
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeMinionInstancesToAutoJoinHelixCluster(2);
+    
+    // Create a table with tasks
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(RAW_TABLE_NAME)
+        .setTaskConfig(new TableTaskConfig(ImmutableMap.of(
+            TASK_TYPE, ImmutableMap.of("schedule", "0 */10 * ? * * *"))))
+        .build();
+    
+    addTableConfig(tableConfig);
+  }
+  
+  @Test
+  public void testGetMinionInstances() throws IOException, URISyntaxException {
+    // Call the API
+    String responseStr = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(new URI(_controllerRequestURLBuilder.forMinionInstances())));
+    
+    // Verify response
+    JsonNode response = JsonUtils.stringToJsonNode(responseStr);
+    assertTrue(response.isArray());
+    assertEquals(response.size(), 2, "Should have 2 minion instances");
+  }
+  
+  @Test
+  public void testGetTaggedMinionInstances() throws IOException, URISyntaxException {
+    // Call the API
+    String responseStr = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(new URI(_controllerRequestURLBuilder.forTaggedMinionInstances())));
+    
+    // Verify response
+    JsonNode response = JsonUtils.stringToJsonNode(responseStr);
+    assertTrue(response.isObject());
+    assertTrue(response.has(MinionConstants.UNTAGGED_INSTANCE));
+    
+    JsonNode untaggedInstances = response.get(MinionConstants.UNTAGGED_INSTANCE);
+    assertTrue(untaggedInstances.isArray());
+    assertEquals(untaggedInstances.size(), 2, "Should have 2 untagged minion instances");
+  }
+  
+  @Test
+  public void testGetPendingTaskCount() throws IOException, URISyntaxException {
+    // Call the API
+    String responseStr = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(new URI(_controllerRequestURLBuilder.forMinionTaskCount())));
+    
+    // Verify response
+    JsonNode response = JsonUtils.stringToJsonNode(responseStr);
+    assertTrue(response.isObject());
+    assertTrue(response.has("totalPendingTasks"));
+    assertTrue(response.has("pendingTasksByType"));
+    assertTrue(response.has("totalMinionInstances"));
+    assertTrue(response.has("tasksPerMinion"));
+    
+    assertEquals(response.get("totalMinionInstances").asInt(), 2, "Should have 2 minion instances");
+  }
+  
+  @Test
+  public void testGetPendingTaskCountByType() throws IOException, URISyntaxException {
+    // Initialize task queue for the task type
+    _controllerStarter.getHelixTaskResourceManager().ensureTaskQueueExists(TASK_TYPE);
+    
+    // Call the API
+    String responseStr = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(new URI(_controllerRequestURLBuilder.forMinionTaskCountByType(TASK_TYPE))));
+    
+    // Verify response
+    JsonNode response = JsonUtils.stringToJsonNode(responseStr);
+    assertTrue(response.isObject());
+    assertTrue(response.has("pendingTasks"));
+    assertTrue(response.has("totalTasks"));
+    assertTrue(response.has("taskStateCount"));
+    assertTrue(response.has("availableMinionInstances"));
+    assertTrue(response.has("tasksPerMinion"));
+  }
+
+  private void addTableConfig(TableConfig tableConfig) throws IOException {
+    try {
+      HttpClient.wrapAndThrowHttpException(
+          _httpClient.sendJsonPostRequest(new URI(_controllerRequestURLBuilder.forTableCreate()),
+              tableConfig.toJsonString(), new HashMap<>()));
+    } catch (URISyntaxException | HttpErrorStatusException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopFakeInstances();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotMinionResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotMinionResourceTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.helix.task.TaskState;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "stateless")
+public class PinotMinionResourceTest {
+
+  private PinotMinionResource _pinotMinionResource;
+  private PinotHelixResourceManager _mockResourceManager;
+  private PinotHelixTaskResourceManager _mockTaskResourceManager;
+  private PinotTaskManager _mockTaskManager;
+
+  @BeforeMethod
+  public void setUp() {
+    // Create mocks
+    _mockResourceManager = mock(PinotHelixResourceManager.class);
+    _mockTaskResourceManager = mock(PinotHelixTaskResourceManager.class);
+    _mockTaskManager = mock(PinotTaskManager.class);
+
+    // Initialize resource
+    _pinotMinionResource = new PinotMinionResource();
+    _pinotMinionResource._pinotHelixResourceManager = _mockResourceManager;
+    _pinotMinionResource._pinotHelixTaskResourceManager = _mockTaskResourceManager;
+    _pinotMinionResource._pinotTaskManager = _mockTaskManager;
+  }
+
+  @Test
+  public void testGetMinionInstances() {
+    // Setup mock
+    Set<String> minionInstances = new HashSet<>(Arrays.asList("Minion_1", "Minion_2", "Minion_3"));
+    when(_mockResourceManager.getAllInstancesForMinion()).thenReturn(minionInstances);
+
+    // Call method
+    Set<String> result = _pinotMinionResource.getMinionInstances();
+
+    // Verify result
+    assertEquals(result, minionInstances);
+    verify(_mockResourceManager).getAllInstancesForMinion();
+  }
+
+  @Test
+  public void testGetTaggedMinionInstances() {
+    // Setup mock for specific tag
+    String testTag = "TestTag";
+    Set<String> taggedInstances = new HashSet<>(Arrays.asList("Minion_1", "Minion_2"));
+    when(_mockResourceManager.getInstancesWithTag(testTag)).thenReturn(taggedInstances);
+
+    // Call method with specific tag
+    Map<String, Set<String>> result = _pinotMinionResource.getTaggedMinionInstances(testTag);
+
+    // Verify result
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(testTag), taggedInstances);
+    verify(_mockResourceManager).getInstancesWithTag(testTag);
+
+    // Setup mock for all tags
+    Map<String, Set<String>> allTaggedInstances = new HashMap<>();
+    allTaggedInstances.put("Tag1", new HashSet<>(Arrays.asList("Minion_1", "Minion_2")));
+    allTaggedInstances.put("Tag2", new HashSet<>(Collections.singletonList("Minion_3")));
+    when(_mockResourceManager.getMinionInstancesWithTags()).thenReturn(allTaggedInstances);
+
+    // Call method with empty tag
+    Map<String, Set<String>> allResult = _pinotMinionResource.getTaggedMinionInstances("");
+
+    // Verify result
+    assertEquals(allResult, allTaggedInstances);
+    verify(_mockResourceManager).getMinionInstancesWithTags();
+  }
+
+  @Test
+  public void testGetPendingTaskCount() {
+    // Setup mocks
+    when(_mockTaskManager.getTotalPendingTaskCount()).thenReturn(5);
+    when(_mockTaskResourceManager.getTaskTypes()).thenReturn(Arrays.asList("Task1", "Task2"));
+    when(_mockTaskManager.getPendingTaskCount("Task1")).thenReturn(3);
+    when(_mockTaskManager.getPendingTaskCount("Task2")).thenReturn(2);
+    when(_mockResourceManager.getAllInstancesForMinion()).thenReturn(
+        new HashSet<>(Arrays.asList("Minion_1", "Minion_2")));
+
+    // Call method
+    Map<String, Object> result = _pinotMinionResource.getPendingTaskCount();
+
+    // Verify result
+    assertEquals(result.get("totalPendingTasks"), 5);
+    assertEquals(result.get("totalMinionInstances"), 2);
+    assertEquals(result.get("tasksPerMinion"), 2.5); // 5 tasks / 2 minions = 2.5
+    
+    Map<String, Integer> pendingTasksByType = (Map<String, Integer>) result.get("pendingTasksByType");
+    assertEquals(pendingTasksByType.get("Task1"), Integer.valueOf(3));
+    assertEquals(pendingTasksByType.get("Task2"), Integer.valueOf(2));
+    
+    // Verify method calls
+    verify(_mockTaskManager).getTotalPendingTaskCount();
+    verify(_mockTaskResourceManager).getTaskTypes();
+    verify(_mockTaskManager).getPendingTaskCount("Task1");
+    verify(_mockTaskManager).getPendingTaskCount("Task2");
+    verify(_mockResourceManager).getAllInstancesForMinion();
+  }
+
+  @Test
+  public void testGetPendingTaskCountByType() {
+    // Setup mocks
+    String taskType = "Task1";
+    when(_mockTaskManager.getPendingTaskCount(taskType)).thenReturn(3);
+    
+    Map<String, TaskState> taskStates = new HashMap<>();
+    taskStates.put("task1", TaskState.IN_PROGRESS);
+    taskStates.put("task2", TaskState.NOT_STARTED);
+    taskStates.put("task3", TaskState.COMPLETED);
+    taskStates.put("task4", TaskState.FAILED);
+    when(_mockTaskResourceManager.getTaskStates(taskType)).thenReturn(taskStates);
+    
+    String taskQueueTag = "Task1_Queue";
+    when(_mockTaskResourceManager.getTaskQueueTag(taskType)).thenReturn(taskQueueTag);
+    
+    Set<String> minionInstances = new HashSet<>(Arrays.asList("Minion_1", "Minion_2"));
+    when(_mockResourceManager.getInstancesWithTag(taskQueueTag)).thenReturn(minionInstances);
+
+    // Call method
+    Map<String, Object> result = _pinotMinionResource.getPendingTaskCountByType(taskType);
+
+    // Verify result
+    assertEquals(result.get("pendingTasks"), 3);
+    assertEquals(result.get("totalTasks"), 4);
+    assertEquals(result.get("availableMinionInstances"), 2);
+    assertEquals(result.get("tasksPerMinion"), 1.5); // 3 tasks / 2 minions = 1.5
+    
+    Map<TaskState, Integer> taskStateCount = (Map<TaskState, Integer>) result.get("taskStateCount");
+    assertEquals(taskStateCount.get(TaskState.IN_PROGRESS), Integer.valueOf(1));
+    assertEquals(taskStateCount.get(TaskState.NOT_STARTED), Integer.valueOf(1));
+    assertEquals(taskStateCount.get(TaskState.COMPLETED), Integer.valueOf(1));
+    assertEquals(taskStateCount.get(TaskState.FAILED), Integer.valueOf(1));
+    
+    // Verify method calls
+    verify(_mockTaskManager).getPendingTaskCount(taskType);
+    verify(_mockTaskResourceManager).getTaskStates(taskType);
+    verify(_mockTaskResourceManager).getTaskQueueTag(taskType);
+    verify(_mockResourceManager).getInstancesWithTag(taskQueueTag);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerTaskCountTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerTaskCountTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.helix.task.TaskState;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.validation.ResourceUtilizationManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "stateless")
+public class PinotTaskManagerTaskCountTest {
+  private PinotTaskManager _pinotTaskManager;
+  private PinotHelixTaskResourceManager _mockTaskResourceManager;
+  private ControllerMetrics _mockControllerMetrics;
+
+  @BeforeMethod
+  public void setUp() {
+    // Create mocks
+    _mockTaskResourceManager = mock(PinotHelixTaskResourceManager.class);
+    PinotHelixResourceManager mockResourceManager = mock(PinotHelixResourceManager.class);
+    LeadControllerManager mockLeadControllerManager = mock(LeadControllerManager.class);
+    _mockControllerMetrics = mock(ControllerMetrics.class);
+    ControllerConf mockControllerConf = mock(ControllerConf.class);
+    PoolingHttpClientConnectionManager mockConnectionManager = mock(PoolingHttpClientConnectionManager.class);
+    ResourceUtilizationManager mockResourceUtilizationManager = mock(ResourceUtilizationManager.class);
+    
+    // Configure task resource manager
+    when(_mockTaskResourceManager.getTaskTypes()).thenReturn(Arrays.asList("Task1", "Task2"));
+    
+    Map<String, TaskState> task1States = new HashMap<>();
+    task1States.put("task1_1", TaskState.IN_PROGRESS);
+    task1States.put("task1_2", TaskState.NOT_STARTED);
+    task1States.put("task1_3", TaskState.COMPLETED);
+    when(_mockTaskResourceManager.getTaskStates("Task1")).thenReturn(task1States);
+    
+    Map<String, TaskState> task2States = new HashMap<>();
+    task2States.put("task2_1", TaskState.IN_PROGRESS);
+    task2States.put("task2_2", TaskState.FAILED);
+    when(_mockTaskResourceManager.getTaskStates("Task2")).thenReturn(task2States);
+    
+    // Create PinotTaskManager with mocks
+    _pinotTaskManager = spy(new PinotTaskManager(_mockTaskResourceManager, mockResourceManager, mockLeadControllerManager,
+        mockControllerConf, _mockControllerMetrics, null, null, mockConnectionManager, mockResourceUtilizationManager));
+  }
+
+  @Test
+  public void testGetTotalPendingTaskCount() {
+    // Call the method under test
+    int totalPendingTasks = _pinotTaskManager.getTotalPendingTaskCount();
+    
+    // Verify the result
+    assertEquals(totalPendingTasks, 3); // 2 IN_PROGRESS + 1 NOT_STARTED
+    
+    // Verify metrics were set
+    verify(_mockControllerMetrics).setValueOfGlobalGauge(ControllerGauge.TOTAL_PENDING_MINION_TASKS, 3);
+  }
+
+  @Test
+  public void testGetPendingTaskCount() {
+    // Call the method under test for Task1
+    int task1PendingCount = _pinotTaskManager.getPendingTaskCount("Task1");
+    
+    // Verify the result
+    assertEquals(task1PendingCount, 2); // 1 IN_PROGRESS + 1 NOT_STARTED
+    
+    // Verify metrics were set
+    verify(_mockControllerMetrics).setValueOfTableGauge("Task1", ControllerGauge.PENDING_MINION_TASKS_PER_TYPE, 2);
+    
+    // Call the method under test for Task2
+    int task2PendingCount = _pinotTaskManager.getPendingTaskCount("Task2");
+    
+    // Verify the result
+    assertEquals(task2PendingCount, 1); // 1 IN_PROGRESS
+    
+    // Verify metrics were set
+    verify(_mockControllerMetrics).setValueOfTableGauge("Task2", ControllerGauge.PENDING_MINION_TASKS_PER_TYPE, 1);
+  }
+
+  @Test
+  public void testReportMetricsUpdatesTaskCounts() {
+    // Call reportMetrics with Task1
+    _pinotTaskManager.reportMetrics("Task1");
+    
+    // Verify that task count methods were called
+    verify(_pinotTaskManager).getPendingTaskCount("Task1");
+    verify(_pinotTaskManager).getTotalPendingTaskCount();
+    
+    // Call reportMetrics with Task2
+    _pinotTaskManager.reportMetrics("Task2");
+    
+    // Verify that task count methods were called again
+    verify(_pinotTaskManager).getPendingTaskCount("Task2");
+    verify(_pinotTaskManager, times(2)).getTotalPendingTaskCount();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -626,4 +626,25 @@ public class ControllerRequestURLBuilder {
   public String forIdealState(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "idealstate");
   }
+
+  // Minion API Endpoints
+  public String forMinionInstances() {
+    return StringUtil.join("/", _baseUrl, "minions", "instances");
+  }
+
+  public String forTaggedMinionInstances() {
+    return StringUtil.join("/", _baseUrl, "minions", "instances", "tagged");
+  }
+
+  public String forTaggedMinionInstances(String tag) {
+    return StringUtil.join("/", _baseUrl, "minions", "instances", "tagged") + "?tag=" + tag;
+  }
+
+  public String forMinionTaskCount() {
+    return StringUtil.join("/", _baseUrl, "minions", "taskcount");
+  }
+
+  public String forMinionTaskCountByType(String taskType) {
+    return StringUtil.join("/", _baseUrl, "minions", "taskcount", taskType);
+  }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Controller exposes task counts via metrics and API for minion auto\-scaling

```mermaid
flowchart TD
  N0["PinotTaskManager#46;reportMetrics #40;F7#41;"]:::stModified
  N1["PinotTaskManager#46;getTotalPendingTaskCount #40;F7#41;"]:::stAdded
  N2["PinotTaskManager#46;getPendingTaskCount #40;F7#41;"]:::stAdded
  N3["PinotMinionResource#46;getPendingTaskCount #40;F9#41;"]:::stAdded
  N4["PinotMinionResource#46;getPendingTaskCountByType #40;F9#41;"]:::stAdded
  N5["HPA template for minion stateless #40;F3#41;"]:::stAdded
  N0 -->|"call"| N1
  N0 -->|"call"| N2
  N3 -->|"call"| N1
  N3 -->|"call"| N2
  N4 -->|"call"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F3: helm/pinot/templates/minion\-stateless/hpa\.yaml — [after](https://github.com/apache/pinot/blob/01af97ca0f619e005700cd930006cba70e2e4d32/helm/pinot/templates/minion-stateless/hpa.yaml)
- F7: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager\.java — [before](https://github.com/apache/pinot/blob/98dd54d52a99144d404f035f6ea77317162999ab/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java) · [after](https://github.com/apache/pinot/blob/01af97ca0f619e005700cd930006cba70e2e4d32/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java)
- F9: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionResource\.java — [after](https://github.com/apache/pinot/blob/01af97ca0f619e005700cd930006cba70e2e4d32/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijk4ZGQ1NGQ1MmE5OTE0NGQ0MDRmMDM1ZjZlYTc3MzE3MTYyOTk5YWIiLCJjb250ZXh0X2hhc2giOiJiNjg5MTk2NmVhNTBhNmU2Y2Q4OTcwMjY1NWVlNDk1NzA2ODdhMDQ5YjY3NDUyYjMzZjNhZWM4YTI5YzFlYjJlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTY1NjIwLCJoZWFkX3NoYSI6IjAxYWY5N2NhMGY2MTllMDA1NzAwY2Q5MzAwMDZjYmE3MGUyZTRkMzIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1YWM1MTU2YTRkZWQ5NTM0NzVmMzEzNTUwM2U0MDQyZTZmMTllZTQ0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1e4802401e5fab819b84b6cb435a4d9b23cbb5e62d2e1f276c1690f91855fbe1 -->
<!-- pinot-pr-flow:end -->

New feature, to add support for managing scaling of minions.



 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
