### PR TITLE
[S3 Plugin]Support requestChecksumCalculationWhenRequired and responseChecksumValidationWhenRequired in S3Config

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -29,6 +29,8 @@ import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
@@ -80,6 +82,8 @@ public class S3Config {
   private static final String HTTP_CLIENT_CONFIG_CONNECTION_ACQUISITION_TIMEOUT = "connectionAcquisitionTimeout";
   private static final String CROSS_REGION_ACCESS_ENABLED = "crossRegionAccessEnabled";
   public static final String ANONYMOUS_CREDENTIALS_PROVIDER = "anonymousCredentialsProvider";
+  public static final String REQUEST_CHECKSUM_CALCULATION = "requestChecksumCalculation";
+  public static final String RESPONSE_CHECKSUM_VALIDATION = "responseChecksumValidation";
 
   private final String _accessKey;
   private final String _secretKey;
@@ -103,6 +107,8 @@ public class S3Config {
   private final ApacheHttpClient.Builder _httpClientBuilder;
   private final boolean _enableCrossRegionAccess;
   private final boolean _anonymousCredentialsProvider;
+  private final RequestChecksumCalculation _requestChecksumCalculationWhenRequired;
+  private final ResponseChecksumValidation _responseChecksumValidationWhenRequired;
 
   public S3Config(PinotConfiguration pinotConfig) {
     _disableAcl = pinotConfig.getProperty(DISABLE_ACL_CONFIG_KEY, DEFAULT_DISABLE_ACL);
@@ -112,6 +118,10 @@ public class S3Config {
     _endpoint = pinotConfig.getProperty(ENDPOINT);
     _anonymousCredentialsProvider = Boolean.parseBoolean(
         pinotConfig.getProperty(ANONYMOUS_CREDENTIALS_PROVIDER, "false"));
+    _requestChecksumCalculationWhenRequired = RequestChecksumCalculation.fromValue(
+        pinotConfig.getProperty(REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation.WHEN_REQUIRED.name()));
+    _responseChecksumValidationWhenRequired = ResponseChecksumValidation.fromValue(
+        pinotConfig.getProperty(RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation.WHEN_REQUIRED.name()));
 
     _storageClass = pinotConfig.getProperty(STORAGE_CLASS);
     if (_storageClass != null) {
@@ -282,5 +292,13 @@ public class S3Config {
 
   public boolean isAnonymousCredentialsProvider() {
     return _anonymousCredentialsProvider;
+  }
+
+  public RequestChecksumCalculation getRequestChecksumCalculationWhenRequired() {
+    return _requestChecksumCalculationWhenRequired;
+  }
+
+  public ResponseChecksumValidation getResponseChecksumValidationWhenRequired() {
+    return _responseChecksumValidationWhenRequired;
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -50,6 +50,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.Region;
@@ -162,6 +164,13 @@ public class S3PinotFS extends BasePinotFS {
       if (s3Config.getStorageClass() != null) {
         _storageClass = StorageClass.fromValue(s3Config.getStorageClass());
         assert (_storageClass != StorageClass.UNKNOWN_TO_SDK_VERSION);
+      }
+
+      if (s3Config.getRequestChecksumCalculationWhenRequired() == RequestChecksumCalculation.WHEN_REQUIRED) {
+        s3ClientBuilder.responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+      }
+      if (s3Config.getResponseChecksumValidationWhenRequired() == ResponseChecksumValidation.WHEN_REQUIRED) {
+        s3ClientBuilder.requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
       }
 
       _s3Client = s3ClientBuilder.build();
@@ -562,7 +571,8 @@ public class S3PinotFS extends BasePinotFS {
   private void visitFiles(URI fileUri, boolean recursive, Consumer<S3Object> objectVisitor,
       // S3 has a concept of CommonPrefixes which act like subdirectories:
       // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CommonPrefix.html
-      @Nullable Consumer<CommonPrefix> commonPrefixVisitor) throws IOException {
+      @Nullable Consumer<CommonPrefix> commonPrefixVisitor)
+      throws IOException {
     try {
       String continuationToken = null;
       boolean isDone = false;


### PR DESCRIPTION
This [PR](https://github.com/apache/pinot/pull/14909) upgrades the AWS library and introduced a regression for [AWS client default enabled the integrity check](https://github.com/aws/aws-sdk-java-v2/discussions/5802) and the [fix]( https://github.com/aws/aws-sdk-java-v2/issues/5819#issuecomment-2610172816) is to disable this.


# release notes

This PR introduces support for two new configuration options in S3PinotFS:

- `requestChecksumCalculation`: default to `WHEN_SUPPORTED`, optional values: { `WHEN_SUPPORTED`, `WHEN_REQUIRED`} 
- `responseChecksumValidation`: default to `WHEN_SUPPORTED`, optional values: { `WHEN_SUPPORTED`, `WHEN_REQUIRED`} 
