### PR TITLE
Improved retention management for hybrid tables

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -194,7 +194,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   // The number of segments in deepstore that do not have corresponding metadata in ZooKeeper.
   // These segments are untracked and should be considered for deletion based on retention policies.
-  UNTRACKED_SEGMENTS_COUNT("untrackedSegmentsCount", false);
+  UNTRACKED_SEGMENTS_COUNT("untrackedSegmentsCount", false),
+
+  // Metric used to track errors during the periodic table retention management
+  RETENTION_MANAGER_ERROR("retentionManagerError", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -111,6 +111,7 @@ import org.apache.pinot.controller.helix.core.statemodel.LeadControllerResourceM
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
 import org.apache.pinot.controller.tuner.TableConfigTunerRegistry;
+import org.apache.pinot.controller.util.BrokerServiceHelper;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.controller.validation.BrokerResourceValidationManager;
 import org.apache.pinot.controller.validation.DiskUtilizationChecker;
@@ -860,8 +861,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
             _controllerMetrics, _taskManagerStatusCache, _executorService, _connectionManager,
             _resourceUtilizationManager);
     periodicTasks.add(_taskManager);
-    _retentionManager =
-        new RetentionManager(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics);
+    BrokerServiceHelper brokerServiceHelper =
+        new BrokerServiceHelper(_helixResourceManager, _config, _executorService, _connectionManager);
+    _retentionManager = new RetentionManager(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
+        brokerServiceHelper);
     periodicTasks.add(_retentionManager);
     _offlineSegmentIntervalChecker =
         new OfflineSegmentIntervalChecker(_config, _helixResourceManager, _leadControllerManager,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -346,6 +346,7 @@ public class ControllerConf extends PinotConfiguration {
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_INITIAL_DELAY = 300L; // 5 minutes
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_FREQUENCY = 300L; // 5 minutes
   private static final boolean DEFAULT_ENABLE_BATCH_MESSAGE_MODE = false;
+  private static final boolean DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY = false;
   private static final String DEFAULT_CONTROLLER_MODE = ControllerMode.DUAL.name();
   private static final String DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY =
       AutoRebalanceStrategy.class.getName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -314,6 +314,8 @@ public class ControllerConf extends PinotConfiguration {
   private static final String RESOURCE_UTILIZATION_CHECKER_FREQUENCY =
       "controller.resource.utilization.checker.frequency";
   private static final String ENABLE_BATCH_MESSAGE_MODE = "controller.enable.batch.message.mode";
+  public static final String ENABLE_HYBRID_TABLE_RETENTION_STRATEGY =
+      "controller.enable.hybrid.table.retention.strategy";
   public static final String DIM_TABLE_MAX_SIZE = "controller.dimTable.maxSize";
 
   // Defines the kind of storage and the underlying PinotFS implementation
@@ -344,6 +346,9 @@ public class ControllerConf extends PinotConfiguration {
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_INITIAL_DELAY = 300L; // 5 minutes
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_FREQUENCY = 300L; // 5 minutes
   private static final boolean DEFAULT_ENABLE_BATCH_MESSAGE_MODE = false;
+  private static final boolean DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY = false;
+  // Disallow any high level consumer (HLC) table
+  private static final boolean DEFAULT_ALLOW_HLC_TABLES = false;
   private static final String DEFAULT_CONTROLLER_MODE = ControllerMode.DUAL.name();
   private static final String DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY =
       AutoRebalanceStrategy.class.getName();
@@ -1035,6 +1040,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean getEnableBatchMessageMode() {
     return getProperty(ENABLE_BATCH_MESSAGE_MODE, DEFAULT_ENABLE_BATCH_MESSAGE_MODE);
+  }
+
+  public boolean isHybridTableRetentionStrategyEnabled() {
+    return getProperty(ENABLE_HYBRID_TABLE_RETENTION_STRATEGY, DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY);
   }
 
   public int getSegmentLevelValidationIntervalInSeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -346,9 +346,6 @@ public class ControllerConf extends PinotConfiguration {
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_INITIAL_DELAY = 300L; // 5 minutes
   private static final long DEFAULT_RESOURCE_UTILIZATION_CHECKER_FREQUENCY = 300L; // 5 minutes
   private static final boolean DEFAULT_ENABLE_BATCH_MESSAGE_MODE = false;
-  private static final boolean DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY = false;
-  // Disallow any high level consumer (HLC) table
-  private static final boolean DEFAULT_ALLOW_HLC_TABLES = false;
   private static final String DEFAULT_CONTROLLER_MODE = ControllerMode.DUAL.name();
   private static final String DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY =
       AutoRebalanceStrategy.class.getName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/BrokerServiceHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/BrokerServiceHelper.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.core.routing.TimeBoundaryInfo;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Helper class for interacting with broker APIs.
+ */
+public class BrokerServiceHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServiceHelper.class);
+  private static final String TIME_BOUNDARY_INFO_API_PATH = "/debug/timeBoundary/%s";
+  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final ControllerConf _controllerConf;
+  private final Executor _executorService;
+  private final PoolingHttpClientConnectionManager _connectionManager;
+  private CompletionServiceHelper _completionServiceHelper;
+
+  public BrokerServiceHelper(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf controllerConf,
+      Executor executor, PoolingHttpClientConnectionManager connectionManager) {
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _controllerConf = controllerConf;
+    _executorService = executor;
+    _connectionManager = connectionManager;
+  }
+
+  @VisibleForTesting
+  // Set the CompletionServiceHelper for testing purposes.
+  public void setCompletionServiceHelper(CompletionServiceHelper completionServiceHelper) {
+    _completionServiceHelper = completionServiceHelper;
+  }
+
+  public BiMap<String, String> getBrokerEndpointsForInstance(List<InstanceConfig> instanceConfigs) {
+    String protocol = _controllerConf.getControllerBrokerProtocol();
+    BiMap<String, String> endpointsToInstances = HashBiMap.create(instanceConfigs.size());
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      String hostName = instanceConfig.getHostName();
+      if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
+        hostName = hostName.substring(CommonConstants.Helix.BROKER_INSTANCE_PREFIX_LENGTH);
+      }
+      int port =
+          _controllerConf.getControllerBrokerPortOverride() > 0 ? _controllerConf.getControllerBrokerPortOverride()
+              : Integer.parseInt(instanceConfig.getPort());
+      String brokerEndpoint = String.format("%s://%s:%d", protocol, hostName, port);
+      endpointsToInstances.put(brokerEndpoint, instanceConfig.getInstanceName());
+    }
+    return endpointsToInstances;
+  }
+
+  public TimeBoundaryInfo getTimeBoundaryInfo(TableConfig offlineTableConfig) {
+    String offlineTableName = offlineTableConfig.getTableName();
+
+    List<InstanceConfig> instanceConfigs = _pinotHelixResourceManager.getBrokerInstancesConfigsFor(offlineTableName);
+    BiMap<String, String> endpointsToInstances = getBrokerEndpointsForInstance(instanceConfigs);
+
+    CompletionServiceHelper completionServiceHelper;
+    if (_completionServiceHelper == null) {
+      completionServiceHelper = new CompletionServiceHelper(_executorService, _connectionManager, endpointsToInstances);
+    } else {
+      completionServiceHelper = _completionServiceHelper;
+    }
+
+    List<String> timeBoundaryInfoUris = new ArrayList<>(endpointsToInstances.size());
+    for (String endpoint : endpointsToInstances.keySet()) {
+      String timeBoundaryInfoUri = endpoint + String.format(TIME_BOUNDARY_INFO_API_PATH, offlineTableName);
+      timeBoundaryInfoUris.add(timeBoundaryInfoUri);
+    }
+    Map<String, String> reqHeaders = new HashMap<>();
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        completionServiceHelper.doMultiGetRequest(timeBoundaryInfoUris, offlineTableName, false, reqHeaders,
+            DEFAULT_REQUEST_TIMEOUT_MS, "get time boundary information for table from broker instances");
+    String responseKey = null;
+    String responseValue = null;
+    for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
+      try {
+        responseKey = streamResponse.getKey();
+        responseValue = streamResponse.getValue();
+        // return the first valid response
+        return JsonUtils.stringToObject(responseValue, TimeBoundaryInfo.class);
+      } catch (JsonProcessingException e) {
+        LOGGER.debug("Error parsing response into TimeBoundaryInfo object. key: {}, value: {}",
+            responseKey, responseValue, e);
+      }
+    }
+    throw new RuntimeException(String.format("Error parsing response into TimeBoundaryInfo object. key: %s, value: %s",
+        responseKey, responseValue));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.util.BrokerServiceHelper;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -64,8 +65,10 @@ public class SegmentLineageCleanupTest {
     ControllerConf controllerConf = new ControllerConf();
     controllerConf.setRetentionControllerFrequencyInSeconds(0);
     controllerConf.setDeletedSegmentsRetentionInDays(0);
+    BrokerServiceHelper brokerServiceHelper =
+        new BrokerServiceHelper(_resourceManager, controllerConf, null, null);
     _retentionManager = new RetentionManager(_resourceManager, mock(LeadControllerManager.class), controllerConf,
-        mock(ControllerMetrics.class));
+        mock(ControllerMetrics.class), brokerServiceHelper);
 
     // Create a schema
     TEST_INSTANCE.addDummySchema(TableNameBuilder.extractRawTableName(OFFLINE_TABLE_NAME));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/BrokerServiceHelperTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/BrokerServiceHelperTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.google.common.collect.BiMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.core.routing.TimeBoundaryInfo;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class BrokerServiceHelperTest {
+  @Test
+  public void testGetBrokerEndpointsForInstance() {
+    // setup
+    InstanceConfig instanceConfig = new InstanceConfig("Broker_localhost_1234");
+    instanceConfig.setHostName("localhost");
+    instanceConfig.setPort("8000");
+
+    ControllerConf controllerConf = new ControllerConf();
+    controllerConf.setControllerBrokerProtocol("http");
+    PinotHelixResourceManager mockResourceManager = mock(PinotHelixResourceManager.class);
+    BrokerServiceHelper brokerServiceHelper =
+        new BrokerServiceHelper(mockResourceManager, controllerConf, null, null);
+
+    // test
+    BiMap<String, String> brokerEndpoints =
+        brokerServiceHelper.getBrokerEndpointsForInstance(Collections.singletonList(instanceConfig));
+
+    // verify
+    assertEquals(brokerEndpoints.size(), 1);
+    assertEquals(brokerEndpoints.get("http://localhost:8000"), "Broker_localhost_1234");
+  }
+
+  @Test
+  public void testGetTimeBoundaryInfo() {
+    // setup
+    InstanceConfig instanceConfig = new InstanceConfig("Broker_localhost_1234");
+    instanceConfig.setHostName("localhost");
+    instanceConfig.setPort("8000");
+
+    ControllerConf controllerConf = new ControllerConf();
+
+    String offlineTableName = "myTable_OFFLINE";
+    TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(offlineTableName).build();
+
+    PinotHelixResourceManager mockResourceManager = mock(PinotHelixResourceManager.class);
+    when(mockResourceManager.getBrokerInstancesConfigsFor(offlineTableConfig.getTableName()))
+        .thenReturn(Collections.singletonList(instanceConfig));
+
+    CompletionServiceHelper mockServiceHelper = mock(CompletionServiceHelper.class);
+
+    // Mock responses
+    Map<String, String> responseMap = new HashMap<>();
+    responseMap.put("http://localhost:8000/debug/timeBoundary/" + offlineTableName,
+        "{ \"timeColumn\": \"daysSinceEpoch\", \"timeValue\": 16000}");
+
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        new CompletionServiceHelper.CompletionServiceResponse();
+    serviceResponse._httpResponses = responseMap;
+
+    when(mockServiceHelper.doMultiGetRequest(anyList(), anyString(), anyBoolean(), anyMap(), anyInt(), anyString()))
+        .thenReturn(serviceResponse);
+
+    // test
+    BrokerServiceHelper brokerServiceHelper =
+        new BrokerServiceHelper(mockResourceManager, controllerConf, null, null);
+    brokerServiceHelper.setCompletionServiceHelper(mockServiceHelper);
+    TimeBoundaryInfo timeBoundaryInfo = brokerServiceHelper.getTimeBoundaryInfo(offlineTableConfig);
+
+    // verify
+    assertNotNull(timeBoundaryInfo);
+    assertNotNull(timeBoundaryInfo.getTimeColumn());
+    assertNotNull(timeBoundaryInfo.getTimeValue());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/TimeBoundaryInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/TimeBoundaryInfo.java
@@ -18,11 +18,16 @@
  */
 package org.apache.pinot.core.routing;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
 public class TimeBoundaryInfo {
   private final String _timeColumn;
   private final String _timeValue;
 
-  public TimeBoundaryInfo(String timeColumn, String timeValue) {
+  @JsonCreator
+  public TimeBoundaryInfo(@JsonProperty("timeColumn") String timeColumn, @JsonProperty("timeValue") String timeValue) {
     _timeColumn = timeColumn;
     _timeValue = timeValue;
   }


### PR DESCRIPTION
## Problem
Previously, RetentionManager would delete segments past retention period from a REALTIME table when the REALTIME table is part of a hybrid table setup. At times this resulted in prematurely deleting segments before the RTO task got a chance to move the segments to the OFFLINE table which resulted in data loss.

## Solution
The changes in this PR makes the RetentionManager hybrid table aware. RetentionManager behavior is enhanced such that segments from a hybrid REALTIME table are eligible for deletion when the segment is older than the hybrid table time boundary. 

## Config
Introduced the feature flag `controller.enable.hybrid.table.retention.strategy` which controls the new behavior. By default, the feature is disabled.

### Testing
Tested E2E in a test cluster
```
2025/03/14 01:49:47.271 INFO [BasePeriodicTask] [pool-20-thread-1] [TaskRequestId: api-301a2a5b] Start running task: RetentionManager
2025/03/14 01:49:47.271 INFO [ControllerPeriodicTask] [pool-20-thread-1] Processing 1 tables in task: RetentionManager
2025/03/14 01:49:47.272 INFO [RetentionManager] [pool-20-thread-1] Start managing retention for table: gitStream001_REALTIME
2025/03/14 01:49:47.277 INFO [RetentionManager] [pool-20-thread-1] Managing retention for hybrid table: gitStream001_REALTIME
2025/03/14 01:49:47.285 INFO [RetentionManager] [pool-20-thread-1] Deleting 1 segments from table: gitStream001_REALTIME
2025/03/14 01:49:47.298 INFO [RetentionManager] [pool-20-thread-1] Segment lineage metadata clean-up is successfully processed for table: gitStream001_REALTIME
2025/03/14 01:49:47.298 INFO [RetentionManager] [pool-20-thread-1] Removing aged deleted segments for all tables
2025/03/14 01:49:47.378 INFO [ControllerPeriodicTask] [pool-20-thread-1] Finish processing 1/1 tables in task: RetentionManager

```