### PR TITLE
Add yaml config for exposing externalviewZnode(Byte)Size metrics

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -28,6 +28,20 @@ rules:
     database: "$2"
     table: "$1$3"
     tableType: "$4"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.externalviewZnodeSize\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\"><>(\\w+)"
+  name: "pinot_controller_externalviewZnodeSize_$5"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.externalviewZnodeByteSize\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\"><>(\\w+)"
+  name: "pinot_controller_externalviewZnodeByteSize_$5"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.replicationFromConfig\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\"><>(\\w+)"
   name: "pinot_controller_replicationFromConfig_$5"
   cache: true


### PR DESCRIPTION
With this change, we should be able to see metrics like pinot_controller_externalviewZnodeSize_Value from /metrics endpoint. Shown as above from a local run:

<img width="1832" alt="Screenshot 2025-03-24 at 11 47 12 PM" src="https://github.com/user-attachments/assets/490c55a1-7811-4ad1-9ce2-bb1cab1482c3" />
