### PR TITLE
Adds log and metric to debug slow ingestion while upsert snapshot

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -55,6 +55,8 @@ public enum ServerTimer implements AbstractMetrics.Timer {
       "Total time taken to delete expired upsert primary keys based on metadataTTL or deletedKeysTTL"),
   GRPC_QUERY_EXECUTION_MS("milliseconds", false, "Total execution time of a successful query over gRPC"),
   UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot"),
+  UPSERT_SNAPSHOT_WRITE_LOCK_TIME_MS("milliseconds", false,
+      "Total time taken to acquire write lock before taking upsert table snapshot"),
 
   DEDUP_REMOVE_EXPIRED_PRIMARY_KEYS_TIME_MS("milliseconds", false,
       "Total time taken to delete expired dedup primary keys based on metadataTTL or deletedKeysTTL"),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -861,8 +861,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
         startTime = System.currentTimeMillis();
         doTakeSnapshot();
-        _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS,
-            System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
+        long duration = System.currentTimeMillis() - startTime;
+        _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS, duration,
+            TimeUnit.MILLISECONDS);
       } catch (Exception e) {
         _logger.warn("Caught exception while taking snapshot", e);
       } finally {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -849,8 +849,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       return;
     }
 
-    long startTime = System.currentTimeMillis();
     try {
+      long startTime = System.currentTimeMillis();
       while (!_snapshotLock.writeLock().tryLock(5, TimeUnit.MINUTES)) {
         _logger.warn("Unable to acquire snapshotLock.writeLock in: {}", System.currentTimeMillis() - startTime);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -860,7 +860,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
             System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
 
         startTime = System.currentTimeMillis();
-
         doTakeSnapshot();
         _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS,
             System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -853,7 +853,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     long startTime = System.currentTimeMillis();
     try {
       while (!_snapshotLock.writeLock().tryLock(5, TimeUnit.MINUTES)) {
-        _logger.info("Unable to acquire snapshotLock.writeLock in: {}", System.currentTimeMillis() - startTime);
+        _logger.warn("Unable to acquire snapshotLock.writeLock in: {}", System.currentTimeMillis() - startTime);
       }
       doTakeSnapshot();
       long duration = System.currentTimeMillis() - startTime;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -853,7 +853,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     try {
       long startTime = System.currentTimeMillis();
       while (!_snapshotLock.writeLock().tryLock(5, TimeUnit.MINUTES)) {
-        _logger.warn("Unable to acquire snapshotLock.writeLock in: {}. Retrying.", System.currentTimeMillis() - startTime);
+        _logger.warn("Unable to acquire snapshotLock.writeLock in: {} ms. Retrying.",
+            System.currentTimeMillis() - startTime);
       }
       try {
         _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_WRITE_LOCK_TIME_MS,
@@ -861,9 +862,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
         startTime = System.currentTimeMillis();
         doTakeSnapshot();
-        long duration = System.currentTimeMillis() - startTime;
-        _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS, duration,
-            TimeUnit.MILLISECONDS);
+        _serverMetrics.addTimedTableValue(_tableNameWithType, ServerTimer.UPSERT_SNAPSHOT_TIME_MS,
+            System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
       } catch (Exception e) {
         _logger.warn("Caught exception while taking snapshot", e);
       } finally {


### PR DESCRIPTION
Snapshot lock is acquired before a consumer starts consuming. When there is slow ingestion, There are no logs if consumer is stuck on upsert snapshot. 