### PR TITLE
Adding ArrowResponseEncoder implementation

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/grpc/PinotGrpcConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/grpc/PinotGrpcConnection.java
@@ -46,6 +46,7 @@ public class PinotGrpcConnection extends AbstractBaseConnection {
   protected static final String[] POSSIBLE_METADATA_MAP_OPTIONS = {
       CommonConstants.Broker.Grpc.BLOCK_ROW_SIZE,
       CommonConstants.Broker.Grpc.COMPRESSION,
+      CommonConstants.Broker.Grpc.ENCODING,
   };
   private GrpcConnection _session;
   private PinotControllerTransport _controllerTransport;

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -130,6 +130,15 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-netty</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
     </dependency>

--- a/pinot-common/src/main/java/org/apache/pinot/common/compression/CompressionFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/compression/CompressionFactory.java
@@ -18,8 +18,15 @@
  */
 package org.apache.pinot.common.compression;
 
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
 public class CompressionFactory {
   private CompressionFactory() {
+  }
+
+  public static String getDefaultCompressionType() {
+    return CommonConstants.Broker.Grpc.DEFAULT_COMPRESSION;
   }
 
   public static String[] getCompressionTypes() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
@@ -1,0 +1,485 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response.encoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.JsonStringArrayList;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.utils.MapUtils;
+
+
+public class ArrowResponseEncoder implements ResponseEncoder {
+  private static final RootAllocator ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
+
+  @Override
+  public byte[] encodeResultTable(ResultTable resultTable, int startRow, int length)
+      throws IOException {
+    // Create an Arrow VectorSchemaRoot from a subrange of rows.
+    try (VectorSchemaRoot root = createVectorSchemaRoot(resultTable, resultTable.getDataSchema(), startRow, length);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+      return out.toByteArray();
+    }
+  }
+
+  private VectorSchemaRoot createVectorSchemaRoot(ResultTable resultTable, DataSchema schema, int startRow,
+      int length) {
+    List<Field> fields = new ArrayList<>();
+    List<FieldVector> vectors = new ArrayList<>();
+    int numColumns = schema.getColumnNames().length; // assuming getter returns String[]
+
+    // Create an Arrow Field and vector for each column based on its type.
+    for (int col = 0; col < numColumns; col++) {
+      String colName = schema.getColumnNames()[col];
+      DataSchema.ColumnDataType colType = schema.getColumnDataTypes()[col];
+      Field field;
+      FieldVector vector;
+      switch (colType) {
+        case BOOLEAN:
+          field = new Field(colName, FieldType.nullable(new ArrowType.Bool()), null);
+          vector = new org.apache.arrow.vector.BitVector(colName, ALLOCATOR);
+          break;
+        case INT:
+          field = new Field(colName, FieldType.nullable(new ArrowType.Int(32, true)), null);
+          vector = new IntVector(colName, ALLOCATOR);
+          break;
+        case LONG:
+          field = new Field(colName, FieldType.nullable(new ArrowType.Int(64, true)), null);
+          vector = new BigIntVector(colName, ALLOCATOR);
+          break;
+        case FLOAT:
+          field =
+              new Field(colName, FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null);
+          vector = new Float4Vector(colName, ALLOCATOR);
+          break;
+        case DOUBLE:
+          field =
+              new Field(colName, FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null);
+          vector = new Float8Vector(colName, ALLOCATOR);
+          break;
+        case TIMESTAMP:
+        case STRING:
+        case BYTES:
+        case BIG_DECIMAL:
+        case JSON:
+        case OBJECT:
+          field = new Field(colName, FieldType.nullable(new ArrowType.Utf8()), null);
+          vector = new VarCharVector(colName, ALLOCATOR);
+          break;
+        case MAP:
+          field = new Field(colName, FieldType.nullable(new ArrowType.Binary()), null);
+          vector = new VarBinaryVector(colName, ALLOCATOR);
+          break;
+        case UNKNOWN:
+          // handle Null value
+          field = new Field(colName, FieldType.nullable(new ArrowType.Null()), null);
+          vector = new NullVector(colName);
+          break;
+        case BOOLEAN_ARRAY:
+          // Define the inner field for a boolean element.
+          List<Field> children =
+              Collections.singletonList(new Field("element", FieldType.nullable(new ArrowType.Bool()), null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        case INT_ARRAY:
+          // Define the inner field for an int element.
+          children =
+              Collections.singletonList(new Field("element", FieldType.nullable(new ArrowType.Int(32, true)), null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        case LONG_ARRAY:
+          // Define the inner field for a long element.
+          children =
+              Collections.singletonList(new Field("element", FieldType.nullable(new ArrowType.Int(64, true)), null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        case FLOAT_ARRAY:
+          // Define the inner field for a float element.
+          children = Collections.singletonList(
+              new Field("element", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+                  null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        case DOUBLE_ARRAY:
+          // Define the inner field for a double element.
+          children = Collections.singletonList(
+              new Field("element", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+                  null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        case TIMESTAMP_ARRAY:
+        case STRING_ARRAY:
+        case BYTES_ARRAY:
+          // Define the inner field for a string element.
+          children = Collections.singletonList(new Field("element", FieldType.nullable(new ArrowType.Utf8()), null));
+          // Define the field for the list column.
+          field = new Field(colName, FieldType.nullable(new ArrowType.List()), children);
+          // Create a ListVector using the field name and allocator.
+          vector = ListVector.empty(colName, ALLOCATOR);
+          // Initialize its children from the defined field.
+          vector.initializeChildrenFromFields(children);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported column type: " + colType);
+      }
+      fields.add(field);
+      vector.allocateNew();
+      vectors.add(vector);
+    }
+
+    // Determine the actual end row.
+    int availableRows = resultTable.getRows().size();
+    int endRow = Math.min(startRow + length, availableRows);
+
+    // Write the rows from startRow to endRow into the corresponding Arrow vectors.
+    for (int i = startRow; i < endRow; i++) {
+      Object[] row = resultTable.getRows().get(i);
+      int rowIndex = i - startRow;
+      for (int col = 0; col < numColumns; col++) {
+        FieldVector vector = vectors.get(col);
+        Object value = row[col];
+        if (value == null) {
+          vector.setNull(rowIndex);
+        } else {
+          DataSchema.ColumnDataType colType = schema.getColumnDataTypes()[col];
+          switch (colType) {
+            case BOOLEAN:
+              ((org.apache.arrow.vector.BitVector) vector).setSafe(rowIndex, ((Boolean) value) ? 1 : 0);
+              break;
+            case INT:
+              ((IntVector) vector).setSafe(rowIndex, ((Number) value).intValue());
+              break;
+            case LONG:
+              ((BigIntVector) vector).setSafe(rowIndex, ((Number) value).longValue());
+              break;
+            case FLOAT:
+              ((Float4Vector) vector).setSafe(rowIndex, ((Number) value).floatValue());
+              break;
+            case DOUBLE:
+              ((Float8Vector) vector).setSafe(rowIndex, ((Number) value).doubleValue());
+              break;
+            case TIMESTAMP:
+            case STRING:
+            case BYTES:
+            case BIG_DECIMAL:
+            case JSON:
+            case OBJECT:
+              byte[] bytes = ((String) value).getBytes(StandardCharsets.UTF_8);
+              ((VarCharVector) vector).setSafe(rowIndex, bytes);
+              break;
+            case MAP:
+              byte[] mapValueBytes = MapUtils.serializeMap((Map) value);
+              ((VarBinaryVector) vector).setSafe(rowIndex, mapValueBytes);
+              break;
+            case UNKNOWN:
+              // Handle null value
+              vector.setNull(rowIndex);
+              break;
+            case BOOLEAN_ARRAY:
+              ListVector booleanArrayVector = (ListVector) vector;
+              boolean[] booleanArray = (boolean[]) value;
+              // Start a new list entry for the current row.
+              booleanArrayVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (BitVector).
+              BitVector bitVector = (BitVector) booleanArrayVector.getDataVector();
+              // Determine the current position in the child vector.
+              int bitVectorIndex = bitVector.getValueCount();
+              // Write each boolean into the child vector.
+              for (boolean v : booleanArray) {
+                bitVector.setSafe(bitVectorIndex, v ? 1 : 0);
+                bitVectorIndex++;
+              }
+              // Update the child vector's value count.
+              bitVector.setValueCount(bitVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              booleanArrayVector.endValue(rowIndex, booleanArray.length);
+              break;
+            case INT_ARRAY:
+              ListVector intArrayVector = (ListVector) vector;
+              int[] intArr = (int[]) value;
+              // Start a new list entry for the current row.
+              intArrayVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (IntVector).
+              IntVector intVector = (IntVector) intArrayVector.getDataVector();
+              // Determine the current position in the child vector.
+              int intVectorIndex = intVector.getValueCount();
+              // Write each integer into the child vector.
+              for (int v : intArr) {
+                intVector.setSafe(intVectorIndex, v);
+                intVectorIndex++;
+              }
+              // Update the child vector's value count.
+              intVector.setValueCount(intVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              intArrayVector.endValue(rowIndex, intArr.length);
+              break;
+            case LONG_ARRAY:
+              ListVector longArrayVector = (ListVector) vector;
+              long[] longArray = (long[]) value;
+              // Start a new list entry for the current row.
+              longArrayVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (BigIntVector).
+              BigIntVector bigIntVector = (BigIntVector) longArrayVector.getDataVector();
+              // Determine the current position in the child vector.
+              int bigIntVectorIndex = bigIntVector.getValueCount();
+              // Write each long into the child vector.
+              for (long v : longArray) {
+                bigIntVector.setSafe(bigIntVectorIndex, v);
+                bigIntVectorIndex++;
+              }
+              // Update the child vector's value count.
+              bigIntVector.setValueCount(bigIntVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              longArrayVector.endValue(rowIndex, longArray.length);
+              break;
+            case FLOAT_ARRAY:
+              ListVector floatArrayVector = (ListVector) vector;
+              float[] floatArray = (float[]) value;
+              // Start a new list entry for the current row.
+              floatArrayVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (Float4Vector).
+              Float4Vector floatVector = (Float4Vector) floatArrayVector.getDataVector();
+              // Determine the current position in the child vector.
+              int floatVectorIndex = floatVector.getValueCount();
+              // Write each float into the child vector.
+              for (float v : floatArray) {
+                floatVector.setSafe(floatVectorIndex, v);
+                floatVectorIndex++;
+              }
+              // Update the child vector's value count.
+              floatVector.setValueCount(floatVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              floatArrayVector.endValue(rowIndex, floatArray.length);
+              break;
+            case DOUBLE_ARRAY:
+              ListVector doubleArrayVector = (ListVector) vector;
+              double[] doubleArray = (double[]) value;
+              // Start a new list entry for the current row.
+              doubleArrayVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (Float8Vector).
+              Float8Vector doubleVector = (Float8Vector) doubleArrayVector.getDataVector();
+              // Determine the current position in the child vector.
+              int doubleVectorIndex = doubleVector.getValueCount();
+              // Write each double into the child vector.
+              for (double v : doubleArray) {
+                doubleVector.setSafe(doubleVectorIndex, v);
+                doubleVectorIndex++;
+              }
+              // Update the child vector's value count.
+              doubleVector.setValueCount(doubleVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              doubleArrayVector.endValue(rowIndex, doubleArray.length);
+              break;
+            case TIMESTAMP_ARRAY:
+            case STRING_ARRAY:
+            case BYTES_ARRAY:
+              ListVector listVector = (ListVector) vector;
+              String[] stringArray = (String[]) value;
+              // Start a new list entry for the current row.
+              listVector.startNewValue(rowIndex);
+              // Retrieve the underlying child vector (VarCharVector).
+              VarCharVector stringVector = (VarCharVector) listVector.getDataVector();
+              // Determine the current position in the child vector.
+              int stringVectorIndex = stringVector.getValueCount();
+              // Write each string into the child vector.
+              for (String v : stringArray) {
+                byte[] stringBytes = v.getBytes(StandardCharsets.UTF_8);
+                stringVector.setSafe(stringVectorIndex, stringBytes);
+                stringVectorIndex++;
+              }
+              // Update the child vector's value count.
+              stringVector.setValueCount(stringVectorIndex);
+              // Finalize the list entry by indicating the number of elements added.
+              listVector.endValue(rowIndex, stringArray.length);
+              break;
+            default:
+              throw new UnsupportedOperationException("Unsupported column type: " + colType);
+          }
+        }
+      }
+    }
+
+    // Set the value count on each vector.
+    int numRows = endRow - startRow;
+    for (FieldVector vector : vectors) {
+      vector.setValueCount(numRows);
+    }
+
+    Schema arrowSchema = new Schema(fields);
+    return new VectorSchemaRoot(arrowSchema, vectors, numRows);
+  }
+
+  @Override
+  public ResultTable decodeResultTable(byte[] bytes, int rowSize, DataSchema schema)
+      throws IOException {
+    try (ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        ArrowStreamReader reader = new ArrowStreamReader(in, ALLOCATOR)) {
+      VectorSchemaRoot root = reader.getVectorSchemaRoot();
+      // Read the first (and only) batch.
+      reader.loadNextBatch();
+      int numRows = root.getRowCount();
+      int numColumns = schema.getColumnNames().length;
+      List<Object[]> rows = new ArrayList<>();
+
+      // For each row, retrieve each column value from the corresponding vector.
+      for (int i = 0; i < numRows; i++) {
+        Object[] row = new Object[numColumns];
+        for (int col = 0; col < numColumns; col++) {
+          FieldVector vector = root.getVector(col);
+          switch (schema.getColumnDataType(col)) {
+            case BOOLEAN:
+              row[col] = ((BitVector) vector).get(i) == 1;
+              break;
+            case TIMESTAMP:
+            case STRING:
+            case BYTES:
+            case BIG_DECIMAL:
+            case JSON:
+            case OBJECT:
+              row[col] = new String(((VarCharVector) vector).get(i), StandardCharsets.UTF_8);
+              break;
+            case MAP:
+              row[col] = MapUtils.deserializeMap(((VarBinaryVector) vector).get(i));
+              break;
+            case UNKNOWN:
+              row[col] = null;
+              break;
+            case BOOLEAN_ARRAY:
+              ListVector booleanArrayListVector = (ListVector) vector;
+              JsonStringArrayList booleanArrayList = (JsonStringArrayList) booleanArrayListVector.getObject(i);
+              boolean[] booleanArray = new boolean[booleanArrayList.size()];
+              for (int j = 0; j < booleanArrayList.size(); j++) {
+                booleanArray[j] = (boolean) booleanArrayList.get(j);
+              }
+              row[col] = booleanArray;
+              break;
+            case INT_ARRAY:
+              ListVector intArrayListVector = (ListVector) vector;
+              List<?> intArrayValues = intArrayListVector.getObject(i);
+              int[] intArray = new int[intArrayValues.size()];
+              for (int j = 0; j < intArrayValues.size(); j++) {
+                intArray[j] = (int) intArrayValues.get(j);
+              }
+              row[col] = intArray;
+              break;
+            case LONG_ARRAY:
+              ListVector longArrayListVector = (ListVector) vector;
+              List<?> longArrayValues = longArrayListVector.getObject(i);
+              long[] longArray = new long[longArrayValues.size()];
+              for (int j = 0; j < longArrayValues.size(); j++) {
+                longArray[j] = (long) longArrayValues.get(j);
+              }
+              row[col] = longArray;
+              break;
+            case FLOAT_ARRAY:
+              ListVector floatArrayListVector = (ListVector) vector;
+              List<?> floatArrayValues = floatArrayListVector.getObject(i);
+              float[] floatArray = new float[floatArrayValues.size()];
+              for (int j = 0; j < floatArrayValues.size(); j++) {
+                floatArray[j] = (float) floatArrayValues.get(j);
+              }
+              row[col] = floatArray;
+              break;
+            case DOUBLE_ARRAY:
+              ListVector doubleArrayListVector = (ListVector) vector;
+              List<?> doubleArrayValues = doubleArrayListVector.getObject(i);
+              double[] doubleArray = new double[doubleArrayValues.size()];
+              for (int j = 0; j < doubleArrayValues.size(); j++) {
+                doubleArray[j] = (double) doubleArrayValues.get(j);
+              }
+              row[col] = doubleArray;
+              break;
+            case TIMESTAMP_ARRAY:
+            case STRING_ARRAY:
+            case BYTES_ARRAY:
+              ListVector listVector = (ListVector) vector;
+              List<?> arrayValues = listVector.getObject(i);
+              String[] array = new String[arrayValues.size()];
+              for (int j = 0; j < arrayValues.size(); j++) {
+                array[j] = arrayValues.get(j).toString();
+              }
+              row[col] = array;
+              break;
+            default:
+              row[col] = vector.getObject(i);
+              break;
+          }
+        }
+        rows.add(row);
+      }
+      // Construct a Pinot ResultTable from the DataSchema and rows.
+      return new ResultTable(schema, rows);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ResponseEncoderFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ResponseEncoderFactory.java
@@ -18,14 +18,29 @@
  */
 package org.apache.pinot.common.response.encoder;
 
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
 public class ResponseEncoderFactory {
   private ResponseEncoderFactory() {
+  }
+
+  public static String[] getResponseEncoderTypes() {
+    return new String[]{
+        "JSON", "ARROW"
+    };
+  }
+
+  public static String getDefaultResponseEncoderType() {
+    return CommonConstants.Broker.Grpc.DEFAULT_ENCODING;
   }
 
   public static ResponseEncoder getResponseEncoder(String format) {
     switch (format.toUpperCase()) {
       case "JSON":
         return new JsonResponseEncoder();
+      case "ARROW":
+        return new ArrowResponseEncoder();
       default:
         throw new IllegalArgumentException("Unsupported format: " + format);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -613,6 +613,8 @@ public class DataSchema {
           return BytesUtils.toHexString((byte[]) value);
         case TIMESTAMP_ARRAY:
           return formatTimestampArray((Timestamp[]) value);
+        case BYTES_ARRAY:
+          return formatBytesArray((byte[][]) value);
         default:
           return (Serializable) value;
       }
@@ -807,6 +809,15 @@ public class DataSchema {
         formattedTimestampArray[i] = timestampArray[i].toString();
       }
       return formattedTimestampArray;
+    }
+
+    private static String[] formatBytesArray(byte[][] byteArray) {
+      int length = byteArray.length;
+      String[] formattedBytesArray = new String[length];
+      for (int i = 0; i < length; i++) {
+        formattedBytesArray[i] = BytesUtils.toHexString(byteArray[i]);
+      }
+      return formattedBytesArray;
     }
 
     public static ColumnDataType fromDataType(DataType dataType, boolean isSingleValue) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoderTest.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response.encoder;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+
+public class ArrowResponseEncoderTest {
+
+  @Test
+  public void testEncodeDecodeSingleRow()
+      throws IOException {
+    // Define a schema with two columns: one integer and one string.
+    DataSchema schema = new DataSchema(
+        new String[]{"col1", "col2"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
+
+    // Create a single row for testing.
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(new Object[]{123, "test value"});
+
+    // Construct the ResultTable.
+    ResultTable resultTable = new ResultTable(schema, rows);
+
+    // Instantiate the encoder.
+    ArrowResponseEncoder encoder = new ArrowResponseEncoder();
+
+    // Encode the entire table (starting at row 0).
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+
+    // Decode the table back.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    // Verify that the schemas match.
+    assertEquals(resultTable.getDataSchema().toString(),
+        decodedTable.getDataSchema().toString(),
+        "Schemas should match");
+
+    // Verify that the row count and row contents are identical.
+    assertEquals(resultTable.getRows().size(), decodedTable.getRows().size(), "Row count should match");
+    for (int i = 0; i < rows.size(); i++) {
+      Object[] row = rows.get(i);
+      for (int j = 0; j < row.length; j++) {
+        assertEquals(row[j], decodedTable.getRows().get(i)[j], "Row " + i + " should match");
+      }
+    }
+  }
+
+  @Test
+  public void testEncodeDecodeMultipleRows()
+      throws IOException {
+    // Define a schema with three columns.
+    DataSchema schema = new DataSchema(
+        new String[]{"id", "name", "score"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.DOUBLE});
+
+    // Create multiple rows.
+    List<Object[]> rows = Arrays.asList(
+        new Object[]{1, "Alice", (double) 95.5},
+        new Object[]{2, "Bob", (double) 88.0},
+        new Object[]{3, "Charlie", (double) 76.3}
+    );
+
+    ResultTable resultTable = new ResultTable(schema, rows);
+    ArrowResponseEncoder encoder = new ArrowResponseEncoder();
+
+    // Encode a sub-range: rows 1 and 2 (i.e. starting at index 1, length 2)
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 1, 2);
+
+    // Decode the subrange.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, 2, schema);
+
+    // Verify that we got two rows.
+    assertEquals(2, decodedTable.getRows().size(), "Should decode two rows");
+
+    // Verify that the decoded rows match rows 1 and 2 of the original table.
+    for (int i = 0; i < 2; i++) {
+      Object[] row = rows.get(i + 1);
+      for (int j = 0; j < row.length; j++) {
+        Object actual = decodedTable.getRows().get(i)[j];
+        Object expected = row[j];
+        assertEquals(actual, expected, "Row " + (i + 1) + " should match");
+      }
+    }
+  }
+
+  @Test
+  public void testEncodeDecodeAllDataTypes()
+      throws IOException {
+    // Define the column names and corresponding data types.
+    String[] columnNames = {
+        "intCol", "longCol", "floatCol", "doubleCol", "bigDecimalCol", "booleanCol", "timestampCol",
+        "stringCol", "jsonCol", "mapCol", "bytesCol", "objectCol", "intArrayCol", "longArrayCol",
+        "floatArrayCol", "doubleArrayCol", "booleanArrayCol", "timestampArrayCol", "stringArrayCol",
+        "bytesArrayCol", "unknownCol"
+    };
+
+    DataSchema.ColumnDataType[] columnTypes = {
+        ColumnDataType.INT,
+        ColumnDataType.LONG,
+        ColumnDataType.FLOAT,
+        ColumnDataType.DOUBLE,
+        ColumnDataType.BIG_DECIMAL,
+        ColumnDataType.BOOLEAN,
+        ColumnDataType.TIMESTAMP,
+        ColumnDataType.STRING,
+        ColumnDataType.JSON,
+        ColumnDataType.MAP,
+        ColumnDataType.BYTES,
+        ColumnDataType.OBJECT,
+        ColumnDataType.INT_ARRAY,
+        ColumnDataType.LONG_ARRAY,
+        ColumnDataType.FLOAT_ARRAY,
+        ColumnDataType.DOUBLE_ARRAY,
+        ColumnDataType.BOOLEAN_ARRAY,
+        ColumnDataType.TIMESTAMP_ARRAY,
+        ColumnDataType.STRING_ARRAY,
+        ColumnDataType.BYTES_ARRAY,
+        ColumnDataType.UNKNOWN
+    };
+
+    DataSchema schema = new DataSchema(columnNames, columnTypes);
+
+    // Create test values for each type.
+    Integer intVal = 42;
+    Long longVal = 1234567890123L;
+    Float floatVal = 3.14f;
+    Double doubleVal = 2.71828;
+    BigDecimal bigDecimalVal = new BigDecimal("12345.6789");
+    Boolean booleanVal = true;
+    Timestamp timestampVal = new Timestamp(1622548800000L);
+    String stringVal = "hello";
+    String jsonVal = "{\"key\":\"value\"}";
+    Map<String, Integer> mapVal = new HashMap<>();
+    mapVal.put("a", 1);
+    mapVal.put("b", 2);
+    byte[] bytesVal = new byte[]{1, 2, 3, 4};
+    String objectVal = "customObject";
+    int[] intArrayVal = new int[]{1, 2, 3};
+    long[] longArrayVal = new long[]{4L, 5L, 6L};
+    float[] floatArrayVal = new float[]{7.7f, 8.8f};
+    double[] doubleArrayVal = new double[]{9.9, 10.1};
+    boolean[] booleanArrayVal = new boolean[]{true, false, true};
+    Timestamp[] timestampArrayVal = new Timestamp[]{
+        new Timestamp(1622548800000L), new Timestamp(1622548801000L)
+    };
+    String[] stringArrayVal = new String[]{"a", "b", "c"};
+    byte[][] bytesArrayVal = new byte[][]{
+        new byte[]{1, 2}, new byte[]{3, 4}
+    };
+    Object unknownVal = null;  // UNKNOWN is represented as null in this example.
+
+    // Build a single row that contains all the above values.
+    List<Object[]> rows = new ArrayList<>();
+    Object[] row = new Object[]{
+        intVal, longVal, floatVal, doubleVal, bigDecimalVal, booleanVal, timestampVal, stringVal,
+        jsonVal, mapVal, bytesVal, objectVal, intArrayVal, longArrayVal, floatArrayVal, doubleArrayVal,
+        booleanArrayVal, timestampArrayVal, stringArrayVal, bytesArrayVal, unknownVal
+    };
+    for (int i = 0; i < row.length; i++) {
+      row[i] = columnTypes[i].format(row[i]); // Convert to internal representation.
+    }
+    rows.add(row);
+    ResultTable resultTable = new ResultTable(schema, rows);
+
+    // Instantiate the encoder and encode the ResultTable.
+    ArrowResponseEncoder encoder = new ArrowResponseEncoder();
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+
+    // Decode the byte array back into a ResultTable.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    // There should be exactly one row in the decoded table.
+    assertEquals(1, decodedTable.getRows().size(), "Row count should be 1");
+    Object[] decodedRow = decodedTable.getRows().get(0);
+    assertEquals(row.length, decodedRow.length, "Column count should match");
+
+    // Compare each column. For array types we use specialized assertions.
+    for (int i = 0; i < row.length; i++) {
+      Object original = row[i];
+      Object decoded = decodedRow[i];
+      if (original != null && original.getClass().isArray()) {
+        // Compare primitive arrays or Object arrays.
+        if (original instanceof boolean[]) {
+          assertEquals((boolean[]) original, (boolean[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof int[]) {
+          assertEquals((int[]) original, (int[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof long[]) {
+          assertEquals((long[]) original, (long[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof float[]) {
+          assertEquals((float[]) original, (float[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof double[]) {
+          assertEquals((double[]) original, (double[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof Object[]) { // e.g., Timestamp[], String[], or byte[][]
+          assertEquals((Object[]) original, (Object[]) decoded, "Column " + columnNames[i] + " should match");
+        } else if (original instanceof byte[]) {
+          assertEquals((byte[]) original, (byte[]) decoded, "Column " + columnNames[i] + " should match");
+        } else {
+          fail("Unsupported array type for column " + columnNames[i]);
+        }
+      } else {
+        // For non-array types, check equality directly.
+        if (original != null) {
+          System.out.println("decoded = " + decoded + ", class = " + decoded.getClass());
+          System.out.println("original = " + original + ", class = " + original.getClass());
+        }
+        assertEquals(original, decoded, "Column " + columnNames[i] + " should match");
+      }
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/JsonResponseEncoderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/JsonResponseEncoderTest.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response.encoder;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class JsonResponseEncoderTest {
+
+  @Test
+  public void testEncodeDecodeSingleRow() throws IOException {
+    // Define a schema with two columns: one integer and one string.
+    DataSchema schema = new DataSchema(
+        new String[] {"col1", "col2"},
+        new ColumnDataType[] {ColumnDataType.INT, ColumnDataType.STRING});
+
+    // Create a single row for testing.
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(new Object[] {123, "test value"});
+
+    // Construct the ResultTable.
+    ResultTable resultTable = new ResultTable(schema, rows);
+
+    // Instantiate the JSON encoder.
+    JsonResponseEncoder encoder = new JsonResponseEncoder();
+
+    // Encode the entire table (starting at row 0).
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+
+    // Decode the table back.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    // Verify that the schemas match.
+    assertEquals(resultTable.getDataSchema().toString(),
+        decodedTable.getDataSchema().toString(), "Schemas should match");
+
+    // Verify that the row count and row contents are identical.
+    assertEquals(resultTable.getRows().size(), decodedTable.getRows().size(), "Row count should match");
+    for (int i = 0; i < rows.size(); i++) {
+      Object[] row = rows.get(i);
+      for (int j = 0; j < row.length; j++) {
+        assertEquals(row[j], decodedTable.getRows().get(i)[j], "Row " + i + " should match");
+      }
+    }
+  }
+
+  @Test
+  public void testEncodeDecodeMultipleRows() throws IOException {
+    // Define a schema with three columns.
+    DataSchema schema = new DataSchema(
+        new String[] {"id", "name", "score"},
+        new ColumnDataType[] {ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.DOUBLE});
+
+    // Create multiple rows.
+    List<Object[]> rows = Arrays.asList(
+        new Object[] {1, "Alice", 95.5},
+        new Object[] {2, "Bob", 88.0},
+        new Object[] {3, "Charlie", 76.3}
+    );
+
+    ResultTable resultTable = new ResultTable(schema, rows);
+    JsonResponseEncoder encoder = new JsonResponseEncoder();
+
+    // Encode a sub-range: rows 1 and 2 (i.e. starting at index 1, length 2)
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 1, 2);
+
+    // Decode the subrange.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, 2, schema);
+
+    // Verify that we got two rows.
+    assertEquals(2, decodedTable.getRows().size(), "Should decode two rows");
+
+    // Verify that the decoded rows match rows 1 and 2 of the original table.
+    for (int i = 0; i < 2; i++) {
+      Object[] row = rows.get(i + 1);
+      for (int j = 0; j < row.length; j++) {
+        Object actual = decodedTable.getRows().get(i)[j];
+        Object expected = row[j];
+        assertEquals(actual, expected, "Row " + (i + 1) + " should match");
+      }
+    }
+  }
+
+  @Test
+  public void testEncodeDecodeAllDataTypes() throws IOException {
+    // Define the column names and corresponding data types.
+    String[] columnNames = {
+        "intCol", "longCol", "floatCol", "doubleCol", "bigDecimalCol", "booleanCol", "timestampCol",
+        "stringCol", "jsonCol", "mapCol", "bytesCol", "objectCol", "intArrayCol", "longArrayCol",
+        "floatArrayCol", "doubleArrayCol", "booleanArrayCol", "timestampArrayCol", "stringArrayCol",
+        "bytesArrayCol", "unknownCol"
+    };
+
+    DataSchema.ColumnDataType[] columnTypes = {
+        ColumnDataType.INT,
+        ColumnDataType.LONG,
+        ColumnDataType.FLOAT,
+        ColumnDataType.DOUBLE,
+        ColumnDataType.BIG_DECIMAL,
+        ColumnDataType.BOOLEAN,
+        ColumnDataType.TIMESTAMP,
+        ColumnDataType.STRING,
+        ColumnDataType.JSON,
+        ColumnDataType.MAP,
+        ColumnDataType.BYTES,
+        ColumnDataType.OBJECT,
+        ColumnDataType.INT_ARRAY,
+        ColumnDataType.LONG_ARRAY,
+        ColumnDataType.FLOAT_ARRAY,
+        ColumnDataType.DOUBLE_ARRAY,
+        ColumnDataType.BOOLEAN_ARRAY,
+        ColumnDataType.TIMESTAMP_ARRAY,
+        ColumnDataType.STRING_ARRAY,
+        ColumnDataType.BYTES_ARRAY,
+        ColumnDataType.UNKNOWN
+    };
+
+    DataSchema schema = new DataSchema(columnNames, columnTypes);
+
+    // Create test values for each type.
+    Integer intVal = 42;
+    Long longVal = 1234567890123L;
+    Float floatVal = 3.14f;
+    Double doubleVal = 2.71828;
+    BigDecimal bigDecimalVal = new BigDecimal("12345.6789");
+    Boolean booleanVal = true;
+    Timestamp timestampVal = new Timestamp(1622548800000L);
+    String stringVal = "hello";
+    String jsonVal = "{\"key\":\"value\"}";
+    Map<String, Integer> mapVal = new HashMap<>();
+    mapVal.put("a", 1);
+    mapVal.put("b", 2);
+    byte[] bytesVal = new byte[] {1, 2, 3, 4};
+    String objectVal = "customObject";
+    int[] intArrayVal = new int[] {1, 2, 3};
+    long[] longArrayVal = new long[] {4L, 5L, 6L};
+    float[] floatArrayVal = new float[] {7.7f, 8.8f};
+    double[] doubleArrayVal = new double[] {9.9, 10.1};
+    boolean[] booleanArrayVal = new boolean[] {true, false, true};
+    Timestamp[] timestampArrayVal = new Timestamp[] {
+        new Timestamp(1622548800000L), new Timestamp(1622548801000L)
+    };
+    String[] stringArrayVal = new String[] {"a", "b", "c"};
+    byte[][] bytesArrayVal = new byte[][] {
+        new byte[] {1, 2}, new byte[] {3, 4}
+    };
+    Object unknownVal = null;  // UNKNOWN is represented as null in this example.
+
+    // Build a single row that contains all the above values.
+    List<Object[]> rows = new ArrayList<>();
+    Object[] row = new Object[] {
+        intVal, longVal, floatVal, doubleVal, bigDecimalVal, booleanVal, timestampVal, stringVal,
+        jsonVal, mapVal, bytesVal, objectVal, intArrayVal, longArrayVal, floatArrayVal, doubleArrayVal,
+        booleanArrayVal, timestampArrayVal, stringArrayVal, bytesArrayVal, unknownVal
+    };
+
+    // Convert each value using the schema's formatting (if needed).
+    for (int i = 0; i < row.length; i++) {
+      row[i] = columnTypes[i].format(row[i]);
+    }
+    rows.add(row);
+    ResultTable resultTable = new ResultTable(schema, rows);
+
+    // Instantiate the JSON encoder and encode the ResultTable.
+    JsonResponseEncoder encoder = new JsonResponseEncoder();
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+
+    // Decode the byte array back into a ResultTable.
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    // There should be exactly one row in the decoded table.
+    assertEquals(1, decodedTable.getRows().size(), "Row count should be 1");
+    Object[] decodedRow = decodedTable.getRows().get(0);
+    assertEquals(row.length, decodedRow.length, "Column count should match");
+
+    // Compare each column. For array types, use appropriate array comparisons.
+    for (int i = 0; i < row.length; i++) {
+      Object original = row[i];
+      Object decoded = decodedRow[i];
+      if (original != null && original.getClass().isArray()) {
+        // Compare primitive arrays or Object arrays.
+        if (original instanceof boolean[]) {
+          assertEquals(Arrays.toString((boolean[]) original), Arrays.toString((boolean[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof int[]) {
+          assertEquals(Arrays.toString((int[]) original), Arrays.toString((int[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof long[]) {
+          assertEquals(Arrays.toString((long[]) original), Arrays.toString((long[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof float[]) {
+          assertEquals(Arrays.toString((float[]) original), Arrays.toString((float[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof double[]) {
+          assertEquals(Arrays.toString((double[]) original), Arrays.toString((double[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof Object[]) { // e.g., Timestamp[], String[], or byte[][]
+          assertEquals(Arrays.deepToString((Object[]) original), Arrays.deepToString((Object[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else if (original instanceof byte[]) {
+          assertEquals(Arrays.toString((byte[]) original), Arrays.toString((byte[]) decoded),
+              "Column " + columnNames[i] + " should match");
+        } else {
+          fail("Unsupported array type for column " + columnNames[i]);
+        }
+      } else {
+        // For non-array types, check equality directly.
+        assertEquals(original, decoded, "Column " + columnNames[i] + " should match");
+      }
+    }
+  }
+}

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +52,10 @@ import org.apache.pinot.broker.broker.helix.BaseBrokerStarter;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.grpc.GrpcConnection;
+import org.apache.pinot.common.compression.CompressionFactory;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.response.encoder.ResponseEncoderFactory;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
@@ -539,13 +543,47 @@ public abstract class ClusterTest extends ControllerTest {
    */
   public JsonNode postQuery(@Language("sql") String query)
       throws Exception {
-    if (System.currentTimeMillis() % 2 == 0) {
-      return queryGrpcEndpoint(query,
-          Map.of(Broker.Request.QUERY_OPTIONS,
-              Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=" + useMultiStageQueryEngine()));
+    if (useGrpcEndpoint()) {
+      return queryBrokerGrpcEndpoint(query);
     }
+    return queryBrokerHttpEndpoint(query);
+  }
+
+  /**
+   * Queries the broker's query endpoint (/query/sql)
+   */
+  public JsonNode queryBrokerHttpEndpoint(@Language("sql") String query)
+      throws Exception {
     return postQuery(query, getBrokerQueryApiUrl(getBrokerBaseApiUrl(), useMultiStageQueryEngine()), null,
         getExtraQueryProperties());
+  }
+
+  /**
+   * Queries the broker's grpc query endpoint (/query/sql).
+   */
+  public JsonNode queryBrokerGrpcEndpoint(@Language("sql") String query)
+      throws Exception {
+    return queryGrpcEndpoint(query,
+        Map.of(
+            Broker.Request.QUERY_OPTIONS,
+            Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=" + useMultiStageQueryEngine(),
+            Broker.Grpc.ENCODING, getRandomEncoding(),
+            Broker.Grpc.COMPRESSION, getRandomCompression()
+        ));
+  }
+
+  private static String getRandomEncoding() {
+    int encodingSeqIdx = (int) (System.currentTimeMillis() % ResponseEncoderFactory.getResponseEncoderTypes().length);
+    return ResponseEncoderFactory.getResponseEncoderTypes()[encodingSeqIdx];
+  }
+
+  private static String getRandomCompression() {
+    int compressionSeqIdx = (int) (System.currentTimeMillis() % CompressionFactory.getCompressionTypes().length);
+    return CompressionFactory.getCompressionTypes()[compressionSeqIdx];
+  }
+
+  private static boolean useGrpcEndpoint() {
+    return System.currentTimeMillis() % 2 == 0;
   }
 
   /**
@@ -584,7 +622,109 @@ public abstract class ClusterTest extends ControllerTest {
         payload.put(extraProperty.getKey(), extraProperty.getValue());
       }
     }
-    return JsonUtils.stringToJsonNode(sendPostRequest(brokerQueryApiUrl, payload.toString(), headers));
+    JsonNode responseJsonNode =
+        JsonUtils.stringToJsonNode(sendPostRequest(brokerQueryApiUrl, payload.toString(), headers));
+    return sanitizeResponse(responseJsonNode);
+  }
+
+  private static JsonNode sanitizeResponse(JsonNode responseJsonNode) {
+    try {
+      DataSchema schema =
+          JsonUtils.jsonNodeToObject(responseJsonNode.get("resultTable").get("dataSchema"), DataSchema.class);
+      JsonNode rowsJsonNode = responseJsonNode.get("resultTable").get("rows");
+      if (rowsJsonNode != null) {
+        for (int i = 0; i < rowsJsonNode.size(); i++) {
+          ArrayNode rowJsonNode = (ArrayNode) rowsJsonNode.get(i);
+          for (int j = 0; j < schema.size(); j++) {
+            DataSchema.ColumnDataType columnDataType = schema.getColumnDataType(j);
+            JsonNode jsonValue = rowJsonNode.get(j);
+            if (columnDataType.isArray()) {
+              rowJsonNode.set(j, extractArray(columnDataType, jsonValue));
+            } else if (columnDataType != DataSchema.ColumnDataType.MAP) {
+              rowJsonNode.set(j, extractValue(columnDataType, jsonValue));
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      // Handle any exceptions that occur during the sanitization process
+      System.err.println("Error sanitizing response: " + e.getMessage());
+    }
+    return responseJsonNode;
+  }
+
+  private static JsonNode extractArray(DataSchema.ColumnDataType columnDataType, JsonNode jsonValue) {
+    Object[] array = new Object[jsonValue.size()];
+    for (int k = 0; k < jsonValue.size(); k++) {
+      if (jsonValue.get(k).isNull()) {
+        array[k] = null;
+      }
+      switch (columnDataType) {
+        case BOOLEAN_ARRAY:
+          array[k] = jsonValue.get(k).asBoolean();
+          break;
+        case INT_ARRAY:
+          array[k] = jsonValue.get(k).asInt();
+          break;
+        case LONG_ARRAY:
+          array[k] = jsonValue.get(k).asLong();
+          break;
+        case FLOAT_ARRAY:
+          array[k] = Double.valueOf(jsonValue.get(k).asDouble()).floatValue();
+          break;
+        case DOUBLE_ARRAY:
+          array[k] = jsonValue.get(k).asDouble();
+          break;
+        case STRING_ARRAY:
+        case TIMESTAMP_ARRAY:
+        case BYTES_ARRAY:
+          array[k] = jsonValue.get(k).textValue();
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported data type: " + columnDataType);
+      }
+    }
+    return JsonUtils.objectToJsonNode(array);
+  }
+
+  private static JsonNode extractValue(DataSchema.ColumnDataType columnDataType, JsonNode jsonValue) {
+    if (jsonValue.isNull()) {
+      return jsonValue;
+    }
+    Object object;
+    switch (columnDataType) {
+      case BOOLEAN:
+        object = jsonValue.asBoolean();
+        break;
+      case INT:
+        object = jsonValue.asInt();
+        break;
+      case LONG:
+        object = jsonValue.asLong();
+        break;
+      case FLOAT:
+        object = Double.valueOf(jsonValue.asDouble()).floatValue();
+        break;
+      case DOUBLE:
+        object = jsonValue.asDouble();
+        break;
+      case STRING:
+      case BYTES:
+      case TIMESTAMP:
+      case JSON:
+      case BIG_DECIMAL:
+        object = jsonValue.textValue();
+        break;
+      case UNKNOWN:
+        object = null;
+        break;
+      case OBJECT:
+      case MAP:
+        return jsonValue;
+      default:
+        throw new IllegalArgumentException("Unsupported data type: " + columnDataType);
+    }
+    return JsonUtils.objectToJsonNode(object);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
     <shade.phase.prop>none</shade.phase.prop>
 
+    <arrow.version>18.2.0</arrow.version>
     <avro.version>1.11.4</avro.version>
     <parquet.version>1.15.1</parquet.version>
     <orc.version>1.9.5</orc.version>
@@ -787,6 +788,18 @@
         <artifactId>pinot-kafka-base</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
+      </dependency>
+
+      <!-- Arrow dependencies for Broker GRPC ResultTable Serde protocol -->
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-vector</artifactId>
+        <version>${arrow.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty</artifactId>
+        <version>${arrow.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Use ARROW for the ResultTable Serde between BrokerGrpc client and server communication.

* Added new encoding type: `ARROW` for brokerGrpc request parameter
* Added `arrow-vector` and `arrow-memory-netty` dependencies for Serde ResultTable
* Added `ArrowResponseEncoder` for Serde protocol

Testing:
* Added comprehensive tests in `ArrowResponseEncoderTest` and `JsonResponseEncoderTest` to verify the encoding and decoding of various data types, including arrays and complex data structures.

## Release notes
Support ARROW as the binary protocol for BrokerGrpc ResultTable serialization and deserialization.