### PR TITLE
Add metrics to track segment operation throttle thresholds and count of number of segments undergoing operation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -53,6 +53,19 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   NETTY_POOLED_ARENAS_HEAP("arenas", true),
   STREAM_DATA_LOSS("streamDataLoss", false),
 
+  // Segment operation throttle metrics - threshold is the upper limit of the throttle and is set whenever the
+  // throttle configs are modified
+  SEGMENT_TABLE_DOWNLOAD_THROTTLE_THRESHOLD("segmentTableDownloadThrottleThreshold", false),
+  SEGMENT_DOWNLOAD_THROTTLE_THRESHOLD("segmentDownloadThrottleThreshold", true),
+  SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD("segmentAllPreprocessThrottleThreshold", true),
+  SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD("segmentStartreePreprocessDownloadThreshold", true),
+  // Segment operation metrics - count is the current number of segments undergoing the given operation.
+  // Incremented when the semaphore is acquired and decremented when the semaphore is released
+  SEGMENT_TABLE_DOWNLOAD_COUNT("segmentTableDownloadCount", false),
+  SEGMENT_DOWNLOAD_COUNT("segmentDownloadCount", true),
+  SEGMENT_ALL_PREPROCESS_COUNT("segmentAllPreprocessCount", true),
+  SEGMENT_STARTREE_PREPROCESS_COUNT("segmentStartreePreprocessCount", true),
+
   /**
    * The size of the small cache.
    * See {@link PooledByteBufAllocatorMetric#smallCacheSize()}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -58,7 +58,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   SEGMENT_TABLE_DOWNLOAD_THROTTLE_THRESHOLD("segmentTableDownloadThrottleThreshold", false),
   SEGMENT_DOWNLOAD_THROTTLE_THRESHOLD("segmentDownloadThrottleThreshold", true),
   SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD("segmentAllPreprocessThrottleThreshold", true),
-  SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD("segmentStartreePreprocessDownloadThreshold", true),
+  SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD("segmentStartreePreprocessThreshold", true),
   // Segment operation metrics - count is the current number of segments undergoing the given operation.
   // Incremented when the semaphore is acquired and decremented when the semaphore is released
   SEGMENT_TABLE_DOWNLOAD_COUNT("segmentTableDownloadCount", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -129,6 +129,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected SegmentOperationsThrottler _segmentOperationsThrottler;
   // Semaphore to restrict the maximum number of parallel segment downloads from deep store for a table
   private Semaphore _segmentDownloadSemaphore;
+  private AtomicInteger _numSegmentsAcquiredDownloadSemaphore;
 
   // Fixed size LRU cache with TableName - SegmentName pair as key, and segment related errors as the value.
   protected Cache<Pair<String, String>, SegmentErrorInfo> _errorCache;
@@ -200,11 +201,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
           "Construct segment download semaphore for Table: {}. Maximum number of parallel segment downloads: {}",
           _tableNameWithType, maxParallelSegmentDownloads);
       _segmentDownloadSemaphore = new Semaphore(maxParallelSegmentDownloads, true);
+      _numSegmentsAcquiredDownloadSemaphore = new AtomicInteger(0);
       _serverMetrics.setValueOfTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_THROTTLE_THRESHOLD,
           maxParallelSegmentDownloads);
       _serverMetrics.setValueOfTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_COUNT, 0);
     } else {
       _segmentDownloadSemaphore = null;
+      _numSegmentsAcquiredDownloadSemaphore = null;
     }
     _logger = LoggerFactory.getLogger(_tableNameWithType + "-" + getClass().getSimpleName());
 
@@ -810,7 +813,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
       _logger.info("Acquiring table level segment download semaphore for segment: {}, queue-length: {} ", segmentName,
           _segmentDownloadSemaphore.getQueueLength());
       _segmentDownloadSemaphore.acquire();
-      _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_COUNT, 1L);
+      _serverMetrics.setValueOfTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_COUNT,
+          _numSegmentsAcquiredDownloadSemaphore.incrementAndGet());
       _logger.info("Acquired table level segment download semaphore for segment: {} (lock-time={}ms, queue-length={}).",
           segmentName, System.currentTimeMillis() - startTime, _segmentDownloadSemaphore.getQueueLength());
     }
@@ -862,7 +866,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     } finally {
       if (_segmentDownloadSemaphore != null) {
         _segmentDownloadSemaphore.release();
-        _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_COUNT, -1L);
+        _serverMetrics.setValueOfTableGauge(_tableNameWithType, ServerGauge.SEGMENT_TABLE_DOWNLOAD_COUNT,
+            _numSegmentsAcquiredDownloadSemaphore.decrementAndGet());
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentAllIndexPreprocessThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentAllIndexPreprocessThrottler.java
@@ -41,8 +41,7 @@ public class SegmentAllIndexPreprocessThrottler extends BaseSegmentOperationsThr
   public SegmentAllIndexPreprocessThrottler(int maxPreprocessConcurrency,
       int maxPreprocessConcurrencyBeforeServingQueries, boolean isServingQueries) {
     super(maxPreprocessConcurrency, maxPreprocessConcurrencyBeforeServingQueries, isServingQueries,
-        ServerGauge.SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD, ServerGauge.SEGMENT_ALL_PREPROCESS_COUNT,
-        LOGGER);
+        ServerGauge.SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD, ServerGauge.SEGMENT_ALL_PREPROCESS_COUNT, LOGGER);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentAllIndexPreprocessThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentAllIndexPreprocessThrottler.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.utils;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,9 @@ public class SegmentAllIndexPreprocessThrottler extends BaseSegmentOperationsThr
    */
   public SegmentAllIndexPreprocessThrottler(int maxPreprocessConcurrency,
       int maxPreprocessConcurrencyBeforeServingQueries, boolean isServingQueries) {
-    super(maxPreprocessConcurrency, maxPreprocessConcurrencyBeforeServingQueries, isServingQueries, LOGGER);
+    super(maxPreprocessConcurrency, maxPreprocessConcurrencyBeforeServingQueries, isServingQueries,
+        ServerGauge.SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD, ServerGauge.SEGMENT_ALL_PREPROCESS_COUNT,
+        LOGGER);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentDownloadThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentDownloadThrottler.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.utils;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,8 @@ public class SegmentDownloadThrottler extends BaseSegmentOperationsThrottler {
    */
   public SegmentDownloadThrottler(int maxDownloadConcurrency, int maxDownloadConcurrencyBeforeServingQueries,
       boolean isServingQueries) {
-    super(maxDownloadConcurrency, maxDownloadConcurrencyBeforeServingQueries, isServingQueries, LOGGER);
+    super(maxDownloadConcurrency, maxDownloadConcurrencyBeforeServingQueries, isServingQueries,
+        ServerGauge.SEGMENT_DOWNLOAD_THROTTLE_THRESHOLD, ServerGauge.SEGMENT_DOWNLOAD_COUNT, LOGGER);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentStarTreePreprocessThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentStarTreePreprocessThrottler.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.utils;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,8 @@ public class SegmentStarTreePreprocessThrottler extends BaseSegmentOperationsThr
   public SegmentStarTreePreprocessThrottler(int maxStarTreePreprocessConcurrency,
       int maxStarTreePreprocessConcurrencyBeforeServingQueries, boolean isServingQueries) {
     super(maxStarTreePreprocessConcurrency, maxStarTreePreprocessConcurrencyBeforeServingQueries, isServingQueries,
-        LOGGER);
+        ServerGauge.SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD,
+        ServerGauge.SEGMENT_STARTREE_PREPROCESS_COUNT, LOGGER);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentStarTreePreprocessThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentStarTreePreprocessThrottler.java
@@ -42,8 +42,8 @@ public class SegmentStarTreePreprocessThrottler extends BaseSegmentOperationsThr
   public SegmentStarTreePreprocessThrottler(int maxStarTreePreprocessConcurrency,
       int maxStarTreePreprocessConcurrencyBeforeServingQueries, boolean isServingQueries) {
     super(maxStarTreePreprocessConcurrency, maxStarTreePreprocessConcurrencyBeforeServingQueries, isServingQueries,
-        ServerGauge.SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD,
-        ServerGauge.SEGMENT_STARTREE_PREPROCESS_COUNT, LOGGER);
+        ServerGauge.SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD, ServerGauge.SEGMENT_STARTREE_PREPROCESS_COUNT,
+        LOGGER);
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.spy;
 
 public class SegmentOperationsThrottlerTest {
 
+  private final ServerMetrics _serverMetrics = ServerMetrics.get();
   private final List<String> _thresholdGauges =
       Arrays.asList(ServerGauge.SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD.getGaugeName(),
           ServerGauge.SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD.getGaugeName(),
@@ -62,8 +63,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.availablePermits(), 4);
       Assert.assertEquals(operationsThrottler.totalPermits(), 4);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, 4);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -71,8 +72,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.availablePermits(), 3);
       Assert.assertEquals(operationsThrottler.totalPermits(), 4);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, 4);
       Assert.assertEquals(countGaugeValue, 1);
 
@@ -80,8 +81,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.availablePermits(), 4);
       Assert.assertEquals(operationsThrottler.totalPermits(), 4);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, 4);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -103,8 +104,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), totalPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, totalPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -113,8 +114,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.availablePermits(), totalPermits - j - 1);
         Assert.assertEquals(operationsThrottler.totalPermits(), totalPermits);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, totalPermits);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -123,8 +124,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.availablePermits(), j + 1);
         Assert.assertEquals(operationsThrottler.totalPermits(), totalPermits);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, totalPermits);
         Assert.assertEquals(countGaugeValue, totalPermits - j - 1);
       }
@@ -189,8 +190,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -199,8 +200,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermits);
         Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermits - j - 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, defaultPermits);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -226,8 +227,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -244,8 +245,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -270,16 +271,16 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
       for (int j = 0; j < initialPermits; j++) {
         operationsThrottler.acquire();
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -297,8 +298,8 @@ public class SegmentOperationsThrottlerTest {
       operationsThrottler.onChange(updatedClusterConfigs.keySet(), updatedClusterConfigs);
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
       Assert.assertEquals(countGaugeValue, initialPermits);
 
@@ -306,8 +307,8 @@ public class SegmentOperationsThrottlerTest {
       for (int j = 0; j < initialPermits; j++) {
         operationsThrottler.acquire();
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
         Assert.assertEquals(countGaugeValue, initialPermits + j + 1);
       }
@@ -316,8 +317,8 @@ public class SegmentOperationsThrottlerTest {
       for (int j = 0; j < (initialPermits * 2); j++) {
         operationsThrottler.release();
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
         Assert.assertEquals(countGaugeValue, (initialPermits * 2) - j - 1);
       }
@@ -345,16 +346,16 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
       for (int j = 0; j < initialPermits; j++) {
         operationsThrottler.acquire();
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -373,16 +374,16 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits / 2);
       Assert.assertEquals(operationsThrottler.availablePermits(), -(initialPermits / 2));
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits / 2);
       Assert.assertEquals(countGaugeValue, initialPermits);
 
       for (int j = 0; j < initialPermits; j++) {
         operationsThrottler.release();
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits / 2);
         Assert.assertEquals(countGaugeValue, initialPermits - j - 1);
       }
@@ -418,8 +419,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery);
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -428,8 +429,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -466,8 +467,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery);
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -476,8 +477,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery);
         Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery - j - 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -487,8 +488,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits - numPermitsToTake);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, numPermitsToTake);
 
@@ -496,8 +497,8 @@ public class SegmentOperationsThrottlerTest {
         operationsThrottler.release();
         Assert.assertEquals(operationsThrottler.availablePermits(), (initialPermits - numPermitsToTake) + j + 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits);
         Assert.assertEquals(countGaugeValue, numPermitsToTake - j - 1);
       }
@@ -537,8 +538,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery - 5);
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery - 5);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery - 5);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -547,8 +548,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery - 5);
         Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery - j - 1 - 5);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery - 5);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -566,8 +567,8 @@ public class SegmentOperationsThrottlerTest {
       // We increased permits but took some before the increase
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery - numPermitsToTake);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
       Assert.assertEquals(countGaugeValue, numPermitsToTake);
 
@@ -578,8 +579,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.availablePermits(),
             defaultPermitsBeforeQuery - numPermitsToTake - j - 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
         Assert.assertEquals(countGaugeValue, numPermitsToTake + j + 1);
       }
@@ -589,8 +590,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits - (numPermitsToTake * 2));
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, numPermitsToTake * 2);
 
@@ -598,8 +599,8 @@ public class SegmentOperationsThrottlerTest {
         operationsThrottler.release();
         Assert.assertEquals(operationsThrottler.availablePermits(), (initialPermits - numPermitsToTake * 2) + j + 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits);
         Assert.assertEquals(countGaugeValue, (numPermitsToTake * 2) - j - 1);
       }
@@ -639,8 +640,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery);
       Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -649,8 +650,8 @@ public class SegmentOperationsThrottlerTest {
         Assert.assertEquals(operationsThrottler.totalPermits(), defaultPermitsBeforeQuery);
         Assert.assertEquals(operationsThrottler.availablePermits(), defaultPermitsBeforeQuery - j - 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, defaultPermitsBeforeQuery);
         Assert.assertEquals(countGaugeValue, j + 1);
       }
@@ -669,8 +670,8 @@ public class SegmentOperationsThrottlerTest {
       // We doubled permits but took all of the previous ones
       Assert.assertEquals(operationsThrottler.availablePermits(), newDefaultPermits - numPermitsToTake);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, newDefaultPermits);
       Assert.assertEquals(countGaugeValue, numPermitsToTake);
 
@@ -679,8 +680,8 @@ public class SegmentOperationsThrottlerTest {
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits - numPermitsToTake);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, numPermitsToTake);
 
@@ -688,8 +689,8 @@ public class SegmentOperationsThrottlerTest {
         operationsThrottler.release();
         Assert.assertEquals(operationsThrottler.availablePermits(), (initialPermits - numPermitsToTake) + j + 1);
 
-        thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-        countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+        thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+        countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
         Assert.assertEquals(thresholdGaugeValue, initialPermits);
         Assert.assertEquals(countGaugeValue, numPermitsToTake - j - 1);
       }
@@ -737,8 +738,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -747,8 +748,8 @@ public class SegmentOperationsThrottlerTest {
       operationsThrottler.onChange(updatedClusterConfigs.keySet(), updatedClusterConfigs);
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -772,8 +773,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -793,8 +794,8 @@ public class SegmentOperationsThrottlerTest {
               : CommonConstants.Helix.DEFAULT_MAX_SEGMENT_DOWNLOAD_PARALLELISM);
       Assert.assertEquals(operationsThrottler.totalPermits(), newTotalPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, newTotalPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -818,8 +819,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -844,8 +845,8 @@ public class SegmentOperationsThrottlerTest {
               : CommonConstants.Helix.DEFAULT_MAX_SEGMENT_DOWNLOAD_PARALLELISM_BEFORE_SERVING_QUERIES);
       Assert.assertEquals(operationsThrottler.totalPermits(), newTotalPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, newTotalPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -869,8 +870,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -885,8 +886,8 @@ public class SegmentOperationsThrottlerTest {
       operationsThrottler.onChange(updatedClusterConfigs.keySet(), updatedClusterConfigs);
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -910,8 +911,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -934,8 +935,8 @@ public class SegmentOperationsThrottlerTest {
       // Since isServingQueries = false, new total should match CONFIG_OF_MAX_SEGMENT_PREPROCESS_PARALLELISM
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -959,8 +960,8 @@ public class SegmentOperationsThrottlerTest {
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
       Assert.assertEquals(countGaugeValue, 0);
 
@@ -983,8 +984,8 @@ public class SegmentOperationsThrottlerTest {
       // Since isServingQueries = false, new total should match higher threshold of before serving queries
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 4);
 
-      thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
-      countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
+      countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 4);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -1008,12 +1009,12 @@ public class SegmentOperationsThrottlerTest {
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits);
 
     for (String thresholdGaugeName : _thresholdGauges) {
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
     }
 
     for (String countGaugeName : _countGauges) {
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
 
@@ -1034,12 +1035,12 @@ public class SegmentOperationsThrottlerTest {
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 2);
 
     for (String thresholdGaugeName : _thresholdGauges) {
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
     }
 
     for (String countGaugeName : _countGauges) {
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
   }
@@ -1063,12 +1064,12 @@ public class SegmentOperationsThrottlerTest {
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 2);
 
     for (String thresholdGaugeName : _thresholdGauges) {
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
     }
 
     for (String countGaugeName : _countGauges) {
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
 
@@ -1097,12 +1098,12 @@ public class SegmentOperationsThrottlerTest {
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 4);
 
     for (String thresholdGaugeName : _thresholdGauges) {
-      Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
+      Long thresholdGaugeValue = _serverMetrics.getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 4);
     }
 
     for (String countGaugeName : _countGauges) {
-      Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
+      Long countGaugeValue = _serverMetrics.getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerTest.java
@@ -37,11 +37,11 @@ import static org.mockito.Mockito.spy;
 
 public class SegmentOperationsThrottlerTest {
 
-  private final List<String> THRESHOLD_GAUGES =
+  private final List<String> _thresholdGauges =
       Arrays.asList(ServerGauge.SEGMENT_ALL_PREPROCESS_THROTTLE_THRESHOLD.getGaugeName(),
           ServerGauge.SEGMENT_STARTREE_PREPROCESS_THROTTLE_THRESHOLD.getGaugeName(),
           ServerGauge.SEGMENT_DOWNLOAD_THROTTLE_THRESHOLD.getGaugeName());
-  private final List<String> COUNT_GAUGES =
+  private final List<String> _countGauges =
       Arrays.asList(ServerGauge.SEGMENT_ALL_PREPROCESS_COUNT.getGaugeName(),
           ServerGauge.SEGMENT_STARTREE_PREPROCESS_COUNT.getGaugeName(),
           ServerGauge.SEGMENT_DOWNLOAD_COUNT.getGaugeName());
@@ -56,8 +56,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.availablePermits(), 4);
       Assert.assertEquals(operationsThrottler.totalPermits(), 4);
@@ -98,8 +98,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), totalPermits);
 
@@ -178,8 +178,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       int defaultPermits = operationsThrottler instanceof SegmentAllIndexPreprocessThrottler
           ? Integer.parseInt(CommonConstants.Helix.DEFAULT_MAX_SEGMENT_PREPROCESS_PARALLELISM)
@@ -220,8 +220,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
       Assert.assertEquals(operationsThrottler.availablePermits(), initialPermits);
@@ -265,8 +265,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -340,8 +340,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -404,8 +404,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       int defaultPermitsBeforeQuery = operationsThrottler instanceof SegmentAllIndexPreprocessThrottler
           ? Integer.parseInt(CommonConstants.Helix.DEFAULT_MAX_SEGMENT_PREPROCESS_PARALLELISM_BEFORE_SERVING_QUERIES)
@@ -449,8 +449,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       int defaultPermitsBeforeQuery = operationsThrottler instanceof SegmentAllIndexPreprocessThrottler
           ? Integer.parseInt(CommonConstants.Helix.DEFAULT_MAX_SEGMENT_PREPROCESS_PARALLELISM_BEFORE_SERVING_QUERIES)
@@ -520,8 +520,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       int defaultPermitsBeforeQuery = operationsThrottler instanceof SegmentAllIndexPreprocessThrottler
           ? Integer.parseInt(CommonConstants.Helix.DEFAULT_MAX_SEGMENT_PREPROCESS_PARALLELISM_BEFORE_SERVING_QUERIES)
@@ -622,8 +622,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       int defaultPermitsBeforeQuery = operationsThrottler instanceof SegmentAllIndexPreprocessThrottler
           ? Integer.parseInt(CommonConstants.Helix.DEFAULT_MAX_SEGMENT_PREPROCESS_PARALLELISM_BEFORE_SERVING_QUERIES)
@@ -732,8 +732,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -767,8 +767,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -813,8 +813,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
@@ -864,8 +864,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -905,8 +905,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits);
 
@@ -954,8 +954,8 @@ public class SegmentOperationsThrottlerTest {
 
     for (int i = 0; i < segmentOperationsThrottlerList.size(); i++) {
       BaseSegmentOperationsThrottler operationsThrottler = segmentOperationsThrottlerList.get(i);
-      String thresholdGaugeName = THRESHOLD_GAUGES.get(i);
-      String countGaugeName = COUNT_GAUGES.get(i);
+      String thresholdGaugeName = _thresholdGauges.get(i);
+      String countGaugeName = _countGauges.get(i);
 
       Assert.assertEquals(operationsThrottler.totalPermits(), initialPermits * 2);
 
@@ -1007,12 +1007,12 @@ public class SegmentOperationsThrottlerTest {
         initialPermits);
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits);
 
-    for (String thresholdGaugeName : THRESHOLD_GAUGES) {
+    for (String thresholdGaugeName : _thresholdGauges) {
       Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits);
     }
 
-    for (String countGaugeName : COUNT_GAUGES) {
+    for (String countGaugeName : _countGauges) {
       Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -1033,12 +1033,12 @@ public class SegmentOperationsThrottlerTest {
         initialPermits * 2);
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 2);
 
-    for (String thresholdGaugeName : THRESHOLD_GAUGES) {
+    for (String thresholdGaugeName : _thresholdGauges) {
       Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
     }
 
-    for (String countGaugeName : COUNT_GAUGES) {
+    for (String countGaugeName : _countGauges) {
       Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -1062,12 +1062,12 @@ public class SegmentOperationsThrottlerTest {
         initialPermits * 2);
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 2);
 
-    for (String thresholdGaugeName : THRESHOLD_GAUGES) {
+    for (String thresholdGaugeName : _thresholdGauges) {
       Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 2);
     }
 
-    for (String countGaugeName : COUNT_GAUGES) {
+    for (String countGaugeName : _countGauges) {
       Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }
@@ -1096,12 +1096,12 @@ public class SegmentOperationsThrottlerTest {
         initialPermits * 4);
     Assert.assertEquals(segmentOperationsThrottler.getSegmentDownloadThrottler().totalPermits(), initialPermits * 4);
 
-    for (String thresholdGaugeName : THRESHOLD_GAUGES) {
+    for (String thresholdGaugeName : _thresholdGauges) {
       Long thresholdGaugeValue = ServerMetrics.get().getGaugeValue(thresholdGaugeName);
       Assert.assertEquals(thresholdGaugeValue, initialPermits * 4);
     }
 
-    for (String countGaugeName : COUNT_GAUGES) {
+    for (String countGaugeName : _countGauges) {
       Long countGaugeValue = ServerMetrics.get().getGaugeValue(countGaugeName);
       Assert.assertEquals(countGaugeValue, 0);
     }


### PR DESCRIPTION
Add metrics to track segment operation throttle thresholds and count of number of segments undergoing the given operation.

Testing done:
- Added tests in `SegmentOperationsThrottlerTest`
- Verified the metrics are correctly handled in `YammerServerPrometheusMetricsTest` by ensuring the test passes, and also walking through the debugger to verify the metric names