### PR TITLE
add .sdkmanrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cscope.*
 .project
 .svn
 .java-version
+.sdkmanrc
 .externalToolBuilders/
 maven-eclipse.xml
 target/


### PR DESCRIPTION
[.sdkmanrc](https://sdkman.io/usage/#env-command) can be used to switch to a specific JDK or SDK every time visit a project in a local setup. Don't want to commit this to the upstream repo accidentally.