### PR TITLE
Update RebalanceResult field order

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.assignment.InstancePartitions;
@@ -30,6 +31,8 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"jobId", "status", "description", "preChecksResult", "rebalanceSummaryResult",
+    "instanceAssignment", "tierInstanceAssignment", "segmentAssignment"})
 public class RebalanceResult {
   private final String _jobId;
   private final Status _status;


### PR DESCRIPTION
Moved `preChecksResult` and `rebalanceSummaryResult` to the top. As it should be looked up first.
```
{
  "jobId": "2982d8ba-f578-4172-b393-0916ba6a3324",
  "status": "NO_OP",
  "description": "Table is already balanced",
  "preChecksResult": {
    ...
  },
  "rebalanceSummaryResult": {
    ...
  },
  "instanceAssignment": {
    ...
  },
  "segmentAssignment": {
    ...
  }
}
```