### PR TITLE
Part 2: Enhance rebalance progress stats - Rollback Progress Stats Support

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
@@ -42,6 +42,10 @@ public class NoOpTableRebalanceObserver implements TableRebalanceObserver {
   }
 
   @Override
+  public void onRollback() {
+  }
+
+  @Override
   public boolean isStopped() {
     return false;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
@@ -49,6 +49,8 @@ public interface TableRebalanceObserver {
 
   void onError(String errorMsg);
 
+  void onRollback();
+
   boolean isStopped();
 
   RebalanceResult.Status getStopStatus();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
@@ -339,6 +339,24 @@ public class TableRebalanceProgressStats {
       _startTimeMs = 0;
     }
 
+    RebalanceProgressStats(RebalanceProgressStats other) {
+      _totalSegmentsToBeAdded = other._totalSegmentsToBeAdded;
+      _totalSegmentsToBeDeleted = other._totalSegmentsToBeDeleted;
+      _totalRemainingSegmentsToBeAdded = other._totalRemainingSegmentsToBeAdded;
+      _totalRemainingSegmentsToBeDeleted = other._totalRemainingSegmentsToBeDeleted;
+      _totalRemainingSegmentsToConverge = other._totalRemainingSegmentsToConverge;
+      _totalCarryOverSegmentsToBeAdded = other._totalCarryOverSegmentsToBeAdded;
+      _totalCarryOverSegmentsToBeDeleted = other._totalCarryOverSegmentsToBeDeleted;
+      _totalUniqueNewUntrackedSegmentsDuringRebalance = other._totalUniqueNewUntrackedSegmentsDuringRebalance;
+      _percentageRemainingSegmentsToBeAdded = other._percentageRemainingSegmentsToBeAdded;
+      _percentageRemainingSegmentsToBeDeleted = other._percentageRemainingSegmentsToBeDeleted;
+      _estimatedTimeToCompleteAddsInSeconds = other._estimatedTimeToCompleteAddsInSeconds;
+      _estimatedTimeToCompleteDeletesInSeconds = other._estimatedTimeToCompleteDeletesInSeconds;
+      _averageSegmentSizeInBytes = other._averageSegmentSizeInBytes;
+      _totalEstimatedDataToBeMovedInBytes = other._totalEstimatedDataToBeMovedInBytes;
+      _startTimeMs = other._startTimeMs;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (!(o instanceof RebalanceProgressStats)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -79,6 +79,9 @@ public class TestZkBasedTableRebalanceObserver {
         rebalanceContext);
     // Both of the changes above will update ZK for progress stats
     assertEquals(observer.getNumUpdatesToZk(), 4);
+    // Try a rollback and this should trigger a ZK update as well
+    observer.onRollback();
+    assertEquals(observer.getNumUpdatesToZk(), 5);
   }
 
   @Test


### PR DESCRIPTION
Add rollback support for rebalance progress stats on IdealState update failure

As part of PR https://github.com/apache/pinot/pull/15266, progress stats were enhanced for Table rebalance. A scenario (details: https://github.com/apache/pinot/pull/15266#issuecomment-2779453530) was found where when the IdealState update fails due to version change, the progress stats may not reflect correctly until the next IS stats trigger.

This PR addresses the above by adding a rollback mechanism to rollback the stats when the above scenario is detected. This scenario is more likely to be hit when `bestEffort=true`.

Testing:
- Did testing with `HybridQuickStart`:
    - `StrictReplicaGroupAssignment` testing (which keeps detecting newly added segments tracked by rebalance)
    - `forceCommit` during rebalance for REALTIME tables
    - `bestEfforts=true` testing
    - Offline / realtime table testing
Verified that the rollback code is indeed called when the IS update fails due to version change and stats are correctly rolled back to before the IS update

Note: The test setup used is very similar to https://github.com/apache/pinot/pull/15266 where I added delays in segment state transition processing to emulate a more realistic scenario of segment processing taking time.

cc @raghavyadav01 @J-HowHuang @klsince @Jackie-Jiang 