### PR TITLE
Initialize OOM protection in GrpcQueryServer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -57,6 +57,7 @@ import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.server.access.GrpcRequesterIdentity;
+import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,6 +178,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Bad request").withCause(e).asException());
       return;
     }
+
+    Tracing.ThreadAccountantOps.setupRunner(queryRequest.getQueryId());
 
     // Table level access control
     GrpcRequesterIdentity requestIdentity = new GrpcRequesterIdentity(request.getMetadataMap());

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/grpc/GrpcQueryServerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/grpc/GrpcQueryServerTest.java
@@ -1,0 +1,69 @@
+package org.apache.pinot.core.transport.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.pinot.common.config.GrpcConfig;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.server.access.AccessControl;
+import org.apache.pinot.spi.trace.Tracing;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class GrpcQueryServerTest {
+    private GrpcQueryServer _grpcQueryServer;
+    @Mock private QueryExecutor _queryExecutor;
+    @Mock private ServerMetrics _serverMetrics;
+    @Mock private AccessControl _accessControl;
+    @Mock private StreamObserver<Server.ServerResponse> _responseObserver;
+    @Mock private GrpcConfig _grpcConfig;
+
+    @BeforeMethod
+    public void setUp() {
+        _queryExecutor = mock(QueryExecutor.class);
+        _serverMetrics = mock(ServerMetrics.class);
+        _accessControl = mock(AccessControl.class);
+        _responseObserver = mock(StreamObserver.class);
+        _grpcConfig = mock(GrpcConfig.class);
+
+        _grpcQueryServer = new GrpcQueryServer(1234, _grpcConfig, null,
+                _queryExecutor, _serverMetrics, _accessControl);
+        _grpcQueryServer.start();
+    }
+
+    @Test
+    public void testEnsureGrpcQueryProcessingInitializesTracingContext() {
+        // Arrange
+        InstanceResponseBlock mockedInstanceResponseBlock = mock(InstanceResponseBlock.class);
+        doNothing().when(_serverMetrics).addMeteredGlobalValue(any(), anyLong());
+        when(_accessControl.hasDataAccess(any(), any())).thenReturn(false);
+        when(_queryExecutor.execute(any(), any(), any())).thenReturn(mockedInstanceResponseBlock);
+
+        Server.ServerRequest serverRequest = Server.ServerRequest
+                .newBuilder()
+                .setSql("SELECT x FROM myTable")
+                .build();
+
+        try (MockedStatic<Tracing.ThreadAccountantOps> mockedStatic =
+                     mockStatic(Tracing.ThreadAccountantOps.class)) {
+            // Act
+            _grpcQueryServer.submit(serverRequest, _responseObserver);
+
+            // Assert: ThreadAccountantOps.setupRunner() was called once.
+            mockedStatic.verify(() -> Tracing.ThreadAccountantOps.setupRunner(anyString()), times(1));
+        }
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        _grpcQueryServer.shutdown();
+    }
+}


### PR DESCRIPTION
## Description

When OOM is enabled, the grpc streming queries always return 0 rows.   This issue has been observered with spark connector as well as trino connector (reported by another user).

```py
from pyspark.sql.functions import col

cutoff_seconds_since_spoch = 1741169418

df = spark \
    .read \
    .format("pinot") \
    .option("controller", "<host>:<port>") \
    .option("table", "<table>") \
    .option("useGrpcServer", "true") \
    .option("tableType", "REALTIME") \
    .option("segmentsPerSplit", 1) \
    .load() \
    .filter(col("secondsSinceEpoch") >= cutoff_seconds_since_spoch)

print("Number of rows: " + str(df.count())) 
```
<img width="358" alt="image" src="https://github.com/user-attachments/assets/ba264900-0b35-4fd3-9f82-c8d99d1402db" />

### Observation: 
- Number of rows return is always zero if OOM is enabled on server tenant
- After disabling OOM, the grpc streaming query works fine.
- After disabling `useGrpcServer` option, the query works fine with http transport.



## Solution
This PR fixes the issue by initialising the missing tracing context for OOM protection.