### PR TITLE
Clean up usage of couple of APIs of Tracing ThreadResourceAccountant

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -351,7 +351,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         requestContext.setErrorCode(queryErrorCode);
         return new BrokerResponseNative(queryErrorCode, consolidatedMessage);
       } finally {
-        Tracing.getThreadAccountant().clear();
+        Tracing.ThreadAccountantOps.clear();
         onQueryFinish(requestId);
       }
       long executionEndTimeNs = System.nanoTime();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -104,7 +104,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
         public void runJob() {
           ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
 
-          Tracing.ThreadAccountantOps.setupWorker(taskId, threadResourceUsageProvider, parentContext);
+          Tracing.ThreadAccountantOps.setupWorker(taskId, parentContext);
 
           // Register the task to the phaser
           // NOTE: If the phaser is terminated (returning negative value) when trying to register the task, that means

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -262,7 +262,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
       futures[i] = reducerContext.getExecutorService().submit(new TraceRunnable() {
         @Override
         public void runJob() {
-          Tracing.ThreadAccountantOps.setupWorker(taskId, new ThreadResourceUsageProvider(), parentContext);
+          Tracing.ThreadAccountantOps.setupWorker(taskId, parentContext);
           try {
             for (DataTable dataTable : reduceGroup) {
               boolean nullHandlingEnabled = _queryContext.isNullHandlingEnabled();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -60,7 +60,6 @@ import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.trace.Tracing;

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
@@ -112,9 +112,7 @@ public class ResourceManagerAccountingTest {
         for (int j = 0; j < 10; j++) {
           int finalJ = j;
           rm.getQueryWorkers().submit(() -> {
-            ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadResourceUsageProvider,
-                threadExecutionContext);
+            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadExecutionContext);
             for (int i = 0; i < (finalJ + 1) * 10; i++) {
               Tracing.ThreadAccountantOps.sample();
               for (int m = 0; m < 1000; m++) {
@@ -173,9 +171,7 @@ public class ResourceManagerAccountingTest {
         for (int j = 0; j < 10; j++) {
           int finalJ = j;
           rm.getQueryWorkers().submit(() -> {
-            ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadResourceUsageProvider,
-                threadExecutionContext);
+            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadExecutionContext);
             long[][] a = new long[1000][];
             for (int i = 0; i < (finalJ + 1) * 10; i++) {
               Tracing.ThreadAccountantOps.sample();
@@ -516,9 +512,7 @@ public class ResourceManagerAccountingTest {
         for (int j = 0; j < 10; j++) {
           int finalJ = j;
           futuresThread[j] = rm.getQueryWorkers().submit(() -> {
-            ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadResourceUsageProvider,
-                threadExecutionContext);
+            Tracing.ThreadAccountantOps.setupWorker(finalJ, threadExecutionContext);
             long[][] a = new long[1000][];
             for (int i = 0; i < (finalK + 1) * 80; i++) {
               Tracing.ThreadAccountantOps.sample();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -28,7 +28,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,10 +53,8 @@ public class OpChainSchedulerService {
         // try-with-resources to ensure that the operator chain is closed
         // TODO: Change the code so we ownership is expressed in the code in a better way
         try (OpChain closeMe = operatorChain) {
-          ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
           Tracing.ThreadAccountantOps.setupWorker(operatorChain.getId().getStageId(),
-              ThreadExecutionContext.TaskType.MSE, threadResourceUsageProvider,
-              operatorChain.getParentContext());
+              ThreadExecutionContext.TaskType.MSE, operatorChain.getParentContext());
           LOGGER.trace("({}): Executing", operatorChain);
           TransferableBlock result = operatorChain.getRoot().nextBlock();
           while (!result.isEndOfStreamBlock()) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -64,7 +64,6 @@ import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 import org.slf4j.Logger;
@@ -382,8 +381,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
       try {
         if (_requests.size() == 1) {
           ServerQueryRequest request = _requests.get(0);
-          ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-          Tracing.ThreadAccountantOps.setupWorker(1, threadResourceUsageProvider, parentContext);
+          Tracing.ThreadAccountantOps.setupWorker(1, parentContext);
 
           InstanceResponseBlock instanceResponseBlock =
               _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
@@ -416,8 +414,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
             ServerQueryRequest request = _requests.get(i);
             int taskId = i;
             futures[i] = _executorService.submit(() -> {
-              ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-              Tracing.ThreadAccountantOps.setupWorker(taskId, threadResourceUsageProvider, parentContext);
+              Tracing.ThreadAccountantOps.setupWorker(taskId, parentContext);
 
               try {
                 InstanceResponseBlock instanceResponseBlock =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -169,7 +169,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
         responseObserver.onCompleted();
         return;
       } finally {
-        Tracing.getThreadAccountant().clear();
+        Tracing.ThreadAccountantOps.clear();
       }
       responseObserver.onNext(
           Worker.QueryResponse.newBuilder()

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
@@ -95,9 +95,7 @@ public class MultiStageAccountingTest implements ITest {
     // Setup Thread Context
     Tracing.ThreadAccountantOps.setupRunner("MultiStageAccountingTest", ThreadExecutionContext.TaskType.MSE);
     ThreadExecutionContext threadExecutionContext = Tracing.getThreadAccountant().getThreadExecutionContext();
-    ThreadResourceUsageProvider threadResourceUsageProvider = new ThreadResourceUsageProvider();
-    Tracing.ThreadAccountantOps.setupWorker(1, ThreadExecutionContext.TaskType.MSE, threadResourceUsageProvider,
-        threadExecutionContext);
+    Tracing.ThreadAccountantOps.setupWorker(1, ThreadExecutionContext.TaskType.MSE, threadExecutionContext);
   }
 
   @BeforeMethod

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -279,24 +279,20 @@ public class Tracing {
     /**
      * Setup metadata of query worker threads. This function assumes that the workers are for Single Stage Engine.
      * @param taskId Query task ID of the thread. In SSE, ID is an incrementing counter. In MSE, id is the stage id.
-     * @param threadResourceUsageProvider Object that measures resource usage.
      * @param threadExecutionContext Context holds metadata about the query.
      */
-    public static void setupWorker(int taskId, ThreadResourceUsageProvider threadResourceUsageProvider,
-        ThreadExecutionContext threadExecutionContext) {
-      setupWorker(taskId, ThreadExecutionContext.TaskType.SSE, threadResourceUsageProvider, threadExecutionContext);
+    public static void setupWorker(int taskId, ThreadExecutionContext threadExecutionContext) {
+      setupWorker(taskId, ThreadExecutionContext.TaskType.SSE, threadExecutionContext);
     }
 
     /**
      * Setup metadata of query worker threads.
      * @param taskId Query task ID of the thread. In SSE, ID is an incrementing counter. In MSE, id is the stage id.
-     * @param threadResourceUsageProvider Object that measures resource usage.
      * @param threadExecutionContext Context holds metadata about the query.
      */
     public static void setupWorker(int taskId, ThreadExecutionContext.TaskType taskType,
-        ThreadResourceUsageProvider threadResourceUsageProvider,
         ThreadExecutionContext threadExecutionContext) {
-      Tracing.getThreadAccountant().setThreadResourceUsageProvider(threadResourceUsageProvider);
+      Tracing.getThreadAccountant().setThreadResourceUsageProvider(new ThreadResourceUsageProvider());
       String queryId = null;
       if (threadExecutionContext != null) {
         queryId = threadExecutionContext.getQueryId();


### PR DESCRIPTION
This PR has a couple of minor cleanups of how Tracing methods are used.
1. Use `Tracing.ThreadAccountantOps.clear`
2. External modules do not need to create a `ThreadUsageProvider`

For 1., the API usage was inconsistent. Context is setup using `Tracing.ThreadAccountantOps.setup[runner|worker]' but was cleared using `Tracing.getThreadAccountant().clear()`. Ideally external modules should not be calling `getThreadAccountant` to be consistent. However that proved to be too large a change.

For 2., all calls to `Tracing.ThreadAccountantOps.setupWorker` were creating a `ThreadResourceUsageProvider` using the default contructor. Since no contextual information is required, this call has been moved into the function. Moreover, `setupRunner` call is also similar.