### PR TITLE
Disables isSegmentAlreadyConsumed check while waiting on prev segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -516,7 +516,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private void doAddConsumingSegment(String segmentName)
       throws AttemptsExceededException, RetriableOperationException {
     SegmentZKMetadata zkMetadata = fetchZKMetadata(segmentName);
-    if ((zkMetadata == null) || (zkMetadata.getStatus().isCompleted())) {
+    if ((!_enforceConsumptionInOrder) && ((zkMetadata == null) || (zkMetadata.getStatus().isCompleted()))) {
       // NOTE: We do not throw exception here because the segment might have just been committed before the state
       //       transition is processed. We can skip adding this segment, and the segment will enter CONSUMING state in
       //       Helix, then we can rely on the following CONSUMING -> ONLINE state transition to add it.

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinatorTest.java
@@ -98,6 +98,11 @@ public class ConsumerCoordinatorTest {
     public Map<String, Map<String, String>> getSegmentAssignment() {
       return _segmentAssignmentMap;
     }
+
+    @Override
+    public boolean isSegmentAlreadyConsumed(String currSegmentName) {
+      return false;
+    }
   }
 
   @Test
@@ -462,7 +467,7 @@ public class ConsumerCoordinatorTest {
     RealtimeTableDataManager realtimeTableDataManager = Mockito.mock(RealtimeTableDataManager.class);
     Mockito.when(realtimeTableDataManager.fetchZKMetadata(getSegmentName(101))).thenReturn(null);
 
-    FakeConsumerCoordinator consumerCoordinator = new FakeConsumerCoordinator(true, realtimeTableDataManager);
+    ConsumerCoordinator consumerCoordinator = new ConsumerCoordinator(true, realtimeTableDataManager);
     Assert.assertTrue(consumerCoordinator.isSegmentAlreadyConsumed(getSegmentName(101)));
 
     SegmentZKMetadata mockSegmentZKMetadata = Mockito.mock(SegmentZKMetadata.class);


### PR DESCRIPTION
- When enforceConsumptionInOrder is enabled, Return early only when previous segment is registered.

Example scnenario where enabling isSegmentAlreadyConsumed is not applicable:
<img width="779" alt="Screenshot 2025-03-28 at 8 00 02 PM" src="https://github.com/user-attachments/assets/130dc50d-bbea-47cf-beb8-67aa1704d0ee" />
