### PR TITLE
Allow lazy init of the record reader in CompactedPinotSegmentRecordReader

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -97,8 +97,8 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     }
 
     int totalDocsAfterCompaction;
-    try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(indexDir,
-        validDocIds)) {
+    try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(validDocIds)) {
+      compactedRecordReader.init(indexDir, null, null);
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName,
           getSchema(tableNameWithType));
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
@@ -45,14 +45,13 @@ public class CompactedPinotSegmentRecordReader implements RecordReader {
   // Flag to mark whether we need to fetch another row
   private boolean _nextRowReturned = true;
 
-  public CompactedPinotSegmentRecordReader(File indexDir, RoaringBitmap validDocIds) {
-    this(indexDir, validDocIds, null);
+  public CompactedPinotSegmentRecordReader(RoaringBitmap validDocIds) {
+    this(validDocIds, null);
   }
 
-  public CompactedPinotSegmentRecordReader(File indexDir, RoaringBitmap validDocIds,
+  public CompactedPinotSegmentRecordReader(RoaringBitmap validDocIds,
       @Nullable String deleteRecordColumn) {
     _pinotSegmentRecordReader = new PinotSegmentRecordReader();
-    _pinotSegmentRecordReader.init(indexDir, null, null);
     _validDocIdsBitmap = validDocIds;
     _validDocIdsIterator = validDocIds.getIntIterator();
     _deleteRecordColumn = deleteRecordColumn;
@@ -61,6 +60,8 @@ public class CompactedPinotSegmentRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
+    // lazy init the record reader
+    _pinotSegmentRecordReader.init(dataFile, null, null);
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReaderTest.java
@@ -92,8 +92,8 @@ public class CompactedPinotSegmentRecordReaderTest {
     List<GenericRow> outputRows = new ArrayList<>();
     List<GenericRow> rewoundOuputRows = new ArrayList<>();
 
-    CompactedPinotSegmentRecordReader compactedReader =
-        new CompactedPinotSegmentRecordReader(_segmentIndexDir, validDocIds);
+    CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(validDocIds);
+    compactedReader.init(_segmentIndexDir, null, null);
     while (compactedReader.hasNext()) {
       outputRows.add(compactedReader.next());
     }
@@ -137,8 +137,9 @@ public class CompactedPinotSegmentRecordReaderTest {
       validDocIds.add(i);
     }
     List<GenericRow> evenOutputRows = new ArrayList<>();
-    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(_segmentIndexDir,
-        validDocIds, DELETE_COLUMN)) {
+    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(validDocIds,
+        DELETE_COLUMN)) {
+      compactedReader.init(_segmentIndexDir, null, null);
       while (compactedReader.hasNext()) {
         evenOutputRows.add(compactedReader.next());
       }
@@ -149,8 +150,9 @@ public class CompactedPinotSegmentRecordReaderTest {
       validDocIds.add(i);
     }
     List<GenericRow> oddOutputRows = new ArrayList<>();
-    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(_segmentIndexDir,
-        validDocIds, DELETE_COLUMN)) {
+    try (CompactedPinotSegmentRecordReader compactedReader = new CompactedPinotSegmentRecordReader(validDocIds,
+        DELETE_COLUMN)) {
+      compactedReader.init(_segmentIndexDir, null, null);
       while (compactedReader.hasNext()) {
         oddOutputRows.add(compactedReader.next());
       }


### PR DESCRIPTION
## Problem
Initializing all the record readers within the task executor carries the risk of minion running into OOM issues.


## Solution
The changes are to init the record readers lazily from the SegmentMapper and the mapper would take care of initializing and closing the record reader. The `UpsertCompactionTaskExecutor` processes one segment at a time and does not make use of the segment processor framework. It's ok to init the record reader within the task executor for this case.

## Testing
Covered by existing integration tests.
