### PR TITLE
Improve consumer lock

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -477,7 +477,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       _logger.info("Changing segment: {} from CONSUMING to ONLINE", segmentName);
       ((RealtimeSegmentDataManager) segmentDataManager).goOnlineFromConsuming(zkMetadata);
       onConsumingToOnline(segmentName);
-    } else if (zkMetadata.getStatus() == Status.DONE) {
+    } else if (zkMetadata.getStatus().isCompleted()) {
       // For pauseless ingestion, the segment is marked ONLINE before it's built and before the COMMIT_END_METADATA
       // call completes.
       // The server should replace the segment only after the CRC is set by COMMIT_END_METADATA and the segment is


### PR DESCRIPTION
#15404 moves the consumer lock acquisition into the consumer thread, and it is no longer blocking the `OFFLINE -> CONSUMING` state transition. Because of this, the `CONSUMING -> ONLINE` state transition can be processed before consumer lock is acquired. This is in general desired, but the corner case described in #15399 won't be handled. It should be an extremely rare corner case, and is very hard to handle without introducing significant overhead, thus added a TODO to revisit if necessary.

This PR simplifies the logic in `ConsumerCoordinator`, and also fixes a bug in `RealtimeTableDataManager` for uploaded segment.