### PR TITLE
Migrate H3 v3 api to v4

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -187,7 +187,7 @@ public class ScalarFunctions {
    */
   @ScalarFunction
   public static long geoToH3(double longitude, double latitude, int resolution) {
-    return H3Utils.H3_CORE.geoToH3(latitude, longitude, resolution);
+    return H3Utils.H3_CORE.latLngToCell(latitude, longitude, resolution);
   }
 
   /**
@@ -201,7 +201,7 @@ public class ScalarFunctions {
     Geometry geometry = GeometrySerializer.deserialize(geoBytes);
     double latitude = geometry.getCoordinate().y;
     double longitude = geometry.getCoordinate().x;
-    return H3Utils.H3_CORE.geoToH3(latitude, longitude, resolution);
+    return H3Utils.H3_CORE.latLngToCell(latitude, longitude, resolution);
   }
 
   @ScalarFunction

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
@@ -77,8 +77,8 @@ public class H3IndexFilterOperator extends BaseFilterOperator {
     }
     assert _h3IndexReader != null;
     int resolution = _h3IndexReader.getH3IndexResolution().getLowestResolution();
-    _h3Id = H3Utils.H3_CORE.geoToH3(coordinate.y, coordinate.x, resolution);
-    _edgeLength = H3Utils.H3_CORE.edgeLength(resolution, LengthUnit.m);
+    _h3Id = H3Utils.H3_CORE.latLngToCell(coordinate.y, coordinate.x, resolution);
+    _edgeLength = H3Utils.H3_CORE.getHexagonEdgeLengthAvg(resolution, LengthUnit.m);
 
     RangePredicate rangePredicate = (RangePredicate) predicate;
     if (!rangePredicate.getLowerBound().equals(RangePredicate.UNBOUNDED)) {
@@ -223,7 +223,7 @@ public class H3IndexFilterOperator extends BaseFilterOperator {
    */
   private List<Long> getH3Ids(int numRings) {
     Preconditions.checkState(numRings <= 100, "Expect numRings <= 100, got: %s", numRings);
-    return H3Utils.H3_CORE.kRing(_h3Id, numRings);
+    return H3Utils.H3_CORE.gridDisk(_h3Id, numRings);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/geospatial/MutableH3Index.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/geospatial/MutableH3Index.java
@@ -76,7 +76,7 @@ public class MutableH3Index implements H3IndexReader, MutableIndex {
         geometry.getGeometryType());
     Coordinate coordinate = geometry.getCoordinate();
     // TODO: support multiple resolutions
-    long h3Id = H3Utils.H3_CORE.geoToH3(coordinate.y, coordinate.x, _lowestResolution);
+    long h3Id = H3Utils.H3_CORE.latLngToCell(coordinate.y, coordinate.x, _lowestResolution);
     _bitmaps.computeIfAbsent(h3Id, k -> new ThreadSafeMutableRoaringBitmap()).add(_nextDocId);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -114,7 +114,7 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
         geometry.getGeometryType());
     Coordinate coordinate = geometry.getCoordinate();
     // TODO: support multiple resolutions
-    long h3Id = H3Utils.H3_CORE.geoToH3(coordinate.y, coordinate.x, _lowestResolution);
+    long h3Id = H3Utils.H3_CORE.latLngToCell(coordinate.y, coordinate.x, _lowestResolution);
     RoaringBitmapWriter<RoaringBitmap> bitmapWriter = _postingListMap.get(h3Id);
     if (bitmapWriter == null) {
       bitmapWriter = _bitmapWriterWizard.get();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -99,7 +99,7 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
           onHeapCreator.add(point);
           offHeapCreator.add(point);
           mutableH3Index.add(GeometrySerializer.serialize(point), -1, docId++);
-          long h3Id = H3Utils.H3_CORE.geoToH3(latitude, longitude, resolution);
+          long h3Id = H3Utils.H3_CORE.latLngToCell(latitude, longitude, resolution);
           expectedCardinalities.merge(h3Id, 1, Integer::sum);
         }
         onHeapCreator.seal();


### PR DESCRIPTION
Migrate usage of `H3CoreV3` to `H3Core` (V4)

## Incompatible
`H3Utils.H3_CORE` is changed from `H3CoreV3` to `H3Core`