### PR TITLE
Enhance rebalance progress stats

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class NoOpTableRebalanceObserver implements TableRebalanceObserver {
   @Override
   public void onTrigger(TableRebalanceObserver.Trigger trigger, Map<String, Map<String, String>> initialState,
-      Map<String, Map<String, String>> targetState) {
+      Map<String, Map<String, String>> targetState, RebalanceContext rebalanceContext) {
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -309,6 +309,7 @@ public class RebalanceSummaryResult {
   public static class SegmentInfo {
     // TODO: Add a metric to estimate the total time it will take to rebalance
     private final int _totalSegmentsToBeMoved;
+    private final int _totalSegmentsToBeDeleted;
     private final int _maxSegmentsAddedToASingleServer;
     private final long _estimatedAverageSegmentSizeInBytes;
     private final long _totalEstimatedDataToBeMovedInBytes;
@@ -322,6 +323,7 @@ public class RebalanceSummaryResult {
     /**
      * Constructor for SegmentInfo
      * @param totalSegmentsToBeMoved total number of segments to be moved as part of this rebalance
+     * @param totalSegmentsToBeDeleted total number of segments to be deleted from any server as part of this rebalance
      * @param maxSegmentsAddedToASingleServer maximum segments added to a single server as part of this rebalance
      * @param estimatedAverageSegmentSizeInBytes estimated average size of segments in bytes
      * @param totalEstimatedDataToBeMovedInBytes total estimated amount of data to be moved as part of this rebalance
@@ -331,6 +333,7 @@ public class RebalanceSummaryResult {
      */
     @JsonCreator
     public SegmentInfo(@JsonProperty("totalSegmentsToBeMoved") int totalSegmentsToBeMoved,
+        @JsonProperty("totalSegmentsToBeDeleted") int totalSegmentsToBeDeleted,
         @JsonProperty("maxSegmentsAddedToASingleServer") int maxSegmentsAddedToASingleServer,
         @JsonProperty("estimatedAverageSegmentSizeInBytes") long estimatedAverageSegmentSizeInBytes,
         @JsonProperty("totalEstimatedDataToBeMovedInBytes") long totalEstimatedDataToBeMovedInBytes,
@@ -338,6 +341,7 @@ public class RebalanceSummaryResult {
         @JsonProperty("numSegmentsInSingleReplica") @Nullable RebalanceChangeInfo numSegmentsInSingleReplica,
         @JsonProperty("numSegmentsAcrossAllReplicas") @Nullable RebalanceChangeInfo numSegmentsAcrossAllReplicas) {
       _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+      _totalSegmentsToBeDeleted = totalSegmentsToBeDeleted;
       _maxSegmentsAddedToASingleServer = maxSegmentsAddedToASingleServer;
       _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
       _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
@@ -349,6 +353,11 @@ public class RebalanceSummaryResult {
     @JsonProperty
     public int getTotalSegmentsToBeMoved() {
       return _totalSegmentsToBeMoved;
+    }
+
+    @JsonProperty
+    public int getTotalSegmentsToBeDeleted() {
+      return _totalSegmentsToBeDeleted;
     }
 
     @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.controller.helix.core.rebalance;
 
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 
 /**
@@ -26,7 +28,6 @@ import java.util.Map;
  * during critical triggers. The 3 main triggers during a rebalance operation are show below.
  * For example, we can track stats + status of rebalance during these triggers.
  */
-
 public interface TableRebalanceObserver {
   enum Trigger {
     // Start of rebalance Trigger
@@ -35,10 +36,12 @@ public interface TableRebalanceObserver {
     EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER,
     // Ideal state changes due to external events and new target for rebalance is computed
     IDEAL_STATE_CHANGE_TRIGGER,
+    // Next assignment calculation change trigger which calculates next assignment to act on
+    NEXT_ASSINGMENT_CALCULATION_TRIGGER,
   }
 
   void onTrigger(Trigger trigger, Map<String, Map<String, String>> currentState,
-      Map<String, Map<String, String>> targetState);
+      Map<String, Map<String, String>> targetState, RebalanceContext rebalanceContext);
 
   void onNoop(String msg);
 
@@ -49,4 +52,29 @@ public interface TableRebalanceObserver {
   boolean isStopped();
 
   RebalanceResult.Status getStopStatus();
+
+  class RebalanceContext {
+    private final long _estimatedAverageSegmentSizeInBytes;
+    private final Set<String> _uniqueSegmentList;
+    private final Set<String> _segmentsToMonitor;
+
+    public RebalanceContext(long estimatedAverageSegmentSizeInBytes, Set<String> uniqueSegmentList,
+        @Nullable Set<String> segmentsToMonitor) {
+      _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
+      _uniqueSegmentList = uniqueSegmentList;
+      _segmentsToMonitor = segmentsToMonitor;
+    }
+
+    public long getEstimatedAverageSegmentSizeInBytes() {
+      return _estimatedAverageSegmentSizeInBytes;
+    }
+
+    public Set<String> getUniqueSegmentList() {
+      return _uniqueSegmentList;
+    }
+
+    public Set<String> getSegmentsToMonitor() {
+      return _segmentsToMonitor;
+    }
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -152,6 +152,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getServerInfo());
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertNotNull(rebalanceSummaryResult.getTagsInfo());
@@ -207,6 +208,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getServerInfo());
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 14);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 14);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
@@ -386,6 +388,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getServerInfo());
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 11);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertNotNull(rebalanceSummaryResult.getTagsInfo());
@@ -474,6 +477,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getServerInfo());
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
@@ -508,6 +512,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     // No move expected since already balanced
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
@@ -563,6 +568,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceSummaryResult.getServerInfo());
     assertNotNull(rebalanceSummaryResult.getSegmentInfo());
     assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 15);
+    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 15);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
     assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -1264,116 +1264,95 @@ public class TableRebalancerTest {
     boolean[] falseAndTrue = new boolean[]{false, true};
 
     // Empty segment states should match
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Do not check segment that does not exist in IdealState
     Map<String, String> instanceStateMap = new TreeMap<>();
     instanceStateMap.put("instance1", ONLINE);
     externalViewSegmentStates.put("segment1", instanceStateMap);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Do not check segment that is OFFLINE in IdealState
     instanceStateMap = new TreeMap<>();
     instanceStateMap.put("instance1", OFFLINE);
     idealStateSegmentStates.put("segment2", instanceStateMap);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Should fail when a segment has CONSUMING instance in IdealState but does not exist in ExternalView
     instanceStateMap.put("instance2", CONSUMING);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Should fail when instance state does not exist
     instanceStateMap = new TreeMap<>();
     externalViewSegmentStates.put("segment2", instanceStateMap);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Should fail when instance state does not match
     instanceStateMap.put("instance2", OFFLINE);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
     // Should pass when instance state matches
     instanceStateMap.put("instance2", CONSUMING);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-      }
+    for (boolean bestEfforts : falseAndTrue) {
+      assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+          idealStateSegmentStates, bestEfforts, null));
     }
 
-    // When there are extra instances in ExternalView, should pass in regular mode but fail in low disk mode
+    // When there are extra instances in ExternalView, should fail (always wait for extra instances to be removed)
     instanceStateMap.put("instance3", CONSUMING);
     for (boolean bestEfforts : falseAndTrue) {
-      assertTrue(
-          TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
-              false, bestEfforts, null));
       assertFalse(
           TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
-              true, bestEfforts, null));
+              bestEfforts, null));
     }
 
     // When instance state is ERROR in ExternalView, should fail in regular mode but pass in best-efforts mode
     instanceStateMap.put("instance2", ERROR);
     instanceStateMap.remove("instance3");
-    for (boolean lowDiskMode : falseAndTrue) {
-      try {
-        TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
-            lowDiskMode, false, null);
-        fail();
-      } catch (Exception e) {
-        // Expected
-      }
-      assertTrue(
-          TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
-              lowDiskMode, true, null));
+    try {
+      TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
+          false, null);
+      fail();
+    } catch (Exception e) {
+      // Expected
     }
+    assertTrue(
+        TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
+            true, null));
 
-    // When the extra instance is in ERROR state, should throw exception in low disk mode when best-efforts is disabled
+    // When the extra instance is in ERROR state, should throw exception when best-efforts is disabled
     instanceStateMap.put("instance2", CONSUMING);
     instanceStateMap.put("instance3", ERROR);
-    for (boolean lowDiskMode : falseAndTrue) {
-      for (boolean bestEfforts : falseAndTrue) {
-        if (lowDiskMode && !bestEfforts) {
-          try {
-            TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-                idealStateSegmentStates, true, false, null);
-            fail();
-          } catch (Exception e) {
-            // Expected
-          }
-        } else {
-          assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
-              idealStateSegmentStates, lowDiskMode, bestEfforts, null));
+    for (boolean bestEfforts : falseAndTrue) {
+      if (!bestEfforts) {
+        try {
+          TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+              idealStateSegmentStates, false, null);
+          fail();
+        } catch (Exception e) {
+          // Expected
         }
+      } else {
+        assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
+            idealStateSegmentStates, bestEfforts, null));
       }
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -19,7 +19,10 @@
 package org.apache.pinot.controller.helix.core.rebalance;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -27,12 +30,15 @@ import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignme
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ERROR;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class TestZkBasedTableRebalanceObserver {
@@ -55,14 +61,24 @@ public class TestZkBasedTableRebalanceObserver {
     source.put("segment2",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
 
-    observer.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, source, target);
+    Set<String> segmentSet = new HashSet<>(source.keySet());
+    segmentSet.addAll(target.keySet());
+    TableRebalanceObserver.RebalanceContext rebalanceContext = new TableRebalanceObserver.RebalanceContext(-1,
+        segmentSet, segmentSet);
+    observer.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, source, target, rebalanceContext);
     assertEquals(observer.getNumUpdatesToZk(), 1);
-    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, source);
-    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, source);
-    assertEquals(observer.getNumUpdatesToZk(), 1);
-    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, target);
-    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, target);
-    assertEquals(observer.getNumUpdatesToZk(), 3);
+    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, source, rebalanceContext);
+    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, source,
+        rebalanceContext);
+    // START_TRIGGER will set up the ZK progress stats to have the diff between source and target. When calling the
+    // triggers for IS and EV-IS, since source and source are compared, the diff will change for the IS trigger
+    // but not for the EV-IS trigger, so ZK must be updated 1 extra time
+    assertEquals(observer.getNumUpdatesToZk(), 2);
+    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, target, rebalanceContext);
+    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, target,
+        rebalanceContext);
+    // Both of the changes above will update ZK for progress stats
+    assertEquals(observer.getNumUpdatesToZk(), 4);
   }
 
   @Test
@@ -107,5 +123,1182 @@ public class TestZkBasedTableRebalanceObserver {
 
     stats = ZkBasedTableRebalanceObserver.getDifferenceBetweenTableRebalanceStates(target, current);
     assertEquals(stats._percentSegmentsToRebalance, 50.0);
+  }
+
+  @Test
+  void testTableRebalanceProgressStatsInitializationTriggers() {
+    long estimatedAverageSegmentSize = 1024;
+
+    // Triggers to initialize the overall or step level progress stats - they should provide similar results
+    List<TableRebalanceObserver.Trigger> triggers = Arrays.asList(TableRebalanceObserver.Trigger.START_TRIGGER,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER);
+    for (TableRebalanceObserver.Trigger trigger : triggers) {
+      Map<String, Map<String, String>> current = new TreeMap<>();
+      current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), ONLINE));
+      current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+      Map<String, Map<String, String>> target = new TreeMap<>();
+      target.put("segment1",
+          SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+      target.put("segment2",
+          SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
+
+      // Stats when there's nothing to rebalance and this is start trigger, both segments present on segments to monitor
+      // and unique segments sets
+      Set<String> segmentSet = new HashSet<>(target.keySet());
+      TableRebalanceObserver.RebalanceContext rebalanceContext = new TableRebalanceObserver.RebalanceContext(
+          estimatedAverageSegmentSize, segmentSet, segmentSet);
+      TableRebalanceProgressStats.RebalanceProgressStats stats =
+          ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, target, rebalanceContext, trigger,
+              new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 0);
+      assertEquals(stats._totalSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, 0);
+
+      // Remove one of the segments from the unique list and segments to monitor list to treat it as a newly added
+      // segment not tracked by this rebalance
+      segmentSet.remove("segment2");
+      rebalanceContext =
+          new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+      stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, target, rebalanceContext, trigger,
+          new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 0);
+      assertEquals(stats._totalSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, 0);
+
+      // Pass null segmentsToMonitor
+      rebalanceContext = new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, null);
+      stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, target, rebalanceContext, trigger,
+          new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 0);
+      assertEquals(stats._totalSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, 0);
+
+      // Start trigger when there's something to converge, all segments on both segments to monitor and unique segments
+      // list
+      segmentSet = new HashSet<>(target.keySet());
+      rebalanceContext =
+          new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+      stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext, trigger,
+          new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 4);
+      assertEquals(stats._totalSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 4);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+
+      // Remove one of the segments from the segments to monitor and unique segments list to treat it as an untracked
+      // newly added segment (outside of rebalance)
+      segmentSet.remove("segment2");
+      rebalanceContext =
+          new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+      stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext, trigger,
+          new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 2);
+      assertEquals(stats._totalSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+
+      // Mark one segment as error/offline/consuming state so it doesn't converge
+      segmentSet = new HashSet<>(target.keySet());
+      List<String> states = Arrays.asList(ERROR, OFFLINE, CONSUMING);
+      for (String state : states) {
+        current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), state));
+        rebalanceContext =
+            new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+        stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext, trigger,
+            new TableRebalanceProgressStats());
+        assertEquals(stats._totalSegmentsToBeAdded, 4);
+        assertEquals(stats._totalSegmentsToBeDeleted, 0);
+        assertEquals(stats._totalRemainingSegmentsToBeAdded, 4);
+        assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+        assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+        assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+        assertEquals(stats._totalRemainingSegmentsToConverge, 1);
+        assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+        assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+        assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+        assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+        assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+        assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+        assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+      }
+
+      // Test delete and partial add convergence
+      current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2"), ONLINE));
+      current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host6"), ONLINE));
+      stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext, trigger,
+          new TableRebalanceProgressStats());
+      assertEquals(stats._totalSegmentsToBeAdded, 3);
+      assertEquals(stats._totalSegmentsToBeDeleted, 1);
+      assertEquals(stats._totalRemainingSegmentsToBeAdded, 3);
+      assertEquals(stats._totalRemainingSegmentsToBeDeleted, 1);
+      assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+      assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+      assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+      assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+      assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+      assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+      assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+      assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+      assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+      assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 3);
+    }
+  }
+
+  @Test
+  void testFullTableRebalanceIterationOfProgressStats() {
+    long estimatedAverageSegmentSize = 1024;
+
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    target.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    target.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+
+    TableRebalanceProgressStats tableRebalanceProgressStats = new TableRebalanceProgressStats();
+
+    // Initialize the start trigger with some change
+    Set<String> segmentSet = new HashSet<>(target.keySet());
+    TableRebalanceObserver.RebalanceContext rebalanceContext = new TableRebalanceObserver.RebalanceContext(
+        estimatedAverageSegmentSize, segmentSet, segmentSet);
+    TableRebalanceProgressStats.RebalanceProgressStats stats =
+        ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+            TableRebalanceObserver.Trigger.START_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Next call EV-IS convergence (assume here that the IS is not yet updated like happens in actual rebalance)
+    segmentSet = new HashSet<>(target.keySet());
+    rebalanceContext = new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(current, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER,
+        tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 0);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, 0);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, 0);
+    TableRebalanceProgressStats.RebalanceProgressStats overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(overallStats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Calculate IS change (no new changes)
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment first and update that
+    Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Check first round of EV-IS convergence with the next assignment
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 50.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 7);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 87.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check second round of EV-IS convergence with the next assignment, but not yet converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3"), OFFLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 2);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 6);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 2);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 75.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check third round of EV-IS convergence with the next assignment, finally converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 6);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 75.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Another IS update, let's add one more segment, but untracked (added externally from rebalance)
+    target.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 6);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 75.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment, let's add all remaining instances for speeding up the test
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 4);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Check first round of EV-IS convergence with the new next assignment
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 3);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 37.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check second round of EV-IS convergence with the next assignment, converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Another IS update, no new change
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment (final), let's match the target
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Check first round of EV-IS convergence with the new next assignment
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 1);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 50.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 50.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 1);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 12.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 50.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check second round of EV-IS convergence with the next assignment, converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 00.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    assertEquals(current, target);
+  }
+
+  @Test
+  void testFullTableRebalanceIterationOfProgressStatsBestEfforts() {
+    long estimatedAverageSegmentSize = 1024;
+
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    target.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    target.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+
+    TableRebalanceProgressStats tableRebalanceProgressStats = new TableRebalanceProgressStats();
+
+    // Initialize the start trigger with some change
+    Set<String> segmentSet = new HashSet<>(target.keySet());
+    TableRebalanceObserver.RebalanceContext rebalanceContext = new TableRebalanceObserver.RebalanceContext(
+        estimatedAverageSegmentSize, segmentSet, segmentSet);
+    TableRebalanceProgressStats.RebalanceProgressStats stats =
+        ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+            TableRebalanceObserver.Trigger.START_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Next call EV-IS convergence (assume here that the IS is not yet updated like happens in actual rebalance)
+    segmentSet = new HashSet<>(target.keySet());
+    rebalanceContext = new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, segmentSet, segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(current, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER,
+        tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 0);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, 0);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, 0);
+    TableRebalanceProgressStats.RebalanceProgressStats overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(overallStats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Calculate IS change (no new changes)
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 8);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment first and update that
+    Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Check first round of EV-IS convergence with the next assignment
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 50.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 7);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 87.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Don't wait for full convergence to complete before moving to next step (to simulate bestEffort=true)
+    // Use the last nextAssignment as the current IS for calculation (current hasn't converged yet so can't use that)
+    Map<String, Map<String, String>> oldNextAssignment = new TreeMap<>(nextAssignment);
+
+    // Another IS update, let's add one more segment, but untracked (added externally from rebalance)
+    target.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, oldNextAssignment, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 6);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 75.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment, let's add all remaining instances for speeding up the test
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, oldNextAssignment,
+        rebalanceContext, TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER,
+        tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 4);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Keep same assignment as last round to simulate bestEffort=true carried over segments that need to converge
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 4);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 1);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 125.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 6);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 1);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 87.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check second round of EV-IS convergence with the next assignment, this time carry over is taken care of and
+    // some segments added this step are processed too
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 3);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 37.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check third round of EV-IS convergence with the next assignment, converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 4);
+    assertEquals(stats._totalSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 4);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(overallStats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Another IS update, no new change
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(target, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 8);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 25.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(stats);
+
+    // Calculate the next assignment (final), let's match the target
+    nextAssignment.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    nextAssignment.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 100.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 100.0);
+    assertEquals(stats._estimatedTimeToCompleteAddsInSeconds, -1.0);
+    assertEquals(stats._estimatedTimeToCompleteDeletesInSeconds, -1.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+
+    // Check first round of EV-IS convergence with the new next assignment
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 1);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 50.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 50.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 1);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 1);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 12.5);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 50.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    // Check second round of EV-IS convergence with the next assignment, converged
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host1", "host3", "host4", "host5"), ONLINE));
+    current.put("segment3", SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("host2", "host3", "host4", "host5"), ONLINE));
+
+    rebalanceContext =
+        new TableRebalanceObserver.RebalanceContext(estimatedAverageSegmentSize, target.keySet(), segmentSet);
+    stats = ZkBasedTableRebalanceObserver.calculateOverallProgressStats(nextAssignment, current, rebalanceContext,
+        TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, tableRebalanceProgressStats);
+    assertEquals(stats._totalSegmentsToBeAdded, 2);
+    assertEquals(stats._totalSegmentsToBeDeleted, 2);
+    assertEquals(stats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(stats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(stats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(stats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(stats._totalUniqueNewUntrackedSegmentsDuringRebalance, 0);
+    assertEquals(stats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(stats._percentageTotalSegmentDeletesRemaining, 00.0);
+    assertTrue(stats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(stats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(stats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(stats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 2);
+    overallStats =
+        ZkBasedTableRebalanceObserver.updateOverallProgressStatsFromStep(tableRebalanceProgressStats,
+            tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep(), stats);
+    assertEquals(overallStats._totalSegmentsToBeAdded, 8);
+    assertEquals(overallStats._totalSegmentsToBeDeleted, 2);
+    assertEquals(overallStats._totalRemainingSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeAdded, 0);
+    assertEquals(overallStats._totalCarryOverSegmentsToBeDeleted, 0);
+    assertEquals(overallStats._totalRemainingSegmentsToConverge, 0);
+    assertEquals(overallStats._totalUniqueNewUntrackedSegmentsDuringRebalance, 1);
+    assertEquals(overallStats._percentageTotalSegmentsAddsRemaining, 0.0);
+    assertEquals(overallStats._percentageTotalSegmentDeletesRemaining, 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteAddsInSeconds >= 0.0);
+    assertTrue(overallStats._estimatedTimeToCompleteDeletesInSeconds >= 0.0);
+    assertEquals(overallStats._averageSegmentSizeInBytes, estimatedAverageSegmentSize);
+    assertEquals(overallStats._totalEstimatedDataToBeMovedInBytes, estimatedAverageSegmentSize * 8);
+    tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(stats);
+    tableRebalanceProgressStats.setRebalanceProgressStatsOverall(overallStats);
+
+    assertEquals(current, target);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -4325,6 +4325,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     if (isSegmentsToBeMoved) {
       assertTrue(summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved() > 0,
           "Segments to be moved should be > 0");
+      assertTrue(summaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted() > 0,
+          "Segments to be moved should be > 0");
       assertEquals(summaryResult.getSegmentInfo().getTotalEstimatedDataToBeMovedInBytes(),
           summaryResult.getSegmentInfo().getTotalSegmentsToBeMoved()
               * summaryResult.getSegmentInfo().getEstimatedAverageSegmentSizeInBytes(),


### PR DESCRIPTION
## Description
This PR enhances the Table Rebalance progress stats.

Today the progress stats can be confusing due to the various sections (there are 3), and it is hard to track progress because most of the time only the EV-IS convergence step is updated and this is only calculated for a single step and not for the full rebalance. To understand the progress stats, the code that does the stats updates must be well understood which is not a good assumption and experience for end users.

Another concern with the existing stats is that the percentage progress calculations are based off the total segments in the target, rather than based on the actual segments that need to be added / deleted. This makes it harder to assess the progress of the rebalance since not all segments may even need to change.

This PR adds the following to the existing progress stats:

```
  "rebalanceProgressStatsOverall" : {
    "totalSegmentsToBeAdded" : 30,
    "totalSegmentsToBeDeleted" : 30,
    "totalRemainingSegmentsToBeAdded" : 14,
    "totalRemainingSegmentsToBeDeleted" : 11,
    "totalCarryOverSegmentsToBeAdded" : 0,
    "totalCarryOverSegmentsToBeDeleted" : 0,
    "totalRemainingSegmentsToConverge": 0,
    "totalUniqueNewUntrackedSegmentsDuringRebalance" : 10,
    "percentageTotalSegmentsAddsRemaining" : 46.666666666666664,
    "percentageTotalSegmentDeletesRemaining" : 36.666666666666664,
    "estimatedTimeToCompleteAddsInSeconds" : 71.768375,
    "estimatedTimeToCompleteDeletesInSeconds" : 47.48584210526316,
    "averageSegmentSizeInBytes" : 35918,
    "totalEstimatedDataToBeMovedInBytes" : 1077540,
    "startTimeMs" : 1742319763143
  },
  "rebalanceProgressStatsCurrentStep" : {
    "totalSegmentsToBeAdded" : 10,
    "totalSegmentsToBeDeleted" : 10,
    "totalRemainingSegmentsToBeAdded" : 4,
    "totalRemainingSegmentsToBeDeleted" : 1,
    "totalCarryOverSegmentsToBeAdded" : 0,
    "totalCarryOverSegmentsToBeDeleted" : 0,
    "totalRemainingSegmentsToConverge": 0,
    "totalUniqueNewUntrackedSegmentsDuringRebalance" : 0,
    "percentageTotalSegmentsAddsRemaining" : 40.0,
    "percentageTotalSegmentDeletesRemaining" : 10.0,
    "estimatedTimeToCompleteAddsInSeconds" : 16.923333333333332,
    "estimatedTimeToCompleteDeletesInSeconds" : 2.8205555555555555,
    "averageSegmentSizeInBytes" : 35918,
    "totalEstimatedDataToBeMovedInBytes" : 359180,
    "startTimeMs" : 1742319819779
  },
```

The overall stats (`rebalanceProgressStatsOverall`) above are updated at each step (`rebalanceProgressStatsCurrentStep`) as well to capture the progress during IS-EV convergence. This is to ensure that users only need to monitor `rebalanceProgressStatsOverall` to find out how much work has already been done. The `rebalanceProgressStatsCurrentStep` can be used for debugging but does not need to be monitored as such.

`_totalUniqueNewUntrackedSegmentsDuringRebalance`: this field is added to track new segments that show up in the IdealState but which aren't being tracked as part of the rebalance. This is just informational and can be used to identify how many additional segments got added during the rebalance run.

The time estimates are based on how much time has passed and how many segments were already processed and how many are remaining. This may not be a very accurate measure and is not based on the actual data moving since different set ups may have different throughput characteristics.

This PR also renames some of the existing stats to make them clearer to understand.

## Interesting Scenario
While experimenting with QuickStart and REALTIME tables, I ran into a situation where rebalance would complete successfully, but the stats I added would always show some segment deletions as not yet processed.

Digging some more, found the following:
https://github.com/apache/pinot/blob/604cd165586716ae04db22856371e50147e30459/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java#L1074

The above only checks for extra assigned instances for given segments if `lowDiskMode` is enabled. So in my scenario, there were some extra instances assigned when I did the stats calculations, but the above check was never performed since `lowDiskMode=false`. The EV-IS convergence was marked as true in this case and the rebalance was completed. 

When I updated the code to comment out `lowDiskMode &&` from the above if, I saw that eventually the EV does get updated to remove the deleted segments, and the EV-IS do match up exactly, but that needs some additional convergence loops. In this case the stats were correctly updated to reflect the deletions.

**As a fix for the above:** updated the code to remove `lowDiskMode &&` so that this convergence loop always runs to ensure deletions are converged for all scenarios and not just for `lowDiskMode`.

## Testing:
All testing done with `minAvailableReplicas = -1`

### Test 1 (no delay in segment adds)
- Ran HybridQuickStart with 6 servers
- Tagged 3 servers with `NewDefaultTenant_OFFLINE` and removed `DefaultTenant_OFFLINE` from these servers
- Ran rebalance of two types:
    - Updated replication of OFFLINE table from 1 -> 3, this got triggered as single step rebalance to add all the new replicas
    - Updated server tenant of OFFLINE table to `NewDefaultTenant` (triggered as a 3 step rebalance to move 1 replica at a time)

### Test 2 (delay in segment adds/deletes)
- Added a random delay between 10 - 30 seconds in the `onBecomeOnlineFromOffline()`, `onBecomeOnlineFromConsuming()`, `onBecomeConsumingFromOffline()` state transition callbacks
- Added a random delay between 0 - 30 seconds in the ` onBecomeDroppedFrom*()` state transition callbacks
- Ran HybridQuickStart with 6 servers
- Tagged 3 servers with `NewDefaultTenant_OFFLINE` and removed `DefaultTenant_OFFLINE` from these servers
- Ran rebalance of two types (both were triggered as multi-step rebalances):
    - Updated replication of OFFLINE table from 1 -> 3, monitored the steps (due to random delay in state transition, could see some segments getting added sooner and others take longer)
    - Updated server tenant of OFFLINE table to `NewDefaultTenant` and similarly monitored the steps

### Additional testing (with delays):
- REALTIME table with and without `includeConsuming` (similar steps as for OFFLINE above)
- Scenario where some segments get added to the IdealState in the middle of rebalance (e.g. forceCommit for REALTIME table) to tag some servers as `NewDefaultTenant_REALTIME` and remove `DefaultTenant_REALTIME` tag
- Test to force some segments into `ERROR` state, and use `bestEfforts=true` to validate that convergence stats are correctly captured. Also verified convergence stats with `forceCommit` since the existing `CONSUMING` segments change to `ONLINE` and the rebalance correctly waits (and stats are correctly updated) until the state convergence also completes.
- Set some segments to `OFFLINE` state in ideal state. Verified that while they are in `OFFLINE` state in ideal state, we skip progress tracking for those. Eventually if they get updated to ONLINE state, we track them again and wait for convergence.
- Updated the code to add fields for carry-over segments that didn't converge in the last step. This will mostly occur if `bestEffort=true`, and we are unable to complete convergence within the timeout. The other scenario was with `lowDiskMode` and extra deletions from EV, but we changed the code here to always wait for additional deletions in the EV. The percentage calculations include these carry-over segments.

cc @raghavyadav01 @Jackie-Jiang @klsince @J-HowHuang 
Something went wrong with the branch of my original PR: https://github.com/apache/pinot/pull/15266
This PR is the exact same. I'll close the other one