### PR TITLE
Fix the completed segment check when trying to add it as consuming segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -516,11 +516,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private void doAddConsumingSegment(String segmentName)
       throws AttemptsExceededException, RetriableOperationException {
     SegmentZKMetadata zkMetadata = fetchZKMetadata(segmentName);
-    if ((!_enforceConsumptionInOrder) && ((zkMetadata == null) || (zkMetadata.getStatus().isCompleted()))) {
+    if (zkMetadata.getStatus().isCompleted()) {
       // NOTE: We do not throw exception here because the segment might have just been committed before the state
       //       transition is processed. We can skip adding this segment, and the segment will enter CONSUMING state in
       //       Helix, then we can rely on the following CONSUMING -> ONLINE state transition to add it.
-      _logger.warn("Segment: {} is already consumed, skipping adding it as CONSUMING segment", segmentName);
+      _logger.warn("Segment: {} is already completed, skipping adding it as CONSUMING segment", segmentName);
       return;
     }
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();


### PR DESCRIPTION
When segment is completed, regardless of wither consumption order is enforced, we should skip adding it as consuming segment, and wait for `CONSUMING -> ONLINE` state transition to bring it directly `ONLINE`