### PR TITLE
Add Tenants Info to Rebalance API summary

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -40,7 +40,7 @@ public class RebalanceSummaryResult {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final SegmentInfo _segmentInfo;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final List<TagsInfo> _tagsInfos;
+  private final List<TagInfo> _tagsInfo;
 
   /**
    * Constructor for RebalanceSummaryResult
@@ -50,10 +50,10 @@ public class RebalanceSummaryResult {
   @JsonCreator
   public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
       @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo,
-      @JsonProperty("tagsInfo") @Nullable List<TagsInfo> tagsInfo) {
+      @JsonProperty("tagsInfo") @Nullable List<TagInfo> tagsInfo) {
     _serverInfo = serverInfo;
     _segmentInfo = segmentInfo;
-    _tagsInfos = tagsInfo;
+    _tagsInfo = tagsInfo;
   }
 
   @JsonProperty
@@ -67,8 +67,8 @@ public class RebalanceSummaryResult {
   }
 
   @JsonProperty
-  public List<TagsInfo> getTagsInfos() {
-    return _tagsInfos;
+  public List<TagInfo> getTagsInfo() {
+    return _tagsInfo;
   }
 
   public static class ServerSegmentChangeInfo {
@@ -170,7 +170,7 @@ public class RebalanceSummaryResult {
     }
   }
 
-  public static class TagsInfo {
+  public static class TagInfo {
     public static final String TAGS_NOT_TAGGED_WITH_TABLE = "OUTDATED_SERVERS";
     private final String _tagName;
     private int _numSegmentsUnchanged;
@@ -178,7 +178,7 @@ public class RebalanceSummaryResult {
     private int _numServerParticipants;
 
     @JsonCreator
-    public TagsInfo(
+    public TagInfo(
         @JsonProperty("tagName") String tagName,
         @JsonProperty("numSegmentsToDownload") int numSegmentsToDownload,
         @JsonProperty("numSegmentsUnchanged") int numSegmentsUnchanged,
@@ -190,7 +190,7 @@ public class RebalanceSummaryResult {
       _numServerParticipants = numServerParticipants;
     }
 
-    public TagsInfo(String tagName) {
+    public TagInfo(String tagName) {
       this(tagName, 0, 0, 0);
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -171,6 +171,7 @@ public class RebalanceSummaryResult {
   }
 
   public static class TenantInfo {
+    public static final String TENANT_NOT_TAGGED_WITH_TABLE = "OUTDATED_SERVERS";
     private final String _tenantName;
     private int _numSegmentsUnchanged;
     private int _numSegmentsToDownload;
@@ -189,7 +190,7 @@ public class RebalanceSummaryResult {
       _numServerParticipants = numServerParticipants;
     }
 
-    public TenantInfo(String tenantName, List<String> usedAsTier) {
+    public TenantInfo(String tenantName) {
       this(tenantName, 0, 0, 0);
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -40,7 +40,7 @@ public class RebalanceSummaryResult {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final SegmentInfo _segmentInfo;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final List<TenantInfo> _tenantsInfo;
+  private final List<TagsInfo> _tagsInfos;
 
   /**
    * Constructor for RebalanceSummaryResult
@@ -50,10 +50,10 @@ public class RebalanceSummaryResult {
   @JsonCreator
   public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
       @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo,
-      @JsonProperty("tenantsInfo") @Nullable List<TenantInfo> tenantsInfo) {
+      @JsonProperty("tagsInfo") @Nullable List<TagsInfo> tagsInfo) {
     _serverInfo = serverInfo;
     _segmentInfo = segmentInfo;
-    _tenantsInfo = tenantsInfo;
+    _tagsInfos = tagsInfo;
   }
 
   @JsonProperty
@@ -67,8 +67,8 @@ public class RebalanceSummaryResult {
   }
 
   @JsonProperty
-  public List<TenantInfo> getTenantsInfo() {
-    return _tenantsInfo;
+  public List<TagsInfo> getTagsInfos() {
+    return _tagsInfos;
   }
 
   public static class ServerSegmentChangeInfo {
@@ -170,33 +170,33 @@ public class RebalanceSummaryResult {
     }
   }
 
-  public static class TenantInfo {
-    public static final String TENANT_NOT_TAGGED_WITH_TABLE = "OUTDATED_SERVERS";
-    private final String _tenantName;
+  public static class TagsInfo {
+    public static final String TAGS_NOT_TAGGED_WITH_TABLE = "OUTDATED_SERVERS";
+    private final String _tagName;
     private int _numSegmentsUnchanged;
     private int _numSegmentsToDownload;
     private int _numServerParticipants;
 
     @JsonCreator
-    public TenantInfo(
-        @JsonProperty("tenantName") String tenantName,
+    public TagsInfo(
+        @JsonProperty("tagName") String tagName,
         @JsonProperty("numSegmentsToDownload") int numSegmentsToDownload,
         @JsonProperty("numSegmentsUnchanged") int numSegmentsUnchanged,
         @JsonProperty("numServerParticipants") int numServerParticipants
     ) {
-      _tenantName = tenantName;
+      _tagName = tagName;
       _numSegmentsUnchanged = numSegmentsUnchanged;
       _numSegmentsToDownload = numSegmentsToDownload;
       _numServerParticipants = numServerParticipants;
     }
 
-    public TenantInfo(String tenantName) {
-      this(tenantName, 0, 0, 0);
+    public TagsInfo(String tagName) {
+      this(tagName, 0, 0, 0);
     }
 
     @JsonProperty
-    public String getTenantName() {
-      return _tenantName;
+    public String getTagName() {
+      return _tagName;
     }
 
     @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -49,7 +49,8 @@ public class RebalanceSummaryResult {
    */
   @JsonCreator
   public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
-      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo, @JsonProperty("tenantsInfo") @Nullable List<TenantInfo> tenantsInfo) {
+      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo,
+      @JsonProperty("tenantsInfo") @Nullable List<TenantInfo> tenantsInfo) {
     _serverInfo = serverInfo;
     _segmentInfo = segmentInfo;
     _tenantsInfo = tenantsInfo;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -173,19 +173,19 @@ public class RebalanceSummaryResult {
   public static class TenantInfo {
     private final String _tenantName;
     private int _numSegmentsUnchanged;
-    private int _numSegmentsReceived;
+    private int _numSegmentsToDownload;
     private int _numServerParticipants;
 
     @JsonCreator
     public TenantInfo(
         @JsonProperty("tenantName") String tenantName,
-        @JsonProperty("numSegmentsReceived") int numSegmentsReceived,
+        @JsonProperty("numSegmentsToDownload") int numSegmentsToDownload,
         @JsonProperty("numSegmentsUnchanged") int numSegmentsUnchanged,
         @JsonProperty("numServerParticipants") int numServerParticipants
     ) {
       _tenantName = tenantName;
       _numSegmentsUnchanged = numSegmentsUnchanged;
-      _numSegmentsReceived = numSegmentsReceived;
+      _numSegmentsToDownload = numSegmentsToDownload;
       _numServerParticipants = numServerParticipants;
     }
 
@@ -204,8 +204,8 @@ public class RebalanceSummaryResult {
     }
 
     @JsonProperty
-    public int getNumSegmentsReceived() {
-      return _numSegmentsReceived;
+    public int getNumSegmentsToDownload() {
+      return _numSegmentsToDownload;
     }
 
     @JsonProperty
@@ -217,8 +217,8 @@ public class RebalanceSummaryResult {
       _numSegmentsUnchanged += numSegments;
     }
 
-    public void increaseNumSegmentsReceived(int numSegments) {
-      _numSegmentsReceived += numSegments;
+    public void increaseNumSegmentsToDownload(int numSegments) {
+      _numSegmentsToDownload += numSegments;
     }
 
     public void increaseNumServerParticipants(int numServers) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -39,6 +39,8 @@ public class RebalanceSummaryResult {
   private final ServerInfo _serverInfo;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final SegmentInfo _segmentInfo;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final List<TenantInfo> _tenantsInfo;
 
   /**
    * Constructor for RebalanceSummaryResult
@@ -47,9 +49,10 @@ public class RebalanceSummaryResult {
    */
   @JsonCreator
   public RebalanceSummaryResult(@JsonProperty("serverInfo") @Nullable ServerInfo serverInfo,
-      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo) {
+      @JsonProperty("segmentInfo") @Nullable SegmentInfo segmentInfo, @JsonProperty("tenantsInfo") @Nullable List<TenantInfo> tenantsInfo) {
     _serverInfo = serverInfo;
     _segmentInfo = segmentInfo;
+    _tenantsInfo = tenantsInfo;
   }
 
   @JsonProperty
@@ -60,6 +63,11 @@ public class RebalanceSummaryResult {
   @JsonProperty
   public SegmentInfo getSegmentInfo() {
     return _segmentInfo;
+  }
+
+  @JsonProperty
+  public List<TenantInfo> getTenantsInfo() {
+    return _tenantsInfo;
   }
 
   public static class ServerSegmentChangeInfo {
@@ -158,6 +166,62 @@ public class RebalanceSummaryResult {
     @JsonProperty
     public int getExpectedValueAfterRebalance() {
       return _expectedValueAfterRebalance;
+    }
+  }
+
+  public static class TenantInfo {
+    private final String _tenantName;
+    private int _numSegmentsUnchanged;
+    private int _numSegmentsReceived;
+    private int _numServersParticipants;
+
+    @JsonCreator
+    public TenantInfo(
+        @JsonProperty("tenantName") String tenantName,
+        @JsonProperty("numSegmentsReceived") int numSegmentsReceived,
+        @JsonProperty("numSegmentsUnchanged") int numSegmentsUnchanged,
+        @JsonProperty("numServerParticipants") int numServersParticipants
+    ) {
+      _tenantName = tenantName;
+      _numSegmentsUnchanged = numSegmentsUnchanged;
+      _numSegmentsReceived = numSegmentsReceived;
+      _numServersParticipants = numServersParticipants;
+    }
+
+    public TenantInfo(String tenantName, List<String> usedAsTier) {
+      this(tenantName, 0, 0, 0);
+    }
+
+    @JsonProperty
+    public String getTenantName() {
+      return _tenantName;
+    }
+
+    @JsonProperty
+    public int getNumSegmentsUnchanged() {
+      return _numSegmentsUnchanged;
+    }
+
+    @JsonProperty
+    public int getNumSegmentsReceived() {
+      return _numSegmentsReceived;
+    }
+
+    @JsonProperty
+    public int getNumServersParticipants() {
+      return _numServersParticipants;
+    }
+
+    public void increaseNumSegmentsUnchanged(int numSegments) {
+      _numSegmentsUnchanged += numSegments;
+    }
+
+    public void increaseNumSegmentsReceived(int numSegments) {
+      _numSegmentsReceived += numSegments;
+    }
+
+    public void increaseNumServersParticipants(int numServers) {
+      _numServersParticipants += numServers;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -174,19 +174,19 @@ public class RebalanceSummaryResult {
     private final String _tenantName;
     private int _numSegmentsUnchanged;
     private int _numSegmentsReceived;
-    private int _numServersParticipants;
+    private int _numServerParticipants;
 
     @JsonCreator
     public TenantInfo(
         @JsonProperty("tenantName") String tenantName,
         @JsonProperty("numSegmentsReceived") int numSegmentsReceived,
         @JsonProperty("numSegmentsUnchanged") int numSegmentsUnchanged,
-        @JsonProperty("numServerParticipants") int numServersParticipants
+        @JsonProperty("numServerParticipants") int numServerParticipants
     ) {
       _tenantName = tenantName;
       _numSegmentsUnchanged = numSegmentsUnchanged;
       _numSegmentsReceived = numSegmentsReceived;
-      _numServersParticipants = numServersParticipants;
+      _numServerParticipants = numServerParticipants;
     }
 
     public TenantInfo(String tenantName, List<String> usedAsTier) {
@@ -209,8 +209,8 @@ public class RebalanceSummaryResult {
     }
 
     @JsonProperty
-    public int getNumServersParticipants() {
-      return _numServersParticipants;
+    public int getNumServerParticipants() {
+      return _numServerParticipants;
     }
 
     public void increaseNumSegmentsUnchanged(int numSegments) {
@@ -221,8 +221,8 @@ public class RebalanceSummaryResult {
       _numSegmentsReceived += numSegments;
     }
 
-    public void increaseNumServersParticipants(int numServers) {
-      _numServersParticipants += numServers;
+    public void increaseNumServerParticipants(int numServers) {
+      _numServerParticipants += numServers;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -171,7 +171,7 @@ public class RebalanceSummaryResult {
   }
 
   public static class TagInfo {
-    public static final String TAGS_NOT_TAGGED_WITH_TABLE = "OUTDATED_SERVERS";
+    public static final String TAG_FOR_OUTDATED_SERVERS = "OUTDATED_SERVERS";
     private final String _tagName;
     private int _numSegmentsUnchanged;
     private int _numSegmentsToDownload;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -671,6 +671,15 @@ public class TableRebalancer {
       tagsInfoMap.put(serverTenantTag,
           new RebalanceSummaryResult.TagsInfo(serverTenantTag));
     }
+    if (tableConfig.getInstanceAssignmentConfigMap() != null) {
+      // for simplicity, including all segment types present in instanceAssignmentConfigMap
+      tableConfig.getInstanceAssignmentConfigMap().values().forEach(instanceAssignmentConfig -> {
+        if (instanceAssignmentConfig.getTagPoolConfig().isPoolBased()) {
+          String tag = instanceAssignmentConfig.getTagPoolConfig().getTag();
+          tagsInfoMap.put(tag, new RebalanceSummaryResult.TagsInfo(tag));
+        }
+      });
+    }
     if (tableConfig.getTierConfigsList() != null) {
       tableConfig.getTierConfigsList().forEach(tierConfig -> {
         String tierTag = tierConfig.getServerTag();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -724,7 +724,7 @@ public class TableRebalancer {
         RebalanceSummaryResult.TenantInfo tenantInfo = tenantInfoEntry.getValue();
         if (serverTags.contains(tenantNameWithType)) {
           tenantInfo.increaseNumSegmentsUnchanged(segmentsUnchanged);
-          tenantInfo.increaseNumSegmentsReceived(segmentsAdded);
+          tenantInfo.increaseNumSegmentsToDownload(segmentsAdded);
           tenantInfo.increaseNumServerParticipants(1);
         }
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.ToIntFunction;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -70,7 +69,6 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
-import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -670,7 +668,8 @@ public class TableRebalancer {
     String serverTenantName = tableConfig.getTenantConfig().getServer();
     if (serverTenantName != null) {
       String serverTenantNameWithType = tenantNameBuilder.tableNameWithType(serverTenantName);
-      tenantInfoMap.put(serverTenantNameWithType, new RebalanceSummaryResult.TenantInfo(serverTenantNameWithType, null));
+      tenantInfoMap.put(serverTenantNameWithType,
+          new RebalanceSummaryResult.TenantInfo(serverTenantNameWithType, null));
     }
     if (tableConfig.getTierConfigsList() != null) {
       tableConfig.getTierConfigsList().forEach(tierConfig -> {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -725,7 +725,7 @@ public class TableRebalancer {
         if (serverTags.contains(tenantNameWithType)) {
           tenantInfo.increaseNumSegmentsUnchanged(segmentsUnchanged);
           tenantInfo.increaseNumSegmentsReceived(segmentsAdded);
-          tenantInfo.increaseNumServersParticipants(1);
+          tenantInfo.increaseNumServerParticipants(1);
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -718,7 +718,13 @@ public class TableRebalancer {
       // Since this is a server in the target assignment, it should contain at least one tag of the tenant or tier
       // server tag. Note that if the server is tagged with multiple tenant or tier tags that are used in the table
       // config, we will count it multiple times, i.e. the total segment count would not add up to the actual total.
-      assert serverTags != null;
+      if (serverTags.isEmpty()) {
+        LOGGER.warn(
+            "Server: {} was assigned to table: {} but does not have any tags. Race condition might happen during the "
+                + "instance assignment.",
+            server, tableNameWithType);
+        continue;
+      }
       for (Map.Entry<String, RebalanceSummaryResult.TenantInfo> tenantInfoEntry : tenantInfoMap.entrySet()) {
         String tenantNameWithType = tenantInfoEntry.getKey();
         RebalanceSummaryResult.TenantInfo tenantInfo = tenantInfoEntry.getValue();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -739,6 +739,7 @@ public class TableRebalancer {
       // The segments remain unchanged or need to download will be accounted to every tag associated with this
       // server instance
       if (relevantTags.isEmpty()) {
+        // this could happen when server's tags changed but reassignInstance=false in the rebalance config
         LOGGER.warn("Server: {} was assigned to table: {} but does not have any relevant tags", server,
             tableNameWithType);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -721,7 +721,7 @@ public class TableRebalancer {
       if (serverTags.isEmpty()) {
         LOGGER.warn(
             "Server: {} was assigned to table: {} but does not have any tags. Race condition might happen during the "
-                + "instance assignment.",
+                + "instance assignment. This could make the tenantInfo in rebalance summary inconsistent.",
             server, tableNameWithType);
         continue;
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -686,10 +686,8 @@ public class TableRebalancer {
     if (tableConfig.getInstanceAssignmentConfigMap() != null) {
       // for simplicity, including all segment types present in instanceAssignmentConfigMap
       tableConfig.getInstanceAssignmentConfigMap().values().forEach(instanceAssignmentConfig -> {
-        if (instanceAssignmentConfig.getTagPoolConfig().isPoolBased()) {
-          String tag = instanceAssignmentConfig.getTagPoolConfig().getTag();
-          tagsInfoMap.put(tag, new RebalanceSummaryResult.TagInfo(tag));
-        }
+        String tag = instanceAssignmentConfig.getTagPoolConfig().getTag();
+        tagsInfoMap.put(tag, new RebalanceSummaryResult.TagInfo(tag));
       });
     }
     if (tableConfig.getTierConfigsList() != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -663,27 +663,27 @@ public class TableRebalancer {
     Set<String> serversRemoved = new HashSet<>();
     Set<String> serversUnchanged = new HashSet<>();
     Set<String> serversGettingNewSegments = new HashSet<>();
-    Map<String, RebalanceSummaryResult.TagsInfo> tagsInfoMap = new HashMap<>();
+    Map<String, RebalanceSummaryResult.TagInfo> tagsInfoMap = new HashMap<>();
     String serverTenantName = tableConfig.getTenantConfig().getServer();
     if (serverTenantName != null) {
       String serverTenantTag =
           TagNameUtils.getServerTagForTenant(serverTenantName, tableConfig.getTableType());
       tagsInfoMap.put(serverTenantTag,
-          new RebalanceSummaryResult.TagsInfo(serverTenantTag));
+          new RebalanceSummaryResult.TagInfo(serverTenantTag));
     }
     if (tableConfig.getInstanceAssignmentConfigMap() != null) {
       // for simplicity, including all segment types present in instanceAssignmentConfigMap
       tableConfig.getInstanceAssignmentConfigMap().values().forEach(instanceAssignmentConfig -> {
         if (instanceAssignmentConfig.getTagPoolConfig().isPoolBased()) {
           String tag = instanceAssignmentConfig.getTagPoolConfig().getTag();
-          tagsInfoMap.put(tag, new RebalanceSummaryResult.TagsInfo(tag));
+          tagsInfoMap.put(tag, new RebalanceSummaryResult.TagInfo(tag));
         }
       });
     }
     if (tableConfig.getTierConfigsList() != null) {
       tableConfig.getTierConfigsList().forEach(tierConfig -> {
         String tierTag = tierConfig.getServerTag();
-        tagsInfoMap.put(tierTag, new RebalanceSummaryResult.TagsInfo(tierTag));
+        tagsInfoMap.put(tierTag, new RebalanceSummaryResult.TagInfo(tierTag));
       });
     }
     Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> serverSegmentChangeInfoMap = new HashMap<>();
@@ -732,15 +732,15 @@ public class TableRebalancer {
         LOGGER.warn("Server: {} was assigned to table: {} but does not have any relevant tags", server,
             tableNameWithType);
 
-        RebalanceSummaryResult.TagsInfo tagsInfo =
-            tagsInfoMap.computeIfAbsent(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE,
-                RebalanceSummaryResult.TagsInfo::new);
+        RebalanceSummaryResult.TagInfo tagsInfo =
+            tagsInfoMap.computeIfAbsent(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE,
+                RebalanceSummaryResult.TagInfo::new);
         tagsInfo.increaseNumSegmentsUnchanged(segmentsUnchanged);
         tagsInfo.increaseNumSegmentsToDownload(segmentsAdded);
         tagsInfo.increaseNumServerParticipants(1);
       }
       for (String tag : relevantTags) {
-        RebalanceSummaryResult.TagsInfo tagsInfo = tagsInfoMap.get(tag);
+        RebalanceSummaryResult.TagInfo tagsInfo = tagsInfoMap.get(tag);
         tagsInfo.increaseNumSegmentsUnchanged(segmentsUnchanged);
         tagsInfo.increaseNumSegmentsToDownload(segmentsAdded);
         tagsInfo.increaseNumServerParticipants(1);

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerRebalanceSummaryResponse.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerRebalanceSummaryResponse.tsx
@@ -34,8 +34,8 @@ export const RebalanceServerRebalanceSummaryResponse = ({ response }) => {
             key: 'segmentInfo'
         },
         {
-            name: 'III. Tenant Information',
-            key: 'tenantsInfo'
+            name: 'III. Server Tags Information',
+            key: 'tagsInfo'
         }
     ];
 

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerRebalanceSummaryResponse.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerRebalanceSummaryResponse.tsx
@@ -32,6 +32,10 @@ export const RebalanceServerRebalanceSummaryResponse = ({ response }) => {
         {
             name: 'II. Segment Information',
             key: 'segmentInfo'
+        },
+        {
+            name: 'III. Tenant Information',
+            key: 'tenantsInfo'
         }
     ];
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -1186,8 +1186,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
-    assertTrue(tenantInfoMap.containsKey(
-        TagNameUtils.getOfflineTagForTenant(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE)));
+    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
         .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1203,16 +1202,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         .getNumSegmentsUnchanged(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumServerParticipants(), 0);
-    assertEquals(tenantInfoMap.get(
-                TagNameUtils.getOfflineTagForTenant(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE))
-            .getNumSegmentsToDownload(),
+    assertEquals(
+        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
         0);
-    assertEquals(tenantInfoMap.get(
-            TagNameUtils.getOfflineTagForTenant(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE))
-        .getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
-    assertEquals(tenantInfoMap.get(
-            TagNameUtils.getOfflineTagForTenant(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE))
-        .getNumServerParticipants(), 6);
+    assertEquals(
+        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(
+        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
+        6);
 
     _helixResourceManager.deleteOfflineTable(TIERED_TABLE_NAME);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -1186,7 +1186,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         .collect(Collectors.toMap(RebalanceSummaryResult.TagInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
-    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE));
+    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TagInfo.TAG_FOR_OUTDATED_SERVERS));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
         .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1203,13 +1203,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumServerParticipants(), 0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAG_FOR_OUTDATED_SERVERS).getNumSegmentsToDownload(),
         0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAG_FOR_OUTDATED_SERVERS).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAG_FOR_OUTDATED_SERVERS).getNumServerParticipants(),
         6);
 
     _helixResourceManager.deleteOfflineTable(TIERED_TABLE_NAME);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -158,7 +158,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         TagNameUtils.getOfflineTagForTenant(null));
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(), numServers);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(), numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -215,7 +215,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 14);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 14);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -388,7 +388,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 11);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 11);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -477,7 +477,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -511,7 +511,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -566,7 +566,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 15);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 15);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -781,7 +781,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -822,7 +822,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -869,16 +869,16 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsReceived(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsUnchanged(),
         5 * NUM_REPLICAS);
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumServersParticipants(),
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumServerParticipants(),
         numServers);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsReceived(),
         NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsUnchanged(), 0);
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumServersParticipants(), 3);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumServerParticipants(), 3);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsReceived(),
         4 * NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsUnchanged(), 0);
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumServersParticipants(), 3);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumServerParticipants(), 3);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -963,7 +963,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -1000,7 +1000,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -1043,7 +1043,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
             .getNumSegmentsUnchanged(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
-            .getNumServersParticipants(),
+            .getNumServerParticipants(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
             .getNumSegmentsReceived(),
@@ -1051,7 +1051,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumSegmentsUnchanged(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
-        .getNumServersParticipants(), 6);
+        .getNumServerParticipants(), 6);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -1104,7 +1104,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
             .getNumSegmentsUnchanged(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
-            .getNumServersParticipants(),
+            .getNumServerParticipants(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
             .getNumSegmentsReceived(),
@@ -1112,7 +1112,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS - 13);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
-        .getNumServersParticipants(), 6);
+        .getNumServerParticipants(), 6);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -152,13 +152,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(), numServers);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(), numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -208,14 +208,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 14);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 14);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 14);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -381,14 +381,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 11);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 11);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 11);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -470,14 +470,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -504,14 +504,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -559,14 +559,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 15);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 15);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 15);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -774,14 +774,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -815,14 +815,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -858,11 +858,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 9);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 3);
-    Map<String, RebalanceSummaryResult.TenantInfo> tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 3);
+    Map<String, RebalanceSummaryResult.TagsInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)));
@@ -956,14 +956,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -993,14 +993,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -1030,11 +1030,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 2);
-    Map<String, RebalanceSummaryResult.TenantInfo> tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 2);
+    Map<String, RebalanceSummaryResult.TagsInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1091,11 +1091,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 13);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 2);
-    tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 2);
+    tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1179,14 +1179,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 3);
-    tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+    assertNotNull(rebalanceSummaryResult.getTagsInfos());
+    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 3);
+    tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
-    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE));
+    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
         .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1203,13 +1203,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumServerParticipants(), 0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
         0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TenantInfo.TENANT_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
         6);
 
     _helixResourceManager.deleteOfflineTable(TIERED_TABLE_NAME);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -156,7 +156,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(), numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
@@ -212,7 +212,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 14);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 14);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 14);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -385,7 +385,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 11);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 11);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 11);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -474,7 +474,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -508,7 +508,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -563,7 +563,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 15);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 15);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 15);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -778,7 +778,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -819,7 +819,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -866,16 +866,16 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)));
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsReceived(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsUnchanged(),
         5 * NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumServerParticipants(),
         numServers);
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsReceived(),
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsToDownload(),
         NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsUnchanged(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumServerParticipants(), 3);
-    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsReceived(),
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsToDownload(),
         4 * NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsUnchanged(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumServerParticipants(), 3);
@@ -960,7 +960,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -997,7 +997,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload(), 0);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServerParticipants(),
@@ -1038,7 +1038,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
-        .getNumSegmentsReceived(), 0);
+        .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
             .getNumSegmentsUnchanged(),
         0);
@@ -1046,7 +1046,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
             .getNumServerParticipants(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
-            .getNumSegmentsReceived(),
+            .getNumSegmentsToDownload(),
         numSegments * NUM_REPLICAS);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumSegmentsUnchanged(), 0);
@@ -1099,7 +1099,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
-        .getNumSegmentsReceived(), 0);
+        .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
             .getNumSegmentsUnchanged(),
         0);
@@ -1107,7 +1107,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
             .getNumServerParticipants(),
         0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
-            .getNumSegmentsReceived(),
+            .getNumSegmentsToDownload(),
         13);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS - 13);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -152,13 +152,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(), numServers);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(), numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -208,14 +208,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 14);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 14);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 14);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -381,14 +381,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 11);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 11);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 11);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -470,14 +470,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -504,14 +504,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -559,14 +559,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 15);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 15);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS - 15);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -774,14 +774,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -815,14 +815,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -858,11 +858,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 9);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 3);
-    Map<String, RebalanceSummaryResult.TagsInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 3);
+    Map<String, RebalanceSummaryResult.TagInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfo()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)));
@@ -956,14 +956,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -993,14 +993,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getTagName(),
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfos().get(0).getNumServerParticipants(),
+    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
         numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -1030,11 +1030,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 2);
-    Map<String, RebalanceSummaryResult.TagsInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 2);
+    Map<String, RebalanceSummaryResult.TagInfo> tenantInfoMap = rebalanceSummaryResult.getTagsInfo()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1091,11 +1091,11 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 13);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 2);
-    tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 2);
+    tenantInfoMap = rebalanceSummaryResult.getTagsInfo()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1179,14 +1179,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfos());
-    assertEquals(rebalanceSummaryResult.getTagsInfos().size(), 3);
-    tenantInfoMap = rebalanceSummaryResult.getTagsInfos()
+    assertNotNull(rebalanceSummaryResult.getTagsInfo());
+    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 3);
+    tenantInfoMap = rebalanceSummaryResult.getTagsInfo()
         .stream()
-        .collect(Collectors.toMap(RebalanceSummaryResult.TagsInfo::getTagName, info -> info));
+        .collect(Collectors.toMap(RebalanceSummaryResult.TagInfo::getTagName, info -> info));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
     assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
-    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE));
+    assertTrue(tenantInfoMap.containsKey(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE));
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
         .getNumSegmentsToDownload(), 0);
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
@@ -1203,13 +1203,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
         .getNumServerParticipants(), 0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsToDownload(),
         0);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumSegmentsUnchanged(),
         numSegments * NUM_REPLICAS);
     assertEquals(
-        tenantInfoMap.get(RebalanceSummaryResult.TagsInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
+        tenantInfoMap.get(RebalanceSummaryResult.TagInfo.TAGS_NOT_TAGGED_WITH_TABLE).getNumServerParticipants(),
         6);
 
     _helixResourceManager.deleteOfflineTable(TIERED_TABLE_NAME);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.restlet.resources.DiskUsageInfo;
@@ -151,6 +152,13 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(), numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -200,6 +208,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 14);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS - 14);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -364,6 +381,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 11);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS - 11);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -444,6 +470,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -469,6 +504,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers + numServersToAdd);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -515,6 +559,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(null));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 15);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS - 15);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -721,6 +774,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -753,6 +815,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -787,6 +858,27 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 9);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 3);
+    Map<String, RebalanceSummaryResult.TenantInfo> tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+        .stream()
+        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)));
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsReceived(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumSegmentsUnchanged(),
+        5 * NUM_REPLICAS);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(NO_TIER_NAME)).getNumServersParticipants(),
+        numServers);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsReceived(),
+        NUM_REPLICAS);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumSegmentsUnchanged(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_A_NAME)).getNumServersParticipants(), 3);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsReceived(),
+        4 * NUM_REPLICAS);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumSegmentsUnchanged(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant(TIER_B_NAME)).getNumServersParticipants(), 3);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -864,6 +956,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -892,6 +993,15 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 1);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME));
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsReceived(), 0);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().get(0).getNumServersParticipants(),
+        numServers);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
@@ -920,6 +1030,28 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 6);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 2);
+    Map<String, RebalanceSummaryResult.TenantInfo> tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+        .stream()
+        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+        .getNumSegmentsReceived(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+            .getNumSegmentsUnchanged(),
+        0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+            .getNumServersParticipants(),
+        0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+            .getNumSegmentsReceived(),
+        numSegments * NUM_REPLICAS);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+        .getNumSegmentsUnchanged(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+        .getNumServersParticipants(), 6);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
@@ -959,6 +1091,28 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 13);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+    assertNotNull(rebalanceSummaryResult.getTenantsInfo());
+    assertEquals(rebalanceSummaryResult.getTenantsInfo().size(), 2);
+    tenantInfoMap = rebalanceSummaryResult.getTenantsInfo()
+        .stream()
+        .collect(Collectors.toMap(RebalanceSummaryResult.TenantInfo::getTenantName, info -> info));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME)));
+    assertTrue(tenantInfoMap.containsKey(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME)));
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+        .getNumSegmentsReceived(), 0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+            .getNumSegmentsUnchanged(),
+        0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + NO_TIER_NAME))
+            .getNumServersParticipants(),
+        0);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+            .getNumSegmentsReceived(),
+        13);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+        .getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS - 13);
+    assertEquals(tenantInfoMap.get(TagNameUtils.getOfflineTagForTenant("replicaAssignment" + TIER_A_NAME))
+        .getNumServersParticipants(), 6);
     assertNotNull(rebalanceResult.getInstanceAssignment());
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -4237,13 +4237,13 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         TagNameUtils.getOfflineTagForTenant(getServerTenant()));
     assertEquals(summaryResult.getTenantsInfo().get(0).getNumServerParticipants(), newNumServers);
     assertEquals(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(),
-        summaryResult.getTenantsInfo().get(0).getNumSegmentsReceived());
+        summaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload());
     // For this single tenant, the number of unchanged segments and the number of received segments should add up to
     // the total present segment
     assertEquals(summaryResult.getSegmentInfo().getNumSegmentsAcrossAllReplicas().getExpectedValueAfterRebalance(),
         summaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged() + summaryResult.getTenantsInfo()
             .get(0)
-            .getNumSegmentsReceived());
+            .getNumSegmentsToDownload());
     if (_tableSize > 0) {
       assertTrue(summaryResult.getSegmentInfo().getEstimatedAverageSegmentSizeInBytes() > 0L,
           "Avg segment size expected to be > 0 but found to be 0");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -65,6 +65,7 @@ import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.api.resources.ServerRebalanceJobStatusResponse;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -4230,6 +4231,19 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "Existing number of servers don't match");
     assertEquals(summaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), newNumServers,
         "New number of servers don't match");
+    // In this cluster integration test, servers are tagged with DefaultTenant only
+    assertEquals(summaryResult.getTenantsInfo().size(), 1);
+    assertEquals(summaryResult.getTenantsInfo().get(0).getTenantName(),
+        TagNameUtils.getOfflineTagForTenant(getServerTenant()));
+    assertEquals(summaryResult.getTenantsInfo().get(0).getNumServerParticipants(), newNumServers);
+    assertEquals(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(),
+        summaryResult.getTenantsInfo().get(0).getNumSegmentsReceived());
+    // For this single tenant, the number of unchanged segments and the number of received segments should add up to
+    // the total present segment
+    assertEquals(summaryResult.getSegmentInfo().getNumSegmentsAcrossAllReplicas().getExpectedValueAfterRebalance(),
+        summaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged() + summaryResult.getTenantsInfo()
+            .get(0)
+            .getNumSegmentsReceived());
     if (_tableSize > 0) {
       assertTrue(summaryResult.getSegmentInfo().getEstimatedAverageSegmentSizeInBytes() > 0L,
           "Avg segment size expected to be > 0 but found to be 0");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -4232,16 +4232,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(summaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), newNumServers,
         "New number of servers don't match");
     // In this cluster integration test, servers are tagged with DefaultTenant only
-    assertEquals(summaryResult.getTenantsInfo().size(), 1);
-    assertEquals(summaryResult.getTenantsInfo().get(0).getTenantName(),
+    assertEquals(summaryResult.getTagsInfos().size(), 1);
+    assertEquals(summaryResult.getTagsInfos().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(getServerTenant()));
-    assertEquals(summaryResult.getTenantsInfo().get(0).getNumServerParticipants(), newNumServers);
+    assertEquals(summaryResult.getTagsInfos().get(0).getNumServerParticipants(), newNumServers);
     assertEquals(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(),
-        summaryResult.getTenantsInfo().get(0).getNumSegmentsToDownload());
+        summaryResult.getTagsInfos().get(0).getNumSegmentsToDownload());
     // For this single tenant, the number of unchanged segments and the number of received segments should add up to
     // the total present segment
     assertEquals(summaryResult.getSegmentInfo().getNumSegmentsAcrossAllReplicas().getExpectedValueAfterRebalance(),
-        summaryResult.getTenantsInfo().get(0).getNumSegmentsUnchanged() + summaryResult.getTenantsInfo()
+        summaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged() + summaryResult.getTagsInfos()
             .get(0)
             .getNumSegmentsToDownload());
     if (_tableSize > 0) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -4232,16 +4232,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(summaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), newNumServers,
         "New number of servers don't match");
     // In this cluster integration test, servers are tagged with DefaultTenant only
-    assertEquals(summaryResult.getTagsInfos().size(), 1);
-    assertEquals(summaryResult.getTagsInfos().get(0).getTagName(),
+    assertEquals(summaryResult.getTagsInfo().size(), 1);
+    assertEquals(summaryResult.getTagsInfo().get(0).getTagName(),
         TagNameUtils.getOfflineTagForTenant(getServerTenant()));
-    assertEquals(summaryResult.getTagsInfos().get(0).getNumServerParticipants(), newNumServers);
+    assertEquals(summaryResult.getTagsInfo().get(0).getNumServerParticipants(), newNumServers);
     assertEquals(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(),
-        summaryResult.getTagsInfos().get(0).getNumSegmentsToDownload());
+        summaryResult.getTagsInfo().get(0).getNumSegmentsToDownload());
     // For this single tenant, the number of unchanged segments and the number of received segments should add up to
     // the total present segment
     assertEquals(summaryResult.getSegmentInfo().getNumSegmentsAcrossAllReplicas().getExpectedValueAfterRebalance(),
-        summaryResult.getTagsInfos().get(0).getNumSegmentsUnchanged() + summaryResult.getTagsInfos()
+        summaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged() + summaryResult.getTagsInfo()
             .get(0)
             .getNumSegmentsToDownload());
     if (_tableSize > 0) {


### PR DESCRIPTION
## Description
For tier table rebalance, it's important to know how many segments are in effect in terms of tenants (usually equivalent to tiers) because the cost can then be assessed.

## Example
```
"rebalanceSummaryResult": {
    "serverInfo": {
      ...
    },
    "segmentInfo": {
      ...
    },
   "tenantsInfo": [
      {
        "tenantName": "DefaultTenant_OFFLINE",
        "numSegmentsReceived": 200,
        "numSegmentsUnchanged": 500,
        "numServersParticipants": 3
      },
      {
        "tenantName": "SSD_OFFLINE",
        "numSegmentsReceived": 0,
        "numSegmentsUnchanged": 200,
        "numServersParticipants": 3
      },
      {
        "tenantName": "HDD_OFFLINE",
        "numSegmentsReceived": 100,
        "numSegmentsUnchanged": 0,
        "numServersParticipants": 5
      }
    ]
```