### PR TITLE
remove snapshotRWlock in upsert table partition mgr

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -34,9 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
@@ -107,7 +105,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   // NOTE: We do not persist snapshot on the first consuming segment because most segments might not be loaded yet
   // We only do this for Full-Upsert tables, for partial-upsert tables, we have a check allSegmentsLoaded
   protected volatile boolean _gotFirstConsumingSegment = false;
-  protected final ReadWriteLock _snapshotLock;
 
   protected long _lastOutOfOrderEventReportTimeNs = Long.MIN_VALUE;
   protected int _numOutOfOrderEvents = 0;
@@ -147,7 +144,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _hashFunction = context.getHashFunction();
     _partialUpsertHandler = context.getPartialUpsertHandler();
     _enableSnapshot = context.isSnapshotEnabled();
-    _snapshotLock = _enableSnapshot ? new ReentrantReadWriteLock() : null;
     _isPreloading = context.isPreloadEnabled();
     _metadataTTL = context.getMetadataTTL();
     _deletedKeysTTL = context.getDeletedKeysTTL();
@@ -284,9 +280,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip adding segment: {} because metadata manager is already stopped", segment.getSegmentName());
       return;
     }
-    if (_enableSnapshot) {
-      _snapshotLock.readLock().lock();
-    }
     try {
       doAddSegment((ImmutableSegmentImpl) segment);
       _trackedSegments.add(segment);
@@ -294,9 +287,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         _updatedSegmentsSinceLastSnapshot.add(segment);
       }
     } finally {
-      if (_enableSnapshot) {
-        _snapshotLock.readLock().unlock();
-      }
       finishOperation();
     }
   }
@@ -404,13 +394,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip preloading segment: {} because metadata manager is already stopped", segmentName);
       return;
     }
-    _snapshotLock.readLock().lock();
     try {
       doPreloadSegment((ImmutableSegmentImpl) segment);
       _trackedSegments.add(segment);
       _updatedSegmentsSinceLastSnapshot.add(segment);
     } finally {
-      _snapshotLock.readLock().unlock();
       finishOperation();
     }
   }
@@ -573,9 +561,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip replacing segment: {} because metadata manager is already stopped", segment.getSegmentName());
       return;
     }
-    if (_enableSnapshot) {
-      _snapshotLock.readLock().lock();
-    }
     try {
       doReplaceSegment(segment, oldSegment);
       if (!(segment instanceof EmptyIndexSegment)) {
@@ -586,9 +571,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
       _trackedSegments.remove(oldSegment);
     } finally {
-      if (_enableSnapshot) {
-        _snapshotLock.readLock().unlock();
-      }
       finishOperation();
     }
   }
@@ -716,9 +698,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip removing segment: {} because metadata manager is already stopped", segmentName);
       return;
     }
-    if (_enableSnapshot) {
-      _snapshotLock.readLock().lock();
-    }
     try {
       // Skip removing the upsert metadata of segment that is out of metadata TTL. The expired metadata is removed
       // while creating new consuming segment in batches.
@@ -729,9 +708,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
       _trackedSegments.remove(segment);
     } finally {
-      if (_enableSnapshot) {
-        _snapshotLock.readLock().unlock();
-      }
       finishOperation();
     }
   }
@@ -849,7 +825,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip taking snapshot because metadata manager is already stopped");
       return;
     }
-    _snapshotLock.writeLock().lock();
     try {
       long startTime = System.currentTimeMillis();
       doTakeSnapshot();
@@ -859,7 +834,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     } catch (Exception e) {
       _logger.warn("Caught exception while taking snapshot", e);
     } finally {
-      _snapshotLock.writeLock().unlock();
       finishOperation();
     }
   }
@@ -1121,12 +1095,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
   private void trackUpdatedSegmentsSinceLastSnapshot(IndexSegment segment) {
     if (_enableSnapshot && segment instanceof ImmutableSegment) {
-      _snapshotLock.readLock().lock();
-      try {
-        _updatedSegmentsSinceLastSnapshot.add(segment);
-      } finally {
-        _snapshotLock.readLock().unlock();
-      }
+      _updatedSegmentsSinceLastSnapshot.add(segment);
     }
   }
 


### PR DESCRIPTION
While committing large upsert segments, we often found that new consuming thread got stuck on waiting snapshotWLock. After looking into the current use of snapshotRWLock and snapshots, it seems safe to not lock at all to update snapshots (or not making things worse):

Threads and operations that take snapshot RWlocks today:
1. new consuming thread takes WLock and then update on-disk snapshots (the single-writer of on-disk snapshots)
2. other threads (Helix threads or prev consuming thread) take RLock to do addSegment/removeSegment/replaceSegment methods, i.e. potentially updating the in-mem validDocIds bitmaps, but those threads don't update on-disk snapshots.

So for those segment operations:
1. `removeSegment` doesn't need RLock, as removing segment doesn't change other segments' validDocIds bitmaps.
2. `replaceSegment` and `addSegment` may change other segments' validDocIds bitmaps. But it should be safe if the new consuming thread is taking snapshots concurrently when both methods are ongoing. Because, the new segments processed by `replaceSegment` and `addSegment` will be loaded on the server eventually, so on-disk snapshots get in sync with segments' in-mem bitmaps eventually. If server crashes now and restarts, it'll continue to load the new segments, so the table partition wouldn't miss valid docs. And before that, on-disk snapshots never have less valid docs than in-mem bitmaps, as required by minion compaction task or segment preloading feature.

What if the new segments get removed before being fully loaded? 
W/o snapshot lock, the existing segments' in-mem bitmaps and on-disk snapshots may see less valid docs than before, because their docs can get invalidated by the newly added segment that's removed immediately afterward. But even with snapshot lock today, removing segment this way can cause similar issue, i.e. the existing segments' in-mem bitmaps see less valid docs, however their on-disk snapshots still see same valid docs as they are not updated yet as blocked by the snapshot lock. But because the in-mem bitmaps get changed, queries already see less valid docs so damage is made already whether using lock or not. Restarting servers to recompute segments' bitmaps can fix the issue for both.