### PR TITLE
Fix real-time table segment download

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,17 +75,17 @@ import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
-import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.RowMetadata;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -127,6 +126,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   public static final long DEFAULT_SEGMENT_DOWNLOAD_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(10); // 10 minutes
   public static final long SLEEP_INTERVAL_MS = 30000; // 30 seconds sleep interval
+  @Deprecated
   private static final String SEGMENT_DOWNLOAD_TIMEOUT_MINUTES = "segmentDownloadTimeoutMinutes";
 
   // TODO: Change it to BooleanSupplier
@@ -564,35 +564,34 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public File downloadSegment(SegmentZKMetadata zkMetadata)
       throws Exception {
-    Preconditions.checkState(zkMetadata.getStatus() != Status.IN_PROGRESS,
-        "Segment: %s is still IN_PROGRESS and cannot be downloaded", zkMetadata.getSegmentName());
-
-    // Case: The commit protocol has completed, and the segment is ready to be downloaded either
-    // from deep storage or from a peer (if peer-to-peer download is enabled).
-    if (zkMetadata.getStatus() == Status.DONE) {
+    Status status = zkMetadata.getStatus();
+    if (status.isCompleted()) {
+      // Segment is completed and ready to be downloaded either from deep storage or from a peer (if peer-to-peer
+      // download is enabled).
       return super.downloadSegment(zkMetadata);
     }
 
     // The segment status is COMMITTING, indicating that the segment commit process is incomplete.
     // Attempting a waited download within the configured time limit.
-    long downloadTimeoutMilliseconds =
-        getDownloadTimeOutMilliseconds(ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType));
-    final long startTime = System.currentTimeMillis();
-    List<URI> onlineServerURIs;
-    while (System.currentTimeMillis() - startTime < downloadTimeoutMilliseconds) {
+    String segmentName = zkMetadata.getSegmentName();
+    Preconditions.checkState(status == Status.COMMITTING, "Invalid status: %s for segment: %s to be downloaded", status,
+        segmentName);
+    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", _tableNameWithType);
+    long downloadTimeoutMs = getDownloadTimeoutMs(tableConfig);
+    long deadlineMs = System.currentTimeMillis() + downloadTimeoutMs;
+    while (System.currentTimeMillis() < deadlineMs) {
       // ZK Metadata may change during segment download process; fetch it on every retry.
-      zkMetadata = fetchZKMetadata(zkMetadata.getSegmentName());
-
-      if (zkMetadata.getDownloadUrl() != null) {
-        // The downloadSegment() will throw an exception in case there are some genuine issues.
-        // We don't want to retry in those scenarios and will throw an exception
-        return downloadSegmentFromDeepStore(zkMetadata);
+      zkMetadata = fetchZKMetadata(segmentName);
+      if (zkMetadata.getStatus().isCompleted()) {
+        return super.downloadSegment(zkMetadata);
       }
 
+      // Segment is still in COMMITTING status, but it might already be ONLINE on some peer servers. Try to find ONLINE
+      // segment and download it from peers.
       if (_peerDownloadScheme != null) {
-        _logger.info("Peer download is enabled for the segment: {}", zkMetadata.getSegmentName());
         try {
-          onlineServerURIs = new ArrayList<>();
+          List<URI> onlineServerURIs = new ArrayList<>();
           PeerServerSegmentFinder.getOnlineServersFromExternalView(_helixManager.getClusterManagmentTool(),
               _helixManager.getClusterName(), _tableNameWithType, zkMetadata.getSegmentName(), _peerDownloadScheme,
               onlineServerURIs);
@@ -600,41 +599,39 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
             return downloadSegmentFromPeers(zkMetadata);
           }
         } catch (Exception e) {
-          _logger.warn("Could not download segment: {} from peer", zkMetadata.getSegmentName(), e);
+          _logger.warn("Caught exception while trying to download segment: {} from peers, continue retrying",
+              segmentName, e);
         }
       }
 
-      long timeElapsed = System.currentTimeMillis() - startTime;
-      long timeRemaining = downloadTimeoutMilliseconds - timeElapsed;
-
-      if (timeRemaining <= 0) {
+      long timeRemainingMs = deadlineMs - System.currentTimeMillis();
+      if (timeRemainingMs <= 0) {
         break;
       }
 
-      _logger.info("Sleeping for 30 seconds as the segment url is missing. Time remaining: {} minutes",
-          Math.round(timeRemaining / 60000.0));
-
-      // Sleep for the shorter of our normal interval or remaining time
-      Thread.sleep(Math.min(SLEEP_INTERVAL_MS, timeRemaining));
+      long sleepTimeMs = Math.min(SLEEP_INTERVAL_MS, timeRemainingMs);
+      _logger.info("Sleeping for: {}ms waiting for segment: {} to be completed. Time remaining: {}ms", sleepTimeMs,
+          segmentName, timeRemainingMs);
+      //noinspection BusyWait
+      Thread.sleep(sleepTimeMs);
     }
 
     // If we exit the loop without returning, throw an exception
     throw new TimeoutException(
-        "Failed to download segment after " + TimeUnit.MILLISECONDS.toMinutes(downloadTimeoutMilliseconds)
-            + " minutes of retrying. Segment: " + zkMetadata.getSegmentName());
+        "Failed to download segment: " + segmentName + " after: " + downloadTimeoutMs + "ms of retrying");
   }
 
-  private long getDownloadTimeOutMilliseconds(@Nullable TableConfig tableConfig) {
-    return Optional.ofNullable(tableConfig).map(TableConfig::getIngestionConfig)
-        .map(IngestionConfig::getStreamIngestionConfig).map(StreamIngestionConfig::getStreamConfigMaps)
-        .filter(maps -> !maps.isEmpty()).map(maps -> maps.get(0)).map(map -> map.get(SEGMENT_DOWNLOAD_TIMEOUT_MINUTES))
-        .map(timeoutStr -> {
-          try {
-            return TimeUnit.MINUTES.toMillis(Long.parseLong(timeoutStr));
-          } catch (NumberFormatException e) {
-            return DEFAULT_SEGMENT_DOWNLOAD_TIMEOUT_MS;
-          }
-        }).orElse(DEFAULT_SEGMENT_DOWNLOAD_TIMEOUT_MS);
+  private long getDownloadTimeoutMs(TableConfig tableConfig) {
+    Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(tableConfig).get(0);
+    String timeoutSeconds = streamConfigMap.get(StreamConfigProperties.PAUSELESS_SEGMENT_DOWNLOAD_TIMEOUT_SECONDS);
+    if (timeoutSeconds != null) {
+      return TimeUnit.SECONDS.toMillis(Integer.parseInt(timeoutSeconds));
+    }
+    String timeoutMinutes = streamConfigMap.get(SEGMENT_DOWNLOAD_TIMEOUT_MINUTES);
+    if (timeoutMinutes != null) {
+      return TimeUnit.MINUTES.toMillis(Integer.parseInt(timeoutMinutes));
+    }
+    return DEFAULT_SEGMENT_DOWNLOAD_TIMEOUT_MS;
   }
 
   @VisibleForTesting

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -20,34 +20,31 @@ package org.apache.pinot.integration.tests;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
-import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingPinotLLCRealtimeSegmentManager;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -55,17 +52,12 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.integration.tests.realtime.utils.FailureInjectingRealtimeTableDataManager.MAX_NUMBER_OF_FAILURES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
 
 
 public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClusterIntegrationTest {
-
-  private static final int NUM_REALTIME_SEGMENTS = 48;
-  protected static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000; // 5 MINUTES
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(PauselessRealtimeIngestionSegmentCommitFailureTest.class);
   private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
-  private List<File> _avroFiles;
+  private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000L;
 
   protected void overrideControllerConf(Map<String, Object> properties) {
     properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
@@ -78,13 +70,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
 
   @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
-    // Set segment store uri to the one used by controller as data dir (i.e. deep store)
-    try {
-      LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),
-          new URI(_controllerConfig.getDataDir()).getScheme());
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
     serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
     serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
         "true");
@@ -110,9 +95,9 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     startServer();
 
     // load data in kafka
-    _avroFiles = unpackAvroData(_tempDir);
+    List<File> avroFiles = unpackAvroData(_tempDir);
     startKafka();
-    pushAvroIntoKafka(_avroFiles);
+    pushAvroIntoKafka(avroFiles);
 
     setMaxSegmentCompletionTimeMillis();
     // create schema for non-pauseless table
@@ -121,104 +106,104 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     addSchema(schema);
 
     // add non-pauseless table
-    TableConfig tableConfig2 = createRealtimeTableConfig(_avroFiles.get(0));
+    TableConfig tableConfig2 = createRealtimeTableConfig(avroFiles.get(0));
     tableConfig2.setTableName(DEFAULT_TABLE_NAME_2);
     tableConfig2.getValidationConfig().setRetentionTimeUnit("DAYS");
     tableConfig2.getValidationConfig().setRetentionTimeValue("100000");
     addTableConfig(tableConfig2);
 
-    // Ensure that the commit protocol for all the segments have completed before injecting failure
     waitForDocsLoaded(600_000L, true, tableConfig2.getTableName());
-    TestUtils.waitForCondition((aVoid) -> {
-      List<SegmentZKMetadata> segmentZKMetadataList =
-          _helixResourceManager.getSegmentsZKMetadata(tableConfig2.getTableName());
-      return assertUrlPresent(segmentZKMetadataList);
-    }, 1000, 100000, "Some segments still have missing url");
 
     // create schema for pauseless table
     schema.setSchemaName(DEFAULT_TABLE_NAME);
     addSchema(schema);
 
     // add pauseless table
-    TableConfig tableConfig = createRealtimeTableConfig(_avroFiles.get(0));
+    TableConfig tableConfig = createRealtimeTableConfig(avroFiles.get(0));
     tableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
     tableConfig.getValidationConfig().setRetentionTimeValue("100000");
 
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    Map<String, String> streamConfigs = indexingConfig.getStreamConfigs();
+    indexingConfig.setStreamConfigs(null);
+    assertNotNull(streamConfigs);
+    streamConfigs.put(StreamConfigProperties.PAUSELESS_SEGMENT_DOWNLOAD_TIMEOUT_SECONDS, "10");
     IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setStreamIngestionConfig(
-        new StreamIngestionConfig(List.of(tableConfig.getIndexingConfig().getStreamConfigs())));
-    ingestionConfig.getStreamIngestionConfig().setPauselessConsumptionEnabled(true);
-    Map<String, String> streamConfigMap = ingestionConfig.getStreamIngestionConfig()
-        .getStreamConfigMaps()
-        .get(0);
-    streamConfigMap.put("segmentDownloadTimeoutMinutes", "1");
-    tableConfig.getIndexingConfig().setStreamConfigs(null);
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(List.of(streamConfigs));
+    streamIngestionConfig.setPauselessConsumptionEnabled(true);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
     tableConfig.setIngestionConfig(ingestionConfig);
 
     addTableConfig(tableConfig);
-    Thread.sleep(60000L);
-    TestUtils.waitForCondition(
-        (aVoid) -> numberOfErrorSegmentInExternalView(TableNameBuilder.REALTIME.tableNameWithType(getTableName()))
-            == MAX_NUMBER_OF_FAILURES,
-        1000, 600000, "Segments still not in error state");
-  }
-
-  @Test
-  public void testSegmentAssignment()
-      throws Exception {
-    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
-
-    // 1) Capture which segments went into the ERROR state
-    List<String> erroredSegments = getErroredSegmentsInExternalView(tableNameWithType);
-    assertFalse(erroredSegments.isEmpty(), "No segments found in ERROR state, expected at least one.");
-
-    // Let the RealtimeSegmentValidationManager run so it can fix up segments
-    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    LOGGER.info("Triggering RealtimeSegmentValidationManager to reingest errored segments");
-    _controllerStarter.getRealtimeSegmentValidationManager().run();
-    LOGGER.info("Finished RealtimeSegmentValidationManager to reingest errored segments");
-
-    // Wait until there are no ERROR segments in the ExternalView
-    TestUtils.waitForCondition(aVoid -> {
-      List<String> errorSegmentsRemaining = getErroredSegmentsInExternalView(tableNameWithType);
-      return errorSegmentsRemaining.isEmpty();
-    }, 10000, 100000, "Some segments are still in ERROR state after resetSegments()");
-
-    // Finally compare metadata across your two tables
-    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(tableNameWithType),
-        _helixResourceManager.getSegmentsZKMetadata(
-            TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2)));
-  }
-
-  /**
-   * Returns the list of segment names in ERROR state from the ExternalView of the given table.
-   */
-  private List<String> getErroredSegmentsInExternalView(String tableName) {
-    ExternalView resourceEV = _helixResourceManager.getHelixAdmin()
-        .getResourceExternalView(_helixResourceManager.getHelixClusterName(), tableName);
-    Map<String, Map<String, String>> segmentAssignment = resourceEV.getRecord().getMapFields();
-    List<String> erroredSegments = new ArrayList<>();
-    for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
-      String segmentName = entry.getKey();
-      Map<String, String> serverToStateMap = entry.getValue();
-      for (String state : serverToStateMap.values()) {
-        if ("ERROR".equals(state)) {
-          erroredSegments.add(segmentName);
-          break; // No need to check other servers for this segment
-        }
-      }
-    }
-    return erroredSegments;
+    String realtimeTableName = tableConfig.getTableName();
+    TestUtils.waitForCondition(aVoid -> getNumErrorSegmentsInEV(realtimeTableName) == MAX_NUMBER_OF_FAILURES, 600_000L,
+        "Segments still not in error state");
   }
 
   private void setMaxSegmentCompletionTimeMillis() {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
-          .setMaxSegmentCompletionTimeoutMs(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).setMaxSegmentCompletionTimeoutMs(
+          MAX_SEGMENT_COMPLETION_TIME_MILLIS);
     }
   }
 
+  private int getNumErrorSegmentsInEV(String realtimeTableName) {
+    ExternalView externalView = _helixResourceManager.getHelixAdmin()
+        .getResourceExternalView(_helixResourceManager.getHelixClusterName(), realtimeTableName);
+    if (externalView == null) {
+      return 0;
+    }
+    int numErrorSegments = 0;
+    for (Map<String, String> instanceStateMap : externalView.getRecord().getMapFields().values()) {
+      for (String state : instanceStateMap.values()) {
+        if (state.equals(SegmentStateModel.ERROR)) {
+          numErrorSegments++;
+        }
+      }
+    }
+    return numErrorSegments;
+  }
+
+  @Test
+  public void testSegmentAssignment()
+      throws Exception {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+
+    // 1) Capture which segments went into the ERROR state
+    List<String> erroredSegments = getErrorSegmentsInEV(realtimeTableName);
+    assertFalse(erroredSegments.isEmpty(), "No segments found in ERROR state, expected at least one.");
+
+    // Let the RealtimeSegmentValidationManager run so it can fix up segments
+    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    _controllerStarter.getRealtimeSegmentValidationManager().run();
+
+    // Wait until there are no ERROR segments in the ExternalView
+    TestUtils.waitForCondition(aVoid -> getErrorSegmentsInEV(realtimeTableName).isEmpty(), 600_000L,
+        "Some segments are still in ERROR state after resetSegments()");
+
+    // Finally compare metadata across your two tables
+    compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(realtimeTableName),
+        _helixResourceManager.getSegmentsZKMetadata(TableNameBuilder.REALTIME.tableNameWithType(DEFAULT_TABLE_NAME_2)));
+  }
+
+  /**
+   * Returns the list of segment names in ERROR state from the ExternalView of the given table.
+   */
+  private List<String> getErrorSegmentsInEV(String realtimeTableName) {
+    ExternalView externalView = _helixResourceManager.getHelixAdmin()
+        .getResourceExternalView(_helixResourceManager.getHelixClusterName(), realtimeTableName);
+    if (externalView == null) {
+      return List.of();
+    }
+    List<String> errorSegments = new ArrayList<>();
+    for (Map.Entry<String, Map<String, String>> entry : externalView.getRecord().getMapFields().entrySet()) {
+      if (entry.getValue().containsValue(SegmentStateModel.ERROR)) {
+        errorSegments.add(entry.getKey());
+      }
+    }
+    return errorSegments;
+  }
 
   private void compareZKMetadataForSegments(List<SegmentZKMetadata> segmentsZKMetadata,
       List<SegmentZKMetadata> segmentsZKMetadata1) {
@@ -256,7 +241,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
   @AfterClass
   public void tearDown()
       throws IOException {
-    LOGGER.info("Tearing down...");
     dropRealtimeTable(getTableName());
     stopServer();
     stopBroker();
@@ -264,43 +248,5 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     stopKafka();
     stopZk();
     FileUtils.deleteDirectory(_tempDir);
-  }
-
-  private void verifyIdealState(String tableName, int numSegmentsExpected) {
-    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, tableName);
-    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
-    assertEquals(segmentAssignment.size(), numSegmentsExpected);
-  }
-
-  private int numberOfErrorSegmentInExternalView(String tableName) {
-    int errorSegmentCount = 0;
-    ExternalView resourceEV = _helixResourceManager.getHelixAdmin()
-        .getResourceExternalView(_helixResourceManager.getHelixClusterName(), tableName);
-    Map<String, Map<String, String>> segmentAssigment = resourceEV.getRecord().getMapFields();
-    for (Map<String, String> serverToStateMap : segmentAssigment.values()) {
-      for (String state : serverToStateMap.values()) {
-        if (state.equals("ERROR")) {
-          errorSegmentCount++;
-        }
-      }
-    }
-    return errorSegmentCount;
-  }
-
-  private void assertUploadUrlEmpty(List<SegmentZKMetadata> segmentZKMetadataList) {
-    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
-      assertNull(segmentZKMetadata.getDownloadUrl());
-    }
-  }
-
-  private boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {
-    for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
-      if (segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
-          && segmentZKMetadata.getDownloadUrl() == null) {
-        LOGGER.warn("URl not found for segment: {}", segmentZKMetadata.getSegmentName());
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -120,7 +120,10 @@ public class StreamConfigProperties {
    * The initial num rows to use for segment size auto tuning. By default 100_000 is used.
    */
   public static final String SEGMENT_FLUSH_AUTOTUNE_INITIAL_ROWS = "realtime.segment.flush.autotune.initialRows";
-  // Time threshold that controller will wait for the segment to be built by the server
+
+  /**
+   * Time threshold that controller will wait for the segment to be built by the server.
+   */
   public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
 
   /**
@@ -132,6 +135,13 @@ public class StreamConfigProperties {
    * Config used to indicate which segment commit protocol implementation controller should use for this table
    */
   public static final String SEGMENT_COMPLETION_FSM_SCHEME = "segment.completion.fsm.scheme";
+
+  /**
+   * For pauseless consumption, the time in seconds that the server will wait for a segment to be ready for download.
+   * 600 seconds (10 minutes) by default.
+   */
+  public static final String PAUSELESS_SEGMENT_DOWNLOAD_TIMEOUT_SECONDS =
+      "realtime.segment.pauseless.download.timeoutSeconds";
 
   /**
    * Helper method to create a stream specific property

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -19,15 +19,16 @@
 package org.apache.pinot.spi.utils;
 
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -67,10 +68,9 @@ public final class IngestionConfigUtils {
     String tableNameWithType = tableConfig.getTableName();
     Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
         "Cannot fetch streamConfigs for OFFLINE table: %s", tableNameWithType);
-    if (tableConfig.getIngestionConfig() != null
-        && tableConfig.getIngestionConfig().getStreamIngestionConfig() != null) {
-      List<Map<String, String>> streamConfigMaps =
-          tableConfig.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps();
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig != null && ingestionConfig.getStreamIngestionConfig() != null) {
+      List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
       Preconditions.checkState(!streamConfigMaps.isEmpty(), "Table must have at least 1 stream");
       /*
       Apply the following checks if there are multiple streamConfigs
@@ -100,8 +100,9 @@ public final class IngestionConfigUtils {
       }
       return streamConfigMaps;
     }
-    if (tableConfig.getIndexingConfig() != null && tableConfig.getIndexingConfig().getStreamConfigs() != null) {
-      return Arrays.asList(tableConfig.getIndexingConfig().getStreamConfigs());
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    if (indexingConfig.getStreamConfigs() != null) {
+      return List.of(indexingConfig.getStreamConfigs());
     }
     throw new IllegalStateException("Could not find streamConfigs for REALTIME table: " + tableNameWithType);
   }


### PR DESCRIPTION
- Fix the handling for `UPLOADED` segment
- Fix the peer download scenario for pauseless consumption
- Simplify the handling of pauseless consumption segment download
- Deprecate `segmentDownloadTimeoutMinutes` and replace it with `realtime.segment.pauseless.download.timeoutSeconds` in stream config
- Reduce the test time for `PauselessRealtimeIngestionSegmentCommitFailureTest`