### PR TITLE
Improve logging for groovy transform functions

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
@@ -62,7 +62,7 @@ public class FunctionEvaluatorFactory {
       } catch (Exception e) {
         throw new IllegalStateException(
             "Caught exception while constructing expression evaluator for transform expression:" + transformExpression
-                + ", of column:" + columnName);
+                + ", of column:" + columnName + e.getMessage(), e);
       }
     } else if (fieldSpec.getFieldType() == FieldSpec.FieldType.TIME) {
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
@@ -61,8 +61,8 @@ public class FunctionEvaluatorFactory {
         functionEvaluator = getExpressionEvaluator(transformExpression);
       } catch (Exception e) {
         throw new IllegalStateException(
-            "Caught exception while constructing expression evaluator for transform expression:" + transformExpression
-                + ", of column:" + columnName + ", exception: " + e.getMessage(), e);
+            "Caught exception while constructing expression evaluator for transform expression: " + transformExpression
+                + " of column: " + columnName + ", exception: " + e.getMessage(), e);
       }
     } else if (fieldSpec.getFieldType() == FieldSpec.FieldType.TIME) {
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
@@ -62,7 +62,7 @@ public class FunctionEvaluatorFactory {
       } catch (Exception e) {
         throw new IllegalStateException(
             "Caught exception while constructing expression evaluator for transform expression:" + transformExpression
-                + ", of column:" + columnName + e.getMessage(), e);
+                + ", of column:" + columnName + ", exception: " + e.getMessage(), e);
       }
     } else if (fieldSpec.getFieldType() == FieldSpec.FieldType.TIME) {
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -83,7 +83,12 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
     _numArguments = _arguments.size();
     _binding = new Binding();
     String scriptText = matcher.group(SCRIPT_GROUP_NAME);
-    _script = createSafeShell(_binding).parse(scriptText);
+    try {
+      _script = createSafeShell(_binding).parse(scriptText);
+    } catch (Exception e) {
+      LOGGER.error("Groovy compilation error: " + closure, e);
+      throw new IllegalStateException("Failed to compile groovy script in transform function:" + e.getMessage(), e);
+    }
   }
 
   public static String getGroovyExpressionPrefix() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -86,8 +86,8 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
     try {
       _script = createSafeShell(_binding).parse(scriptText);
     } catch (Exception e) {
-      LOGGER.error("Groovy compilation error: " + closure, e);
-      throw new IllegalStateException("Failed to compile groovy script in transform function:" + e.getMessage(), e);
+      throw new IllegalStateException(
+          "Failed to compile groovy script in transform function with exception:" + e.getMessage(), e);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -86,8 +86,8 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
     try {
       _script = createSafeShell(_binding).parse(scriptText);
     } catch (Exception e) {
-      throw new IllegalStateException(
-          "Failed to compile groovy script in transform function with exception:" + e.getMessage(), e);
+      throw new IllegalStateException("Failed to compile groovy script: " + closure + ", exception: " + e.getMessage(),
+          e);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -378,7 +378,7 @@ public final class TableConfigUtils {
             FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
           } catch (Exception e) {
             throw new IllegalStateException(
-                "Invalid filter function " + filterFunction + ", exception: " + e.getMessage(), e);
+                "Invalid filter function '" + filterFunction + "', exception: " + e.getMessage(), e);
           }
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -538,7 +538,8 @@ public final class TableConfigUtils {
             expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
           } catch (Exception e) {
             throw new IllegalStateException(
-                "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'" + e.getMessage() , e);
+                "Invalid transform function '" + transformFunction + "' for column '" + columnName
+                    + "'" + e.getMessage(), e);
           }
           List<String> arguments = expressionEvaluator.getArguments();
           if (arguments.contains(columnName)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -377,7 +377,8 @@ public final class TableConfigUtils {
           try {
             FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
           } catch (Exception e) {
-            throw new IllegalStateException("Invalid filter function " + filterFunction + e.getMessage(), e);
+            throw new IllegalStateException(
+                "Invalid filter function " + filterFunction + ", exception: " + e.getMessage(), e);
           }
         }
       }
@@ -539,7 +540,7 @@ public final class TableConfigUtils {
           } catch (Exception e) {
             throw new IllegalStateException(
                 "Invalid transform function '" + transformFunction + "' for column '" + columnName
-                    + "'" + e.getMessage(), e);
+                    + "', exception: " + e.getMessage(), e);
           }
           List<String> arguments = expressionEvaluator.getArguments();
           if (arguments.contains(columnName)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -377,7 +377,7 @@ public final class TableConfigUtils {
           try {
             FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
           } catch (Exception e) {
-            throw new IllegalStateException("Invalid filter function " + filterFunction, e);
+            throw new IllegalStateException("Invalid filter function " + filterFunction + e.getMessage(), e);
           }
         }
       }
@@ -538,7 +538,7 @@ public final class TableConfigUtils {
             expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
           } catch (Exception e) {
             throw new IllegalStateException(
-                "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);
+                "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'" + e.getMessage() , e);
           }
           List<String> arguments = expressionEvaluator.getArguments();
           if (arguments.contains(columnName)) {


### PR DESCRIPTION
This change enhances error handling and display in Groovy transformation functions. When a Groovy script fails to compile, the error is logged into the controller logs and passed through the call stack.
Changes - 
Wrapped the call (createSafeShell(_binding).parse(scriptText))to compile the Groovy script in a try-catch block. When a compilation error occurs, the exception is now: 
- Logged using LOGGER.error, including the full stack trace and original error message. 
- Rethrown as an IllegalStateException with a message that includes the original exception’s message from the compiler.
For a invalid groovy script like:

Groovy({def slrpr= new groovy.json.JsonSlurper(); def input = slrpr.parseText(opens); def df = new SimpleDateFormat(\"yyyy-MM-dd'T'HH:mm:ss'Z'\"); input.collect(df.parse(it.created_at[$date]).getTime())}, opens)

An error message is displayed like: 
![Screenshot 2025-04-07 at 6 55 45 PM](https://github.com/user-attachments/assets/4fe0d192-190e-4162-b72a-ba1c950ac425)

“ERROR [GroovyFunctionEvaluator] [grizzly-http-server-22] Groovy compilation error: Groovy({def slrpr= new groovy.json.JsonSlurper(); def input = slrpr.parseText(opens); def df = new SimpleDateFormat(\"yyyy-MM-dd'T'HH:mm:ss'Z'\"); input.collect(df.parse(it.created_at[$date]).getTime())}, opens) org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed: Script1.groovy: 1: unexpected char: '\' @ line 1, column 109.
   def df = new SimpleDateFormat(\"yyyy-MM-
                                 ^

1 error”