### PR TITLE
Make PinotTaskManager Fully Pluggable by Avoiding Overridable Method Calls in Constructor

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -816,6 +816,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _taskManagerStatusCache = getTaskManagerStatusCache();
     // Create and add task manager
     _taskManager = createTaskManager();
+    _taskManager.init();
     periodicTasks.add(_taskManager);
     BrokerServiceHelper brokerServiceHelper =
         new BrokerServiceHelper(_helixResourceManager, _config, _executorService, _connectionManager);


### PR DESCRIPTION
This change follows up on [#15429](https://github.com/apache/pinot/pull/15429) and makes PinotTaskManager fully pluggable.

Currently, the constructor of PinotTaskManager includes code paths—such as checkTableConfigChanges()—that can lead to the invocation of updateCronTaskScheduler(). This method is overridable and may be overridden in a subclass. Invoking it during the base class constructor can lead to bugs if the derived class is not fully initialized yet.

This update ensures that such calls are deferred appropriately to avoid potential issues during construction. Use existing tests to confirm it does not introduce regressions.