### PR TITLE
Fallback for bad values in periodic controller task configurations

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -263,6 +263,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
           "tenant-rebalance-thread-%d");
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
+
     // Initialize the table config tuner registry.
     TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -263,7 +263,6 @@ public abstract class BaseControllerStarter implements ServiceStartable {
           "tenant-rebalance-thread-%d");
       _tenantRebalancer = new DefaultTenantRebalancer(_helixResourceManager, _tenantRebalanceExecutorService);
     }
-
     // Initialize the table config tuner registry.
     TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -699,6 +699,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getRebalanceCheckerFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.REBALANCE_CHECKER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.REBALANCE_CHECKER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period))
         .orElse(ControllerPeriodicTasksConf.DEFAULT_REBALANCE_CHECKER_FREQUENCY_IN_SECONDS);
   }
@@ -754,6 +756,8 @@ public class ControllerConf extends PinotConfiguration {
    */
   public int getSegmentRelocatorFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> {
           Integer segmentRelocatorFreqSeconds =
               getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS, Integer.class);
@@ -868,6 +872,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getTaskManagerFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -35,8 +35,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
@@ -88,9 +86,6 @@ public class ControllerConf extends PinotConfiguration {
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerConf.class);
-
 
   public static class ControllerPeriodicTasksConf {
     // frequency configs
@@ -372,7 +367,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String EXIT_ON_SCHEMA_CHECK_FAILURE = "controller.startup.exitOnSchemaCheckFailure";
   public static final boolean DEFAULT_EXIT_ON_SCHEMA_CHECK_FAILURE = true;
 
-  private final Map<String, String> _warnings = new HashMap<>();
+  private final Map<String, String> _invalidConfigs = new HashMap<>();
 
   public ControllerConf() {
     super(new HashMap<>());
@@ -1241,20 +1236,19 @@ public class ControllerConf extends PinotConfiguration {
     if (TimeUtils.isPeriodValid(periodStr)) {
       return true;
     } else {
-      String message = String.format(
-          "Invalid time spec '%s' for config '%s'. Falling back to default config.", periodStr,
-          propertyKey);
-      addControllerInvalidConfigs(propertyKey, message);
+      addControllerInvalidConfigs(propertyKey,
+          String.format("Invalid time spec '%s' for config '%s'. Falling back to default config.",
+              periodStr, propertyKey));
       return false;
     }
   }
 
   private void addControllerInvalidConfigs(String propertyKey, String errorMessage) {
-    _warnings.put(propertyKey, errorMessage);
+    _invalidConfigs.put(propertyKey, errorMessage);
   }
 
-  public Map<String, String> getControllerInvalidConfigs() {
-    return _warnings;
+  public Map<String, String> getInvalidConfigs() {
+    return _invalidConfigs;
   }
 
   private String getSupportedProtocol(String property) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -35,6 +35,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
@@ -86,6 +88,9 @@ public class ControllerConf extends PinotConfiguration {
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerConf.class);
+
 
   public static class ControllerPeriodicTasksConf {
     // frequency configs
@@ -589,6 +594,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getRetentionControllerFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_RETENTION_MANAGER_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_RETENTION_MANAGER_FREQUENCY_IN_SECONDS));
@@ -612,6 +619,8 @@ public class ControllerConf extends PinotConfiguration {
   public int getOfflineSegmentIntervalCheckerFrequencyInSeconds() {
     return Optional.ofNullable(
             getProperty(ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> getProperty(
             ControllerPeriodicTasksConf.DEPRECATED_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS,
             ControllerPeriodicTasksConf.DEFAULT_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS));
@@ -634,6 +643,8 @@ public class ControllerConf extends PinotConfiguration {
    */
   public int getRealtimeSegmentValidationFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS));
@@ -656,6 +667,8 @@ public class ControllerConf extends PinotConfiguration {
    */
   public int getBrokerResourceValidationFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS));
@@ -673,6 +686,7 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getStatusCheckerFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(ControllerPeriodicTasksConf.STATUS_CHECKER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_STATUS_CHECKER_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_STATUS_CHECKER_FREQUENCY_IN_SECONDS));
@@ -707,6 +721,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getTaskMetricsEmitterFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.TASK_METRICS_EMITTER_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.TASK_METRICS_EMITTER_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS));
@@ -719,6 +735,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getStatusCheckerWaitForPushTimeInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.STATUS_CHECKER_WAIT_FOR_PUSH_TIME_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.STATUS_CHECKER_WAIT_FOR_PUSH_TIME_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS));
@@ -863,6 +881,8 @@ public class ControllerConf extends PinotConfiguration {
   @Deprecated
   public int getMinionInstancesCleanupTaskFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
                 ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
@@ -890,6 +910,8 @@ public class ControllerConf extends PinotConfiguration {
   public int getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() {
     return Optional.ofNullable(
         getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> getProperty(
             ControllerPeriodicTasksConf.
                 DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
@@ -906,6 +928,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getStaleInstancesCleanupTaskFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period))
         // Backward compatible for existing users who configured MinionInstancesCleanupTask
         .orElse(getMinionInstancesCleanupTaskFrequencyInSeconds());
@@ -928,6 +952,8 @@ public class ControllerConf extends PinotConfiguration {
   public int getStaleInstancesCleanupTaskInstancesRetentionInSeconds() {
     return Optional.ofNullable(
             getProperty(ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period))
         // Backward compatible for existing users who configured MinionInstancesCleanupTask
         .orElse(getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds());
@@ -1049,12 +1075,15 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(ENABLE_HYBRID_TABLE_RETENTION_STRATEGY, DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY);
   }
 
-  public int getSegmentLevelValidationIntervalInSeconds() {
-    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD))
-        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
-            () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
-                ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS));
-  }
+   public int getSegmentLevelValidationIntervalInSeconds() {
+      return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD))
+          .filter(period -> isValidPeriodWithLogging(
+              ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD, period))
+          .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
+              () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
+                  ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS));
+    }
+
 
   public boolean isAutoResetErrorSegmentsOnValidationEnabled() {
     return getProperty(ControllerPeriodicTasksConf.AUTO_RESET_ERROR_SEGMENTS_VALIDATION, false);
@@ -1198,6 +1227,16 @@ public class ControllerConf extends PinotConfiguration {
 
   private long convertPeriodToSeconds(String period) {
     return convertPeriodToUnit(period, TimeUnit.SECONDS);
+  }
+
+  private boolean isValidPeriodWithLogging(String propertyKey, String periodStr) {
+    if (TimeUtils.isPeriodValid(periodStr)) {
+      return true;
+    } else {
+      LOGGER.error("Invalid time spec '{}' for config '{}'. Falling back to default config.", periodStr,
+          propertyKey);
+      return false;
+    }
   }
 
   private String getSupportedProtocol(String property) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -372,6 +372,8 @@ public class ControllerConf extends PinotConfiguration {
   public static final String EXIT_ON_SCHEMA_CHECK_FAILURE = "controller.startup.exitOnSchemaCheckFailure";
   public static final boolean DEFAULT_EXIT_ON_SCHEMA_CHECK_FAILURE = true;
 
+  private final Map<String, String> _warnings = new HashMap<>();
+
   public ControllerConf() {
     super(new HashMap<>());
   }
@@ -1239,10 +1241,20 @@ public class ControllerConf extends PinotConfiguration {
     if (TimeUtils.isPeriodValid(periodStr)) {
       return true;
     } else {
-      LOGGER.error("Invalid time spec '{}' for config '{}'. Falling back to default config.", periodStr,
+      String message = String.format(
+          "Invalid time spec '%s' for config '%s'. Falling back to default config.", periodStr,
           propertyKey);
+      addControllerInvalidConfigs(propertyKey, message);
       return false;
     }
+  }
+
+  private void addControllerInvalidConfigs(String propertyKey, String errorMessage) {
+    _warnings.put(propertyKey, errorMessage);
+  }
+
+  public Map<String, String> getControllerInvalidConfigs() {
+    return _warnings;
   }
 
   private String getSupportedProtocol(String property) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
@@ -367,7 +368,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String EXIT_ON_SCHEMA_CHECK_FAILURE = "controller.startup.exitOnSchemaCheckFailure";
   public static final boolean DEFAULT_EXIT_ON_SCHEMA_CHECK_FAILURE = true;
 
-  private final Map<String, String> _invalidConfigs = new HashMap<>();
+  private final Map<String, String> _invalidConfigs = new ConcurrentHashMap<>();
 
   public ControllerConf() {
     super(new HashMap<>());
@@ -1085,7 +1086,7 @@ public class ControllerConf extends PinotConfiguration {
           .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
               () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
                   ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS));
-    }
+  }
 
 
   public boolean isAutoResetErrorSegmentsOnValidationEnabled() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
@@ -122,12 +122,12 @@ public class PinotControllerHealthCheck {
   }
 
   @GET
-  @Path("/pinot-controller/invalid/configs")
+  @Path("invalidconfigs")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_HEALTH)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "List cluster config warnings")
+  @ApiOperation(value = "List invalid controller configs")
   public Response getConfigWarnings() {
-    Map<String, String> warnings = _controllerConf.getControllerInvalidConfigs();
+    Map<String, String> warnings = _controllerConf.getInvalidConfigs();
     if (warnings.isEmpty()) {
       return Response.ok(Collections.emptyMap()).build();
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java
@@ -29,6 +29,8 @@ import io.swagger.annotations.SwaggerDefinition;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.GET;
@@ -117,6 +119,20 @@ public class PinotControllerHealthCheck {
     Instant now = Instant.now();
     Duration uptime = Duration.between(_startTime, now);
     return uptime.getSeconds();
+  }
+
+  @GET
+  @Path("/pinot-controller/invalid/configs")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_HEALTH)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "List cluster config warnings")
+  public Response getConfigWarnings() {
+    Map<String, String> warnings = _controllerConf.getControllerInvalidConfigs();
+    if (warnings.isEmpty()) {
+      return Response.ok(Collections.emptyMap()).build();
+    }
+
+    return Response.ok(warnings).build();
   }
 
   @GET

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -88,9 +88,10 @@ public class ControllerConfTest {
    * are thrown when invalid new configurations are read (there is no fall-back to the corresponding
    * valid deprecated configuration). For all valid new configurations, they override the
    * corresponding deprecated configuration.
+   * Added fallback logic to use valid deprecated config when new config is invalid.
    */
   @Test
-  public void invalidNewConfigShouldThrowExceptionOnReadWithoutFallbackToCorrespondingValidDeprecatedConfig() {
+  public void invalidNewConfigShouldNotThrowExceptionOnReadWithFallbackToCorrespondingValidDeprecatedConfig() {
     //setup
     Map<String, Object> controllerConfig = new HashMap<>();
     int durationInSeconds = getRandomDurationInSeconds();
@@ -101,7 +102,11 @@ public class ControllerConfTest {
     //put some invalid new configs
     controllerConfig.put(RETENTION_MANAGER_FREQUENCY_PERIOD, getRandomString());
     ControllerConf conf = new ControllerConf(controllerConfig);
-    Assert.assertThrows(IllegalArgumentException.class, conf::getRetentionControllerFrequencyInSeconds);
+    Assert.assertEquals(
+        conf.getRetentionControllerFrequencyInSeconds(),
+        durationInSeconds, // expected fallback value
+        "Should fallback to deprecated config value"
+    );
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -100,12 +100,23 @@ public class ControllerConfTest {
     String randomPeriodInMinutes = getRandomPeriodInMinutes();
     NEW_CONFIGS.forEach(config -> controllerConfig.put(config, randomPeriodInMinutes));
     //put some invalid new configs
-    controllerConfig.put(RETENTION_MANAGER_FREQUENCY_PERIOD, getRandomString());
+    String randomInvalidString = getRandomString();
+    controllerConfig.put(RETENTION_MANAGER_FREQUENCY_PERIOD, randomInvalidString);
     ControllerConf conf = new ControllerConf(controllerConfig);
     Assert.assertEquals(
         conf.getRetentionControllerFrequencyInSeconds(),
         durationInSeconds, // expected fallback value
         "Should fallback to deprecated config value"
+    );
+    //test to assert that invalid config is captured in the invalid config map value
+    Map<String, String> invalidConfigs = conf.getInvalidConfigs();
+    Assert.assertTrue(invalidConfigs.containsKey(RETENTION_MANAGER_FREQUENCY_PERIOD));
+    Assert.assertEquals(
+        conf.getInvalidConfigs().get(RETENTION_MANAGER_FREQUENCY_PERIOD),
+        String.format(
+            "Invalid time spec '%s' for config '%s'. Falling back to default config.",
+            randomInvalidString, RETENTION_MANAGER_FREQUENCY_PERIOD
+        )
     );
   }
 


### PR DESCRIPTION
This change improves how the controller conf applies the values for periodic task configurations. Previously, invalid new configuration values were throwing exceptions and not letting the service startup. With this update, we now: Validate that the configured period strings (like 7200s, 2h) pass the validation check in TimeUtils.isPeriodValid(). Log an error message when an invalid period string is configured, and the fallback to the default deprecated old configuration. Continue to fallback to default deprecated old configuration values when new configuration is not provided. These are configurations that are updated in this change: getRetentionControllerFrequencyInSeconds()
getOfflineSegmentIntervalCheckerFrequencyInSeconds() getRealtimeSegmentValidationFrequencyInSeconds()
getBrokerResourceValidationFrequencyInSeconds()
getStatusCheckerFrequencyInSeconds()
getStatusCheckerWaitForPushTimeInSeconds()
getTaskMetricsEmitterFrequencyInSeconds()
getSegmentLevelValidationIntervalInSeconds()
getMinionInstancesCleanupTaskFrequencyInSeconds()
getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() getStaleInstancesCleanupTaskFrequencyInSeconds()
getStaleInstancesCleanupTaskInstancesRetentionInSeconds()
