### PR TITLE
Expose more parameters in rebalance config via controller config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -908,7 +908,7 @@ public class ControllerConf extends PinotConfiguration {
   @Deprecated
   public int getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() {
     return Optional.ofNullable(
-            getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
+        getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> getProperty(
             ControllerPeriodicTasksConf.
                 DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -199,10 +199,10 @@ public class ControllerConf extends PinotConfiguration {
     public static final String SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY =
         "controller.segmentRelocator.rebalanceTablesSequentially";
     public static final String SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING =
-        "controller.segmentRelocator.rebalanceIncludeConsuming";
+        "controller.segmentRelocator.includeConsuming";
     // Available options are: "ENABLE", "DISABLE", "DEFAULT"
     public static final String SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT =
-        "controller.segmentRelocator.rebalanceMinimizeDataMovement";
+        "controller.segmentRelocator.minimizeDataMovement";
 
     public static final String REBALANCE_CHECKER_FREQUENCY_PERIOD = "controller.rebalance.checker.frequencyPeriod";
     // Because segment level validation is expensive and requires heavy ZK access, we run segment level validation

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -200,6 +200,7 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segmentRelocator.rebalanceTablesSequentially";
     public static final String SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING =
         "controller.segmentRelocator.rebalanceIncludeConsuming";
+    // Available options are: "ENABLE", "DISABLE", "DEFAULT"
     public static final String SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT =
         "controller.segmentRelocator.rebalanceMinimizeDataMovement";
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -198,6 +198,10 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segmentRelocator.enableLocalTierMigration";
     public static final String SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY =
         "controller.segmentRelocator.rebalanceTablesSequentially";
+    public static final String SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING =
+        "controller.segmentRelocator.rebalanceIncludeConsuming";
+    public static final String SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT =
+        "controller.segmentRelocator.rebalanceMinimizeDataMovement";
 
     public static final String REBALANCE_CHECKER_FREQUENCY_PERIOD = "controller.rebalance.checker.frequencyPeriod";
     // Because segment level validation is expensive and requires heavy ZK access, we run segment level validation
@@ -800,6 +804,20 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY, false);
   }
 
+  public boolean isSegmentRelocatorIncludingConsuming() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING, false);
+  }
+
+  public RebalanceConfig.MinimizeDataMovementOptions getSegmentRelocatorRebalanceMinimizeDataMovement() {
+    String value = getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT,
+        RebalanceConfig.MinimizeDataMovementOptions.ENABLE.name());
+    try {
+      return RebalanceConfig.MinimizeDataMovementOptions.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return RebalanceConfig.MinimizeDataMovementOptions.ENABLE;
+    }
+  }
+
   public boolean tieredSegmentAssignmentEnabled() {
     return getProperty(CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT, false);
   }
@@ -889,7 +907,7 @@ public class ControllerConf extends PinotConfiguration {
   @Deprecated
   public int getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() {
     return Optional.ofNullable(
-        getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
+            getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> getProperty(
             ControllerPeriodicTasksConf.
                 DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
@@ -1108,7 +1126,6 @@ public class ControllerConf extends PinotConfiguration {
   public void setUntrackedSegmentDeletionEnabled(boolean untrackedSegmentDeletionEnabled) {
     setProperty(ControllerPeriodicTasksConf.ENABLE_UNTRACKED_SEGMENT_DELETION, untrackedSegmentDeletionEnabled);
   }
-
 
   public long getPinotTaskManagerInitialDelaySeconds() {
     return getPeriodicTaskInitialDelayInSeconds();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -74,6 +74,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
   private final boolean _bestEfforts;
   private final long _externalViewCheckIntervalInMs;
   private final long _externalViewStabilizationTimeoutInMs;
+  private final boolean _includeConsuming;
+  private final RebalanceConfig.MinimizeDataMovementOptions _minimizeDataMovement;
 
   private final Set<String> _waitingTables;
   private final BlockingQueue<String> _waitingQueue;
@@ -94,6 +96,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     _downtime = config.getSegmentRelocatorDowntime();
     _minAvailableReplicas = config.getSegmentRelocatorMinAvailableReplicas();
     _bestEfforts = config.getSegmentRelocatorBestEfforts();
+    _includeConsuming = config.isSegmentRelocatorIncludingConsuming();
+    _minimizeDataMovement = config.getSegmentRelocatorRebalanceMinimizeDataMovement();
     // Best effort to let inner part of the task run no longer than the task interval, although not enforced strictly.
     long taskIntervalInMs = config.getSegmentRelocatorFrequencyInSeconds() * 1000L;
     _externalViewCheckIntervalInMs =
@@ -187,6 +191,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     rebalanceConfig.setExternalViewCheckIntervalInMs(_externalViewCheckIntervalInMs);
     rebalanceConfig.setExternalViewStabilizationTimeoutInMs(_externalViewStabilizationTimeoutInMs);
     rebalanceConfig.setUpdateTargetTier(TierConfigUtils.shouldRelocateToTiers(tableConfig));
+    rebalanceConfig.setIncludeConsuming(_includeConsuming);
+    rebalanceConfig.setMinimizeDataMovement(_minimizeDataMovement);
 
     try {
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.


### PR DESCRIPTION
## Description

In most cases, particuarly for tables using tiered storage, this segmentRelocator is used to move committed segments to remote tier. Given this `includeConsuming=false` and `minimizeDataMovement=ENABLE` is the more reasonable default.

New controller configs: 
* `controller.segmentRelocator.rebalanceIncludeConsuming`, default=false
* `controller.segmentRelocator.rebalanceMinimizeDataMovement`, default=ENABLE (options: `ENABLE`, `DISABLE`, `DEFAULT`)