### PR TITLE
Make PinotTaskManager pluggable

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1116,6 +1116,12 @@ public class CommonConstants {
     public static final String CONFIG_OF_INSTANCE_ID = "pinot.controller.instance.id";
     public static final String CONFIG_OF_CONTROLLER_QUERY_REWRITER_CLASS_NAMES =
         "pinot.controller.query.rewriter.class.names";
+
+    // Task Manager configuration
+    public static final String CONFIG_OF_TASK_MANAGER_CLASS = "pinot.controller.task.manager.class";
+    public static final String DEFAULT_TASK_MANAGER_CLASS =
+        "org.apache.pinot.controller.helix.core.minion.PinotTaskManager";
+
     //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
     public static final String CONTROLLER_SERVICE_AUTO_DISCOVERY = "pinot.controller.service.auto.discovery";
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.controller.logger.root.dir";


### PR DESCRIPTION
This PR is a follow-up to the [previous work](https://github.com/apache/pinot/pull/14717) on making PinotTaskManager fully pluggable.

Currently, the issue is that the controller starter always creates a default PinotTaskManager instance, even when we want to use a custom, pluggable implementation. To address this, we adopt the same approach used for PlanMaker ([reference](https://github.com/apache/pinot/pull/10269/files)): using reflection to dynamically load the desired PinotTaskManager implementation.

Existing [PinotTaskManagerStatelessTest](https://github.com/apache/pinot/blob/c57c166ccb00b54439374369c1744cefc83d39f7/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java) will still cover this change.