### PR TITLE
Metrics for monitoring PROPERTYSTORE/SEGMENTS/<table>'s getChildren response size

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=21.0.6-tem

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=21.0.6-tem

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -54,6 +54,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // be queried from the table.
   SEGMENT_COUNT_INCLUDING_REPLACED("SegmentCount", false),
 
+  // Track response size of getChildren from /PROPERTYSTORE/SEGMENTS/<table>
+  PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE("propertystore", false),
   IDEALSTATE_ZNODE_SIZE("idealstate", false),
   IDEALSTATE_ZNODE_BYTE_SIZE("idealstate", false),
   EXTERNALVIEW_ZNODE_SIZE("externalview", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -256,7 +256,8 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         segmentNamesBytesSize += segmentName.getBytes().length;
       }
     }
-    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE, segmentNamesBytesSize);
+    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE,
+        segmentNamesBytesSize);
 
     Set<String> segments;
     if (segmentsIncludingReplaced.isEmpty()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -248,16 +248,19 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     // be queried from the table.
     ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
 
-    String segmentsPath = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType);
-    List<String> segmentNames = propertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT);
-    long segmentNamesBytesSize = 0;
-    if (segmentNames != null) {
-      for (String segmentName : segmentNames) {
-        segmentNamesBytesSize += segmentName.getBytes().length;
+    if (propertyStore != null) {
+      String segmentsPath = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType);
+      List<String> segmentNames = propertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT);
+      long segmentNamesBytesSize = 0;
+      if (segmentNames != null) {
+        for (String segmentName : segmentNames) {
+          segmentNamesBytesSize += segmentName.getBytes().length;
+        }
       }
+      _controllerMetrics.setValueOfTableGauge(tableNameWithType,
+          ControllerGauge.PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE,
+          segmentNamesBytesSize);
     }
-    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE,
-        segmentNamesBytesSize);
 
     Set<String> segments;
     if (segmentsIncludingReplaced.isEmpty()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -37,6 +38,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.lineage.SegmentLineageUtils;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -245,6 +247,17 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     // Get the segments excluding the replaced segments which are specified in the segment lineage entries and cannot
     // be queried from the table.
     ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+
+    String segmentsPath = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType);
+    List<String> segmentNames = propertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT);
+    long segmentNamesBytesSize = 0;
+    if (segmentNames != null) {
+      for (String segmentName : segmentNames) {
+        segmentNamesBytesSize += segmentName.getBytes().length;
+      }
+    }
+    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE, segmentNamesBytesSize);
+
     Set<String> segments;
     if (segmentsIncludingReplaced.isEmpty()) {
       segments = Set.of();


### PR DESCRIPTION
Currently, we lack visibility into how much large the getChildren() response could be under "/PROPERTYSTORE/SEGMENTS/\<table\>" especially when the number of segments is huge.

This PR adds a new metric PROPERTYSTORE_SEGMENT_CHILDREN_BYTE_SIZE to track the total bytes used by segment names for each table in ZooKeeper's PropertyStore.

Modified existing integration tests in ControllerPeriodicTasksIntegrationTest to verify the new metric is correctly calculated and reported.

Also able to read metrics like pinot_controller_propertystoreSegmentChildrenByteSize_Value from /metrics
<img width="1178" alt="Screenshot 2025-03-26 at 2 26 42 PM" src="https://github.com/user-attachments/assets/597a68dc-a158-4107-a01b-00d94d794349" />