### PR TITLE
Fix HttpsSegmentFetcher to use the configurable timeouts

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -44,9 +44,9 @@ import org.apache.pinot.spi.utils.retry.RetryPolicies;
 
 public class HttpSegmentFetcher extends BaseSegmentFetcher {
   protected FileUploadDownloadClient _httpClient;
-  private static final String CONNECTION_REQUEST_TIMEOUT_CONFIG_KEY =
+  public static final String CONNECTION_REQUEST_TIMEOUT_CONFIG_KEY =
       "http.request.connectionRequestTimeoutMs";
-  private static final String SOCKET_TIMEOUT_CONFIG_KEY = "http.request.socketTimeoutMs";
+  public static final String SOCKET_TIMEOUT_CONFIG_KEY = "http.request.socketTimeoutMs";
   private int _connectionRequestTimeoutMs;
   private int _socketTimeoutMs;
 
@@ -54,6 +54,17 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   void setHttpClient(FileUploadDownloadClient httpClient) {
     _httpClient = httpClient;
   }
+
+  @VisibleForTesting
+  public int getConnectionRequestTimeoutMs() {
+    return _connectionRequestTimeoutMs;
+  }
+
+  @VisibleForTesting
+  public int getSocketTimeoutMs() {
+    return _socketTimeoutMs;
+  }
+
 
   @Override
   protected void doInit(PinotConfiguration config) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
@@ -71,5 +71,6 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
 
     SSLContext sslContext = new ClientSSLContextGenerator(sslConfig).generate();
     _httpClient = new FileUploadDownloadClient(HttpClientConfig.newBuilder(config).build(), sslContext);
+    super.doInit(config);
   }
 }


### PR DESCRIPTION
In https://github.com/apache/pinot/pull/15010, we added configs to make http request/client timeouts tunable. 

However, these configs are not applied to `HttpsSegmentFetcher`

So, in HttpsSegmentFetcher, we end up using `ConnectionRequestTimeoutMs = 0` and `socketTimeoutMs=0`. 


When we execute a request using this HttpClient, and no connection is immediately available in the pool, it leads to `ConnectionRequestTimeoutException` instead of waiting for an available connection.