### PR TITLE
[multistage] Add Physical Plan Nodes / Trait Assignment / Logical Agg Rule

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotLogicalAggregateRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotLogicalAggregateRule.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.calcite.rel.logical.PinotLogicalAggregate;
+import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
+
+
+/**
+ * This rule converts Calcite's Aggregate into {@link PinotLogicalAggregate}. Additionally, if a Sort exists above
+ * the aggregate, then we push it down to the aggregate to enable group trim.
+ */
+public class PinotLogicalAggregateRule {
+  public static class SortProjectAggregate extends RelOptRule {
+    public static final SortProjectAggregate INSTANCE = new SortProjectAggregate(PinotRuleUtils.PINOT_REL_FACTORY);
+
+    private SortProjectAggregate(RelBuilderFactory factory) {
+      // NOTE: Explicitly match for LogicalAggregate because after applying the rule, LogicalAggregate is replaced with
+      //       PinotLogicalAggregate, and the rule won't be applied again.
+      super(operand(Sort.class, operand(Project.class, operand(LogicalAggregate.class, any()))), factory, null);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      LogicalAggregate aggRel = call.rel(2);
+      if (aggRel.getGroupSet().isEmpty()) {
+        return;
+      }
+      Map<String, String> hintOptions =
+          PinotHintStrategyTable.getHintOptions(aggRel.getHints(), PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+      if (hintOptions == null || !Boolean.parseBoolean(
+          hintOptions.get(PinotHintOptions.AggregateOptions.IS_ENABLE_GROUP_TRIM))) {
+        return;
+      }
+      Sort sortRel = call.rel(0);
+      Project projectRel = call.rel(1);
+      List<RexNode> projects = projectRel.getProjects();
+      List<RelFieldCollation> collations = sortRel.getCollation().getFieldCollations();
+      List<RelFieldCollation> newCollations = new ArrayList<>(collations.size());
+      for (RelFieldCollation fieldCollation : collations) {
+        RexNode project = projects.get(fieldCollation.getFieldIndex());
+        if (project instanceof RexInputRef) {
+          newCollations.add(fieldCollation.withFieldIndex(((RexInputRef) project).getIndex()));
+        } else {
+          // Cannot enable group trim when the sort key is not a direct reference to the input.
+          return;
+        }
+      }
+      int limit = 0;
+      if (sortRel.fetch != null) {
+        limit = RexLiteral.intValue(sortRel.fetch);
+      }
+      if (limit <= 0) {
+        // Cannot enable group trim when there is no limit.
+        return;
+      }
+      PinotLogicalAggregate newAggRel = createPlan(aggRel, newCollations, limit);
+      RelNode newProjectRel = projectRel.copy(projectRel.getTraitSet(), List.of(newAggRel));
+      call.transformTo(sortRel.copy(sortRel.getTraitSet(), List.of(newProjectRel)));
+    }
+  }
+
+  public static class SortAggregate extends RelOptRule {
+    public static final SortAggregate INSTANCE = new SortAggregate(PinotRuleUtils.PINOT_REL_FACTORY);
+
+    private SortAggregate(RelBuilderFactory factory) {
+      // NOTE: Explicitly match for LogicalAggregate because after applying the rule, LogicalAggregate is replaced with
+      //       PinotLogicalAggregate, and the rule won't be applied again.
+      super(operand(Sort.class, operand(LogicalAggregate.class, any())), factory, null);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      LogicalAggregate aggRel = call.rel(1);
+      if (aggRel.getGroupSet().isEmpty()) {
+        return;
+      }
+      Map<String, String> hintOptions =
+          PinotHintStrategyTable.getHintOptions(aggRel.getHints(), PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+      if (hintOptions == null || !Boolean.parseBoolean(
+          hintOptions.get(PinotHintOptions.AggregateOptions.IS_ENABLE_GROUP_TRIM))) {
+        return;
+      }
+
+      Sort sortRel = call.rel(0);
+      List<RelFieldCollation> collations = sortRel.getCollation().getFieldCollations();
+      int limit = 0;
+      if (sortRel.fetch != null) {
+        limit = RexLiteral.intValue(sortRel.fetch);
+      }
+      if (limit <= 0) {
+        // Cannot enable group trim when there is no limit.
+        return;
+      }
+
+      PinotLogicalAggregate newAggRel = createPlan(aggRel, collations, limit);
+      call.transformTo(sortRel.copy(sortRel.getTraitSet(), List.of(newAggRel)));
+    }
+  }
+
+  /**
+   * Convert any remaining LogicalAggregate to PinotLogicalAggregate. Some nodes may already be converted as part of
+   * the aggregate group-trim rules above.
+   */
+  public static class PinotLogicalAggregateConverter extends RelOptRule {
+    public static final PinotLogicalAggregateConverter INSTANCE = new PinotLogicalAggregateConverter(
+        PinotRuleUtils.PINOT_REL_FACTORY);
+
+    private PinotLogicalAggregateConverter(RelBuilderFactory factory) {
+      super(operand(LogicalAggregate.class, any()), factory, null);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      Aggregate aggRel = call.rel(0);
+      call.transformTo(createWithNoGroupTrim(aggRel));
+    }
+  }
+
+  private static PinotLogicalAggregate createWithNoGroupTrim(Aggregate aggRel) {
+    return createPlan(aggRel, null, 0);
+  }
+
+  private static PinotLogicalAggregate createPlan(Aggregate aggRel, @Nullable List<RelFieldCollation> collations,
+      int limit) {
+    Map<String, String> hintOptions =
+        PinotHintStrategyTable.getHintOptions(aggRel.getHints(), PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+    if (hintOptions == null) {
+      hintOptions = Map.of();
+    }
+    boolean leafReturnFinalResult =
+        Boolean.parseBoolean(hintOptions.get(PinotHintOptions.AggregateOptions.IS_LEAF_RETURN_FINAL_RESULT));
+    RelNode input = aggRel.getInput();
+    // TODO: Remove AggType from logical aggregate. For now use DIRECT.
+    return new PinotLogicalAggregate(aggRel, input, aggRel.getAggCallList(), AggType.DIRECT,
+        leafReturnFinalResult, collations, limit);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -153,5 +153,14 @@ public class PinotQueryRuleSets {
       CoreRules.FILTER_REDUCE_EXPRESSIONS,
       PinotTableScanConverterRule.INSTANCE
   );
+
+  public static final List<RelOptRule> PINOT_POST_RULES_V2 = List.of(
+      PinotTableScanConverterRule.INSTANCE,
+      PinotLogicalAggregateRule.SortProjectAggregate.INSTANCE,
+      PinotLogicalAggregateRule.SortAggregate.INSTANCE,
+      PinotLogicalAggregateRule.PinotLogicalAggregateConverter.INSTANCE,
+      // Evaluate the Literal filter nodes
+      CoreRules.FILTER_REDUCE_EXPRESSIONS
+  );
   //@formatter:on
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTrait.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTrait.java
@@ -25,17 +25,17 @@ import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
 
 
 /**
- * Execution strategy defines how a fragment of the plan tree will be executed by Pinot. There are three types of
- * strategies:
+ * Execution strategy defines how a sub-tree of the plan will be executed by Pinot. There are three strategies:
  * <ol>
  *   <li>Streaming: This is the default strategy that indicates the operator will emit data in chunks until EOS.</li>
  *   <li>
  *     Pipeline Breaker: This indicates that Pinot Server will consume the entire output of this operator, before
- *     it compiles the Physical plan for the rest of the corresponding Plan Fragment.
+ *     it compiles the plan for the rest of the Plan Fragment.
  *   </li>
  *   <li>
  *     Sub Plan: This indicates that Pinot Broker should execute the entire plan under this operator first, and then
- *     continue with planning the rest of the plan tree.
+ *     continue with planning the rest of the plan tree. Usually, you would get a constant out of the Sub-Plan, which
+ *     can be put back in the original plan tree.
  *   </li>
  * </ol>
  */

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTrait.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTrait.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.traits;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+
+
+/**
+ * Execution strategy defines how a fragment of the plan tree will be executed by Pinot. There are three types of
+ * strategies:
+ * <ol>
+ *   <li>Streaming: This is the default strategy that indicates the operator will emit data in chunks until EOS.</li>
+ *   <li>
+ *     Pipeline Breaker: This indicates that Pinot Server will consume the entire output of this operator, before
+ *     it compiles the Physical plan for the rest of the corresponding Plan Fragment.
+ *   </li>
+ *   <li>
+ *     Sub Plan: This indicates that Pinot Broker should execute the entire plan under this operator first, and then
+ *     continue with planning the rest of the plan tree.
+ *   </li>
+ * </ol>
+ */
+public class PinotExecStrategyTrait implements RelTrait {
+  public static final PinotExecStrategyTrait STREAMING = new PinotExecStrategyTrait(PinotRelExchangeType.STREAMING);
+  public static final PinotExecStrategyTrait PIPELINE_BREAKER = new PinotExecStrategyTrait(
+      PinotRelExchangeType.PIPELINE_BREAKER);
+  public static final PinotExecStrategyTrait SUB_PLAN = new PinotExecStrategyTrait(PinotRelExchangeType.SUB_PLAN);
+
+  /**
+   * <b>Implementation Note:</b> We use {@link PinotRelExchangeType} in this trait because Pinot Runtime uses that
+   * enum to determine the execution strategy in the dispatched plan to the server, and we can't change it now due to
+   * b/w compatibility. Ideally we would have liked to introduce a new Enum in this trait, similar to
+   * {@link org.apache.calcite.rel.RelDistribution}.
+   */
+  private final PinotRelExchangeType _type;
+
+  PinotExecStrategyTrait(PinotRelExchangeType type) {
+    _type = type;
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public RelTraitDef getTraitDef() {
+    return PinotExecStrategyTraitDef.INSTANCE;
+  }
+
+  @Override
+  public boolean satisfies(RelTrait trait) {
+    return trait.getTraitDef() == getTraitDef() && ((PinotExecStrategyTrait) trait)._type == _type;
+  }
+
+  @Override
+  public void register(RelOptPlanner planner) {
+  }
+
+  public PinotRelExchangeType getType() {
+    return _type;
+  }
+
+  public static PinotExecStrategyTrait getDefaultExecStrategy() {
+    return STREAMING;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTraitDef.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/PinotExecStrategyTraitDef.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.traits;
+
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+public class PinotExecStrategyTraitDef extends RelTraitDef<PinotExecStrategyTrait> {
+  public static final PinotExecStrategyTraitDef INSTANCE = new PinotExecStrategyTraitDef();
+
+  @Override
+  public Class<PinotExecStrategyTrait> getTraitClass() {
+    return PinotExecStrategyTrait.class;
+  }
+
+  @Override
+  public String getSimpleName() {
+    return "pinotExecStrategy";
+  }
+
+  @Override
+  public @Nullable RelNode convert(RelOptPlanner planner, RelNode rel, PinotExecStrategyTrait toTrait,
+      boolean allowInfiniteCostConverters) {
+    if (rel.getTraitSet().contains(toTrait)) {
+      return rel;
+    }
+    return rel.copy(rel.getTraitSet().plus(toTrait), rel.getInputs());
+  }
+
+  @Override
+  public boolean canConvert(RelOptPlanner planner, PinotExecStrategyTrait fromTrait, PinotExecStrategyTrait toTrait) {
+    return true;
+  }
+
+  @Override
+  public PinotExecStrategyTrait getDefault() {
+    return PinotExecStrategyTrait.getDefaultExecStrategy();
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.traits;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.Window;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.rules.PinotRuleUtils;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalProject;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalSort;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalTableScan;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalWindow;
+
+
+/**
+ * Assign trait constraints to the plan emitted by the Logical Planning phase run in Calcite.
+ * This operates with Physical RelNodes because Calcite emits Logical RelNodes, many of which drop traits on copy.
+ */
+public class TraitAssignment {
+  private final Supplier<Integer> _planIdGenerator;
+
+  public TraitAssignment(Supplier<Integer> planIdGenerator) {
+    _planIdGenerator = planIdGenerator;
+  }
+
+  public static RelNode assign(RelNode relNode, PhysicalPlannerContext physicalPlannerContext) {
+    TraitAssignment traitAssignment = new TraitAssignment(physicalPlannerContext.getNodeIdGenerator());
+    return traitAssignment.assign(relNode);
+  }
+
+  public RelNode assign(RelNode node) {
+    // Process inputs first.
+    List<RelNode> newInputs = new ArrayList<>();
+    for (RelNode input : node.getInputs()) {
+      newInputs.add(assign(input));
+    }
+    node = node.copy(node.getTraitSet(), newInputs);
+    // Process current node.
+    if (node instanceof PhysicalSort) {
+      return assignSort((PhysicalSort) node);
+    } else if (node instanceof PhysicalJoin) {
+      return assignJoin((PhysicalJoin) node);
+    } else if (node instanceof PhysicalAggregate) {
+      return assignAggregate((PhysicalAggregate) node);
+    } else if (node instanceof PhysicalWindow) {
+      return assignWindow((PhysicalWindow) node);
+    }
+    return node;
+  }
+
+  /**
+   * Always converge to a single stream for Sort. So we add the SINGLETON trait to the input.
+   */
+  @VisibleForTesting
+  RelNode assignSort(PhysicalSort sort) {
+    RelNode input = sort.getInput();
+    RelTraitSet newTraitSet = input.getTraitSet().plus(RelDistributions.SINGLETON);
+    input = input.copy(newTraitSet, input.getInputs());
+    return sort.copy(sort.getTraitSet(), ImmutableList.of(input));
+  }
+
+  @VisibleForTesting
+  RelNode assignJoin(PhysicalJoin join) {
+    // Case-1: Handle lookup joins.
+    if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
+      return assignLookupJoin(join);
+    }
+    // Case-2: Handle dynamic filter for semi joins.
+    JoinInfo joinInfo = join.analyzeCondition();
+    if (join.isSemiJoin() && joinInfo.nonEquiConditions.isEmpty() && joinInfo.leftKeys.size() == 1) {
+      if (PinotRuleUtils.canPushDynamicBroadcastToLeaf(join.getLeft())) {
+        return assignDynamicFilterSemiJoin(join);
+      }
+    }
+    // Case-3: Default case.
+    // TODO(mse-physical): Support colocated join hint (see F2: https://github.com/apache/pinot/issues/15455).
+    // TODO(mse-physical): Consider random exchange on left input. We skip exchange on the left by default because
+    //   it is uncommon for joins to have a huge skew across workers, and it doesn't make a lot of sense to add the
+    //   overhead of a full shuffle by default. (see F3: https://github.com/apache/pinot/issues/15455).
+    RelDistribution leftDistribution = joinInfo.leftKeys.isEmpty() ? null : RelDistributions.hash(joinInfo.leftKeys);
+    RelDistribution rightDistribution = joinInfo.rightKeys.isEmpty() ? RelDistributions.BROADCAST_DISTRIBUTED
+        : RelDistributions.hash(joinInfo.rightKeys);
+    RelNode leftInput = join.getInput(0);
+    RelNode rightInput = join.getInput(1);
+    if (leftDistribution != null) {
+      RelTraitSet leftTraitSet = leftInput.getTraitSet().plus(leftDistribution);
+      leftInput = leftInput.copy(leftTraitSet, leftInput.getInputs());
+    }
+    RelTraitSet rightTraitSet = rightInput.getTraitSet().plus(rightDistribution);
+    rightInput = rightInput.copy(rightTraitSet, rightInput.getInputs());
+    return join.copy(join.getTraitSet(), ImmutableList.of(leftInput, rightInput));
+  }
+
+  /**
+   * When group-by keys are empty, we can use SINGLETON distribution. Otherwise, we use hash distribution on the
+   * group-by keys.
+   */
+  RelNode assignAggregate(PhysicalAggregate aggregate) {
+    RelNode input = aggregate.getInput(0);
+    if (aggregate.getGroupCount() == 0) {
+      RelTraitSet newTraitSet = input.getTraitSet().plus(RelDistributions.SINGLETON);
+      input = input.copy(newTraitSet, input.getInputs());
+    } else {
+      RelTraitSet newTraitSet = input.getTraitSet().plus(RelDistributions.hash(aggregate.getGroupSet().asList()));
+      input = input.copy(newTraitSet, input.getInputs());
+    }
+    return aggregate.copy(aggregate.getTraitSet(), ImmutableList.of(input));
+  }
+
+  RelNode assignWindow(PhysicalWindow window) {
+    Preconditions.checkState(window.groups.size() <= 1,
+        "Different partition-by clause not allowed in window functions yet");
+    RelCollation windowGroupCollation = getCollation(window);
+    RelNode input = window.getInput(0);
+    if (window.groups.isEmpty() || window.groups.get(0).keys.isEmpty()) {
+      // Case-1: No partition by clause in Window function.
+      if (!windowGroupCollation.getKeys().isEmpty()) {
+        // Push collation trait.
+        if (input instanceof PhysicalSort) {
+          // If input is sort with a different collation, add another sort.
+          PhysicalSort sort = (PhysicalSort) input;
+          if (!sort.getCollation().equals(windowGroupCollation)) {
+            RelTraitSet traitSetOfNewSort = RelTraitSet.createEmpty().plus(windowGroupCollation)
+                .plus(RelDistributions.SINGLETON);
+            input = new PhysicalSort(sort.getCluster(), traitSetOfNewSort, List.of() /* hints */,
+                windowGroupCollation, null /* offset */, null /* fetch */, sort, _planIdGenerator.get(),
+                ImmutableList.of(sort), null /* pinot data distribution */, false /* leaf stage */);
+          } else {
+            input = input.copy(input.getTraitSet().plus(RelDistributions.SINGLETON), input.getInputs());
+          }
+        } else {
+          RelTraitSet newTraitSet = input.getTraitSet().plus(RelDistributions.SINGLETON)
+              .plus(windowGroupCollation);
+          input = input.copy(newTraitSet, input.getInputs());
+        }
+      } else {
+        input = input.copy(input.getTraitSet().plus(RelDistributions.SINGLETON), input.getInputs());
+      }
+    } else {
+      // Case-2: Partition-by clause present in window.
+      Window.Group group = window.groups.get(0);
+      List<Integer> partitionKeys = group.keys.asList();
+      RelDistribution newHashDistTrait = RelDistributions.hash(partitionKeys);
+      if (!windowGroupCollation.getKeys().isEmpty()) {
+        if (input instanceof PhysicalSort && !windowGroupCollation.equals(((PhysicalSort) input).getCollation())) {
+          // If input is sort with a different collation, add another sort.
+          PhysicalSort sort = (PhysicalSort) input;
+          RelTraitSet traitSetOfNewSort = RelTraitSet.createEmpty().plus(windowGroupCollation)
+              .plus(newHashDistTrait);
+          input = new PhysicalSort(sort.getCluster(), traitSetOfNewSort, List.of() /* hints */,
+              windowGroupCollation, null /* offset */, null /* fetch */, sort, _planIdGenerator.get(),
+              ImmutableList.of(sort), null /* pinot data distribution */, false /* leaf stage */);
+        } else {
+          RelTraitSet newTraitSet = input.getTraitSet().plus(newHashDistTrait).plus(windowGroupCollation);
+          input = input.copy(newTraitSet, input.getInputs());
+        }
+      } else {
+        input = input.copy(input.getTraitSet().plus(newHashDistTrait), input.getInputs());
+      }
+    }
+    return window.copy(window.getTraitSet(), ImmutableList.of(input));
+  }
+
+  private RelNode assignLookupJoin(PhysicalJoin join) {
+    /*
+     * Lookup join expects right input to have project and table-scan nodes exactly. Moreover, lookup join is used
+     * with Dimension tables only. Given this, we expect the entire right input to be available in all workers
+     * selected for the left input. For now, we will assign broadcast trait to the entire right input. Worker
+     * assignment will have to handle this explicitly regardless.
+     */
+    RelNode leftInput = join.getInputs().get(0);
+    RelNode rightInput = join.getInputs().get(1);
+    Preconditions.checkState(rightInput instanceof PhysicalProject, "Expected project as right input of table scan");
+    Preconditions.checkState(rightInput.getInput(0) instanceof PhysicalTableScan,
+        "Expected table scan under project for right input of lookup join");
+    PhysicalProject oldProject = (PhysicalProject) rightInput;
+    PhysicalTableScan oldTableScan = (PhysicalTableScan) oldProject.getInput(0);
+    PhysicalTableScan newTableScan =
+        (PhysicalTableScan) oldTableScan.copy(oldTableScan.getTraitSet().plus(
+            RelDistributions.BROADCAST_DISTRIBUTED), Collections.emptyList());
+    PhysicalProject newProject =
+        (PhysicalProject) oldProject.copy(oldProject.getTraitSet().plus(RelDistributions.BROADCAST_DISTRIBUTED),
+            ImmutableList.of(newTableScan));
+    return join.copy(join.getTraitSet(), ImmutableList.of(leftInput, newProject));
+  }
+
+  private RelNode assignDynamicFilterSemiJoin(PhysicalJoin join) {
+    /*
+     * When dynamic broadcast is enabled, push broadcast trait to right input along with the pipeline breaker
+     * trait. Use hash trait if a hint is given to indicate that the left-input is partitioned.
+     */
+    RelNode leftInput = join.getInput(0);
+    RelNode rightInput = join.getInput(1);
+    JoinInfo joinInfo = join.analyzeCondition();
+    Preconditions.checkState(rightInput.getTraitSet().getDistribution() == null,
+        "Found existing dist trait on right input of semi-join");
+    RelDistribution distribution = RelDistributions.BROADCAST_DISTRIBUTED;
+    if (Boolean.TRUE.equals(PinotHintOptions.JoinHintOptions.isColocatedByJoinKeys(join))) {
+      distribution = RelDistributions.hash(joinInfo.rightKeys);
+    }
+    RelTraitSet rightTraitSet = rightInput.getTraitSet().plus(distribution)
+        .plus(PinotExecStrategyTrait.PIPELINE_BREAKER);
+    rightInput = rightInput.copy(rightTraitSet, rightInput.getInputs());
+    return join.copy(join.getTraitSet(), ImmutableList.of(leftInput, rightInput));
+  }
+
+  private RelCollation getCollation(PhysicalWindow window) {
+    return window.groups.isEmpty() ? RelCollations.EMPTY : window.groups.get(0).collation();
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
@@ -170,7 +170,7 @@ public class TraitAssignment {
                 .plus(RelDistributions.SINGLETON);
             input = new PhysicalSort(sort.getCluster(), traitSetOfNewSort, List.of() /* hints */,
                 windowGroupCollation, null /* offset */, null /* fetch */, sort, _planIdGenerator.get(),
-                ImmutableList.of(sort), null /* pinot data distribution */, false /* leaf stage */);
+                null /* pinot data distribution */, false /* leaf stage */);
           } else {
             input = input.copy(input.getTraitSet().plus(RelDistributions.SINGLETON), input.getInputs());
           }
@@ -195,7 +195,7 @@ public class TraitAssignment {
               .plus(newHashDistTrait);
           input = new PhysicalSort(sort.getCluster(), traitSetOfNewSort, List.of() /* hints */,
               windowGroupCollation, null /* offset */, null /* fetch */, sort, _planIdGenerator.get(),
-              ImmutableList.of(sort), null /* pinot data distribution */, false /* leaf stage */);
+              null /* pinot data distribution */, false /* leaf stage */);
         } else {
           RelTraitSet newTraitSet = input.getTraitSet().plus(newHashDistTrait).plus(windowGroupCollation);
           input = input.copy(newTraitSet, input.getInputs());

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+
+
+public class PhysicalAggregate extends Aggregate implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+  private final boolean _leafStage;
+  /*
+   * Pinot related aggregation information follows.
+   */
+  private final AggregateNode.AggType _aggType;
+  private final boolean _leafReturnFinalResult;
+  // The following fields are set when group trim is enabled, and are extracted from the Sort on top of this Aggregate.
+  private final List<RelFieldCollation> _collations;
+  private final int _limit;
+
+  public PhysicalAggregate(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints,
+      ImmutableBitSet groupSet, @Nullable List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls,
+      int nodeId, PRelNode pRelInput, @Nullable PinotDataDistribution pinotDataDistribution, boolean leafStage,
+      AggregateNode.AggType aggType, boolean leafReturnFinalResult, List<RelFieldCollation> collations,
+      int limit) {
+    super(cluster, traitSet, hints, pRelInput.unwrap(), groupSet, groupSets, aggCalls);
+    _nodeId = nodeId;
+    _pRelInputs = List.of(pRelInput);
+    _pinotDataDistribution = pinotDataDistribution;
+    _leafStage = leafStage;
+    _aggType = aggType;
+    _leafReturnFinalResult = leafReturnFinalResult;
+    _collations = collations;
+    _limit = limit;
+  }
+
+  @Override
+  public Aggregate copy(RelTraitSet traitSet, RelNode input, ImmutableBitSet groupSet,
+      @Nullable List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
+    return new PhysicalAggregate(getCluster(), traitSet, getHints(), groupSet, groupSets, aggCalls, _nodeId,
+        (PRelNode) input, _pinotDataDistribution, _leafStage, _aggType, _leafReturnFinalResult, _collations, _limit);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return _leafStage;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalAggregate(getCluster(), getTraitSet(), getHints(), getGroupSet(), getGroupSets(),
+        getAggCallList(), newNodeId, newInputs.get(0), newDistribution, _leafStage, _aggType, _leafReturnFinalResult,
+        _collations, _limit);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalJoin.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalJoin.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rex.RexNode;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalJoin extends Join implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalJoin(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints,
+      RexNode condition, Set<CorrelationId> variablesSet, JoinRelType joinType, int nodeId, PRelNode left,
+      PRelNode right, @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, traitSet, hints, left.unwrap(), right.unwrap(), condition, variablesSet, joinType);
+    _nodeId = nodeId;
+    _pRelInputs = List.of(left, right);
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public Join copy(RelTraitSet traitSet, RexNode conditionExpr, RelNode left, RelNode right, JoinRelType joinType,
+      boolean semiJoinDone) {
+    return new PhysicalJoin(getCluster(), traitSet, getHints(), conditionExpr, getVariablesSet(), joinType, _nodeId,
+        (PRelNode) left, (PRelNode) right, _pinotDataDistribution);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalJoin(getCluster(), getTraitSet(), getHints(), getCondition(), getVariablesSet(), getJoinType(),
+        newNodeId, newInputs.get(0), newInputs.get(1), newDistribution);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalMinus.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalMinus.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalMinus extends Minus implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalMinus(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints, List<PRelNode> inputs,
+      boolean all, int nodeId, @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, traits, hints, inputs.stream().map(PRelNode::unwrap).collect(Collectors.toList()), all);
+    _nodeId = nodeId;
+    _pRelInputs = inputs;
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+    return new PhysicalMinus(getCluster(), traitSet, getHints(), inputs.stream().map(PRelNode.class::cast)
+        .collect(Collectors.toList()), all, _nodeId, _pinotDataDistribution);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalMinus(getCluster(), getTraitSet(), getHints(), newInputs, all, newNodeId, newDistribution);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalProject.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalProject.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalProject extends Project implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+  private final boolean _leafStage;
+
+  public PhysicalProject(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints,
+      List<? extends RexNode> projects, RelDataType rowType, Set<CorrelationId> variableSet, int nodeId,
+      PRelNode pRelInput, @Nullable PinotDataDistribution pinotDataDistribution, boolean leafStage) {
+    super(cluster, traits, hints, pRelInput.unwrap(), projects, rowType, variableSet);
+    _nodeId = nodeId;
+    _pRelInputs = List.of(pRelInput);
+    _pinotDataDistribution = pinotDataDistribution;
+    _leafStage = leafStage;
+  }
+
+  @Override
+  public Project copy(RelTraitSet traitSet, RelNode input, List<RexNode> projects, RelDataType rowType) {
+    Preconditions.checkState(input instanceof PRelNode, "Expected input of PhysicalProject to be "
+        + "a PRelNode. Found: %s", input);
+    return new PhysicalProject(getCluster(), traitSet, getHints(), projects, rowType, getVariablesSet(),
+        _nodeId, (PRelNode) input, _pinotDataDistribution, _leafStage);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return _leafStage;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalProject(getCluster(), getTraitSet(), getHints(), getProjects(), getRowType(), getVariablesSet(),
+        newNodeId, newInputs.get(0), newDistribution, _leafStage);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rex.RexNode;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalSort extends Sort implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+  private final boolean _leafStage;
+
+  public PhysicalSort(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints,
+      RelCollation collation, @Nullable RexNode offset, @Nullable RexNode fetch,
+      PRelNode input, int nodeId, List<PRelNode> pRelInputs, @Nullable PinotDataDistribution pinotDataDistribution,
+      boolean leafStage) {
+    super(cluster, traits, hints, input.unwrap(), collation, offset, fetch);
+    _nodeId = nodeId;
+    _pRelInputs = pRelInputs;
+    _pinotDataDistribution = pinotDataDistribution;
+    _leafStage = leafStage;
+  }
+
+  @Override
+  public Sort copy(RelTraitSet traitSet, RelNode newInput, RelCollation newCollation, @Nullable RexNode offset,
+      @Nullable RexNode fetch) {
+    return new PhysicalSort(getCluster(), traitSet, getHints(), newCollation, offset, fetch, (PRelNode) newInput,
+        _nodeId, _pRelInputs, _pinotDataDistribution, _leafStage);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return _leafStage;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalSort(getCluster(), getTraitSet(), getHints(), getCollation(), offset, fetch, newInputs.get(0),
+        newNodeId, newInputs, newDistribution, _leafStage);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
@@ -40,11 +40,11 @@ public class PhysicalSort extends Sort implements PRelNode {
 
   public PhysicalSort(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints,
       RelCollation collation, @Nullable RexNode offset, @Nullable RexNode fetch,
-      PRelNode input, int nodeId, List<PRelNode> pRelInputs, @Nullable PinotDataDistribution pinotDataDistribution,
+      PRelNode input, int nodeId, @Nullable PinotDataDistribution pinotDataDistribution,
       boolean leafStage) {
     super(cluster, traits, hints, input.unwrap(), collation, offset, fetch);
     _nodeId = nodeId;
-    _pRelInputs = pRelInputs;
+    _pRelInputs = List.of(input);
     _pinotDataDistribution = pinotDataDistribution;
     _leafStage = leafStage;
   }
@@ -53,7 +53,7 @@ public class PhysicalSort extends Sort implements PRelNode {
   public Sort copy(RelTraitSet traitSet, RelNode newInput, RelCollation newCollation, @Nullable RexNode offset,
       @Nullable RexNode fetch) {
     return new PhysicalSort(getCluster(), traitSet, getHints(), newCollation, offset, fetch, (PRelNode) newInput,
-        _nodeId, _pRelInputs, _pinotDataDistribution, _leafStage);
+        _nodeId, _pinotDataDistribution, _leafStage);
   }
 
   @Override
@@ -85,6 +85,6 @@ public class PhysicalSort extends Sort implements PRelNode {
   @Override
   public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
     return new PhysicalSort(getCluster(), getTraitSet(), getHints(), getCollation(), offset, fetch, newInputs.get(0),
-        newNodeId, newInputs, newDistribution, _leafStage);
+        newNodeId, newDistribution, _leafStage);
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalUnion.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalUnion.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalUnion extends Union implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  /**
+   * See javadocs for {@link PhysicalExchange}.
+   */
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalUnion(RelOptCluster cluster, RelTraitSet traits, List<RelHint> hints, boolean all,
+      List<PRelNode> inputs, int nodeId, @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, traits, hints, inputs.stream().map(PRelNode::unwrap).collect(Collectors.toList()), all);
+    _nodeId = nodeId;
+    _pRelInputs = inputs;
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public Union copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+    return new PhysicalUnion(getCluster(), traitSet, getHints(), all, inputs.stream().map(PRelNode.class::cast)
+        .collect(Collectors.toList()), _nodeId, _pinotDataDistribution);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalUnion(getCluster(), getTraitSet(), getHints(), all, newInputs, newNodeId, newDistribution);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalValues.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalValues.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalValues extends Values implements PRelNode {
+  private final int _nodeId;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalValues(RelOptCluster cluster, List<RelHint> hints, RelDataType rowType,
+      ImmutableList<ImmutableList<RexLiteral>> tuples, RelTraitSet traits, int nodeId,
+      @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, hints, rowType, tuples, traits);
+    _nodeId = nodeId;
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public Values copy(RelTraitSet traitSet, List<RelNode> newInputs) {
+    Preconditions.checkState(newInputs.isEmpty(), "PhysicalValues should not have any inputs. Found: %s", newInputs);
+    return new PhysicalValues(getCluster(), getHints(), getRowType(), getTuples(), traitSet, _nodeId,
+        _pinotDataDistribution);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return List.of();
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalValues(getCluster(), getHints(), getRowType(), getTuples(), getTraitSet(), newNodeId,
+        newDistribution);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalWindow.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalWindow.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalWindow extends Window implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalWindow(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints,
+      List<RexLiteral> constants, RelDataType rowType, List<Group> groups, int nodeId, PRelNode pRelInput,
+      @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, traitSet, hints, pRelInput.unwrap(), constants, rowType, groups);
+    _nodeId = nodeId;
+    _pRelInputs = List.of(pRelInput);
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public Window copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    Preconditions.checkState(inputs.size() == 1, "Expect exactly 1 input to window. Found: %s", inputs);
+    return new PhysicalWindow(getCluster(), traitSet, getHints(), getConstants(), getRowType(), groups, _nodeId,
+        (PRelNode) inputs.get(0), _pinotDataDistribution);
+  }
+
+  @Override
+  public Window copy(List<RexLiteral> constants) {
+    return new PhysicalWindow(getCluster(), getTraitSet(), getHints(), constants, getRowType(), groups, _nodeId,
+        _pRelInputs.get(0), _pinotDataDistribution);
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalWindow(getCluster(), getTraitSet(), getHints(), getConstants(), getRowType(), groups, newNodeId,
+        newInputs.get(0), newDistribution);
+  }
+}


### PR DESCRIPTION
Builds on top of #15371.

This adds the following:

* All the required Physical Plan Nodes
* Trait constraint assignment, as we defined it in the [design doc](https://docs.google.com/document/d/17ApZbvNphKgEdSAOlZwTwAnnL_dAt9QbjcpzjHb4M0w/edit?tab=t.0#heading=h.txhamf1ek7k).
* Aggregate rule that converts to `PinotLogicalAggregate` and pushes down group-trim. It is nearly the same as the existing `PinotAggregateExchangeNodeInsertRule`. The differences are mentioned in the javadocs of the new rule.

### Trait Constraint Assignment

The key change in this PR is to add the Trait Constraint Assignment logic. We are using traits as constraints, and the Physical Planner will add Exchange to meet these constraints as required.

### Test Plan

I have created a separate tracker for [tests related to the Physical Planner](https://github.com/apache/pinot/issues/15319?issue=apache%7Cpinot%7C15456). Once the E2E logic is wired in, I'll copy the JSON files with the explain plan output, which will do complete E2E testing for all features.