### PR TITLE
Preserve the Order of the Pre-check Items

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -78,6 +78,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
 
     LOGGER.info("Start pre-checks for table: {} with rebalanceJobId: {}", tableNameWithType, rebalanceJobId);
 
+    // If pre-check items are to be done in parallel, we should not use linked hash map but to sort the result in the
+    // end
     Map<String, RebalancePreCheckerResult> preCheckResult = new LinkedHashMap<>();
     // Check for reload status
     preCheckResult.put(NEEDS_RELOAD_STATUS, checkReloadNeededOnServers(rebalanceJobId, tableNameWithType,
@@ -131,7 +133,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
       Map<String, JsonNode> needsReloadMetadata = needsReloadMetadataPair.getServerReloadJsonResponses();
       int failedResponses = needsReloadMetadataPair.getNumFailedResponses();
       LOGGER.info("Received {} needs reload responses and {} failed responses from servers for table: {} with "
-          + "rebalanceJobId: {}, number of servers queried: {}", needsReloadMetadata.size(), failedResponses,
+              + "rebalanceJobId: {}, number of servers queried: {}", needsReloadMetadata.size(), failedResponses,
           tableNameWithType, rebalanceJobId, currentlyAssignedServers.size());
       needsReload = needsReloadMetadata.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
       if (!needsReload && failedResponses > 0) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,7 +78,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
 
     LOGGER.info("Start pre-checks for table: {} with rebalanceJobId: {}", tableNameWithType, rebalanceJobId);
 
-    Map<String, RebalancePreCheckerResult> preCheckResult = new HashMap<>();
+    Map<String, RebalancePreCheckerResult> preCheckResult = new LinkedHashMap<>();
     // Check for reload status
     preCheckResult.put(NEEDS_RELOAD_STATUS, checkReloadNeededOnServers(rebalanceJobId, tableNameWithType,
         preCheckContext.getCurrentAssignment()));


### PR DESCRIPTION
## Description

To preserve a certain order of the pre-check items. Use `LinkedHashMap` instead of `HashMap` to store the pre-check result. It will order the items as inserting order. We have the inserting order: 
https://github.com/apache/pinot/blob/b9da6a7786a1e46dc6dda68be872dae668de0c2b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java#L82-L100


### Before
<img width="908" alt="image" src="https://github.com/user-attachments/assets/a7fdd7f3-be9d-4263-bbd7-f5f0e7d6929f" />

### After
<img width="911" alt="image" src="https://github.com/user-attachments/assets/c05522c8-1719-4129-9fb9-f6f9829ca29e" />

## Note
If pre-check items are to be done in parallel in the future, then we should sort the items in the end instead of using linked hash map.