### PR TITLE
Fix segment throttle metrics by initializing them

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -61,6 +61,8 @@ import org.apache.pinot.client.PinotConnection;
 import org.apache.pinot.client.PinotDriver;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerGauge;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.ServiceStatus;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -61,8 +61,6 @@ import org.apache.pinot.client.PinotConnection;
 import org.apache.pinot.client.PinotDriver;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.common.metrics.ServerGauge;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.ServiceStatus;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottler.java
@@ -66,6 +66,17 @@ public class SegmentOperationsThrottler implements PinotClusterConfigChangeListe
     return _segmentDownloadThrottler;
   }
 
+  /**
+   * The ServerMetrics may be created after these objects are created. In that case, the initialization that happens
+   * in the constructor may have occurred on the NOOP metrics. This should be called after the server metrics are
+   * created and registered
+   */
+  public void initializeMetrics() {
+    _segmentAllIndexPreprocessThrottler.initializeMetrics();
+    _segmentStarTreePreprocessThrottler.initializeMetrics();
+    _segmentDownloadThrottler.initializeMetrics();
+  }
+
   public synchronized void startServingQueries() {
     _segmentAllIndexPreprocessThrottler.startServingQueries();
     _segmentStarTreePreprocessThrottler.startServingQueries();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -98,6 +98,10 @@ public class ServerInstance {
     _serverMetrics.initializeGlobalMeters();
     _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
     ServerMetrics.register(_serverMetrics);
+    if (segmentOperationsThrottler != null) {
+      // Initialize the metrics for the throttler so it picks up the newly registered ServerMetrics object
+      segmentOperationsThrottler.initializeMetrics();
+    }
 
     String instanceDataManagerClassName = serverConf.getInstanceDataManagerClassName();
     LOGGER.info("Initializing instance data manager of class: {}", instanceDataManagerClassName);


### PR DESCRIPTION
As part of PR https://github.com/apache/pinot/pull/15392 metrics were added for tracking segment throttle thresholds and count of the operations undergoing the given operation. The metrics only show up as 0 in spite of the changes.

On debugging, found the following:
- `ServerMetrics` are initialized to a NOOP variant at the start
- `SegmentOperationsThrottler` is created and passed to `ServerInstance`. This object needs to set up the metrics and initialize them, but at this point the `ServerMetrics` object is still NOOP. Thus it creates and registers with this NOOP object.
- `ServerInstance` object is created, and in the constructor `ServerMetrics` is actually created and registered, where the correct `ServerMetrics` object is set up (NOOP is replaced)
- `_serverMetrics` is cached in the `SegmentOperationsThrottler` class, so even future metric updates land up updating against the NOOP server metrics rather than the correctly created and registered one.

To address the above, I've added:
- New `initializeMetrics` method to `BaseSegmentOperationsThrottler` and `SegmentOperationsThrottler` objects
- Call the above method in `ServerInstance` after the `ServerMetrics` are created and registered

It is safe to do the above because we have not yet registered `SegmentOperationsThrottler` with the `InstanceDataManager` so no segment operations are happening yet.

Testing:
- Verified in the debugger that the above code is correctly called and the NOOP `ServerMetrics` is replaced with the newly registered `ServerMetrics` which is not the NOOP variant. Prior to this change, the `ServerMetrics` object would never have been updated from NOOP.

cc @klsince @Jackie-Jiang 