### PR TITLE
Fix needReload rebalance pre-check to only fetch status from currently assigned servers

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -126,8 +126,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
       // exception for servers that don't contain segments for the given table
       Set<String> serverInstanceSet = getCurrentlyAssignedServerSet(currentAssignment);
       TableMetadataReader.TableReloadJsonResponse needsReloadMetadataPair =
-          metadataReader.getServerCheckSegmentsReloadMetadataForServerSet(tableNameWithType, 30_000,
-              serverInstanceSet);
+          metadataReader.getServerSetCheckSegmentsReloadMetadata(tableNameWithType, 30_000, serverInstanceSet);
       Map<String, JsonNode> needsReloadMetadata = needsReloadMetadataPair.getServerReloadJsonResponses();
       int failedResponses = needsReloadMetadataPair.getNumFailedResponses();
       LOGGER.info("Received {} needs reload responses and {} failed responses from servers for table: {} with "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -79,7 +79,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
 
     Map<String, RebalancePreCheckerResult> preCheckResult = new HashMap<>();
     // Check for reload status
-    preCheckResult.put(NEEDS_RELOAD_STATUS, checkReloadNeededOnServers(rebalanceJobId, tableNameWithType));
+    preCheckResult.put(NEEDS_RELOAD_STATUS, checkReloadNeededOnServers(rebalanceJobId, tableNameWithType,
+        preCheckContext.getCurrentAssignment()));
     // Check whether minimizeDataMovement is set in TableConfig
     preCheckResult.put(IS_MINIMIZE_DATA_MOVEMENT, checkIsMinimizeDataMovement(rebalanceJobId,
         tableNameWithType, tableConfig, rebalanceConfig));
@@ -107,7 +108,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
    * TODO: Add an API to check for whether segments in deep store are up to date with the table configs and schema
    *       and add a pre-check here to call that API.
    */
-  private RebalancePreCheckerResult checkReloadNeededOnServers(String rebalanceJobId, String tableNameWithType) {
+  private RebalancePreCheckerResult checkReloadNeededOnServers(String rebalanceJobId, String tableNameWithType,
+      Map<String, Map<String, String>> currentAssignment) {
     LOGGER.info("Fetching whether reload is needed for table: {} with rebalanceJobId: {}", tableNameWithType,
         rebalanceJobId);
     Boolean needsReload = null;
@@ -119,12 +121,18 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     try (PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager()) {
       TableMetadataReader metadataReader = new TableMetadataReader(_executorService, connectionManager,
           _pinotHelixResourceManager);
+      // Only send needReload request to servers that are part of the current assignment. The tagged server list may
+      // include new servers which are part of target assignment but not current assignment. needReload throws an
+      // exception for servers that don't contain segments for the given table
+      Set<String> serverInstanceSet = getCurrentlyAssignedServerSet(currentAssignment);
       TableMetadataReader.TableReloadJsonResponse needsReloadMetadataPair =
-          metadataReader.getServerCheckSegmentsReloadMetadata(tableNameWithType, 30_000);
+          metadataReader.getServerCheckSegmentsReloadMetadataForServerSet(tableNameWithType, 30_000,
+              serverInstanceSet);
       Map<String, JsonNode> needsReloadMetadata = needsReloadMetadataPair.getServerReloadJsonResponses();
       int failedResponses = needsReloadMetadataPair.getNumFailedResponses();
       LOGGER.info("Received {} needs reload responses and {} failed responses from servers for table: {} with "
-          + "rebalanceJobId: {}", needsReloadMetadata.size(), failedResponses, tableNameWithType, rebalanceJobId);
+          + "rebalanceJobId: {}, serverSet queried: {}", needsReloadMetadata.size(), failedResponses, tableNameWithType,
+          rebalanceJobId, serverInstanceSet);
       needsReload = needsReloadMetadata.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
       if (!needsReload && failedResponses > 0) {
         LOGGER.warn("Received {} failed responses from servers and needsReload is false from returned responses, "
@@ -227,6 +235,14 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
       LOGGER.warn("Error while trying to fetch instance assignment config, assuming minimizeDataMovement is false", e);
     }
     return RebalancePreCheckerResult.error("Got exception when fetching instance assignment, check manually");
+  }
+
+  private Set<String> getCurrentlyAssignedServerSet(Map<String, Map<String, String>> currentAssignment) {
+    Set<String> serverList = new HashSet<>();
+    for (Map<String, String> serverStateMap : currentAssignment.values()) {
+      serverList.addAll(serverStateMap.keySet());
+    }
+    return serverList;
   }
 
   private RebalancePreCheckerResult checkDiskUtilization(Map<String, Map<String, String>> currentAssignment,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -80,8 +80,8 @@ public class TableMetadataReader {
   }
 
   /**
-   * Check if segments need a reload on any servers based on a provided server list (useful for rebalance where the
-   * server list may not match the currently tagged server list)
+   * Check if segments need a reload on any servers based on a provided server set (useful for rebalance where the
+   * currently assigned servers may not match the currently tagged server list)
    * @return response containing a) number of failed responses, b) reload responses returned
    */
   public TableReloadJsonResponse getServerSetCheckSegmentsReloadMetadata(String tableNameWithType,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -76,7 +76,7 @@ public class TableMetadataReader {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     List<String> serverInstances = _pinotHelixResourceManager.getServerInstancesForTable(tableNameWithType, tableType);
     Set<String> serverInstanceSet = new HashSet<>(serverInstances);
-    return getReloadCheckResponsesForServerSet(tableNameWithType, timeoutMs, serverInstanceSet);
+    return getServerSetReloadCheckResponses(tableNameWithType, timeoutMs, serverInstanceSet);
   }
 
   /**
@@ -84,15 +84,15 @@ public class TableMetadataReader {
    * server list may not match the currently tagged server list)
    * @return response containing a) number of failed responses, b) reload responses returned
    */
-  public TableReloadJsonResponse getServerCheckSegmentsReloadMetadataForServerSet(String tableNameWithType,
+  public TableReloadJsonResponse getServerSetCheckSegmentsReloadMetadata(String tableNameWithType,
       int timeoutMs, Set<String> serverSet)
       throws InvalidConfigException, IOException {
-    ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getReloadCheckResponsesForServerSet(
+    ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getServerSetReloadCheckResponses(
         tableNameWithType, timeoutMs, serverSet);
     return processSegmentMetadataReloadResponse(segmentsMetadataResponse);
   }
 
-  public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponsesForServerSet(String tableNameWithType,
+  public ServerSegmentMetadataReader.TableReloadResponse getServerSetReloadCheckResponses(String tableNameWithType,
       int timeoutMs, Set<String> serverInstanceSet) throws InvalidConfigException {
     BiMap<String, String> endpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverInstanceSet);
     ServerSegmentMetadataReader serverSegmentMetadataReader =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -61,20 +61,14 @@ public class TableMetadataReader {
 
   /**
    * Check if segments need a reload on any servers
-   * @return pair of: a) number of failed responses, b) reload responses returned
+   * @return response containing a) number of failed responses, b) reload responses returned
    */
   public TableReloadJsonResponse getServerCheckSegmentsReloadMetadata(String tableNameWithType,
       int timeoutMs)
       throws InvalidConfigException, IOException {
-    ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataPair =
-        getReloadCheckResponses(tableNameWithType, timeoutMs);
-    List<String> segmentsMetadata = segmentsMetadataPair.getServerReloadResponses();
-    Map<String, JsonNode> response = new HashMap<>();
-    for (String segmentMetadata : segmentsMetadata) {
-      JsonNode responseJson = JsonUtils.stringToJsonNode(segmentMetadata);
-      response.put(responseJson.get("instanceId").asText(), responseJson);
-    }
-    return new TableReloadJsonResponse(segmentsMetadataPair.getNumFailedResponses(), response);
+    ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getReloadCheckResponses(
+        tableNameWithType, timeoutMs);
+    return processSegmentMetadataReloadResponse(segmentsMetadataResponse);
   }
 
   public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponses(String tableNameWithType,
@@ -82,11 +76,41 @@ public class TableMetadataReader {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     List<String> serverInstances = _pinotHelixResourceManager.getServerInstancesForTable(tableNameWithType, tableType);
     Set<String> serverInstanceSet = new HashSet<>(serverInstances);
+    return getReloadCheckResponsesForServerSet(tableNameWithType, timeoutMs, serverInstanceSet);
+  }
+
+  /**
+   * Check if segments need a reload on any servers based on a provided server list (useful for rebalance where the
+   * server list may not match the currently tagged server list)
+   * @return response containing a) number of failed responses, b) reload responses returned
+   */
+  public TableReloadJsonResponse getServerCheckSegmentsReloadMetadataForServerSet(String tableNameWithType,
+      int timeoutMs, Set<String> serverSet)
+      throws InvalidConfigException, IOException {
+    ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse = getReloadCheckResponsesForServerSet(
+        tableNameWithType, timeoutMs, serverSet);
+    return processSegmentMetadataReloadResponse(segmentsMetadataResponse);
+  }
+
+  public ServerSegmentMetadataReader.TableReloadResponse getReloadCheckResponsesForServerSet(String tableNameWithType,
+      int timeoutMs, Set<String> serverInstanceSet) throws InvalidConfigException {
     BiMap<String, String> endpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverInstanceSet);
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager);
     return serverSegmentMetadataReader.getCheckReloadSegmentsFromServer(tableNameWithType, serverInstanceSet, endpoints,
         timeoutMs);
+  }
+
+  private TableReloadJsonResponse processSegmentMetadataReloadResponse(
+      ServerSegmentMetadataReader.TableReloadResponse segmentsMetadataResponse)
+      throws IOException {
+    List<String> segmentsMetadata = segmentsMetadataResponse.getServerReloadResponses();
+    Map<String, JsonNode> response = new HashMap<>();
+    for (String segmentMetadata : segmentsMetadata) {
+      JsonNode responseJson = JsonUtils.stringToJsonNode(segmentMetadata);
+      response.put(responseJson.get("instanceId").asText(), responseJson);
+    }
+    return new TableReloadJsonResponse(segmentsMetadataResponse.getNumFailedResponses(), response);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -889,6 +889,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.DONE,
         "Instance assignment not allowed, no need for minimizeDataMovement",
         RebalancePreCheckerResult.PreCheckStatus.PASS, "No need to reload",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "All rebalance parameters look good",
         RebalancePreCheckerResult.PreCheckStatus.PASS);
     rebalanceConfig.setReassignInstances(false);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -878,6 +878,25 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         RebalancePreCheckerResult.PreCheckStatus.PASS, "All rebalance parameters look good",
         RebalancePreCheckerResult.PreCheckStatus.PASS);
 
+    // Add a new server (to force change in instance assignment) and enable reassignInstances
+    // Validate that the status for reload is still PASS (i.e. even though an extra server is tagged which has no
+    // segments assigned for this table, we don't try to get needReload status from that extra server, otherwise
+    // ERROR status would be returned)
+    BaseServerStarter serverStarter0 = startOneServer(NUM_SERVERS);
+    rebalanceConfig.setReassignInstances(true);
+    tableConfig.setInstanceAssignmentConfigMap(null);
+    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    checkRebalancePreCheckStatus(rebalanceResult, RebalanceResult.Status.DONE,
+        "Instance assignment not allowed, no need for minimizeDataMovement",
+        RebalancePreCheckerResult.PreCheckStatus.PASS, "No need to reload",
+        RebalancePreCheckerResult.PreCheckStatus.PASS);
+    rebalanceConfig.setReassignInstances(false);
+
+    // Stop the added server
+    serverStarter0.stop();
+    TestUtils.waitForCondition(aVoid -> _resourceManager.dropInstance(serverStarter0.getInstanceId()).isSuccessful(),
+        60_000L, "Failed to drop added server");
+
     // Add a schema change
     Schema schema = createSchema();
     schema.addField(new MetricFieldSpec("NewAddedIntMetric", DataType.INT, 1));


### PR DESCRIPTION
This PR enhances the needReload pre-check done as part of table rebalancer to only fetch the status from the list of servers currently assigned based on the current assignment (ideal state).

Without setting this explicit list, the existing needReload API fetches the list of servers tagged based on the table's server tenant tag. Sometimes this results in failed responses from servers that are not assigned any segments (e.g. they are newly added and that's why we're trying to rebalance) and an ERROR status can be returned from the pre-check indicating that needReload must be run manually.

While the current needReload API is enough for most cases, when it comes to rebalance, we often want to move segments to new servers (uplift, tenant migration) or off of existing servers (downlift). The tenant tags should have already been updated prior to trying to rebalance, so the server list fetched is not correct.

Another issue is that when some servers are removed, the existing needReload API will not fetch the status from the servers going away (which were untagged). This may be less of a concern since these segments will be deleted anyways, but it may still be useful to know the correct status

Testing done:
- Added a test case to `OfflineClusterIntegrationTest` to catch this scenario. Without this change, the `testRebalancePreChecks()` test will fail. With this change, it passes
- Tested manually using `HybridQuickStart` with 4 servers to simulate multiple scenarios of tagging / untagging servers
- Ran all the table rebalance unit tests