### PR TITLE
Added support to apply record enrichers before complex transformations

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -82,9 +82,14 @@ public class SegmentMapper {
       List<RecordTransformer> customRecordTransformers, SegmentProcessorConfig processorConfig, File mapperOutputDir) {
     this(recordReaderFileConfigs,
         new TransformPipeline(
-            CompositeTransformer.composeAllTransformers(customRecordTransformers, processorConfig.getTableConfig(),
-                processorConfig.getSchema()),
-            ComplexTypeTransformer.getComplexTypeTransformer(processorConfig.getTableConfig())),
+            // pre-complex type transformers
+            CompositeTransformer.getPreComplexTypeTransformers(processorConfig.getTableConfig()),
+            // complex type transformer
+            ComplexTypeTransformer.getComplexTypeTransformer(processorConfig.getTableConfig()),
+            // plain record transformations
+            CompositeTransformer.composeAllTransformers(
+                customRecordTransformers, processorConfig.getTableConfig(), processorConfig.getSchema()
+            )),
         processorConfig, mapperOutputDir);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -39,11 +39,28 @@ import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherRegistry;
  * The {@code CompositeTransformer} class performs multiple transforms based on the inner {@link RecordTransformer}s.
  */
 public class CompositeTransformer implements RecordTransformer {
+  // TODO: Integrate ComplexTypeTransformer into the CompositeTransformer.
   private final List<RecordTransformer> _transformers;
 
   /**
+   * Returns a list of record transformers that perform enrichment of the record before the record is passed onto the
+   * ComplexType transformer. The transform pipeline order is as follows:
+   * <ol>
+   *  <li> pre-complex type transformers</li>
+   *  <li> complex type transformers</li>
+   *  <li> plain record transformers</li>
+   * </ol>
+   */
+  public static List<RecordTransformer> getPreComplexTypeTransformers(TableConfig tableConfig) {
+    List<RecordTransformer> preComplexTypeTransformers = new ArrayList<>();
+    addRecordEnricherTransformers(tableConfig, preComplexTypeTransformers, true);
+    return preComplexTypeTransformers;
+  }
+
+  /**
    * Returns a record transformer that performs null value handling, time/expression/data-type transformation and record
-   * sanitization.
+   * sanitization. Note that the list of transformers returned from this method does not include the pre-complex type
+   * and complex type transformers.
    * <p>NOTE: DO NOT CHANGE THE ORDER OF THE RECORD TRANSFORMERS
    * <ul>
    *   <li>
@@ -87,20 +104,7 @@ public class CompositeTransformer implements RecordTransformer {
    */
   public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema) {
     List<RecordTransformer> transformers = new ArrayList<>();
-    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
-    if (ingestionConfig != null) {
-      List<EnrichmentConfig> enrichmentConfigs = ingestionConfig.getEnrichmentConfigs();
-      if (enrichmentConfigs != null) {
-        for (EnrichmentConfig enrichmentConfig : enrichmentConfigs) {
-          try {
-            addIfNotNoOp(transformers, RecordEnricherRegistry.createRecordEnricher(enrichmentConfig));
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to instantiate record enricher " + enrichmentConfig.getEnricherType(),
-                e);
-          }
-        }
-      }
-    }
+    addRecordEnricherTransformers(tableConfig, transformers, false);
     addIfNotNoOp(transformers, new ExpressionTransformer(tableConfig, schema));
     addIfNotNoOp(transformers, new FilterTransformer(tableConfig));
     addIfNotNoOp(transformers, new SchemaConformingTransformer(tableConfig, schema));
@@ -115,6 +119,29 @@ public class CompositeTransformer implements RecordTransformer {
   private static void addIfNotNoOp(List<RecordTransformer> transformers, RecordTransformer transformer) {
     if (!transformer.isNoOp()) {
       transformers.add(transformer);
+    }
+  }
+
+  private static void addRecordEnricherTransformers(TableConfig tableConfig,
+      List<RecordTransformer> transformers, boolean preComplexTypeTransformers) {
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig != null) {
+      List<EnrichmentConfig> enrichmentConfigs = ingestionConfig.getEnrichmentConfigs();
+      if (enrichmentConfigs != null) {
+        for (EnrichmentConfig enrichmentConfig : enrichmentConfigs) {
+          // if pre-ComplexType transformers are requested, add only pre-ComplexType transformers. Similarly, if
+          // non pre-ComplexType transformers are requested, add only non pre-ComplexType transformers.
+          if (preComplexTypeTransformers != enrichmentConfig.isPreComplexTypeTransform()) {
+            continue;
+          }
+          try {
+            addIfNotNoOp(transformers, RecordEnricherRegistry.createRecordEnricher(enrichmentConfig));
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to instantiate record enricher " + enrichmentConfig.getEnricherType(),
+                e);
+          }
+        }
+      }
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -39,18 +39,21 @@ import org.apache.pinot.spi.recordtransformer.RecordTransformer;
  * It is used mainly but not limited by RealTimeDataManager for each row that is going to be indexed into Pinot.
  */
 public class TransformPipeline {
-  private final RecordTransformer _recordTransformer;
+  private final List<RecordTransformer> _preComplexTypeTransformers;
   private final ComplexTypeTransformer _complexTypeTransformer;
+  private final RecordTransformer _recordTransformer;
 
   /**
    * Constructs a transform pipeline with customized RecordTransformer and customized ComplexTypeTransformer
-   * @param recordTransformer the customized record transformer
+   * @param preComplexTypeTransformers the list of customized pre-complex type transformers
    * @param complexTypeTransformer the customized complexType transformer
+   * @param recordTransformer the customized record transformer
    */
-  public TransformPipeline(RecordTransformer recordTransformer,
-      @Nullable ComplexTypeTransformer complexTypeTransformer) {
-    _recordTransformer = recordTransformer;
+  public TransformPipeline(@Nullable List<RecordTransformer> preComplexTypeTransformers,
+      @Nullable ComplexTypeTransformer complexTypeTransformer, RecordTransformer recordTransformer) {
+    _preComplexTypeTransformers = preComplexTypeTransformers;
     _complexTypeTransformer = complexTypeTransformer;
+    _recordTransformer = recordTransformer;
   }
 
   /**
@@ -59,18 +62,21 @@ public class TransformPipeline {
    * @param schema the table schema
    */
   public TransformPipeline(TableConfig tableConfig, Schema schema) {
-    // Create record transformer
-    _recordTransformer = CompositeTransformer.getDefaultTransformer(tableConfig, schema);
+    // Create pre complex type transformers
+    _preComplexTypeTransformers = CompositeTransformer.getPreComplexTypeTransformers(tableConfig);
 
     // Create complex type transformer
     _complexTypeTransformer = ComplexTypeTransformer.getComplexTypeTransformer(tableConfig);
+
+    // Create record transformer
+    _recordTransformer = CompositeTransformer.getDefaultTransformer(tableConfig, schema);
   }
 
   /**
    * Returns a pass through pipeline that does not transform the record.
    */
   public static TransformPipeline getPassThroughPipeline() {
-    return new TransformPipeline(CompositeTransformer.getPassThroughTransformer(), null);
+    return new TransformPipeline(null, null, CompositeTransformer.getPassThroughTransformer());
   }
 
   public Collection<String> getInputColumns() {
@@ -92,6 +98,13 @@ public class TransformPipeline {
   public void processRow(GenericRow decodedRow, Result reusedResult)
       throws Exception {
     reusedResult.reset();
+
+    if (_preComplexTypeTransformers != null) {
+      for (RecordTransformer preComplexTypeTransformer : _preComplexTypeTransformers) {
+        decodedRow = preComplexTypeTransformer.transform(decodedRow);
+      }
+    }
+
     if (_complexTypeTransformer != null) {
       // TODO: consolidate complex type transformer into composite type transformer
       decodedRow = _complexTypeTransformer.transform(decodedRow);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.recordtransformer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.EnrichmentConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.recordtransformer.RecordTransformer;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+
+public class CompositeTransformerTest {
+  @Test
+  public void testGetPreComplexTypeTransformers()
+      throws JsonProcessingException {
+    String tableName = "myTable_OFFLINE";
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    EnrichmentConfig erc1 = new EnrichmentConfig("generateColumn",
+        new ObjectMapper().readTree("{\"fieldToFunctionMap\": {}}"), true);
+    EnrichmentConfig erc2 = new EnrichmentConfig("noOp",
+        new ObjectMapper().readTree("{}"), false);
+    List<EnrichmentConfig> enrichmentConfigs = Arrays.asList(erc1, erc2);
+    ingestionConfig.setEnrichmentConfigs(enrichmentConfigs);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
+        .setIngestionConfig(ingestionConfig).build();
+    List<RecordTransformer> recordTransformers = CompositeTransformer.getPreComplexTypeTransformers(tableConfig);
+    assertEquals(recordTransformers.size(), 1);
+  }
+
+  @Test
+  public void testGetDefaultTransformers()
+      throws JsonProcessingException {
+    String tableName = "myTable_OFFLINE";
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    EnrichmentConfig erc1 = new EnrichmentConfig("generateColumn",
+        new ObjectMapper().readTree("{\"fieldToFunctionMap\": {}}"), true);
+    List<EnrichmentConfig> enrichmentConfigs = List.of(erc1);
+    ingestionConfig.setEnrichmentConfigs(enrichmentConfigs);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
+        .setIngestionConfig(ingestionConfig).build();
+    Schema schema = new Schema();
+    schema.setSchemaName(tableName);
+    schema.addField(new DimensionFieldSpec("id", FieldSpec.DataType.STRING, true));
+    List<RecordTransformer> recordTransformers = CompositeTransformer.getDefaultTransformers(tableConfig, schema);
+    assertEquals(recordTransformers.size(), 3);
+    Set<String> recordTransformerNames = new HashSet<>();
+    for (RecordTransformer recordTransformer : recordTransformers) {
+      recordTransformerNames.add(recordTransformer.getClass().getSimpleName());
+    }
+    assertFalse(recordTransformerNames.contains("CustomFunctionEnricher"));
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/EnrichmentConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/EnrichmentConfig.java
@@ -32,11 +32,16 @@ public class EnrichmentConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Enricher properties")
   private final JsonNode _properties;
 
+  @JsonPropertyDescription("The transformation that is applied before the complex type transformation")
+  private final boolean _preComplexTypeTransform;
+
   @JsonCreator
   public EnrichmentConfig(@JsonProperty("enricherType") String enricherType,
-      @JsonProperty("properties") JsonNode properties) {
+      @JsonProperty("properties") JsonNode properties,
+      @JsonProperty("preComplexTypeTransform") boolean preComplexTypeTransform) {
     _enricherType = enricherType;
     _properties = properties;
+    _preComplexTypeTransform = preComplexTypeTransform;
   }
 
   public String getEnricherType() {
@@ -45,5 +50,9 @@ public class EnrichmentConfig extends BaseJsonConfig {
 
   public JsonNode getProperties() {
     return _properties;
+  }
+
+  public boolean isPreComplexTypeTransform() {
+    return _preComplexTypeTransform;
   }
 }


### PR DESCRIPTION
Make https://github.com/apache/pinot/pull/15267 prod ready.

Added support to apply enrichments to incoming records before the record is passed on to the Complex transformer. With this change, a record undergoes transformations in the following order within the transform pipeline:
- Apply record pre-enricher transformations
- Apply complex type transformations
- Apply plain records transformations including enrichments

## Problem
The ComplexType transformer helps un-nest and flatten records when desired. However, it's required that a valid field in the incoming data is specified within the complex type config. Often times, the incoming record does not have a fixed field name and has dynamic data (schema-less data).

## Solution
The solution was to enrich the record before passing the record onto the complex transformer.

## Example

Consider the following json input.
```
{
  "cscores": {
    "ctype1": {
      "score": 7.93,
      "score_type": "modelName"
    },
    "ctype2": {
      "score": 56.0,
      "score_type": "modelName"
    },
    "ctype3": {
      "score": 8.5,
      "score_type": "modelName"
    }
  }
}
```

The enrichment configuration.

```
{
  "enrichmentConfigs": [
    {
      "enricherType": "generateColumn",
      "preComplexTypeTransform": true,
      "properties": {
        "fieldToFunctionMap": {
          "c_score_array": "Groovy({ def outputList = cscores.collect { dimension, data -> return [dimension: dimension, score: data.score, score_type: data.score_type ]}}, cscores)"
        }
      }
    }
  ],
  "complexTypeConfig": {
    "fieldsToUnnest": [
      "c_score_array"
    ],
    "delimiter": ".",
    "collectionNotUnnestedToJson": "NON_PRIMITIVE"
  }
}
```

The table schema.

```
{
  "schemaName": "cscores001",
  "dimensionFieldSpecs": [
    {
      "name": "c_score_array.dimension",
      "dataType": "STRING",
      "fieldType": "DIMENSION"
    },
    {
      "name": "c_score_array.score",
      "dataType": "FLOAT",
      "fieldType": "DIMENSION"
    },
    {
      "name": "c_score_array.score_type",
      "dataType": "STRING",
      "fieldType": "DIMENSION"
    }
  ]
}
```

Query results.
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/66efc2b1-475e-4029-a0bc-3a061e8fc44e" />

