### PR TITLE
Initialize MSE worker thread context for TSE queries

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -237,7 +237,8 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   @Override
   public void submitTimeSeries(Worker.TimeSeriesQueryRequest request,
       StreamObserver<Worker.TimeSeriesResponse> responseObserver) {
-    try (QueryThreadContext.CloseableContext closeable = QueryThreadContext.open()) {
+    try (QueryThreadContext.CloseableContext queryTlClosable = QueryThreadContext.open();
+        QueryThreadContext.CloseableContext mseTlCloseable = MseWorkerThreadContext.open()) {
       // TODO: populate the thread context with TSE information
       QueryThreadContext.setQueryEngine("tse");
       _queryRunner.processTimeSeriesQuery(request.getDispatchPlanList(), request.getMetadataMap(), responseObserver);


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/15180 didn't add the MSE worker thread context initialization for TSE queries.
- This isn't an issue for actual TSE queries in real clusters since "strict" mode would be disabled but this will cause tests to fail.