### PR TITLE
Fix up parsing of controller timers tableRebalanceExecutionTimeMs and cronSchedulerJobExecutionTimeMs

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -48,6 +48,21 @@ rules:
     table: "$2$4"
     tableType: "$5"
     taskType: "$6"
+  # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$5"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    taskType: "$4"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)\\.(\\w+)\\.tableRebalanceExecutionTimeMs\"><>(\\w+)"
+  name: "pinot_controller_tableRebalanceExecutionTimeMs_$5"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    status: "$4"
 # Gauges that accept taskType and task status
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.([^.]*)\\.([^.]*)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_$1_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -48,21 +48,23 @@ rules:
     table: "$2$4"
     tableType: "$5"
     taskType: "$6"
-  # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
-  name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$5"
+  # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs which use table name, table type and another string for status / taskType
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$6"
   cache: true
   labels:
     database: "$2"
     table: "$1$3"
-    taskType: "$4"
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)\\.(\\w+)\\.tableRebalanceExecutionTimeMs\"><>(\\w+)"
-  name: "pinot_controller_tableRebalanceExecutionTimeMs_$5"
+    tableType: "$4"
+    taskType: "$5"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.tableRebalanceExecutionTimeMs\"><>(\\w+)"
+  name: "pinot_controller_tableRebalanceExecutionTimeMs_$6"
   cache: true
   labels:
     database: "$2"
     table: "$1$3"
-    status: "$4"
+    tableType: "$4"
+    status: "$5"
 # Gauges that accept taskType and task status
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.([^.]*)\\.([^.]*)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_$1_$4"

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -72,13 +72,26 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
       _controllerMetrics.addTimedValue(controllerTimer, 30_000, TimeUnit.MILLISECONDS);
       assertTimerExportedCorrectly(controllerTimer.getTimerName(), EXPORTED_METRIC_PREFIX);
     } else {
-      _controllerMetrics.addTimedTableValue(TABLE_NAME_WITH_TYPE, controllerTimer, 30_000L, TimeUnit.MILLISECONDS);
-      _controllerMetrics.addTimedTableValue(ExportedLabelValues.TABLENAME, controllerTimer, 30_000L,
-          TimeUnit.MILLISECONDS);
+      if (controllerTimer == ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS) {
+        _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE, "DONE"),
+            ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS, 100_000, TimeUnit.MILLISECONDS);
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.JOBSTATUS_TABLE_NAME_WITH_TYPE,
+            EXPORTED_METRIC_PREFIX);
+      } else if (controllerTimer == ControllerTimer.CRON_SCHEDULER_JOB_EXECUTION_TIME_MS) {
+        _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE,
+                ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT),
+            ControllerTimer.CRON_SCHEDULER_JOB_EXECUTION_TIME_MS, 100_000, TimeUnit.MILLISECONDS);
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TASKTYPE_TABLE_NAME_WITH_TYPE,
+            EXPORTED_METRIC_PREFIX);
+      } else {
+        _controllerMetrics.addTimedTableValue(TABLE_NAME_WITH_TYPE, controllerTimer, 30_000L, TimeUnit.MILLISECONDS);
+        _controllerMetrics.addTimedTableValue(ExportedLabelValues.TABLENAME, controllerTimer, 30_000L,
+            TimeUnit.MILLISECONDS);
 
-      assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TABLENAME_TABLETYPE,
-          EXPORTED_METRIC_PREFIX);
-      assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TABLENAME, EXPORTED_METRIC_PREFIX);
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TABLENAME_TABLETYPE,
+            EXPORTED_METRIC_PREFIX);
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TABLENAME, EXPORTED_METRIC_PREFIX);
+      }
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -73,7 +73,9 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
       assertTimerExportedCorrectly(controllerTimer.getTimerName(), EXPORTED_METRIC_PREFIX);
     } else {
       if (controllerTimer == ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS) {
-        _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE, "DONE"),
+        _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE, ExportedLabelValues.DONE
+
+            ),
             ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS, 100_000, TimeUnit.MILLISECONDS);
         assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.JOBSTATUS_TABLENAME_TABLETYPE,
             EXPORTED_METRIC_PREFIX);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -75,13 +75,13 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
       if (controllerTimer == ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS) {
         _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE, "DONE"),
             ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS, 100_000, TimeUnit.MILLISECONDS);
-        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.JOBSTATUS_TABLE_NAME_WITH_TYPE,
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.JOBSTATUS_TABLENAME_TABLETYPE,
             EXPORTED_METRIC_PREFIX);
       } else if (controllerTimer == ControllerTimer.CRON_SCHEDULER_JOB_EXECUTION_TIME_MS) {
         _controllerMetrics.addTimedTableValue(String.format("%s.%s", TABLE_NAME_WITH_TYPE,
                 ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT),
             ControllerTimer.CRON_SCHEDULER_JOB_EXECUTION_TIME_MS, 100_000, TimeUnit.MILLISECONDS);
-        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TASKTYPE_TABLE_NAME_WITH_TYPE,
+        assertTimerExportedCorrectly(controllerTimer.getTimerName(), ExportedLabels.TASKTYPE_TABLENAME_TABLETYPE,
             EXPORTED_METRIC_PREFIX);
       } else {
         _controllerMetrics.addTimedTableValue(TABLE_NAME_WITH_TYPE, controllerTimer, 30_000L, TimeUnit.MILLISECONDS);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
@@ -180,7 +180,7 @@ public abstract class PinotPrometheusMetricsTest {
     List<PromMetric> promMetrics;
     try {
       promMetrics = parseExportedPromMetrics(getExportedPromMetrics().getResponse());
-      for (String meterType : METER_TYPES) {
+      for (String meterType : TIMER_TYPES) {
         PromMetric expectedTimer =
             PromMetric.withNameAndLabels(exportedMetricPrefix + exportedTimerPrefix + "_" + meterType, labels);
         Assert.assertTrue(promMetrics.contains(expectedTimer),

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
@@ -165,8 +165,8 @@ public abstract class PinotPrometheusMetricsTest {
     List<PromMetric> promMetrics;
     try {
       promMetrics = parseExportedPromMetrics(getExportedPromMetrics().getResponse());
-      for (String meterType : TIMER_TYPES) {
-        PromMetric expectedTimer = PromMetric.withName(exportedMetricPrefix + exportedTimerPrefix + "_" + meterType);
+      for (String timerType : TIMER_TYPES) {
+        PromMetric expectedTimer = PromMetric.withName(exportedMetricPrefix + exportedTimerPrefix + "_" + timerType);
         Assert.assertTrue(promMetrics.contains(expectedTimer),
             "Cannot find timer: " + expectedTimer + " in exported metrics");
       }
@@ -180,9 +180,9 @@ public abstract class PinotPrometheusMetricsTest {
     List<PromMetric> promMetrics;
     try {
       promMetrics = parseExportedPromMetrics(getExportedPromMetrics().getResponse());
-      for (String meterType : TIMER_TYPES) {
+      for (String timerType : TIMER_TYPES) {
         PromMetric expectedTimer =
-            PromMetric.withNameAndLabels(exportedMetricPrefix + exportedTimerPrefix + "_" + meterType, labels);
+            PromMetric.withNameAndLabels(exportedMetricPrefix + exportedTimerPrefix + "_" + timerType, labels);
         Assert.assertTrue(promMetrics.contains(expectedTimer),
             "Cannot find timer: " + expectedTimer + " in exported metrics");
       }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
@@ -330,12 +330,12 @@ public abstract class PinotPrometheusMetricsTest {
             ExportedLabelValues.TABLETYPE_REALTIME, ExportedLabelKeys.TASKTYPE,
             ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT);
 
-    public static final List<String> JOBSTATUS_TABLE_NAME_WITH_TYPE =
-        List.of(STATUS, ExportedLabelValues.DONE, TABLE, ExportedLabelValues.TABLENAME_WITH_TYPE_REALTIME);
+    public static final List<String> JOBSTATUS_TABLENAME_TABLETYPE =
+        List.of(STATUS, ExportedLabelValues.DONE, TABLE, ExportedLabelValues.TABLENAME, TABLETYPE, TABLETYPE_REALTIME);
 
-    public static final List<String> TASKTYPE_TABLE_NAME_WITH_TYPE =
-        List.of(TASKTYPE, ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT, TABLE,
-            ExportedLabelValues.TABLENAME_WITH_TYPE_REALTIME);
+    public static final List<String> TASKTYPE_TABLENAME_TABLETYPE =
+        List.of(TASKTYPE, ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT, TABLE, ExportedLabelValues.TABLENAME,
+            TABLETYPE, TABLETYPE_REALTIME);
   }
 
   public static class ExportedLabelKeys {

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
@@ -329,6 +329,13 @@ public abstract class PinotPrometheusMetricsTest {
         List.of(ExportedLabelKeys.TABLE, ExportedLabelValues.TABLENAME, ExportedLabelKeys.TABLETYPE,
             ExportedLabelValues.TABLETYPE_REALTIME, ExportedLabelKeys.TASKTYPE,
             ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT);
+
+    public static final List<String> JOBSTATUS_TABLE_NAME_WITH_TYPE =
+        List.of(STATUS, ExportedLabelValues.DONE, TABLE, ExportedLabelValues.TABLENAME_WITH_TYPE_REALTIME);
+
+    public static final List<String> TASKTYPE_TABLE_NAME_WITH_TYPE =
+        List.of(TASKTYPE, ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT, TABLE,
+            ExportedLabelValues.TABLENAME_WITH_TYPE_REALTIME);
   }
 
   public static class ExportedLabelKeys {
@@ -351,6 +358,7 @@ public abstract class PinotPrometheusMetricsTest {
     public static final String CONTROLLER_PERIODIC_TASK_CHC = "ClusterHealthCheck";
     public static final String MINION_TASK_SEGMENT_IMPORT = "SegmentImportTask";
     public static final String IN_PROGRESS = "IN_PROGRESS";
+    public static final String DONE = "DONE";
   }
 
   /*


### PR DESCRIPTION
Today the two controller timers `tableRebalanceExecutionTimeMs` and `cronSchedulerJobExecutionTimeMs` are showing up in Prometheus with the following type of metric names:

- `pinot_controller_myTable_REALTIME_95thPercentile{status="tableRebalanceExecutionTimeMs",taskType="DONE"}`

The actual metric name is showing up as a label, whereas the metric name seems to contain the table name. This is not the correct naming scheme for these metrics and it is hard to create dashboards for such metrics.

This PR copies over the metric definitions for each of these from `pinot.yml` to `controller.yml` and updates the tests. The new metrics will show up as follows in Prometheus:

- `pinot_controller_tableRebalanceExecutionTimeMs_95thPercentile{status="DONE",table="myTable_REALTIME"}`

cc @suddendust @klsince @Jackie-Jiang 