### PR TITLE
Reducing the pauseless metric complexity

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -139,17 +139,12 @@ public class SegmentCompletionManager {
     }
 
     if (factoryName == null) {
-      // Create a metric identifier at partition level granularity, similar to server metrics
-      // in RealtimeSegmentValidationManager
-      String tableNameAndPartitionGroupId = realtimeTableName + "-" + llcSegmentName.getPartitionGroupId();
       if (PauselessConsumptionUtils.isPauselessEnabled(tableConfig)) {
         factoryName = _segmentCompletionConfig.getDefaultPauselessFsmScheme();
-        _controllerMetrics.setValueOfTableGauge(tableNameAndPartitionGroupId,
-            ControllerGauge.PAUSELESS_CONSUMPTION_ENABLED, 1);
+        _controllerMetrics.setValueOfTableGauge(realtimeTableName, ControllerGauge.PAUSELESS_CONSUMPTION_ENABLED, 1);
       } else {
         factoryName = _segmentCompletionConfig.getDefaultFsmScheme();
-        _controllerMetrics.setValueOfTableGauge(tableNameAndPartitionGroupId,
-            ControllerGauge.PAUSELESS_CONSUMPTION_ENABLED, 0);
+        _controllerMetrics.setValueOfTableGauge(realtimeTableName, ControllerGauge.PAUSELESS_CONSUMPTION_ENABLED, 0);
       }
     }
 


### PR DESCRIPTION
## Context

The metric `PAUSELESS_CONSUMPTION_ENABLED` was not getting scraped by Prometheus due to regex mismatch. 
We had two options:
1. Simplify the metric
2. Add another regex to allow scarping this metric

## Scope of the PR

The PR changes the tag for the metric to just table name as this metric is agnostic of the partition at hand. Moreover, logs have the exact information of the `fsm` picked for each partition in case this is needed for debugging. 

Using `avg` of this metric for each controller can give us additional information on whether each partition is using the same fsm or not. The `avg` value should either be 0 or 1 (i.e. the value of this metric is 0 or 1 for all the partitions).

### When can the value be between 0 and 1
Enabling/ disabling pauseless flag without pausing the ingestion can lead to a situation where some partitions use `BlockingFSM` while other's use `PauselessFSM`.
