### PR TITLE
Add tests to clarify the limits of base64 encoded string detector.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformer.java
@@ -94,8 +94,8 @@ import org.slf4j.LoggerFactory;
  * }
  * Apart from the basic transformation above, this transformer today also does the following additional tasks (which in
  * future can be decoupled from this transformer):
- *    1. Put all field + value pair in a special column "_mergedTextIndex" to facilitate text indexing and search. This
- *       extra step can be enabled via mergedTextIndexFieldSpec.
+ *    1. Put all field + value pair in a special column "_mergedTextIndex" to facilitate full text indexing and search.
+ *    This extra step can be enabled via mergedTextIndexFieldSpec.
  *    2. Allow users to tag certain fields in the input record not to be included in the catch-all field.
  * </pre>
  * <p>
@@ -338,7 +338,8 @@ public class SchemaConformingTransformer implements RecordTransformer {
       putExtrasField(_transformerConfig.getUnindexableExtrasField(), _unindexableExtrasFieldType,
           extraFieldsContainer.getUnindexableExtras(), outputRecord);
 
-      // Generate merged text index
+      // Generate merged text index. This optional step puts all field + value pairs in the input record in a special
+      // column "_mergedTextIndex" to perform full text indexing and search.
       if (null != _mergedTextIndexFieldSpec && !mergedTextIndexMap.isEmpty()) {
         List<String> luceneDocuments = getLuceneDocumentsFromMergedTextIndexMap(mergedTextIndexMap);
         if (_mergedTextIndexFieldSpec.isSingleValueField()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/SchemaConformingTransformerTest.java
@@ -1037,13 +1037,20 @@ public class SchemaConformingTransformerTest {
     String binaryDataWithTrailingPeriods = "ABCxyz12345-_+/=..";
     String binaryDataWithRandomPeriods = "A.BCxy.z12345-_+/=..";
     String shortBinaryData = "short";
+    String longBinaryDataWithColon = "field:1:1:v1Cgy+ypzk8yf9JzsdkBjvZ1jM8Mem/BTtNilst64Df/34xmJzeRstmihpfrWZ";
+    String jsonBinaryData = "{\"field\":\"text:1:1:v1Cgy+ypzk8yf9JzsdkBjvZ1jM8Mem/BTtNilst64Df/34xmJzeRstmihpfrWZ\"}";
     int minLength = 10;
 
+    // A space is not expected in a based64 encoded string.
     assertFalse(SchemaConformingTransformer.base64ValueFilter(text.getBytes(), minLength));
     assertTrue(SchemaConformingTransformer.base64ValueFilter(binaryData.getBytes(), minLength));
     assertTrue(SchemaConformingTransformer.base64ValueFilter(binaryDataWithTrailingPeriods.getBytes(), minLength));
     assertFalse(SchemaConformingTransformer.base64ValueFilter(binaryDataWithRandomPeriods.getBytes(), minLength));
     assertFalse(SchemaConformingTransformer.base64ValueFilter(shortBinaryData.getBytes(), minLength));
+    // A colon : is not expected in base64 encoded string.
+    assertFalse(SchemaConformingTransformer.base64ValueFilter(longBinaryDataWithColon.getBytes(), minLength));
+    // Json string can not be detected as base64 encoded string even one field has base64 encoded strings.
+    assertFalse(SchemaConformingTransformer.base64ValueFilter(jsonBinaryData.getBytes(), minLength));
   }
 
   @Test


### PR DESCRIPTION
 - `testing`
- `cleanup`

Today the base64 detector used in the SchemaConformingTransformer can not classify base64 strings correctly if the the base64 strings are part of a longer string. These tests added clarify the limits.
