### PR TITLE
Allows consumption during build for dedup/partial-upsert

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -53,6 +53,7 @@ import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -291,8 +292,9 @@ public class TableConfigSerDeTest {
       ingestionConfig.setBatchIngestionConfig(
           new BatchIngestionConfig(Collections.singletonList(Collections.singletonMap("batchType", "s3")), "APPEND",
               "HOURLY"));
-      ingestionConfig.setStreamIngestionConfig(
-          new StreamIngestionConfig(Collections.singletonList(Collections.singletonMap("streamType", "kafka"))));
+      StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(Collections.singletonMap("streamType", "kafka")));
+      streamIngestionConfig.setParallelSegmentConsumptionPolicy(ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY);
+      ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
       ingestionConfig.setFilterConfig(new FilterConfig("filterFunc(foo)"));
       ingestionConfig.setTransformConfigs(
           Arrays.asList(new TransformConfig("bar", "func(moo)"), new TransformConfig("zoo", "myfunc()")));
@@ -477,7 +479,8 @@ public class TableConfigSerDeTest {
     assertNotNull(ingestionConfig.getStreamIngestionConfig());
     assertNotNull(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps());
     assertEquals(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps().size(), 1);
-    assertEquals(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps().get(0).get("streamType"), "kafka");
+    assertEquals(ingestionConfig.getStreamIngestionConfig().getParallelSegmentConsumptionPolicy(),
+        ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY);
   }
 
   private void checkTierConfigList(TableConfig tableConfig) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -292,8 +292,10 @@ public class TableConfigSerDeTest {
       ingestionConfig.setBatchIngestionConfig(
           new BatchIngestionConfig(Collections.singletonList(Collections.singletonMap("batchType", "s3")), "APPEND",
               "HOURLY"));
-      StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(Collections.singletonMap("streamType", "kafka")));
-      streamIngestionConfig.setParallelSegmentConsumptionPolicy(ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY);
+      StreamIngestionConfig streamIngestionConfig =
+          new StreamIngestionConfig(Collections.singletonList(Collections.singletonMap("streamType", "kafka")));
+      streamIngestionConfig.setParallelSegmentConsumptionPolicy(
+          ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY);
       ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
       ingestionConfig.setFilterConfig(new FilterConfig("filterFunc(foo)"));
       ingestionConfig.setTransformConfigs(

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1683,7 +1683,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     // Acquire semaphore to create stream consumers
     try {
-      _partitionGroupConsumerSemaphore.tryAcquire(5, TimeUnit.MINUTES);
+      long startTimeMs = System.currentTimeMillis();
+      while (!_partitionGroupConsumerSemaphore.tryAcquire(5, TimeUnit.MINUTES)) {
+        _segmentLogger.warn("Failed to acquire partitionGroupConsumerSemaphore in: {} ms. Retrying.",
+            System.currentTimeMillis() - startTimeMs);
+      }
       _acquiredConsumerSemaphore.set(true);
     } catch (InterruptedException e) {
       String errorMsg = "InterruptedException when acquiring the partitionConsumerSemaphore";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1682,11 +1682,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     // Acquire semaphore to create stream consumers
     try {
-      long startTimeMs = System.currentTimeMillis();
-      while (!_partitionGroupConsumerSemaphore.tryAcquire(5, TimeUnit.MINUTES)) {
-        _segmentLogger.warn("Failed to acquire partitionGroupConsumerSemaphore in: {} ms. Retrying.",
-            System.currentTimeMillis() - startTimeMs);
-      }
+      _partitionGroupConsumerSemaphore.tryAcquire(5, TimeUnit.MINUTES);
       _acquiredConsumerSemaphore.set(true);
     } catch (InterruptedException e) {
       String errorMsg = "InterruptedException when acquiring the partitionConsumerSemaphore";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -79,7 +79,6 @@ import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentZKPropsConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy;
-import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.metrics.PinotMeter;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1459,9 +1459,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   protected void downloadSegmentAndReplace(SegmentZKMetadata segmentZKMetadata)
       throws Exception {
-    // for partial upsert and dedup tables, do not release _partitionGroupConsumerSemaphore proactively and rely on offload()
-    // to release the semaphore. This ensures new consuming segment is not consuming until the segment replacement is
-    // complete.
+    // for partial upsert and dedup tables, do not release _partitionGroupConsumerSemaphore proactively and rely on
+    // offload() to release the semaphore. This ensures new consuming segment is not consuming until the segment
+    // replacement is complete.
     if (_allowConsumptionDuringDownload) {
       closeStreamConsumers();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -74,10 +74,13 @@ import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.CompletionConfig;
+import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentZKPropsConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -330,7 +333,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final StreamPartitionMsgOffset _latestStreamOffsetAtStartupTime;
   private final CompletionMode _segmentCompletionMode;
   private final List<String> _filteredMessageOffsets = new ArrayList<>();
-  private boolean _trackFilteredMessageOffsets = false;
+  private final boolean _trackFilteredMessageOffsets;
   private final ParallelSegmentConsumptionPolicy _parallelSegmentConsumptionPolicy;
 
   // TODO each time this method is called, we print reason for stop. Good to print only once.
@@ -1073,8 +1076,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   @VisibleForTesting
   protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
-    if ((_parallelSegmentConsumptionPolicy == ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS) || (
-        _parallelSegmentConsumptionPolicy == ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY)) {
+    if (_parallelSegmentConsumptionPolicy.isAllowedDuringBuild()) {
       closeStreamConsumers();
     }
     // Do not allow building segment when table data manager is already shut down
@@ -1458,8 +1460,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   protected void downloadSegmentAndReplace(SegmentZKMetadata segmentZKMetadata)
       throws Exception {
-    if ((_parallelSegmentConsumptionPolicy == ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS) || (
-        _parallelSegmentConsumptionPolicy == ParallelSegmentConsumptionPolicy.ALLOW_DURING_DOWNLOAD_ONLY)) {
+    if (_parallelSegmentConsumptionPolicy.isAllowedDuringDownload()) {
       closeStreamConsumers();
     }
     _realtimeTableDataManager.downloadAndReplaceConsumingSegment(segmentZKMetadata);
@@ -1562,6 +1563,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _segmentCompletionMode = completionConfig != null
         && CompletionMode.DOWNLOAD.toString().equalsIgnoreCase(completionConfig.getCompletionMode())
         ? CompletionMode.DOWNLOAD : CompletionMode.DEFAULT;
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    _trackFilteredMessageOffsets = ingestionConfig != null && ingestionConfig.getStreamIngestionConfig() != null
+        && ingestionConfig.getStreamIngestionConfig().isTrackFilteredMessageOffsets();
+    _parallelSegmentConsumptionPolicy = getParallelConsumptionPolicy();
 
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
@@ -1604,12 +1609,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _partitionRateLimiter = RealtimeConsumptionRateManager.getInstance()
         .createRateLimiter(_streamConfig, _tableNameWithType, _serverMetrics, _clientId);
     _serverRateLimiter = RealtimeConsumptionRateManager.getInstance().getServerRateLimiter();
-
-    if (tableConfig.getIngestionConfig() != null
-        && tableConfig.getIngestionConfig().getStreamIngestionConfig() != null) {
-      _trackFilteredMessageOffsets =
-          tableConfig.getIngestionConfig().getStreamIngestionConfig().isTrackFilteredMessageOffsets();
-    }
 
     // Read the max number of rows
     int segmentMaxRowCount = segmentZKMetadata.getSizeThresholdToFlushSegment();
@@ -1711,7 +1710,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           new SegmentCommitterFactory(_segmentLogger, _protocolHandler, tableConfig, indexLoadingConfig, serverMetrics);
       _segmentLogger.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}",
           llcSegmentName, _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
-      _parallelSegmentConsumptionPolicy = getParallelConsumptionPolicy();
     } catch (Throwable t) {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
@@ -1746,33 +1744,44 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
-  // Consumption while downloading and replacing the slow replicas is not allowed for the following tables:
-  // 1. Partial Upserts
-  // 2. Dedup Tables
-  // For the above table types, we would be looking into the metadata information when inserting a new record,
-  // so it is not right to allow consumption while downloading and replacing the consuming segment as we might see
-  // duplicates in dedup tables and inconsistent entries compared to lead replicas for partial
-  // upsert tables. If tables are dedup/partial upsert enabled check for table and server config properties to see if
-  // consumption is allowed
-  private boolean isConsumptionAllowedDuringCommit() {
-    return (!_realtimeTableDataManager.isDedupEnabled() || _tableConfig.getDedupConfig()
-        .isAllowDedupConsumptionDuringCommit()) && (!_realtimeTableDataManager.isPartialUpsertEnabled()
-        || _tableConfig.getUpsertConfig().isAllowPartialUpsertConsumptionDuringCommit());
-  }
-
   @VisibleForTesting
   ParallelSegmentConsumptionPolicy getParallelConsumptionPolicy() {
+    IngestionConfig ingestionConfig = _tableConfig.getIngestionConfig();
     ParallelSegmentConsumptionPolicy parallelSegmentConsumptionPolicy = null;
-    if ((_tableConfig.getIngestionConfig() != null) && (_tableConfig.getIngestionConfig().getStreamIngestionConfig()
-        != null)) {
+    boolean pauseless = false;
+    if (ingestionConfig != null && ingestionConfig.getStreamIngestionConfig() != null) {
       parallelSegmentConsumptionPolicy =
-          _tableConfig.getIngestionConfig().getStreamIngestionConfig().getParallelSegmentConsumptionPolicy();
+          ingestionConfig.getStreamIngestionConfig().getParallelSegmentConsumptionPolicy();
+      pauseless = ingestionConfig.getStreamIngestionConfig().isPauselessConsumptionEnabled();
     }
     if (parallelSegmentConsumptionPolicy != null) {
       return parallelSegmentConsumptionPolicy;
     }
-    if (!isConsumptionAllowedDuringCommit()) {
-      return ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS;
+    // When the policy is not set:
+    // - Without dedup or partial upsert, allow consumption during build and download
+    // - With dedup or partial upsert, in order to get consistent behavior we need to ensure the metadata contains all
+    //   previous records before starting consumption:
+    //   - If the table config allows consumption during commit, allow consumption during build and download
+    //   - For pauseless tables, allow consumption during build, but disallow consumption during download
+    //   - For non-pauseless tables, disallow consumption during build and download
+    //     TODO: Revisit the non-pauseless handling
+    if (_realtimeTableDataManager.isDedupEnabled()) {
+      DedupConfig dedupConfig = _tableConfig.getDedupConfig();
+      assert dedupConfig != null;
+      if (dedupConfig.isAllowDedupConsumptionDuringCommit()) {
+        return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
+      }
+      return pauseless ? ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY
+          : ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS;
+    }
+    if (_realtimeTableDataManager.isPartialUpsertEnabled()) {
+      UpsertConfig upsertConfig = _tableConfig.getUpsertConfig();
+      assert upsertConfig != null;
+      if (upsertConfig.isAllowPartialUpsertConsumptionDuringCommit()) {
+        return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
+      }
+      return pauseless ? ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY
+          : ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS;
     }
     return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1723,6 +1723,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
       // Hence releasing the semaphore here to unblock reset operation via Helix Admin.
+      _segmentLogger.info("Releasing the _partitionGroupConsumerSemaphore");
       _partitionGroupConsumerSemaphore.release();
       _acquiredConsumerSemaphore.set(false);
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1748,7 +1748,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   }
 
   // Consumption while downloading and replacing the slow replicas is not allowed for the following tables:
-  // Consumption while downloading and replacing consuming segment is not allowed for the following tables:
   // 1. Partial Upserts
   // 2. Dedup Tables
   // For the above table types, we would be looking into the metadata information when inserting a new record,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1077,6 +1077,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     // to release the semaphore. This ensures new consuming segment is not consuming until the segment replacement is
     // complete.
     if (_allowConsumptionDuringBuild) {
+      if (!_allowConsumptionDuringDownload) {
+        _segmentLogger.info("Releasing semaphore early before the build where forCommit:{}", forCommit);
+      }
       closeStreamConsumers();
     }
     // Do not allow building segment when table data manager is already shut down

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1078,7 +1078,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     // complete.
     if (_allowConsumptionDuringBuild) {
       if (!_allowConsumptionDuringDownload) {
-        _segmentLogger.info("Releasing semaphore early before the build where forCommit:{}", forCommit);
+        _segmentLogger.info("Releasing partitionGroupConsumerSemaphore early before segment build, forCommit:{}",
+            forCommit);
       }
       closeStreamConsumers();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -905,7 +905,8 @@ public class RealtimeSegmentDataManagerTest {
       throws Exception {
     // no partial upsert or dedup enabled.
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager()) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
     }
 
     // enable dedup
@@ -915,12 +916,14 @@ public class RealtimeSegmentDataManagerTest {
     tableConfig.setDedupConfig(dedupConfig);
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
         null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
     }
     dedupConfig.setAllowDedupConsumptionDuringCommit(false);
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
         null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
     }
 
     // enable partial upsert
@@ -930,12 +933,14 @@ public class RealtimeSegmentDataManagerTest {
     tableConfig.setUpsertConfig(upsertConfig);
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
         null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
     }
     upsertConfig.setAllowPartialUpsertConsumptionDuringCommit(false);
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
         null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
     }
 
     // enable full upsert
@@ -944,7 +949,8 @@ public class RealtimeSegmentDataManagerTest {
     tableConfig.setUpsertConfig(upsertConfig);
     try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
         null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(), ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
+      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
+          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ParallelSegmentConsumptionPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ParallelSegmentConsumptionPolicy.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table.ingestion;
+
+/**
+ * Policy to determine the behaviour of parallel consumption for Realtime Ingestion.
+ */
+public enum ParallelSegmentConsumptionPolicy {
+  ALLOW_ALWAYS,               // Allow consumption of next segment during both build and download of the previous
+  ALLOW_DURING_BUILD_ONLY,    // Allow consumption of next segment during build but not download of the previous
+  ALLOW_DURING_DOWNLOAD_ONLY, // Allow consumption of next segment during download but not build of the previous
+  DISALLOW_ALWAYS             // Don't allow consumption of next segment during either build or download of the
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ParallelSegmentConsumptionPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ParallelSegmentConsumptionPolicy.java
@@ -22,8 +22,26 @@ package org.apache.pinot.spi.config.table.ingestion;
  * Policy to determine the behaviour of parallel consumption for Realtime Ingestion.
  */
 public enum ParallelSegmentConsumptionPolicy {
-  ALLOW_ALWAYS,               // Allow consumption of next segment during both build and download of the previous
-  ALLOW_DURING_BUILD_ONLY,    // Allow consumption of next segment during build but not download of the previous
-  ALLOW_DURING_DOWNLOAD_ONLY, // Allow consumption of next segment during download but not build of the previous
-  DISALLOW_ALWAYS             // Don't allow consumption of next segment during either build or download of the
+  ALLOW_ALWAYS(true, true),
+  ALLOW_DURING_BUILD_ONLY(true, false),
+  ALLOW_DURING_DOWNLOAD_ONLY(false, true),
+  DISALLOW_ALWAYS(false, false);
+
+  /// Whether the consumption of next segment is allowed during build of the previous segment.
+  private final boolean _allowedDuringBuild;
+  /// Whether the consumption of next segment is allowed during download of the previous segment.
+  private final boolean _allowedDuringDownload;
+
+  ParallelSegmentConsumptionPolicy(boolean allowedDuringBuild, boolean allowedDuringDownload) {
+    _allowedDuringBuild = allowedDuringBuild;
+    _allowedDuringDownload = allowedDuringDownload;
+  }
+
+  public boolean isAllowedDuringBuild() {
+    return _allowedDuringBuild;
+  }
+
+  public boolean isAllowedDuringDownload() {
+    return _allowedDuringDownload;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -43,6 +43,9 @@ public class StreamIngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether pauseless consumption is enabled for the table")
   private boolean _pauselessConsumptionEnabled = false;
 
+  @JsonPropertyDescription("Policy to determine the behaviour of parallel consumption.")
+  private ParallelSegmentConsumptionPolicy _parallelSegmentConsumptionPolicy;
+
   @JsonCreator
   public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {
     _streamConfigMaps = streamConfigMaps;
@@ -74,5 +77,13 @@ public class StreamIngestionConfig extends BaseJsonConfig {
 
   public void setPauselessConsumptionEnabled(boolean pauselessConsumptionEnabled) {
     _pauselessConsumptionEnabled = pauselessConsumptionEnabled;
+  }
+
+  public ParallelSegmentConsumptionPolicy getParallelSegmentConsumptionPolicy() {
+    return _parallelSegmentConsumptionPolicy;
+  }
+
+  public void setParallelSegmentConsumptionPolicy(ParallelSegmentConsumptionPolicy parallelSegmentConsumptionPolicy) {
+    _parallelSegmentConsumptionPolicy = parallelSegmentConsumptionPolicy;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
@@ -79,6 +80,7 @@ public class StreamIngestionConfig extends BaseJsonConfig {
     _pauselessConsumptionEnabled = pauselessConsumptionEnabled;
   }
 
+  @Nullable
   public ParallelSegmentConsumptionPolicy getParallelSegmentConsumptionPolicy() {
     return _parallelSegmentConsumptionPolicy;
   }


### PR DESCRIPTION
**Problem**
Currently Dedup enabled tables blocks consumption of next consuming segment until the current consumer persists the immutable segment.  Given that the dedup metadata is updated during indexing of each consumed row, We don't need to wait for Immutable segment persistence. The next consuming segment should be allowed to acquire the semaphore and start consuming.

**Solution**
Adds new config:
```
public enum ParallelSegmentConsumptionPolicy {
  ALLOW_ALWAYS,               // Allow consumption of next segment during both build and download of the previous
  ALLOW_DURING_BUILD_ONLY,    // Allow consumption of next segment during build but not download of the previous
  ALLOW_DURING_DOWNLOAD_ONLY, // Allow consumption of next segment during download but not build of the previous
  DISALLOW_ALWAYS             // Don't allow consumption of next segment during either build or download of the
}
```

This `ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY` will be useful for below two cases:
- Incase of fast server: The next consumer should be allowed to consume while the previous consumed segment has not persisted. (Because this server did build the prev consumed segment and the dedup metadata is updated)
- Incase of slow server: The next consumer shall wait if the previous consumer decided that it will download it's segment. (Because the dedup metadata will only be updated after the segment is downloaded)