### PR TITLE
Delete Znode of COMMITTING segments of a pauseless table when a table is deleted

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -376,6 +376,15 @@ public class ZKMetadataProvider {
     return propertyStore.remove(constructPropertyStorePathForSegment(tableNameWithType, segmentName),
         AccessOption.PERSISTENT);
   }
+  public static boolean removePauselessDebugMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    String pauselessDebugMetadataPath = constructPropertyStorePathForPauselessDebugMetadata(tableNameWithType);
+    if (propertyStore.exists(pauselessDebugMetadataPath, AccessOption.PERSISTENT)) {
+      return propertyStore.remove(pauselessDebugMetadataPath, AccessOption.PERSISTENT);
+    }
+    return true;
+  }
+
 
   @Nullable
   public static ZNRecord getZnRecord(ZkHelixPropertyStore<ZNRecord> propertyStore, String path) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2127,6 +2127,15 @@ public class PinotHelixResourceManager {
     ZKMetadataProvider.removeResourceSegmentsFromPropertyStore(_propertyStore, tableNameWithType);
     LOGGER.info("Deleting table {}: Removed segment metadata", tableNameWithType);
 
+    // Remove COMMITTING segment list
+    if (TableNameBuilder.REALTIME.equals(tableType)) {
+      if (ZKMetadataProvider.removePauselessDebugMetadata(_propertyStore, tableNameWithType)) {
+        LOGGER.info("Deleting table {}: Removed pauseless debug metadata", tableNameWithType);
+      } else {
+        LOGGER.info("Deleting table {}: Failed to remove pauseless debug metadata.", tableNameWithType);
+      }
+    }
+
     // Remove instance partitions
     if (tableType == TableType.OFFLINE) {
       InstancePartitionsUtils.removeInstancePartitions(_propertyStore, tableNameWithType);


### PR DESCRIPTION
## Scope of the PR

- The znode of contains committing segments for a pauseless table was kept dangling when a table was deleted. 
- The changes allow deletion of this node when a table is deleted
- The deletion will happen for Realtime tables irrespective of whether pauseless is enabled or not
    -  This has been done to ensure that the COMMITTING segments are cleared for a table for which pauseless has been disabled

## List of API's that will trigger this deletion

```
/tables/{tableName}
/tableConfigs/{tableName}
/databases/{databaseName}
```

## Handling deleted segments
- The removal of deleted segments from this metadata is already handled by the function `getCommittingSegments` called from `syncCommittingSegments`