### PR TITLE
Remove "is not resolvable to a concrete type." warning

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -289,7 +289,7 @@ public class PinotBrokerDebug {
   @Path("/debug/threads/resourceUsage")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get resource usage of threads")
-  public Collection<? extends ThreadResourceTracker> getThreadResourceUsage() {
+  public List<ThreadResourceTracker> getThreadResourceUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
     return threadAccountant.getThreadResources();
   }
@@ -300,9 +300,9 @@ public class PinotBrokerDebug {
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get current resource usage of queries in this service", notes = "This is a debug endpoint, "
       + "and won't maintain backward compatibility")
-  public Collection<? extends QueryResourceTracker> getQueryUsage() {
+  public List<QueryResourceTracker> getQueryUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
-    return threadAccountant.getQueryResources().values();
+    return new ArrayList<>(threadAccountant.getQueryResources().values());
   }
 
   @GET

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/AggregateByQueryIdAccountantFactoryForTest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/AggregateByQueryIdAccountantFactoryForTest.java
@@ -73,7 +73,7 @@ public class AggregateByQueryIdAccountantFactoryForTest implements ThreadAccount
    */
   public static class AggregateByQueryIdAccountant
       extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
-    Map<String, QueryResourceTrackerImpl> _queryMemUsage = new ConcurrentHashMap<>();
+    Map<String, QueryResourceTracker> _queryMemUsage = new ConcurrentHashMap<>();
 
     public AggregateByQueryIdAccountant(PinotConfiguration config, String instanceId) {
       super(config, instanceId);
@@ -84,13 +84,14 @@ public class AggregateByQueryIdAccountantFactoryForTest implements ThreadAccount
       super.sampleThreadBytesAllocated();
       ThreadExecutionContext context = getThreadExecutionContext();
       QueryResourceTrackerImpl queryResourceTracker =
-          _queryMemUsage.computeIfAbsent(context.getQueryId(), s -> new QueryResourceTrackerImpl(context.getQueryId()));
+          (QueryResourceTrackerImpl) _queryMemUsage.computeIfAbsent(context.getQueryId(),
+              s -> new QueryResourceTrackerImpl(context.getQueryId()));
       queryResourceTracker.setAllocatedBytes(
           queryResourceTracker.getAllocatedBytes() + getThreadEntry().getAllocatedBytes());
     }
 
     @Override
-    public Map<String, ? extends QueryResourceTracker> getQueryResources() {
+    public Map<String, QueryResourceTracker> getQueryResources() {
       return _queryMemUsage;
     }
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -133,7 +132,7 @@ public class DebugResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get current resource usage of threads",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
-  public Collection<? extends ThreadResourceTracker> getThreadUsage() {
+  public List<ThreadResourceTracker> getThreadUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
     return threadAccountant.getThreadResources();
   }
@@ -143,10 +142,9 @@ public class DebugResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get current resource usage of queries in this service",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
-  public Collection<? extends QueryResourceTracker> getQueryUsage() {
+  public List<QueryResourceTracker> getQueryUsage() {
     ThreadResourceUsageAccountant threadAccountant = Tracing.getThreadAccountant();
-    Collection<? extends QueryResourceTracker> resources = threadAccountant.getQueryResources().values();
-    return resources;
+    return new ArrayList<>(threadAccountant.getQueryResources().values());
   }
 
   private List<SegmentServerDebugInfo> getSegmentServerDebugInfo(String tableNameWithType, TableType tableType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.spi.accounting;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -87,11 +87,11 @@ public interface ThreadResourceUsageAccountant {
    * Get all the ThreadResourceTrackers for all threads executing query tasks
    * @return A collection of ThreadResourceTracker objects
    */
-  Collection<? extends ThreadResourceTracker> getThreadResources();
+  List<ThreadResourceTracker> getThreadResources();
 
   /**
    * Get all the QueryResourceTrackers for all the queries executing in a broker or server.
    * @return A Map of String, QueryResourceTracker for all the queries.
    */
-  Map<String, ? extends QueryResourceTracker> getQueryResources();
+  Map<String, QueryResourceTracker> getQueryResources();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -20,8 +20,8 @@ package org.apache.pinot.spi.trace;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
@@ -246,12 +246,12 @@ public class Tracing {
     }
 
     @Override
-    public Collection<? extends ThreadResourceTracker> getThreadResources() {
+    public List<ThreadResourceTracker> getThreadResources() {
       return Collections.emptyList();
     }
 
     @Override
-    public Map<String, ? extends QueryResourceTracker> getQueryResources() {
+    public Map<String, QueryResourceTracker> getQueryResources() {
       return Collections.emptyMap();
     }
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
@@ -295,14 +294,7 @@ public class MultistageEngineQuickStart extends Quickstart {
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configOverrides = new HashMap<>();
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
     configOverrides.put(CommonConstants.Broker.CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION, true);
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        PerQueryCPUMemAccountantFactory.class.getCanonicalName());
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_QUERY_CANCELLATION, true);
     return configOverrides;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
@@ -294,7 +295,14 @@ public class MultistageEngineQuickStart extends Quickstart {
   protected Map<String, Object> getConfigOverrides() {
     Map<String, Object> configOverrides = new HashMap<>();
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
+    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
     configOverrides.put(CommonConstants.Broker.CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION, true);
+    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
+        PerQueryCPUMemAccountantFactory.class.getCanonicalName());
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_QUERY_CANCELLATION, true);
     return configOverrides;
   }


### PR DESCRIPTION
Specifically, the following warnings have been removed by using change the method signatures to return concrete types.

```
WARNING: Return type, java.util.Collection<? extends org.apache.pinot.spi.accounting.ThreadResourceTracker>, of method, public java.util.Collection<? extends org.apache.pinot.spi.accounting.ThreadResourceTracker> org.apache.pinot.broker.api.resources.PinotBrokerDebug.getThreadResourceUsage(), is not resolvable to a concrete type.

WARNING: Return type, java.util.Collection<? extends org.apache.pinot.spi.accounting.QueryResourceTracker>, of method, public java.util.Collection<? extends org.apache.pinot.spi.accounting.QueryResourceTracker> org.apache.pinot.broker.api.resources.PinotBrokerDebug.getQueryResourceUsage(), is not resolvable to a concrete type.
```