### PR TITLE
Clear FSM on segment build failure retry

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -269,6 +269,7 @@ public class SegmentCompletionManager {
       return SegmentCompletionProtocol.RESP_DISCARD;
     }
     _segmentManager.reduceSegmentSizeAndReset(new LLCSegmentName(reqParams.getSegmentName()), reqParams.getNumRows());
+    _fsmMap.remove(segmentName);
     return SegmentCompletionProtocol.RESP_PROCESSED;
   }
 


### PR DESCRIPTION
`feature`  `bugfix`  `performance`
follow up on https://github.com/apache/pinot/pull/15234

In the event of segment build failure retry, e.g. there are 2 replicas A and B.

1. A and (or) B send `segmentConsumed` request to controller, and get response, A -> Commit, B -> Hold, controller -> COMMIT_NOTIFIED
2. A build failure and send send `segmentBuildDeterministicFailure` to controller
3. Controller reduce the segment size and reset segments
4. A and B destroy the immutable segments and rebuild it
5. A or B consumed all messages, and send `segmentConsumed` request to controller.

What's happened next?

- If A sends it, and `now > _maxTimeAllowedToCommitMs`, A starts to commit, happy path
- If B sends it, and `now > _maxTimeAllowedToCommitMs`, B starts to commit, also happy path
- If A sends it, and `now <= _maxTimeAllowedToCommitMs`, highly possible A sent an offset < FSM's recorded offset, DISCARD response will be sent
- If B sends it, and `now <= _maxTimeAllowedToCommitMs`, highly possible A sent an offset < FSM's recorded offset, CATCH_UP response will be sent

The previous patch did not consider the last 2 conditions. And this PR will catch that by removing the previous status in FSM.
