### PR TITLE
Registering pauseless FSM by default and picking this FSM for pauseless enabled tables

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
@@ -30,12 +30,10 @@ public class SegmentCompletionConfig {
   public static final String DEFAULT_FSM_SCHEME_KEY =
       CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.default";
   public static final String DEFAULT_PAUSELESS_FSM_SCHEME_KEY =
-      CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.pauselessDefault";
+      CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.pauseless";
   public static final String DEFAULT_FSM_SCHEME = "default";
-  public static final String DEFAULT_PAUSELESS_FSM_SCHEME = "pauselessDefault";
+  public static final String DEFAULT_PAUSELESS_FSM_SCHEME = "pauseless";
   private final Map<String, String> _fsmSchemes = new HashMap<>();
-  private final String _defaultFsmScheme;
-  private final String _defaultPauselessFsmScheme;
 
   public SegmentCompletionConfig(PinotConfiguration configuration) {
     // Parse properties to extract FSM schemes
@@ -47,11 +45,6 @@ public class SegmentCompletionConfig {
         _fsmSchemes.put(scheme, className);
       }
     }
-
-    // Get the default FSM and pauseless FSM scheme
-    _defaultFsmScheme = configuration.getProperty(DEFAULT_FSM_SCHEME_KEY, DEFAULT_FSM_SCHEME);
-    _defaultPauselessFsmScheme =
-        configuration.getProperty(DEFAULT_PAUSELESS_FSM_SCHEME_KEY, DEFAULT_PAUSELESS_FSM_SCHEME);
   }
 
   public Map<String, String> getFsmSchemes() {
@@ -59,10 +52,10 @@ public class SegmentCompletionConfig {
   }
 
   public String getDefaultFsmScheme() {
-    return _defaultFsmScheme;
+    return DEFAULT_FSM_SCHEME;
   }
 
   public String getDefaultPauselessFsmScheme() {
-    return _defaultPauselessFsmScheme;
+    return DEFAULT_PAUSELESS_FSM_SCHEME;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
@@ -29,9 +29,13 @@ public class SegmentCompletionConfig {
       CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.";
   public static final String DEFAULT_FSM_SCHEME_KEY =
       CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.default";
+  public static final String DEFAULT_PAUSELESS_FSM_SCHEME_KEY =
+      CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.pauseless";
   public static final String DEFAULT_FSM_SCHEME = "default";
+  public static final String DEFAULT_PAUSELESS_FSM_SCHEME = "pauseless";
   private final Map<String, String> _fsmSchemes = new HashMap<>();
   private final String _defaultFsmScheme;
+  private final String _defaultPauselessFsmScheme;
 
   public SegmentCompletionConfig(PinotConfiguration configuration) {
     // Parse properties to extract FSM schemes
@@ -44,8 +48,10 @@ public class SegmentCompletionConfig {
       }
     }
 
-    // Get the default FSM scheme
+    // Get the default FSM and pauseless FSM scheme
     _defaultFsmScheme = configuration.getProperty(DEFAULT_FSM_SCHEME_KEY, DEFAULT_FSM_SCHEME);
+    _defaultPauselessFsmScheme =
+        configuration.getProperty(DEFAULT_PAUSELESS_FSM_SCHEME_KEY, DEFAULT_PAUSELESS_FSM_SCHEME);
   }
 
   public Map<String, String> getFsmSchemes() {
@@ -54,5 +60,9 @@ public class SegmentCompletionConfig {
 
   public String getDefaultFsmScheme() {
     return _defaultFsmScheme;
+  }
+
+  public String getDefaultPauselessFsmScheme() {
+    return _defaultPauselessFsmScheme;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfig.java
@@ -30,9 +30,9 @@ public class SegmentCompletionConfig {
   public static final String DEFAULT_FSM_SCHEME_KEY =
       CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.default";
   public static final String DEFAULT_PAUSELESS_FSM_SCHEME_KEY =
-      CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.pauseless";
+      CommonConstants.Controller.PREFIX_OF_PINOT_CONTROLLER_SEGMENT_COMPLETION + ".fsm.scheme.pauselessDefault";
   public static final String DEFAULT_FSM_SCHEME = "default";
-  public static final String DEFAULT_PAUSELESS_FSM_SCHEME = "pauseless";
+  public static final String DEFAULT_PAUSELESS_FSM_SCHEME = "pauselessDefault";
   private final Map<String, String> _fsmSchemes = new HashMap<>();
   private final String _defaultFsmScheme;
   private final String _defaultPauselessFsmScheme;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactory.java
@@ -49,8 +49,12 @@ public class SegmentCompletionFSMFactory {
   public static void register(String scheme, Class<? extends SegmentCompletionFSM> fsmClass) {
     Preconditions.checkNotNull(scheme, "Scheme cannot be null");
     Preconditions.checkNotNull(fsmClass, "FSM Class cannot be null");
-    Preconditions.checkState(FSM_CLASS_MAP.put(scheme, fsmClass) == null,
-        "FSM class already registered for scheme: " + scheme);
+
+    Class<? extends SegmentCompletionFSM> previousFsmClass = FSM_CLASS_MAP.put(scheme, fsmClass);
+    if (previousFsmClass != null) {
+      LOGGER.warn("Replacing existing FSM: {} for scheme: {} with: {}",
+          previousFsmClass, scheme, fsmClass);
+    }
     LOGGER.info("Registered SegmentCompletionFSM class {} for scheme {}", fsmClass, scheme);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactory.java
@@ -34,9 +34,10 @@ public class SegmentCompletionFSMFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentCompletionFSMFactory.class);
   private static final Map<String, Class<? extends SegmentCompletionFSM>> FSM_CLASS_MAP = new HashMap<>();
 
-  // Static block to register the default FSM
+  // Static block to register the default FSM and pauseless FSM
   static {
     register(SegmentCompletionConfig.DEFAULT_FSM_SCHEME, BlockingSegmentCompletionFSM.class);
+    register(SegmentCompletionConfig.DEFAULT_PAUSELESS_FSM_SCHEME, PauselessSegmentCompletionFSM.class);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -138,7 +139,8 @@ public class SegmentCompletionManager {
     }
 
     if (factoryName == null) {
-      factoryName = _segmentCompletionConfig.getDefaultFsmScheme();
+      factoryName = PauselessConsumptionUtils.isPauselessEnabled(tableConfig)
+          ? _segmentCompletionConfig.getDefaultPauselessFsmScheme() : _segmentCompletionConfig.getDefaultFsmScheme();
     }
 
     Preconditions.checkState(SegmentCompletionFSMFactory.isFactoryTypeSupported(factoryName),

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfigTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfigTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.realtime;
+
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig.*;
+
+
+public class SegmentCompletionConfigTest {
+
+  private static final String DEFAULT_FSM_CLASS =
+      "org.apache.pinot.controller.helix.core.realtime.BlockingSegmentCompletionFSM";
+  private static final String PAUSELESS_FSM_CLASS =
+      "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM";
+  private static final String CUSTOM_FSM_CLASS =
+      "org.apache.pinot.controller.helix.core.realtime.CustomSegmentCompletionFSM";
+
+  @Test
+  public void testGetFsmSchemes() {
+    String customSchemeKey = FSM_SCHEME + "custom";
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(
+        Map.of(DEFAULT_PAUSELESS_FSM_SCHEME_KEY, PAUSELESS_FSM_CLASS, DEFAULT_FSM_SCHEME_KEY, DEFAULT_FSM_CLASS,
+            customSchemeKey, CUSTOM_FSM_CLASS));
+    SegmentCompletionConfig segmentCompletionConfig = new SegmentCompletionConfig(pinotConfiguration);
+    Map<String, String> expectedFsmSchemes =
+        Map.of(DEFAULT_FSM_SCHEME, DEFAULT_FSM_CLASS, DEFAULT_PAUSELESS_FSM_SCHEME, PAUSELESS_FSM_CLASS, "custom",
+            CUSTOM_FSM_CLASS);
+    Assert.assertEquals(expectedFsmSchemes, segmentCompletionConfig.getFsmSchemes());
+    Assert.assertEquals(segmentCompletionConfig.getDefaultFsmScheme(), DEFAULT_FSM_SCHEME);
+    Assert.assertEquals(segmentCompletionConfig.getDefaultPauselessFsmScheme(), DEFAULT_PAUSELESS_FSM_SCHEME);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfigTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionConfigTest.java
@@ -28,10 +28,8 @@ import static org.apache.pinot.controller.helix.core.realtime.SegmentCompletionC
 
 public class SegmentCompletionConfigTest {
 
-  private static final String DEFAULT_FSM_CLASS =
-      "org.apache.pinot.controller.helix.core.realtime.BlockingSegmentCompletionFSM";
-  private static final String PAUSELESS_FSM_CLASS =
-      "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM";
+  private static final String DEFAULT_FSM_CLASS = BlockingSegmentCompletionFSM.class.getName();
+  private static final String PAUSELESS_FSM_CLASS = PauselessSegmentCompletionFSM.class.getName();
   private static final String CUSTOM_FSM_CLASS =
       "org.apache.pinot.controller.helix.core.realtime.CustomSegmentCompletionFSM";
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactoryTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.realtime;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig.DEFAULT_FSM_SCHEME_KEY;
+import static org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig.DEFAULT_PAUSELESS_FSM_SCHEME_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class SegmentCompletionFSMFactoryTest {
+  private static final String DEFAULT_FSM_CLASS =
+      "org.apache.pinot.controller.helix.core.realtime.BlockingSegmentCompletionFSM";
+
+  private static final String LLC_SEGMENT_NAME = "tableName__0__0__20250228T1903Z";
+
+  @AfterMethod
+  public void tearDown() {
+    // Clear the factory's static state between tests
+    SegmentCompletionFSMFactory.shutdown();
+
+    // Re-register the default mappings
+    SegmentCompletionFSMFactory.register(SegmentCompletionConfig.DEFAULT_FSM_SCHEME,
+        BlockingSegmentCompletionFSM.class);
+    SegmentCompletionFSMFactory.register(SegmentCompletionConfig.DEFAULT_PAUSELESS_FSM_SCHEME,
+        PauselessSegmentCompletionFSM.class);
+  }
+
+  @Test
+  public void testCreateFSMWithDefaultFsm() {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(Collections.emptyMap());
+    SegmentCompletionConfig segmentCompletionConfig = new SegmentCompletionConfig(pinotConfiguration);
+    SegmentCompletionFSMFactory.init(segmentCompletionConfig);
+
+    // mock different objects that are required for creating FSM
+    SegmentCompletionManager segmentCompletionManager = mock(SegmentCompletionManager.class);
+    LongMsgOffsetFactory longMsgOffsetFactory = mock(LongMsgOffsetFactory.class);
+    when(segmentCompletionManager.getCurrentTimeMs()).thenReturn(System.currentTimeMillis());
+    when(segmentCompletionManager.getStreamPartitionMsgOffsetFactory(any())).thenReturn(longMsgOffsetFactory);
+    when(longMsgOffsetFactory.create(anyString())).thenReturn(new LongMsgOffset(100));
+
+    SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(segmentZKMetadata.getNumReplicas()).thenReturn(3);
+    when(segmentZKMetadata.getEndOffset()).thenReturn("100");
+
+    PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager = mock(PinotLLCRealtimeSegmentManager.class);
+    when(pinotLLCRealtimeSegmentManager.getCommitTimeoutMS(anyString())).thenReturn(System.currentTimeMillis());
+
+    // Asset that the default fsm (BlockingSegmentCompletionFSM) is picked when the "default" scheme is passed
+    Assert.assertTrue(
+        SegmentCompletionFSMFactory.createFSM(segmentCompletionConfig.getDefaultFsmScheme(), segmentCompletionManager,
+            pinotLLCRealtimeSegmentManager, new LLCSegmentName(LLC_SEGMENT_NAME),
+            segmentZKMetadata) instanceof BlockingSegmentCompletionFSM);
+
+    // Asset that the default pauseless fsm (PauselessSegmentCompletionFSM) is picked when the "pauseless" scheme is
+    // passed
+    Assert.assertTrue(SegmentCompletionFSMFactory.createFSM(segmentCompletionConfig.getDefaultPauselessFsmScheme(),
+        segmentCompletionManager, pinotLLCRealtimeSegmentManager, new LLCSegmentName(LLC_SEGMENT_NAME),
+        segmentZKMetadata) instanceof PauselessSegmentCompletionFSM);
+  }
+
+  @Test
+  public void testCreateFSMWithCustomProvidedFsm() {
+
+    String fakeCustomeFsmClass =
+        "org.apache.pinot.controller.helix.core.realtime.SegmentCompletionFSMFactoryTest$FakeCustomFSM";
+
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(
+        Map.of(DEFAULT_PAUSELESS_FSM_SCHEME_KEY, fakeCustomeFsmClass, DEFAULT_FSM_SCHEME_KEY, DEFAULT_FSM_CLASS));
+
+    // mock different objects that are required for creating FSM
+    SegmentCompletionConfig segmentCompletionConfig = new SegmentCompletionConfig(pinotConfiguration);
+    SegmentCompletionFSMFactory.init(segmentCompletionConfig);
+
+    SegmentCompletionManager segmentCompletionManager = mock(SegmentCompletionManager.class);
+    LongMsgOffsetFactory longMsgOffsetFactory = mock(LongMsgOffsetFactory.class);
+    when(segmentCompletionManager.getCurrentTimeMs()).thenReturn(System.currentTimeMillis());
+    when(segmentCompletionManager.getStreamPartitionMsgOffsetFactory(any())).thenReturn(longMsgOffsetFactory);
+    when(longMsgOffsetFactory.create(anyString())).thenReturn(new LongMsgOffset(100));
+
+    SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(segmentZKMetadata.getNumReplicas()).thenReturn(3);
+    when(segmentZKMetadata.getEndOffset()).thenReturn("100");
+
+    PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager = mock(PinotLLCRealtimeSegmentManager.class);
+    when(pinotLLCRealtimeSegmentManager.getCommitTimeoutMS(anyString())).thenReturn(System.currentTimeMillis());
+
+    // Assert that registering for the same scheme i.e. "default", works as expected and BlockingSegmentCompletionFSM
+    // object is created
+    Assert.assertTrue(
+        SegmentCompletionFSMFactory.createFSM(segmentCompletionConfig.getDefaultFsmScheme(), segmentCompletionManager,
+            pinotLLCRealtimeSegmentManager, new LLCSegmentName(LLC_SEGMENT_NAME),
+            segmentZKMetadata) instanceof BlockingSegmentCompletionFSM);
+
+    // Assert that changing the default for pauseless returns the new custom fsm.
+    Assert.assertTrue(SegmentCompletionFSMFactory.createFSM(segmentCompletionConfig.getDefaultPauselessFsmScheme(),
+        segmentCompletionManager, pinotLLCRealtimeSegmentManager, new LLCSegmentName(LLC_SEGMENT_NAME),
+        segmentZKMetadata) instanceof FakeCustomFSM);
+  }
+
+  public static class FakeCustomFSM extends BlockingSegmentCompletionFSM {
+
+    public FakeCustomFSM(PinotLLCRealtimeSegmentManager segmentManager,
+        SegmentCompletionManager segmentCompletionManager, LLCSegmentName segmentName,
+        SegmentZKMetadata segmentMetadata) {
+      super(segmentManager, segmentCompletionManager, segmentName, segmentMetadata);
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSMFactoryTest.java
@@ -38,9 +38,7 @@ import static org.mockito.Mockito.when;
 
 
 public class SegmentCompletionFSMFactoryTest {
-  private static final String DEFAULT_FSM_CLASS =
-      "org.apache.pinot.controller.helix.core.realtime.BlockingSegmentCompletionFSM";
-
+  private static final String DEFAULT_FSM_CLASS = BlockingSegmentCompletionFSM.class.getName();
   private static final String LLC_SEGMENT_NAME = "tableName__0__0__20250228T1903Z";
 
   @AfterMethod

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -30,7 +30,6 @@ import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingPinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.PauselessRealtimeTestUtils;
@@ -48,7 +47,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
-import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
 import static org.testng.Assert.assertTrue;
 
 
@@ -79,8 +77,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   protected void overrideControllerConf(Map<String, Object> properties) {
     properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
     properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
-    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
-        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
     properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
         500);
   }
@@ -158,10 +154,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     ingestionConfig.setStreamIngestionConfig(
         new StreamIngestionConfig(List.of(tableConfig.getIndexingConfig().getStreamConfigs())));
     ingestionConfig.getStreamIngestionConfig().setPauselessConsumptionEnabled(true);
-    ingestionConfig.getStreamIngestionConfig()
-        .getStreamConfigMaps()
-        .get(0)
-        .put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
     tableConfig.getIndexingConfig().setStreamConfigs(null);
     tableConfig.setIngestionConfig(ingestionConfig);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionCommitEndMetadataFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionCommitEndMetadataFailureTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
 import org.apache.pinot.integration.tests.realtime.utils.PauselessRealtimeTestUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNull;
@@ -30,6 +32,11 @@ import static org.testng.Assert.assertNull;
 
 public class PauselessRealtimeIngestionCommitEndMetadataFailureTest
     extends BasePauselessRealtimeIngestionTest {
+
+  // The total number of real-time segments is NUM_REALTIME_SEGMENTS.
+  // Two segments are in the CONSUMING state, meaning they are still ingesting data.
+  // The remaining segments (NUM_REALTIME_SEGMENTS - 2) are in the committing state,
+  private static final int NUM_REALTIME_SEGMENTS_IN_COMMITTING_STATE = 46;
 
   @Override
   protected String getFailurePoint() {
@@ -56,6 +63,21 @@ public class PauselessRealtimeIngestionCommitEndMetadataFailureTest
       throws Exception {
     String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
     PauselessRealtimeTestUtils.verifyIdealState(tableNameWithType, NUM_REALTIME_SEGMENTS, _helixManager);
+
+    // the setup() function only waits till all the documents have been loaded
+    // this has lead to race condition in the commit protocol and validation manager run leading to test failures
+    // checking the completion of the commit protocol i.e. segment marked COMMITTING before triggering
+    // validation manager in the tests prevents this.
+
+    // All the segments should be in COMMITTING state for pauseless table having commitEndMetadata failure
+    TestUtils.waitForCondition((aVoid) -> {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+          _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      return segmentZKMetadataList.stream()
+          .filter(
+              segmentZKMetadata -> segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING)
+          .count() == NUM_REALTIME_SEGMENTS_IN_COMMITTING_STATE;
+    }, 1000, 100000, "Some segments are still IN_PROGRESS");
 
     List<SegmentZKMetadata> segmentZKMetadataList = _helixResourceManager.getSegmentsZKMetadata(tableNameWithType);
     for (SegmentZKMetadata metadata : segmentZKMetadataList) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -35,7 +35,6 @@ import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionConfig;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingPinotLLCRealtimeSegmentManager;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
@@ -54,7 +53,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.integration.tests.realtime.utils.FailureInjectingRealtimeTableDataManager.MAX_NUMBER_OF_FAILURES;
-import static org.apache.pinot.spi.stream.StreamConfigProperties.SEGMENT_COMPLETION_FSM_SCHEME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -72,8 +70,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
   protected void overrideControllerConf(Map<String, Object> properties) {
     properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
     properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
-    properties.put(SegmentCompletionConfig.FSM_SCHEME + "pauseless",
-        "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM");
     // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
     // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
     properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
@@ -155,7 +151,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     Map<String, String> streamConfigMap = ingestionConfig.getStreamIngestionConfig()
         .getStreamConfigMaps()
         .get(0);
-    streamConfigMap.put(SEGMENT_COMPLETION_FSM_SCHEME, "pauseless");
     streamConfigMap.put("segmentDownloadTimeoutMinutes", "1");
     tableConfig.getIndexingConfig().setStreamConfigs(null);
     tableConfig.setIngestionConfig(ingestionConfig);


### PR DESCRIPTION
### Context

To enable pauseless table we need to add a config for controller and two parameters for the table config:

#### Controller config

```
{
    "pinot.controller.segment.completion.fsm.scheme.pauseless": "org.apache.pinot.controller.helix.core.realtime.PauselessSegmentCompletionFSM"
}
```

#### Table config

```
 "ingestionConfig": {
 "streamIngestionConfig": {
   "pauselessConsumptionEnabled": true, // parameter 1
   "streamConfigMaps": [
     {
       ...
       ...
       "segment.completion.fsm.scheme": "pauseless" // parameter 2
     }
   ]
 }
}
```

For now we have two types of realtime tables with respect to the FSM they use:
- Conventional realtime tables
- Pauseless realtime tables

Conventional tables always use `BlockingSegmentCompletionFSM` while Pauseless tables always use `PauselessSegmentCompletionFSM`

Thus, this additional config makes enabling pauseless a little more error prone. 

### Scope of the PR

The PR aims to register `PauselessSegmentCompletionFSM` as the default FSM class to be used for pauseless tables.
The user only needs to set following parameter in the table config to enable pauseless.

```
"pauselessConsumptionEnabled": true
```

The user still has the ability to use a custom fsm by  adding following

Controller config

```
{
"pinot.controller.segment.completion.fsm.scheme.<fsm_scheme_name>": "<fsm_class>"
}
```

Table Config

```
 "ingestionConfig": {
 "streamIngestionConfig": {
   "streamConfigMaps": [
     {
       ...
       ...
       "segment.completion.fsm.scheme": "<fsm_scheme_name>" // use the scheme provided above
     }
   ]
 }
}
```

### Testing

The segments can be marked COMMITTING only when PauselessSegmentCompletionFSM is used. 
Updated the integration tests to ensure that the expected number of segments are marked committing for the table. 