### PR TITLE
Normalize excessive whitespaces in sql to avoid regex performance issues

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -100,7 +100,7 @@ public class CalciteSqlParser {
       throws SqlCompilationException {
     long parseStartTimeNs = System.nanoTime();
 
-    sql = ParserUtils.sanitizeSqlForParsing(sql);
+    sql = ParserUtils.sanitizeSql(sql);
 
     // extract and remove OPTIONS string
     List<String> options = extractOptionsFromSql(sql);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -100,6 +100,8 @@ public class CalciteSqlParser {
       throws SqlCompilationException {
     long parseStartTimeNs = System.nanoTime();
 
+    sql = ParserUtils.sanitizeSqlForParsing(sql);
+
     // extract and remove OPTIONS string
     List<String> options = extractOptionsFromSql(sql);
     if (!options.isEmpty()) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
@@ -49,9 +49,6 @@ public class ParserUtils {
    *         or {@code null} if the input was {@code null}.
    */
   public static String sanitizeSqlForParsing(String sql) {
-    if (sql == null) {
-      return null;
-    }
 
     // 1. Remove excessive whitespace
 
@@ -76,11 +73,14 @@ public class ParserUtils {
       }
     }
 
+    if (sql.length() == builder.length()) {
+      return sql; // No excessive whitespace found
+    }
+
     // Likewise extend for other improvements
 
-    return builder.toString().trim();
+    return builder.toString();
   }
-
 
   private static void validateJsonExtractScalarFunction(List<Expression> operands) {
     // Check that there are 3 or 4 arguments

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
@@ -39,6 +39,49 @@ public class ParserUtils {
     }
   }
 
+  /**
+   * Sanitize the sql string for parsing by normalizing whitespace which can
+   * cause performance issues with regex based parsing.
+   * This method replaces multiple consecutive whitespace characters with a single space.
+   *
+   * @param sql The raw SQL string to sanitize. May be null.
+   * @return A sanitized SQL string with normalized whitespace and no trailing spaces,
+   *         or {@code null} if the input was {@code null}.
+   */
+  public static String sanitizeSqlForParsing(String sql) {
+    if (sql == null) {
+      return null;
+    }
+
+    // 1. Remove excessive whitespace
+
+    int length = sql.length();
+    StringBuilder builder = new StringBuilder(length);
+    boolean inWhitespaceBlock = false;
+
+    for (int charIndex = 0; charIndex < length; charIndex++) {
+      char currentChar = sql.charAt(charIndex);
+
+      if (Character.isWhitespace(currentChar)) {
+        if (currentChar == '\n' || currentChar == '\r') {
+          builder.append(currentChar); // preserve line breaks
+          inWhitespaceBlock = false; // reset space block
+        } else if (!inWhitespaceBlock) {
+          builder.append(' ');
+          inWhitespaceBlock = true;
+        }
+      } else {
+        builder.append(currentChar);
+        inWhitespaceBlock = false; // reset space block
+      }
+    }
+
+    // Likewise extend for other improvements
+
+    return builder.toString().trim();
+  }
+
+
   private static void validateJsonExtractScalarFunction(List<Expression> operands) {
     // Check that there are 3 or 4 arguments
     int numOperands = operands.size();

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/ParserUtils.java
@@ -40,46 +40,24 @@ public class ParserUtils {
   }
 
   /**
-   * Sanitize the sql string for parsing by normalizing whitespace which can
-   * cause performance issues with regex based parsing.
-   * This method replaces multiple consecutive whitespace characters with a single space.
-   *
-   * @param sql The raw SQL string to sanitize. May be null.
-   * @return A sanitized SQL string with normalized whitespace and no trailing spaces,
-   *         or {@code null} if the input was {@code null}.
+   * Sanitize the sql string for parsing by normalizing whitespace
+   * which is likely to cause performance issues with regex parsing.
+   * @param sql string to sanitize
+   * @return sanitized sql string
    */
-  public static String sanitizeSqlForParsing(String sql) {
+  public static String sanitizeSql(String sql) {
 
-    // 1. Remove excessive whitespace
+    // 1. Remove trailing whitespaces
 
-    int length = sql.length();
-    StringBuilder builder = new StringBuilder(length);
-    boolean inWhitespaceBlock = false;
-
-    for (int charIndex = 0; charIndex < length; charIndex++) {
-      char currentChar = sql.charAt(charIndex);
-
-      if (Character.isWhitespace(currentChar)) {
-        if (currentChar == '\n' || currentChar == '\r') {
-          builder.append(currentChar); // preserve line breaks
-          inWhitespaceBlock = false; // reset space block
-        } else if (!inWhitespaceBlock) {
-          builder.append(' ');
-          inWhitespaceBlock = true;
-        }
-      } else {
-        builder.append(currentChar);
-        inWhitespaceBlock = false; // reset space block
-      }
+    int endIndex = sql.length() - 1;
+    while (endIndex >= 0 && Character.isWhitespace(sql.charAt(endIndex))) {
+      endIndex--;
     }
-
-    if (sql.length() == builder.length()) {
-      return sql; // No excessive whitespace found
-    }
+    sql = sql.substring(0, endIndex + 1);
 
     // Likewise extend for other improvements
 
-    return builder.toString();
+    return sql;
   }
 
   private static void validateJsonExtractScalarFunction(List<Expression> operands) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
@@ -28,22 +28,32 @@ public class ParserUtilsTest {
 
     testRemoveExcessiveWhiteSpace(
       "SELECT * FROM mytable " + " ".repeat(20000),
-      "SELECT * FROM mytable "
-    );
-
-    testRemoveExcessiveWhiteSpace(
-      "SELECT * FROM " + " ".repeat(20000) + " mytable",
       "SELECT * FROM mytable"
     );
 
     testRemoveExcessiveWhiteSpace(
+      "SELECT * FROM " + " ".repeat(20000) + " mytable",
+      "SELECT * FROM " + " ".repeat(20000) + " mytable"
+    );
+
+    testRemoveExcessiveWhiteSpace(
       "SELECT * " + " ".repeat(20000) + "FROM mytable " + " ".repeat(20000),
-      "SELECT * FROM mytable "
+      "SELECT * " + " ".repeat(20000) + "FROM mytable"
     );
 
     testRemoveExcessiveWhiteSpace(
       "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000),
-      "SELECT * FROM mytable options(a=b) "
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)"
+    );
+
+    testRemoveExcessiveWhiteSpace(
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b) /* comment */" + " ".repeat(20000),
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b) /* comment */"
+    );
+
+    testRemoveExcessiveWhiteSpace(
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000) + " /* comment */",
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000) + " /* comment */"
     );
   }
 
@@ -51,7 +61,7 @@ public class ParserUtilsTest {
       String sqlWithExcessiveWhitespace,
       String expectedSqlAfterSanitization
   ) {
-    String sanitizedSql = ParserUtils.sanitizeSqlForParsing(sqlWithExcessiveWhitespace);
+    String sanitizedSql = ParserUtils.sanitizeSql(sqlWithExcessiveWhitespace);
     Assert.assertEquals(sanitizedSql, expectedSqlAfterSanitization);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
@@ -28,7 +28,7 @@ public class ParserUtilsTest {
 
     testRemoveExcessiveWhiteSpace(
       "SELECT * FROM mytable " + " ".repeat(20000),
-      "SELECT * FROM mytable"
+      "SELECT * FROM mytable "
     );
 
     testRemoveExcessiveWhiteSpace(
@@ -38,12 +38,12 @@ public class ParserUtilsTest {
 
     testRemoveExcessiveWhiteSpace(
       "SELECT * " + " ".repeat(20000) + "FROM mytable " + " ".repeat(20000),
-      "SELECT * FROM mytable"
+      "SELECT * FROM mytable "
     );
 
     testRemoveExcessiveWhiteSpace(
-        "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000),
-      "SELECT * FROM mytable options(a=b)"
+      "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000),
+      "SELECT * FROM mytable options(a=b) "
     );
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/ParserUtilsTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ParserUtilsTest {
+
+  @Test
+  public void testRemoveExcessiveWhiteSpace() {
+
+    testRemoveExcessiveWhiteSpace(
+      "SELECT * FROM mytable " + " ".repeat(20000),
+      "SELECT * FROM mytable"
+    );
+
+    testRemoveExcessiveWhiteSpace(
+      "SELECT * FROM " + " ".repeat(20000) + " mytable",
+      "SELECT * FROM mytable"
+    );
+
+    testRemoveExcessiveWhiteSpace(
+      "SELECT * " + " ".repeat(20000) + "FROM mytable " + " ".repeat(20000),
+      "SELECT * FROM mytable"
+    );
+
+    testRemoveExcessiveWhiteSpace(
+        "SELECT * FROM mytable" + " ".repeat(20000) + " options(a=b)" + " ".repeat(20000),
+      "SELECT * FROM mytable options(a=b)"
+    );
+  }
+
+  private void testRemoveExcessiveWhiteSpace(
+      String sqlWithExcessiveWhitespace,
+      String expectedSqlAfterSanitization
+  ) {
+    String sanitizedSql = ParserUtils.sanitizeSqlForParsing(sqlWithExcessiveWhitespace);
+    Assert.assertEquals(sanitizedSql, expectedSqlAfterSanitization);
+  }
+}


### PR DESCRIPTION
## Summary
This change strips trailing whitespaces to prevent excessive backtracking in the query options parser, which significantly slowed down parsing when no query options were specified.


The query options regex is
```java
private static final Pattern OPTIONS_REGEX_PATTEN =
      Pattern.compile("\\s*option\\s*\\(([^)]+)\\)\\s*;?\\s*\\Z", Pattern.CASE_INSENSITIVE);
```

## Improvement

Created a synthetic SQL query with a large amount of trailing whitespace to highlight the difference in behaviour:

```java
String sql = "SELECT * FROM t " + " ".repeat(20000);
```

- Query options parser runtime before: ~1100- 1500ms (can go higher as well)
- Query options parser runtime after: <10ms (Most test runs succeeded in 1ms)