### PR TITLE
Fix concern with uploaded segments leading to API failure

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -1274,11 +1274,19 @@ public class PinotSegmentRestletResource {
     Map<Integer, Set<String>> partitionToSegmentsToDelete = new HashMap<>();
 
     for (String segmentName : idealStateSegmentsSet) {
-      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
+      if (llcSegmentName == null) {
+        LOGGER.info("Skip segment: {} not in low-level consumer format", segmentName);
+        continue;
+      }
       int partitionId = llcSegmentName.getPartitionGroupId();
 
       LLCSegmentName oldestSegment = partitionToOldestSegment.get(partitionId);
-      if (oldestSegment != null && oldestSegment.getSequenceNumber() <= llcSegmentName.getSequenceNumber()) {
+      if (oldestSegment == null) {
+        continue;
+      }
+
+      if (oldestSegment.getSequenceNumber() <= llcSegmentName.getSequenceNumber()) {
         partitionToSegmentsToDelete
             .computeIfAbsent(partitionId, k -> new HashSet<>())
             .add(segmentName);
@@ -1300,7 +1308,9 @@ public class PinotSegmentRestletResource {
 
     for (String segment : segments) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
-      Preconditions.checkState(llcSegmentName != null, "Invalid LLC segment: " + segment);
+      if (llcSegmentName == null) {
+        LOGGER.warn("Skip segment: {} not in low-level consumer format", segment);
+      }
 
       // ignore segments that are not present in the ideal state
       if (!idealStateSegmentsSet.contains(segment)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -1310,6 +1310,7 @@ public class PinotSegmentRestletResource {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
       if (llcSegmentName == null) {
         LOGGER.warn("Skip segment: {} not in low-level consumer format", segment);
+        continue;
       }
 
       // ignore segments that are not present in the ideal state

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -110,6 +110,11 @@ public class PinotSegmentRestletResourceTest {
       segmentsToInstanceState.put(segment, null);
     }
 
+    // Add segments for partition 2. None of the segments of this partition should be deleted.
+    for (String segment : getSegmentForPartition(tableName, 2, 0, 10, currentTime)) {
+      segmentsToInstanceState.put(segment, null);
+    }
+
     // Mock response for fetching segment to instance state map
     when(idealState.getRecord()).thenReturn(znRecord);
     when(znRecord.getMapFields()).thenReturn(segmentsToInstanceState);


### PR DESCRIPTION
- The existing implementation used to throw an exception in case a segment is not an LLC segment
- This is a concern as an uploaded segment might not follow the LLC naming convention
- This PR logs those cases instead of failing the API.
