### PR TITLE
[Issue 12676 - Part 2.2] Define versions from submodule POMs in root POM

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -419,7 +419,7 @@
               <dependency>
                 <groupId>net.sourceforge.fmpp</groupId>
                 <artifactId>fmpp</artifactId>
-                <version>0.9.16</version>
+                <version>${fmpp.version}</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <s3mock.version>2.17.0</s3mock.version>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.github.os72</groupId>
       <artifactId>protobuf-dynamic</artifactId>
-      <version>1.0.1</version>
+      <version>${protobuf-dynamic.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -32,7 +32,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <localstack-utils.version>0.2.23</localstack-utils.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,10 @@
     <jbcrypt.version>0.4</jbcrypt.version>
     <plexus-classworlds.version>2.9.0</plexus-classworlds.version>
     <scala-xml.version>2.3.0</scala-xml.version>
+    <fmpp.version>0.9.16</fmpp.version>
+    <s3mock.version>2.17.0</s3mock.version>
+    <localstack-utils.version>0.2.23</localstack-utils.version>
+    <protobuf-dynamic.version>1.0.1</protobuf-dynamic.version>
 
     <spark2.version>2.4.8</spark2.version>
     <spark3.version>3.5.3</spark3.version>


### PR DESCRIPTION
Continue the work on the proposal outlined in the issue [#12676](https://github.com/apache/pinot/issues/12676).

I have done the following:
1. I moved the version declarations from submodules POM to the root POM. 
    - Affected dependencies: 
       - `com.adobe.testing:s3mock-testcontainers` 
       - `cloud.localstack:localstack-utils`
2. I declared the dependency version in the root POM and replaced the hardcoded number with the variables defined in the root POM.
    - Affected dependencies: 
       - `net.sourceforge.fmpp:fmpp`
       - `com.github.os72:protobuf-dynamic`
3. There is a version conflict between `scala-library` 2.12.20 (from the root POM) and 2.13.16 (from `pinot-confluent-json`). I used `maven-shade-plugin` to relocate the `scala-library` dependency from `pinot-confluent-json` plugin.

@siddharthteotia @gviedma 