### PR TITLE
add MetricsExecutor to track number of tasks started and finished in MSE

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -171,6 +171,15 @@ public enum ServerMeter implements AbstractMetrics.Meter {
    */
   WINDOW_TIMES_MAX_ROWS_REACHED("times", true),
 
+  /// Number of tasks started by the MSE query runner
+  MULTI_STAGE_RUNNER_STARTED_TASKS("tasks", true),
+  /// Number of stats completed by the MSE query runner
+  MULTI_STAGE_RUNNER_COMPLETED_TASKS("tasks", true),
+  /// Number of tasks started by the MSE query submission executor
+  MULTI_STAGE_SUBMISSION_STARTED_TASKS("tasks", true),
+  /// Number of tasks completed by the MSE query submission executor
+  MULTI_STAGE_SUBMISSION_COMPLETED_TASKS("tasks", true),
+
   // predownload metrics
   PREDOWNLOAD_SEGMENT_DOWNLOAD_COUNT("predownloadSegmentCount", true),
   PREDOWNLOAD_SEGMENT_DOWNLOAD_FAILURE_COUNT("predownloadSegmentFailureCount", true),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
@@ -75,6 +76,7 @@ import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.executor.ExecutorServiceUtils;
 import org.apache.pinot.spi.executor.HardLimitExecutor;
+import org.apache.pinot.spi.executor.MetricsExecutor;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -176,14 +178,19 @@ public class QueryRunner {
     String joinOverflowModeStr = config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_JOIN_OVERFLOW_MODE);
     _joinOverflowMode = joinOverflowModeStr != null ? JoinOverFlowMode.valueOf(joinOverflowModeStr) : null;
 
+    ExecutorService baseExecutorService = ExecutorServiceUtils.create(
+        config,
+        Server.MULTISTAGE_EXECUTOR_CONFIG_PREFIX,
+        "query-runner-on-" + port,
+        Server.DEFAULT_MULTISTAGE_EXECUTOR_TYPE
+    );
+
+    MetricsExecutor metricsExecutor = new MetricsExecutor(
+        baseExecutorService,
+        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_STARTED_TASKS),
+        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_COMPLETED_TASKS));
     _executorService = MseWorkerThreadContext.contextAwareExecutorService(
-        QueryThreadContext.contextAwareExecutorService(
-            ExecutorServiceUtils.create(
-                config,
-                Server.MULTISTAGE_EXECUTOR_CONFIG_PREFIX, "query-runner-on-" + port,
-                Server.DEFAULT_MULTISTAGE_EXECUTOR_TYPE
-            )
-        )
+        QueryThreadContext.contextAwareExecutorService(metricsExecutor)
     );
 
     int hardLimit = HardLimitExecutor.getMultiStageExecutorHardLimit(config);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.service.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -36,6 +37,8 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.NamedThreadFactory;
@@ -49,6 +52,8 @@ import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.QueryRunner;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.executor.MetricsExecutor;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -76,17 +81,26 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
 
   private Server _server = null;
 
+  @VisibleForTesting
   public QueryServer(int port, QueryRunner queryRunner, @Nullable TlsConfig tlsConfig) {
+    this(port, queryRunner, tlsConfig, ServerMetrics.get(), new PinotConfiguration());
+  }
+
+  public QueryServer(int port, QueryRunner queryRunner, @Nullable TlsConfig tlsConfig,
+      ServerMetrics serverMetrics, PinotConfiguration config) {
     _port = port;
     _queryRunner = queryRunner;
     _tlsConfig = tlsConfig;
+
+    ExecutorService baseExecutor = Executors.newCachedThreadPool(
+        new NamedThreadFactory("query_submission_executor_on_" + _port + "_port"));
+
+    MetricsExecutor withMetrics = new MetricsExecutor(
+        baseExecutor,
+        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_STARTED_TASKS),
+        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_COMPLETED_TASKS));
     _querySubmissionExecutorService = MseWorkerThreadContext.contextAwareExecutorService(
-        QueryThreadContext.contextAwareExecutorService(
-            Executors.newCachedThreadPool(
-                new NamedThreadFactory("query_submission_executor_on_" + _port + "_port")
-            )
-        )
-    );
+        QueryThreadContext.contextAwareExecutorService(withMetrics));
   }
 
   public void start() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -78,7 +78,7 @@ public class QueryServerEnclosure {
     InstanceDataManager instanceDataManager = factory.buildInstanceDataManager();
     HelixManager helixManager = mockHelixManager(factory.buildSchemaMap());
     _queryRunner = new QueryRunner();
-    _queryRunner.init(new PinotConfiguration(runnerConfig), instanceDataManager, helixManager, mockServiceMetrics(),
+    _queryRunner.init(new PinotConfiguration(runnerConfig), instanceDataManager, helixManager, ServerMetrics.get(),
         null);
   }
 
@@ -99,10 +99,6 @@ public class QueryServerEnclosure {
     HelixManager helixManager = mock(HelixManager.class);
     when(helixManager.getHelixPropertyStore()).thenReturn(zkHelixPropertyStore);
     return helixManager;
-  }
-
-  private ServerMetrics mockServiceMetrics() {
-    return mock(ServerMetrics.class);
   }
 
   public int getPort() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
@@ -43,7 +43,7 @@ public class WorkerQueryServer {
         CommonConstants.MultiStageQueryRunner.DEFAULT_QUERY_SERVER_PORT);
     QueryRunner queryRunner = new QueryRunner();
     queryRunner.init(_configuration, instanceDataManager, helixManager, serverMetrics, tlsConfig);
-    _queryWorkerService = new QueryServer(_queryServicePort, queryRunner, tlsConfig);
+    _queryWorkerService = new QueryServer(_queryServicePort, queryRunner, tlsConfig, serverMetrics, configuration);
   }
 
   private static PinotConfiguration toWorkerQueryConfig(PinotConfiguration configuration) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/MetricsExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/MetricsExecutor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.executor;
 
+import com.google.common.base.Preconditions;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.spi.metrics.PinotMeter;
@@ -33,6 +34,9 @@ public class MetricsExecutor extends DecoratorExecutorService {
 
   public MetricsExecutor(ExecutorService executorService, PinotMeter startedTasks, PinotMeter completedTasks) {
     super(executorService);
+    // These tests are added to fail fast in case null meters are sent, which is normal in tests when using mocks.
+    Preconditions.checkNotNull(startedTasks, "Started tasks meter should not be null");
+    Preconditions.checkNotNull(completedTasks, "Completed tasks meter should not be null");
     _startedTasks = startedTasks;
     _completedTasks = completedTasks;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/MetricsExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/MetricsExecutor.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.executor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.spi.metrics.PinotMeter;
+
+
+/**
+ * An executor that keeps track of the number of tasks that have been started and finished
+ */
+public class MetricsExecutor extends DecoratorExecutorService {
+
+  private final PinotMeter _startedTasks;
+  private final PinotMeter _completedTasks;
+
+  public MetricsExecutor(ExecutorService executorService, PinotMeter startedTasks, PinotMeter completedTasks) {
+    super(executorService);
+    _startedTasks = startedTasks;
+    _completedTasks = completedTasks;
+  }
+
+  @Override
+  protected <T> Callable<T> decorate(Callable<T> task) {
+    return () -> {
+      _startedTasks.mark();
+      try {
+        return task.call();
+      } finally {
+        _completedTasks.mark();
+      }
+    };
+  }
+
+  @Override
+  protected Runnable decorate(Runnable task) {
+    return () -> {
+      _startedTasks.mark();
+      try {
+        task.run();
+      } finally {
+        _completedTasks.mark();
+      }
+    };
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -875,8 +875,6 @@ public class CommonConstants {
     public static final String MULTISTAGE_EXECUTOR = "multistage.executor";
     public static final String MULTISTAGE_EXECUTOR_CONFIG_PREFIX =
         QUERY_EXECUTOR_CONFIG_PREFIX + "." + MULTISTAGE_EXECUTOR;
-    public static final String TYPE = "type";
-    public static final String CONFIG_OF_MULTISTAGE_EXECUTOR_TYPE = MULTISTAGE_EXECUTOR_CONFIG_PREFIX + "." + TYPE;
     public static final String DEFAULT_MULTISTAGE_EXECUTOR_TYPE = "cached";
     @Deprecated
     public static final String CONFIG_OF_QUERY_EXECUTOR_OPCHAIN_EXECUTOR = MULTISTAGE_EXECUTOR_CONFIG_PREFIX;


### PR DESCRIPTION
This PR adds 4 new metrics to track the number of tasks started and finished in both submission and runner MSE thread runners.

These metrics will be useful for analyzing the impact of different changes in MSE and for determining the number of tasks running at each moment.