### PR TITLE
Remove mockito and bytebuddy warnings during test runs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2197,6 +2197,9 @@
               --add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED
               --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
               -Dnet.bytebuddy.experimental=true
+              -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar
+              -Xshare:off
+              -XX:+EnableDynamicAgentLoading
             </argLine>
           </configuration>
           <!-- Explicitly select the test provider, instead of relying on the classpath -->


### PR DESCRIPTION
References:
https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3 https://stackoverflow.com/questions/79278490/mockito-is-currently-self-attaching-to-enable-the-inline-mock-maker-this-will-n

The following warning is removed. This warning appears many times during a test setup.

```
2025-03-27T16:11:45.8857117Z WARNING: A Java agent has been loaded dynamically (/home/runner/.m2/repository/net/bytebuddy/byte-buddy-agent/1.15.11/byte-buddy-agent-1.15.11.jar)
2025-03-27T16:11:45.8859448Z WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
2025-03-27T16:11:45.8887419Z WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
2025-03-27T16:11:45.8907229Z WARNING: Dynamic loading of agents will be disallowed by default in a future release
2025-03-27T16:11:55.0231912Z Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3
```