### PR TITLE
Ensure that minAvailableReplicas has an upper bound of existing numReplicas to fix infinite loop in rebalance for StrictReplicaGroup assignment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -438,6 +438,17 @@ public class TableRebalancer {
       minAvailableReplicas = Math.max(numReplicas + minReplicasToKeepUpForNoDowntime, 0);
     }
 
+    int numCurrentAssignmentReplicas = Integer.MAX_VALUE;
+    for (String segment : segmentsToMove) {
+      numCurrentAssignmentReplicas = Math.min(currentAssignment.get(segment).size(), numCurrentAssignmentReplicas);
+    }
+    if (minAvailableReplicas > numCurrentAssignmentReplicas) {
+      LOGGER.warn("For rebalanceId: {}, minAvailableReplicas: {} larger than existing number of replicas: {}, "
+          + "resetting minAvailableReplicas to {}", rebalanceJobId, minAvailableReplicas, numCurrentAssignmentReplicas,
+          numCurrentAssignmentReplicas);
+      minAvailableReplicas = numCurrentAssignmentReplicas;
+    }
+
     LOGGER.info(
         "For rebalanceId: {}, rebalancing table: {} with minAvailableReplicas: {}, enableStrictReplicaGroup: {}, "
             + "bestEfforts: {}, externalViewCheckIntervalInMs: {}, externalViewStabilizationTimeoutInMs: {}",


### PR DESCRIPTION
When running table rebalance, we need to specify the `minAvailableReplicas` to keep up as part of the rebalance. Internally we track the number of replicas based on the target assignment only, which can be problematic for certain scenarios.

For strict replica group based assignment, I found that the rebalance can get into an infinite loop for the following conditions:
- Starting replication = 1
- Target replication = 3
- minAvailableReplicas = -1 (or 2) [basically higher than the starting replication]

In the above scenario, when doing the assignment for the segments, we hit the following condition:
```
          if (availableInstances.size() >= minAvailableReplicas) {
            ...
          } else {
            // New assignment cannot be added, use the current instance state map
            nextAssignment.put(segmentName, currentInstanceStateMap);
            return currentAvailableInstances;
          }
```
Since `availableInstances.size()` is always 1 (since we start with just 1 replica), and `minAvailableReplicas` is 2 based on the configuration passed in to rebalance, we never make progress and keep setting the current assignment for such segments.

What I noticed is that for a few of the partitions it does move forward initially, because of this block at the start:
```
        if (currentAvailableInstances == null) {
          // First segment assigned to these instances, use the new assignment and update the available instances
          nextAssignment.put(segmentName, assignment._instanceStateMap);
          updateNumSegmentsToOffloadMap(numSegmentsToOffloadMap, currentInstanceStateMap.keySet(), k);
          return availableInstances;
        } else {
```

This PR fixes the above by mandating that `minAvailableReplicas` is never higher than the starting replication factor, and if detected that it is higher, it is set to the starting replication factor. It also logs a warning when this scenario is detected. 

Testing: Added a test case to reproduce this scenario and verified that with the fix the test passes. Also verified by running `HybridQuickStart` with 6 servers and tried out this rebalance with and without the change.

cc @Jackie-Jiang @xiangfu0 @klsince 