### PR TITLE
Dynamic Buffer Sizing for Dictionary Forward Indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -61,7 +61,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   private final PinotDataBufferMemoryManager _memoryManager;
   private final String _allocationContext;
   private int _capacityInRows = 0;
-  
+
   // Dynamic buffer sizing parameters
   private static final int INITIAL_CHUNK_SIZE_MULTIPLIER = 1;
   private static final int MAX_CHUNK_SIZE_MULTIPLIER = 16;
@@ -277,23 +277,20 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     if (!_dynamicResizingEnabled) {
       return;
     }
-    
     _rowsObservedSinceLastResize++;
-    
     if (_rowsObservedSinceLastResize >= _maxRowsToObserveBeforeResize) {
       // If we've created multiple small buffers, increase the chunk size for future allocations
       if (_writers.size() > 1 && _currentChunkSizeMultiplier < MAX_CHUNK_SIZE_MULTIPLIER) {
         int newMultiplier = Math.min(_currentChunkSizeMultiplier * 2, MAX_CHUNK_SIZE_MULTIPLIER);
         int newNumRowsPerChunk = _initialNumRowsPerChunk * newMultiplier;
-        
-        LOGGER.info("Increasing buffer chunk size from {} to {} rows for: {}", 
+
+        LOGGER.info("Increasing buffer chunk size from {} to {} rows for: {}",
             _numRowsPerChunk, newNumRowsPerChunk, _allocationContext);
-        
+
         _numRowsPerChunk = newNumRowsPerChunk;
         _chunkSizeInBytes = (long) _numRowsPerChunk * _valueSizeInBytes;
         _currentChunkSizeMultiplier = newMultiplier;
       }
-      
       _rowsObservedSinceLastResize = 0;
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -207,35 +207,35 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   public void setDictId(int docId, int dictId) {
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setInt(docId, dictId);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   @Override
   public void setInt(int docId, int value) {
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setInt(docId, value);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   @Override
   public void setLong(int docId, long value) {
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setLong(docId, value);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   @Override
   public void setFloat(int docId, float value) {
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setFloat(docId, value);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   @Override
   public void setDouble(int docId, double value) {
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setDouble(docId, value);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   @Override
@@ -251,7 +251,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     addBufferIfNeeded(docId);
     getWriterForRow(docId).setBytes(docId, value);
-    maybeAdjustBufferSize();
+    adjustBufferSizeIfNeeded();
   }
 
   private WriterWithOffset getWriterForRow(int row) {
@@ -270,10 +270,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   /**
-   * Checks if buffer size should be adjusted based on observed data patterns
-   * and adjusts the buffer size for future allocations if needed.
+   * Checks if buffer size should be adjusted based on observed data patterns and adjusts the buffer size for future
+   * allocations if needed.
    */
-  private void maybeAdjustBufferSize() {
+  private void adjustBufferSizeIfNeeded() {
     if (!_dynamicResizingEnabled) {
       return;
     }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Dynamic buffer sizing adjusts forward index chunk size based on observed write patterns\.

```mermaid
flowchart TD
  N0["Constructor #40;F1#41;"]:::stAdded
  N1["Set method #40;setInt#47;setLong#47;etc#41; #40;F1#41;"]:::stAdded
  N2["addBufferIfNeeded #40;F1#41;"]:::stAdded
  N3["addBuffer #40;F1#41;"]:::stAdded
  N4["adjustBufferSizeIfNeeded #40;F1#41;"]:::stAdded
  N5["Increase buffer size #40;double multiplier#41; #40;F1#41;"]:::stAdded
  N6["Reset observation counter #40;F1#41;"]:::stAdded
  N7["Early return when dynamic sizing disabled #40;F1#41;"]:::stAdded
  N0 -->|"calls addBuffer after field init"| N3
  N0 -->|"provides config flags"| N4
  N1 -->|"calls addBufferIfNeeded"| N2
  N1 -->|"calls adjustBufferSizeIfNeeded after write"| N4
  N2 -->|"calls addBuffer when capacity exceeded"| N3
  N4 -->|"early return if #33;#95;dynamicBufferSizingEnabled"| N7
  N4 -->|"reset counter when threshold reached"| N6
  N4 -->|"increase buffer if writers#62;1 #38;#38; multiplier#60;max"| N5
  N5 -->|"reset counter after increasing"| N6
  N5 -->|"updated #95;currentBufferSizeMultiplier used in addBuffer"| N3
  N0 -->|"#95;dynamicBufferSizingEnabled#44; #95;initialNumRowsPerChunk#44; #95;init#95;"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex\.java — [before](https://github.com/apache/pinot/blob/b80e56afaeb4b99dcf1a1b5d8cf5cce9ad79ff02/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java) · [after](https://github.com/apache/pinot/blob/e30f9fcd57dcdb61a10db7c8c717f54a69cd2c7e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI4MGU1NmFmYWViNGI5OWRjZjFhMWI1ZDhjZjVjY2U5YWQ3OWZmMDIiLCJjb250ZXh0X2hhc2giOiJkMzI3NzJjOWYwMWRlOGU3NzFhNDc3NGQyNWRiOGUyOGNiMWExZjIwZDhlZTcyODczOTk1YjkyODI5MjMzM2Q3IiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDE2NDY2LCJoZWFkX3NoYSI6ImUzMGY5ZmNkNTdkY2RiNjFhMTBkYjdjOGM3MTdmNTRhNjljZDJjN2UiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmYjAyZjA0NTE2OWViMzRhZWUwNTg3YzA0MGIwNzhmYWJmODAzZGJiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f5d77b099d81b2d3f0311f8fe5c4f9653dea7d224351b9007d0fca102fe173f9 -->
<!-- pinot-pr-flow:end -->

- Addresses: https://github.com/apache/pinot/issues/15147
- Made `_numRowsPerChunk` and `_chunkSizeInBytes` mutable to allow dynamic adjustment.
- Introduced parameters for tracking and controlling buffer sizing:
      - Initial chunk size tracking
      - Chunk size multiplier (1x to 16x)
      - Observation counter for triggering resizing
- Implemented `adjustBufferSizeIfNeeded()` to:
     - Monitor buffer usage patterns
     - Scale up buffer size based on actual cardinality
     - Reduce small buffer allocations dynamically