### PR TITLE
Disable reingestion for Pauseless dedup

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -192,7 +192,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   UNTRACKED_SEGMENTS_COUNT("untrackedSegmentsCount", false),
 
   // Metric used to track errors during the periodic table retention management
-  RETENTION_MANAGER_ERROR("retentionManagerError", false);
+  RETENTION_MANAGER_ERROR("retentionManagerError", false),
+
+  // Metric used to track when segments in error state are detected for pauseless table
+  PAUSELESS_SEGMENTS_IN_ERROR_COUNT("pauselessSegmentsInErrorCount", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -195,7 +195,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   RETENTION_MANAGER_ERROR("retentionManagerError", false),
 
   // Metric used to track when segments in error state are detected for pauseless table
-  PAUSELESS_SEGMENTS_IN_ERROR_COUNT("pauselessSegmentsInErrorCount", false);
+  PAUSELESS_SEGMENTS_IN_ERROR_COUNT("pauselessSegmentsInErrorCount", false),
+
+  PAUSELESS_SEGMENTS_IN_UNRECOVERABLE_ERROR_COUNT("pauselessSegmentsInUnrecoverableErrorCount", false);
+
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -197,6 +197,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Metric used to track when segments in error state are detected for pauseless table
   PAUSELESS_SEGMENTS_IN_ERROR_COUNT("pauselessSegmentsInErrorCount", false),
 
+  // Metric used to track when segments in error state are detected for pauseless table for which needs
+  // manual intervention for repair
   PAUSELESS_SEGMENTS_IN_UNRECOVERABLE_ERROR_COUNT("pauselessSegmentsInUnrecoverableErrorCount", false);
 
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -38,7 +38,6 @@ import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTas
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.config.table.PauseState;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -127,15 +126,9 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     }
 
     boolean isPauselessConsumptionEnabled = PauselessConsumptionUtils.isPauselessEnabled(tableConfig);
-    boolean isPartialUpsertEnabled =
-        tableConfig.getUpsertConfig() != null && tableConfig.getUpsertConfig().getMode() == UpsertConfig.Mode.PARTIAL;
-    boolean isDedupEnabled = tableConfig.getDedupConfig() != null && tableConfig.getDedupConfig().isDedupEnabled();
-
     if (isPauselessConsumptionEnabled) {
-      if (!(isPartialUpsertEnabled || isDedupEnabled)) {
-        // For pauseless tables without dedup or partial upsert, repair segments in error state
-        _llcRealtimeSegmentManager.repairSegmentsInErrorStateForPauselessConsumption(tableConfig.getTableName());
-      }
+      // For pauseless tables without dedup or partial upsert, repair segments in error state
+      _llcRealtimeSegmentManager.repairSegmentsInErrorStateForPauselessConsumption(tableConfig);
     } else if (_segmentAutoResetOnErrorAtValidation) {
       // Reset for pauseless tables is already handled in repairSegmentsInErrorStateForPauselessConsumption method with
       // additional checks for pauseless consumption


### PR DESCRIPTION
We cannot support reingestion with dedup since deduping requires in-order consumption.