### PR TITLE
[bugfix][ui] Fixes for table rebalance UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
@@ -64,7 +64,13 @@ export const RebalanceResponse = ({ response }) => {
             {
                 responseSectionsToShow.map((section) => {
                     if (Object.keys(response).includes(section.key)) {
-                        return <RebalanceServerSectionResponse key={section.key} sectionTitle={section.name} sectionData={response[section.key]} />
+                        return (
+                            <Grid item xs={12}>
+                                <RebalanceServerResponseCard>
+                                    <RebalanceServerSectionResponse key={section.key} sectionTitle={section.name} sectionData={response[section.key]} />
+                                </RebalanceServerResponseCard>
+                            </Grid>
+                        );
                     }
                 })
             }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
@@ -18,7 +18,7 @@
  */
 import {RebalanceServerSection} from "./RebalanceServerSection";
 import React from 'react';
-import {Grid, Paper} from "@material-ui/core";
+import {Box, Grid, IconButton, Paper, Snackbar, Typography} from "@material-ui/core";
 import CustomCodemirror from "../../../CustomCodemirror";
 import {
     RebalanceServerSectionResponse
@@ -29,7 +29,31 @@ import {
     RebalanceServerRebalanceSummaryResponse
 } from "./RebalanceServerResponses/RebalanceServerRebalanceSummaryResponse";
 import {RebalanceServerResponseCard} from "./RebalanceServerResponses/RebalanceServerResponseCard";
+import {FileCopyOutlined} from "@material-ui/icons";
 
+const CopyJobIdToClipboardButton = ({ jobId }: { jobId: string }) => {
+    const [open, setOpen] = React.useState<boolean>(false);
+
+    const handleClick = () => {
+        setOpen(true);
+        navigator.clipboard.writeText(jobId);
+    };
+
+    return (
+        <>
+            <IconButton onClick={handleClick} color="primary">
+                <FileCopyOutlined color="disabled" fontSize="small" />
+            </IconButton>
+            <Snackbar
+                message="Copied job id to clibboard"
+                anchorOrigin={{ vertical: "top", horizontal: "center" }}
+                autoHideDuration={2000}
+                onClose={() => setOpen(false)}
+                open={open}
+            />
+        </>
+    );
+};
 export const RebalanceResponse = ({ response }) => {
     const responseSectionsToShow = [
         {
@@ -54,7 +78,15 @@ export const RebalanceResponse = ({ response }) => {
                         <Grid container spacing={2}>
                             <Grid item xs={6}><RebalanceServerResponseLabelValue label='Description' value={response.description} /></Grid>
                             <Grid item xs={6}><RebalanceServerResponseLabelValue label='Status' value={response.status} /></Grid>
-                            <Grid item xs={6}><RebalanceServerResponseLabelValue label='Job Id' value={response.jobId} /></Grid>
+                            <Grid item xs={6}>
+                                <Typography color='textSecondary' variant='caption'>Job Id</Typography>
+                                <Box flexDirection="row" display="flex" alignItems="center" marginTop={-1.25}>
+                                    <Typography style={{ fontWeight: 600 }} variant='body2'>
+                                        {response.jobId}
+                                    </Typography>
+                                    <CopyJobIdToClipboardButton jobId={response.jobId} />
+                                </Box>
+                            </Grid>
                         </Grid>
                     </RebalanceServerSection>
                 </Paper>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOption.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOption.tsx
@@ -29,14 +29,22 @@ import {
 } from "./RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect";
 
 export const RebalanceServerConfigurationOption = (
-    { option, handleConfigChange }: { option: RebalanceServerOption, handleConfigChange: (config: { [key: string]: string | number | boolean }) => void }) => {
+    {
+        option,
+        handleConfigChange,
+        rebalanceConfig
+    }: {
+        option: RebalanceServerOption,
+        handleConfigChange: (config: { [key: string]: string | number | boolean }) => void
+        rebalanceConfig: { [optionName: string]: string | boolean | number },
+    }) => {
     switch (option.type) {
         case "BOOL":
-            return <RebalanceServerConfigurationOptionSwitch option={option} handleConfigChange={handleConfigChange} />;
+            return <RebalanceServerConfigurationOptionSwitch rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
         case "INTEGER":
-            return <RebalanceServerConfigurationOptionInteger option={option} handleConfigChange={handleConfigChange} />;
+            return <RebalanceServerConfigurationOptionInteger rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
         case "SELECT":
-            return <RebalanceServerConfigurationOptionSelect option={option} handleConfigChange={handleConfigChange} />;
+            return <RebalanceServerConfigurationOptionSelect rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
         default:
             return null;
     }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionInteger.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionInteger.tsx
@@ -22,6 +22,7 @@ import {RebalanceServerOption} from "../RebalanceServerOptions";
 import {
     RebalanceServerConfigurationOptionLabel
 } from "./RebalanceServerConfigurationOptionLabel/RebalanceServerConfigurationOptionLabel";
+import Utils from "../../../../../utils/Utils";
 
 type RebalanceServerConfigurationOptionIntegerProps = {
     option: RebalanceServerOption;
@@ -32,7 +33,7 @@ export const RebalanceServerConfigurationOptionInteger = (
     { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionIntegerProps
 ) => {
     const [value, setValue] = useState<number>(
-        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as number
+        Utils.getRebalanceConfigValue(rebalanceConfig, option) as number
     );
     return (
         <Box display='flex' flexDirection='column'>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionInteger.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionInteger.tsx
@@ -26,11 +26,14 @@ import {
 type RebalanceServerConfigurationOptionIntegerProps = {
     option: RebalanceServerOption;
     handleConfigChange: (config: { [key: string]: string | number | boolean }) => void;
+    rebalanceConfig: { [optionName: string]: string | boolean | number };
 }
 export const RebalanceServerConfigurationOptionInteger = (
-    { option, handleConfigChange }: RebalanceServerConfigurationOptionIntegerProps
+    { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionIntegerProps
 ) => {
-    const [value, setValue] = useState<number>(option.defaultValue as number);
+    const [value, setValue] = useState<number>(
+        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as number
+    );
     return (
         <Box display='flex' flexDirection='column'>
             <FormControl fullWidth>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect.tsx
@@ -24,6 +24,7 @@ import {RebalanceServerOption} from "../RebalanceServerOptions";
 import {
     RebalanceServerConfigurationOptionLabel
 } from "./RebalanceServerConfigurationOptionLabel/RebalanceServerConfigurationOptionLabel";
+import Utils from "../../../../../utils/Utils";
 
 type RebalanceServerConfigurationOptionSelectProps = {
     option: RebalanceServerOption;
@@ -34,7 +35,7 @@ export const RebalanceServerConfigurationOptionSelect = (
     { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionSelectProps
 ) => {
     const [value, setValue] = useState<string>(
-        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as string
+        Utils.getRebalanceConfigValue(rebalanceConfig, option) as string
     );
     return (
         <Box display='flex' flexDirection='column'>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect.tsx
@@ -28,11 +28,14 @@ import {
 type RebalanceServerConfigurationOptionSelectProps = {
     option: RebalanceServerOption;
     handleConfigChange: (config: { [key: string]: string | number | boolean }) => void;
+    rebalanceConfig: { [optionName: string]: string | boolean | number };
 }
 export const RebalanceServerConfigurationOptionSelect = (
-    { option, handleConfigChange }: RebalanceServerConfigurationOptionSelectProps
+    { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionSelectProps
 ) => {
-    const [value, setValue] = useState<string>(option.defaultValue as string);
+    const [value, setValue] = useState<string>(
+        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as string
+    );
     return (
         <Box display='flex' flexDirection='column'>
             <FormControl fullWidth={true}>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionToggleSwitch.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionToggleSwitch.tsx
@@ -26,10 +26,13 @@ import {
 type RebalanceServerConfigurationOptionSwitchProps = {
     option: RebalanceServerOption;
     handleConfigChange: (config: { [key: string]: string | number | boolean }) => void;
+    rebalanceConfig: { [optionName: string]: string | boolean | number };
 }
 export const RebalanceServerConfigurationOptionSwitch = (
-    { option, handleConfigChange }: RebalanceServerConfigurationOptionSwitchProps) => {
-    const [isChecked, setIsChecked] = useState<boolean>(option.defaultValue as boolean);
+    { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionSwitchProps) => {
+    const [isChecked, setIsChecked] = useState<boolean>(
+        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as boolean
+    );
     return (
         <Box display='flex' flexDirection='column'>
             <FormControlLabel

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionToggleSwitch.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionToggleSwitch.tsx
@@ -22,6 +22,7 @@ import {RebalanceServerOption} from "../RebalanceServerOptions";
 import {
     RebalanceServerConfigurationOptionLabel
 } from "./RebalanceServerConfigurationOptionLabel/RebalanceServerConfigurationOptionLabel";
+import Utils from "../../../../../utils/Utils";
 
 type RebalanceServerConfigurationOptionSwitchProps = {
     option: RebalanceServerOption;
@@ -31,7 +32,7 @@ type RebalanceServerConfigurationOptionSwitchProps = {
 export const RebalanceServerConfigurationOptionSwitch = (
     { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionSwitchProps) => {
     const [isChecked, setIsChecked] = useState<boolean>(
-        (Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue) as boolean
+        Utils.getRebalanceConfigValue(rebalanceConfig, option) as boolean
     );
     return (
         <Box display='flex' flexDirection='column'>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
@@ -25,7 +25,7 @@ export const RebalanceServerResponseLabelValue = (
     return (
         <Box>
             <Typography color='textSecondary' variant='caption'>{label}</Typography>
-            <div><Typography style={{ fontWeight: 600 }} variant='body2'>{value.split("\n").join("<br />")}</Typography></div>
+            <Typography style={{ fontWeight: 600 }} variant='body2'>{value.split("\n").join("<br />")}</Typography>
         </Box>
     );
 }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
@@ -25,7 +25,7 @@ export const RebalanceServerResponseLabelValue = (
     return (
         <Box>
             <Typography color='textSecondary' variant='caption'>{label}</Typography>
-            <Typography style={{ fontWeight: 600 }} variant='body2'>{value}</Typography>
+            <div><Typography style={{ fontWeight: 600 }} variant='body2'>{value.split("\n").join("<br />")}</Typography></div>
         </Box>
     );
 }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
@@ -25,7 +25,7 @@ export const RebalanceServerResponseLabelValue = (
     return (
         <Box>
             <Typography color='textSecondary' variant='caption'>{label}</Typography>
-            <Typography style={{ fontWeight: 600 }} variant='body2'>{value.split("\n").join("<br />")}</Typography>
+            <Typography style={{ fontWeight: 600, whiteSpace: "pre" }} variant='body2'>{value}</Typography>
         </Box>
     );
 }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerTableOp.tsx
@@ -47,6 +47,14 @@ const DryRunAction = ({ handleOnRun, disabled }: { handleOnRun: () => void, disa
   );
 }
 
+const BackAction = ({ onClick }: { onClick: () => void }) => {
+  return (
+      <Button onClick={onClick} variant="outlined" color="primary">
+        Back
+      </Button>
+  );
+}
+
 export default function RebalanceServerTableOp({
   hideModal,
   tableName,
@@ -127,6 +135,10 @@ export default function RebalanceServerTableOp({
     )
   }
 
+  const handleBackBtnOnClick = () => {
+    setRebalanceResponse(null);
+  }
+
   return (
     <Dialog
       showTitleDivider
@@ -139,7 +151,11 @@ export default function RebalanceServerTableOp({
       handleSave={handleSave}
       btnOkText='Rebalance'
       showOkBtn={!rebalanceResponse}
-      moreActions={!rebalanceResponse ? <DryRunAction disabled={pending} handleOnRun={handleDryRun} /> : null}
+      moreActions={
+        !rebalanceResponse ?
+            <DryRunAction disabled={pending} handleOnRun={handleDryRun} /> :
+            <BackAction onClick={handleBackBtnOnClick} />
+      }
     >
         {!rebalanceResponse ?
           <Box flexDirection="column">
@@ -156,7 +172,7 @@ export default function RebalanceServerTableOp({
               <Grid container spacing={2}>
                 {rebalanceServerOptions.filter(option => !option.isAdvancedConfig && !option.isStatsGatheringConfig).map((option) => (
                     <Grid item xs={12} key={`basic-options-${option.name}`}>
-                      <RebalanceServerConfigurationOption option={option} handleConfigChange={handleConfigChange} />
+                      <RebalanceServerConfigurationOption rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />
                     </Grid>
                 ))}
               </Grid>
@@ -166,7 +182,7 @@ export default function RebalanceServerTableOp({
               <Grid container spacing={2}>
                 {rebalanceServerOptions.filter(option => option.isAdvancedConfig).map((option) => (
                     <Grid item xs={12} key={`advanced-options-${option.name}`}>
-                      <RebalanceServerConfigurationOption option={option} handleConfigChange={handleConfigChange} />
+                      <RebalanceServerConfigurationOption rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />
                     </Grid>
                 ))}
               </Grid>

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -32,6 +32,16 @@ import {
 } from 'Models';
 import Loading from '../components/Loading';
 import moment from "moment";
+import {RebalanceServerOption} from "../components/Homepage/Operations/RebalanceServer/RebalanceServerOptions";
+
+const getRebalanceConfigValue = (
+    rebalanceConfig: { [optionName: string]: string | boolean | number },
+    option: RebalanceServerOption
+) => {
+  return (
+      Object.keys(rebalanceConfig).includes(option.name) ? rebalanceConfig[option.name] : option.defaultValue
+  );
+}
 
 const sortArray = function (sortingArr, keyName, ascendingFlag) {
   if (ascendingFlag) {
@@ -483,5 +493,6 @@ export default {
   pinotTableDetailsFormat,
   pinotTableDetailsFromArray,
   getLoadingTableData,
-  formatTime
+  formatTime,
+  getRebalanceConfigValue
 };


### PR DESCRIPTION
### Description
This PR adds the following fixes:

1. Adds a `back` button to go back after `Dry Run` or `Rebalance` action.
2. Adds boxes around `segment map` and `instance map`
3. Sorts the table rebalance response on the basis of `submissionTimeMs`
4. Handles rendering of `\n`
5. Adds new copy button


https://github.com/user-attachments/assets/b3a8c80d-15d2-4c81-b6cd-4701f817b34a



