### PR TITLE
[Issue 12676 - Part 2.1] Adding com.google.api.grpc:proto-google-common-protos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1237,6 +1237,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- com.google.api.grpc:proto-google-common-protos needs to appear before com.google.cloud:libraries-bom -->
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>${proto-google-common-protos.version}</version>
+      </dependency>
       <!-- libraries-bom should be imported after protobuf-bom and grpc-bom to honor their versions -->
       <dependency>
         <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,7 @@
     <ipaddress.version>5.5.1</ipaddress.version>
     <openhft.posix.version>2.27ea1</openhft.posix.version>
     <openhft.chronicle-core.version>2.27ea2</openhft.chronicle-core.version>
+    <proto-google-common-protos.version>2.54.1</proto-google-common-protos.version>
 
     <!-- Test Libraries -->
     <testng.version>7.11.0</testng.version>


### PR DESCRIPTION
As per the discussion in [#15437](https://github.com/apache/pinot/pull/15437), I have added `com.google.api.grpc:proto-google-common-protos` to the root POM before the declaration of `com.google.cloud:libraries-bom`.

I made this change because some Google Cloud libraries override the version defined in `io.grpc` bom. Since`com.google.api.grpc:proto-google-common-protos` is a transitive dependency that can be overridden, explicitly pinning its version before importing google cloud libraries allows it to control its version.

Referenced comments:
https://github.com/apache/pinot/pull/15437#discussion_r2027407183
https://github.com/apache/pinot/pull/15437#discussion_r2029552651

cc @siddharthteotia @gviedma 