### PR TITLE
Fix wording to explain minAvailableReplicas better in rebalance UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -109,7 +109,7 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "defaultValue": -1,
         "type": "INTEGER",
         "label": "Min Available Replicas",
-        "description": "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum number of replicas allowed to be unavailable if value is negative. Should not be 0 unless for downtime=true",
+        "description": "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance if value is positive, or 'numReplicas + value' replicas to keep alive if value is negative (e.g. if -1, replicas to keep alive = 'numReplicas + (-1)'). Should not be 0 unless for downtime=true",
         "isAdvancedConfig": false,
         "isStatsGatheringConfig": false,
         "markWithWarningIcon": false


### PR DESCRIPTION
The current explanation of `minAvailableReplicas` in the rebalance UI can be confusing. This PR updates the wording and adds an example as well.

Testing done:
- Ran `HybridQuickStart` locally and verified that the updated wording is present in the UI

cc @himanish-star @jayeshchoudhary @Jackie-Jiang @klsince 