### PR TITLE
Deprecates AllowConsumptionDuringCommit Config

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
@@ -47,6 +47,8 @@ public class DedupConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to preload segments for fast dedup metadata recovery")
   private boolean _enablePreload;
 
+  /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
+  @Deprecated
   @JsonPropertyDescription("Whether to pause dedup table's partition consumption during commit")
   private boolean _allowDedupConsumptionDuringCommit;
 
@@ -104,10 +106,12 @@ public class DedupConfig extends BaseJsonConfig {
     _enablePreload = enablePreload;
   }
 
+  @Deprecated
   public boolean isAllowDedupConsumptionDuringCommit() {
     return _allowDedupConsumptionDuringCommit;
   }
 
+  @Deprecated
   public void setAllowDedupConsumptionDuringCommit(boolean allowDedupConsumptionDuringCommit) {
     _allowDedupConsumptionDuringCommit = allowDedupConsumptionDuringCommit;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -101,6 +101,8 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to drop out-of-order record")
   private boolean _dropOutOfOrderRecord;
 
+  /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
+  @Deprecated
   @JsonPropertyDescription("Whether to pause partial upsert table's partition consumption during commit")
   private boolean _allowPartialUpsertConsumptionDuringCommit;
 
@@ -301,10 +303,12 @@ public class UpsertConfig extends BaseJsonConfig {
     _metadataManagerConfigs = metadataManagerConfigs;
   }
 
+  @Deprecated
   public void setAllowPartialUpsertConsumptionDuringCommit(boolean allowPartialUpsertConsumptionDuringCommit) {
     _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
   }
 
+  @Deprecated
   public boolean isAllowPartialUpsertConsumptionDuringCommit() {
     return _allowPartialUpsertConsumptionDuringCommit;
   }


### PR DESCRIPTION
Deprecate `_allowDedupConsumptionDuringCommit` and `_allowPartialUpsertConsumptionDuringCommit`.
Because: 

1. These configs are confusing because the name and behaviour of these config are not the same. These configs control that whether the consumer should start consumption when the consumer of any previous segment is building the segment or the helix thread is downloading any previous segment. Build can happen during commit and non-commit cases as well in a server.
2. We have a new config now: `ParallelSegmentConsumptionPolicy`