### PR TITLE
Add Murmur2 as an alias for Murmur Partition function.

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 public class PartitionFunctionFactory {
   // Enum for various partition functions to be added.
   public enum PartitionFunctionType {
-    Modulo, Murmur, Murmur3, ByteArray, HashCode, BoundedColumnValue;
+    Modulo, Murmur, Murmur2, Murmur3, ByteArray, HashCode, BoundedColumnValue;
     // Add more functions here.
 
     private static final Map<String, PartitionFunctionType> VALUE_MAP = new HashMap<>();
@@ -76,6 +76,7 @@ public class PartitionFunctionFactory {
         return new ModuloPartitionFunction(numPartitions);
 
       case Murmur:
+      case Murmur2:
         return new MurmurPartitionFunction(numPartitions);
 
       case Murmur3:

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -90,17 +90,22 @@ public class PartitionFunctionTest {
    */
   @Test
   public void testMurmurPartitioner() {
+    // Both Murmur and Murmur2 are aliases for MurmurPartitionFunction
+    testMurmurPartitioner("mUrmur");
+    testMurmurPartitioner("mUrMuR2");
+  }
+
+  private void testMurmurPartitioner(String functionName) {
     long seed = System.currentTimeMillis();
     Random random = new Random(seed);
 
     for (int i = 0; i < NUM_ROUNDS; i++) {
       int numPartitions = random.nextInt(MAX_NUM_PARTITIONS) + 1;
 
-      String functionName = "mUrmur";
       PartitionFunction partitionFunction =
           PartitionFunctionFactory.getPartitionFunction(functionName, numPartitions, null);
 
-      testBasicProperties(partitionFunction, functionName, numPartitions);
+      testBasicProperties(partitionFunction, "murmur", numPartitions);
 
       for (int j = 0; j < NUM_ROUNDS; j++) {
         int value = j == 0 ? Integer.MIN_VALUE : random.nextInt();


### PR DESCRIPTION
Added Mummur2 as an alias for Murmur Partition Function.
- The existing Murmur partition funciton is actually Murmur2.
- Users end up using Murmur2 in configs, only to get an error, today.
- Enhanced existing unit test to cover `Murmur2` as well.
- The PartitionFunctionType is not persisted (afaik) so adding a new enum in the middle should not break anything.