### PR TITLE
Fix Null value for group by queries when no aggregate was called

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -252,8 +252,9 @@ public class GroupByResultsBlock extends BaseResultsBlock {
         Object[] values = iterator.next().getValues();
         for (int i = 0; i < numColumns; i++) {
           Object value = values[i];
-          assert value != null;
-          if (storedColumnDataTypes[i] == ColumnDataType.OBJECT) {
+          if (value == null) {
+            dataTableBuilder.setNull(i);
+          } else if (storedColumnDataTypes[i] == ColumnDataType.OBJECT) {
             dataTableBuilder.setColumn(i, aggregationFunctions[i - numKeyColumns].serializeIntermediateResult(value));
           } else {
             setDataTableColumn(storedColumnDataTypes[i], dataTableBuilder, i, value);


### PR DESCRIPTION
This PR is similar to the previous [PR](https://github.com/apache/pinot/pull/15382) (which fixed the aggregation only queries) but it fixes the one with group-by query pattern.

Basically if the `aggregate(int length, AggregationResultHolder aggregationResultHolder, Map<ExpressionContext, BlockValSet> blockValSetMap)` method never gets invoked, the `Object _value;` inside the AggregationResultHolder class will be null, which is a valid case.