### PR TITLE
fixing NPE when ArrowResponseEncoder reading the vector data as null

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
@@ -397,6 +397,10 @@ public class ArrowResponseEncoder implements ResponseEncoder {
         Object[] row = new Object[numColumns];
         for (int col = 0; col < numColumns; col++) {
           FieldVector vector = root.getVector(col);
+          if (vector.isNull(i)) {
+            row[col] = null;
+            continue;
+          }
           switch (schema.getColumnDataType(col)) {
             case BOOLEAN:
               row[col] = ((BitVector) vector).get(i) == 1;


### PR DESCRIPTION
Fix the NPE: https://github.com/apache/pinot/actions/runs/14242077339/job/39914086390?pr=15448 