### PR TITLE
Adds a new config to create a configurable JFR recording in continuous mode

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -79,6 +79,7 @@ import org.apache.pinot.core.query.utils.rewriter.ResultRewriterFactory;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.segment.local.function.GroovyFunctionEvaluator;
@@ -193,6 +194,8 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         Helix.PREFIX_OF_BROKER_INSTANCE, _instanceId);
 
     _brokerConf.setProperty(Broker.CONFIG_OF_BROKER_ID, _instanceId);
+
+    ContinuousJfrStarter.init(_brokerConf);
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -126,6 +126,7 @@ import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
 import org.apache.pinot.core.segment.processing.lifecycle.PinotSegmentLifecycleEventListenerManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.segment.local.function.GroovyFunctionEvaluator;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -271,6 +272,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
     TableConfigUtils.setDisableGroovy(_config.isDisableIngestionGroovy());
     TableConfigUtils.setEnforcePoolBasedAssignment(_config.isEnforcePoolBasedAssignmentEnabled());
+
+    ContinuousJfrStarter.init(_config);
   }
 
   // If thread pool size is not configured executor will use cached thread pool

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util.trace;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class ContinuousJfrStarter {
+
+  /// Key that controls whether to enable continuous JFR recording.
+  public static final String ENABLED = "enabled";
+  /// Default value for the enabled key.
+  public static final boolean DEFAULT_ENABLED = false;
+
+  /// Key that controls the JFR configuration to use. Valid values are 'default' or 'profile', but more can be added
+  /// by adding custom configurations/settings. See the JFR documentation for more information.
+  ///
+  /// The default value is 'default', which is the default JFR configuration and the one that has a target of less
+  /// than 1% overhead.
+  public static final String CONFIGURATION = "configuration";
+  /// Default value for the configuration key.
+  public static final String DEFAULT_CONFIGURATION = "default";
+  /// Key that controls the name of the recording.
+  ///
+  /// This is used to identify the recording in the JFR UI.
+  /// The default value is 'pinot-continuous'.
+  public static final String NAME = "name";
+  /// Default value for the name key.
+  public static final String DEFAULT_NAME = "pinot-continuous";
+
+
+  /// Key that controls whether to dump the recording on exit.
+  public static final String DUMP_ON_EXIT = "dumpOnExit";
+  /// Default value for the dumpOnExit key.
+  ///
+  /// If true, the recording will be dumped to a file when the JVM exits.
+  public static final boolean DEFAULT_DUMP_ON_EXIT = true;
+  /// Key that controls the directory to store the recordings when dumped on exit.
+  ///
+  /// The default value is the current working directory.
+  /// The filename will be 'recording-<timestamp>.jfr'.
+  public static final String DIRECTORY = "directory";
+
+  /// Key that controls whether to buffer the recording to disk.
+  /// If false, the recording will only be kept in memory.
+  /// If true, the recording will be written to disk periodically. This may affect performance but increases the window
+  /// of time that can be recorded.
+  public static final String TO_DISK = "toDisk";
+  /// Default value for the toDisk key.
+  public static final boolean DEFAULT_TO_DISK = true;
+  /// Key that controls the maximum size of the recording file.
+  /// Once the file reaches this size, older events will be discarded.
+  /// If both maxSize and maxAge are set, the recording will be discarded when either condition is met.
+  ///
+  /// This is only used if toDisk is true.
+  /// The value is in bytes.
+  /// The default value is 200MB.
+  ///
+  /// @see #MAX_AGE
+  public static final String MAX_SIZE = "maxSize";
+  public static final int DEFAULT_MAX_SIZE = 200 * 1024 * 1024;
+  /// Key that controls the maximum age of the recording file.
+  /// Once the file reaches this age, older events will be discarded.
+  /// If both maxSize and maxAge are set, the recording will be discarded when either condition is met.
+  ///
+  /// This is only used if toDisk is true.
+  /// The value is a duration string, as defined by the Duration class.
+  /// The default value is 1 day (P1D).
+  ///
+  /// @see #MAX_SIZE
+  public static final String MAX_AGE = "maxAge";
+  public static final String DEFAULT_MAX_AGE = "P1D";
+
+  /// A flag to track whether the JFR recording has been started.
+  /// This is specially useful for testing and quickstarts, where servers, brokers and other components are executed
+  /// in the same JVM.
+  private static boolean _started = false;
+
+  private ContinuousJfrStarter() {
+  }
+
+  public synchronized static void init(PinotConfiguration config) {
+    PinotConfiguration subset = config.subset(CommonConstants.JFR);
+
+    if (!subset.getProperty(ENABLED, DEFAULT_ENABLED)) {
+      return;
+    }
+    if (_started) {
+      return;
+    }
+
+    Path directory = Path.of(subset.getProperty(DIRECTORY, Paths.get(".").toString()));
+
+    Recording recording;
+    String jfrConfName = subset.getProperty(CONFIGURATION, DEFAULT_CONFIGURATION);
+    try {
+      Configuration configuration = Configuration.getConfiguration(jfrConfName);
+      recording = new Recording(configuration);
+    } catch (ParseException e) {
+      throw new RuntimeException("Failed to parse JFR configuration '" + jfrConfName + "'", e);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read JFR configuration '" + jfrConfName + "'", e);
+    }
+    boolean dumpOnExit = subset.getProperty(DUMP_ON_EXIT, DEFAULT_DUMP_ON_EXIT);
+    recording.setDumpOnExit(dumpOnExit);
+    if (dumpOnExit) {
+      try {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"));
+        String filename = "recording-" + timestamp + ".jfr";
+        Path recordingPath = directory.resolve(filename);
+        boolean newFile = recordingPath.toFile().createNewFile();
+        if (!newFile) {
+          throw new RuntimeException("Failed to create new file: " + recordingPath);
+        }
+        recording.setDestination(recordingPath);
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to create new recording file", e);
+      }
+    }
+
+    try {
+      recording.setName(subset.getProperty(NAME, DEFAULT_NAME));
+      boolean toDisk = subset.getProperty(TO_DISK, DEFAULT_TO_DISK);
+      if (toDisk) {
+        recording.setToDisk(true);
+        recording.setMaxSize(subset.getProperty(MAX_SIZE, DEFAULT_MAX_SIZE));
+        recording.setMaxAge(Duration.parse(subset.getProperty(MAX_AGE, DEFAULT_MAX_AGE).toUpperCase(Locale.ENGLISH)));
+      }
+    } catch (DateTimeParseException e) {
+      throw new RuntimeException("Failed to parse duration", e);
+    }
+    recording.start();
+    _started = true;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
@@ -149,9 +149,8 @@ public class ContinuousJfrStarter {
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"));
         String filename = "recording-" + timestamp + ".jfr";
         Path recordingPath = directory.resolve(filename);
-        boolean newFile = recordingPath.toFile().createNewFile();
-        if (!newFile) {
-          throw new RuntimeException("Failed to create new file: " + recordingPath);
+        if (!recordingPath.toFile().canWrite()) {
+          throw new RuntimeException("Cannot write: " + recordingPath);
         }
         recording.setDestination(recordingPath);
       } catch (IOException e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
@@ -81,6 +81,7 @@ public class ContinuousJfrStarter {
   /// If set, the directory will be cleaned up to keep only the most recent dumps.
   ///
   /// This is a Pinot feature, not a JFR feature and defaults to 10.
+  /// If negative, no file will be removed.
   public static final String MAX_DUMPS = "maxDumps";
   public static final int DEFAULT_MAX_DUMPS = 10;
 
@@ -186,6 +187,10 @@ public class ContinuousJfrStarter {
   }
 
   private static void cleanUpDumps(Path directory, int maxDumps) {
+    if (maxDumps < 0) {
+      LOGGER.debug("maxDumps is negative, no cleanup will be performed");
+      return;
+    }
     File[] files = directory.toFile().listFiles();
     if (files == null) {
       return;

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -54,6 +54,7 @@ import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.minion.event.DefaultMinionTaskObserverStorageManager;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
 import org.apache.pinot.minion.event.MinionEventObserverFactory;
@@ -131,6 +132,8 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
     MinionEventObservers.init(_config, _executorService);
+
+    ContinuousJfrStarter.init(_config);
   }
 
   private void updateInstanceConfigIfNeeded() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -78,6 +78,7 @@ import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManage
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshManager;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.local.utils.SegmentAllIndexPreprocessThrottler;
@@ -255,6 +256,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
         _helixClusterName, _instanceId);
     _helixManager =
         HelixManagerFactory.getZKHelixManager(_helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkAddress);
+
+    ContinuousJfrStarter.init(_serverConf);
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -72,6 +72,8 @@ public class CommonConstants {
 
   public static final String CONFIG_OF_PINOT_TAR_COMPRESSION_CODEC_NAME = "pinot.tar.compression.codec.name";
 
+  public static final String JFR = "pinot.jfr";
+
   /**
    * The state of the consumer for a given segment
    */


### PR DESCRIPTION
This PR adds the ability to run with JFR enabled. We could already do this with jcmd or Java options, but AFAIK, it is not easy to specify a filename that includes the date. This is especially difficult when running on Kubernetes.

Another feature that is not supported natively by the JVM is the ability to remove old dumps. This is something that is not difficult to do with startup scripts, but it is probably better to have that in Java directly

This feature is disabled by default.