### PR TITLE
Metrics that Tracks the Number of Table Rebalance Job In Progress

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -181,6 +181,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   TABLE_REBALANCE_IN_PROGRESS("tableRebalanceInProgress", false),
 
+  TABLE_REBALANCE_IN_PROGRESS_GLOBAL("jobs", true),
+
   // Number of reingested segments getting uploaded
   REINGESTED_SEGMENT_UPLOADS_IN_PROGRESS("reingestedSegmentUploadsInProgress", true),
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -62,6 +62,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false),
   SEGMENT_MISSING_DEEP_STORE_LINK("RealtimeSegmentMissingDeepStoreLink", false),
   DELETED_TMP_SEGMENT_COUNT("DeletedTmpSegmentCount", false),
+  TABLE_REBALANCE_IN_PROGRESS_GLOBAL("jobs", true),
   TABLE_REBALANCE_FAILURE_DETECTED("TableRebalanceFailureDetected", false),
   TABLE_REBALANCE_RETRY("TableRebalanceRetry", false),
   TABLE_REBALANCE_RETRY_TOO_MANY_TIMES("TableRebalanceRetryTooManyTimes", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -62,7 +62,6 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false),
   SEGMENT_MISSING_DEEP_STORE_LINK("RealtimeSegmentMissingDeepStoreLink", false),
   DELETED_TMP_SEGMENT_COUNT("DeletedTmpSegmentCount", false),
-  TABLE_REBALANCE_IN_PROGRESS_GLOBAL("jobs", true),
   TABLE_REBALANCE_FAILURE_DETECTED("TableRebalanceFailureDetected", false),
   TABLE_REBALANCE_RETRY("TableRebalanceRetry", false),
   TABLE_REBALANCE_RETRY_TOO_MANY_TIMES("TableRebalanceRetryTooManyTimes", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -35,6 +35,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -56,7 +57,7 @@ import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ControllerTimer;
 import org.apache.pinot.common.tier.PinotServerTierStorage;
@@ -141,6 +142,7 @@ public class TableRebalancer {
   // TODO: Consider making the timeoutMs below table rebalancer configurable
   private static final int TABLE_SIZE_READER_TIMEOUT_MS = 30_000;
   private static final int STREAM_PARTITION_OFFSET_READ_TIMEOUT_MS = 10_000;
+  private static final AtomicInteger _rebalanceJobCounter = new AtomicInteger(0);
   private final HelixManager _helixManager;
   private final HelixDataAccessor _helixDataAccessor;
   private final TableRebalanceObserver _tableRebalanceObserver;
@@ -182,11 +184,17 @@ public class TableRebalancer {
     String tableNameWithType = tableConfig.getTableName();
     RebalanceResult.Status status = RebalanceResult.Status.UNKNOWN_ERROR;
     try {
+      int jobCount = _rebalanceJobCounter.incrementAndGet();
+      if (_controllerMetrics != null) {
+        _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, jobCount);
+      }
       RebalanceResult result = doRebalance(tableConfig, rebalanceConfig, rebalanceJobId, providedTierToSegmentsMap);
       status = result.getStatus();
       return result;
     } finally {
+      int jobCount = _rebalanceJobCounter.decrementAndGet();
       if (_controllerMetrics != null) {
+        _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, jobCount);
         _controllerMetrics.addTimedTableValue(String.format("%s.%s", tableNameWithType, status.toString()),
             ControllerTimer.TABLE_REBALANCE_EXECUTION_TIME_MS, System.currentTimeMillis() - startTime,
             TimeUnit.MILLISECONDS);
@@ -421,10 +429,6 @@ public class TableRebalancer {
         estimatedAverageSegmentSizeInBytes, allSegmentsFromIdealState, segmentsToMonitor);
 
     // Record the beginning of rebalance
-    // We emit this metric only when the rebalance does get to this code path, i.e. excluding dry-run and downtime
-    if (_controllerMetrics != null) {
-      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, 1L);
-    }
     _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, currentAssignment,
         targetAssignment, rebalanceContext);
 
@@ -497,17 +501,11 @@ public class TableRebalancer {
         String errorMsg = "Caught exception while waiting for ExternalView to converge, aborting the rebalance";
         tableRebalanceLogger.warn(errorMsg, e);
         if (_tableRebalanceObserver.isStopped()) {
-          if (_controllerMetrics != null) {
-            _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
-          }
           return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
               "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
               tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
         }
         _tableRebalanceObserver.onError(errorMsg);
-        if (_controllerMetrics != null) {
-          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
-        }
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED,
             "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -583,9 +581,6 @@ public class TableRebalancer {
         tableRebalanceLogger.info(msg);
         // Record completion
         _tableRebalanceObserver.onSuccess(msg);
-        if (_controllerMetrics != null) {
-          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
-        }
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.DONE,
             "Success with minAvailableReplicas: " + minAvailableReplicas
                 + " (both IdealState and ExternalView should reach the target segment assignment)",
@@ -600,9 +595,6 @@ public class TableRebalancer {
       // Update the segment list as the IDEAL_STATE_CHANGE_TRIGGER should've captured the newly added / deleted segments
       allSegmentsFromIdealState = currentAssignment.keySet();
       if (_tableRebalanceObserver.isStopped()) {
-        if (_controllerMetrics != null) {
-          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
-        }
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState", instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -618,9 +610,6 @@ public class TableRebalancer {
       _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER,
           currentAssignment, nextAssignment, rebalanceContext);
       if (_tableRebalanceObserver.isStopped()) {
-        if (_controllerMetrics != null) {
-          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
-        }
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState with the next assignment",
             instancePartitionsMap, tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -56,6 +56,7 @@ import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ControllerTimer;
 import org.apache.pinot.common.tier.PinotServerTierStorage;
@@ -420,6 +421,8 @@ public class TableRebalancer {
         estimatedAverageSegmentSizeInBytes, allSegmentsFromIdealState, segmentsToMonitor);
 
     // Record the beginning of rebalance
+    // We emit this metric only when the rebalance does get to this code path, i.e. excluding dry-run and downtime
+    _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, 1L);
     _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, currentAssignment,
         targetAssignment, rebalanceContext);
 
@@ -492,11 +495,13 @@ public class TableRebalancer {
         String errorMsg = "Caught exception while waiting for ExternalView to converge, aborting the rebalance";
         tableRebalanceLogger.warn(errorMsg, e);
         if (_tableRebalanceObserver.isStopped()) {
+          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
           return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
               "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
               tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
         }
         _tableRebalanceObserver.onError(errorMsg);
+        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED,
             "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -572,6 +577,7 @@ public class TableRebalancer {
         tableRebalanceLogger.info(msg);
         // Record completion
         _tableRebalanceObserver.onSuccess(msg);
+        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.DONE,
             "Success with minAvailableReplicas: " + minAvailableReplicas
                 + " (both IdealState and ExternalView should reach the target segment assignment)",
@@ -586,6 +592,7 @@ public class TableRebalancer {
       // Update the segment list as the IDEAL_STATE_CHANGE_TRIGGER should've captured the newly added / deleted segments
       allSegmentsFromIdealState = currentAssignment.keySet();
       if (_tableRebalanceObserver.isStopped()) {
+        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState", instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -601,6 +608,7 @@ public class TableRebalancer {
       _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER,
           currentAssignment, nextAssignment, rebalanceContext);
       if (_tableRebalanceObserver.isStopped()) {
+        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState with the next assignment",
             instancePartitionsMap, tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -422,7 +422,9 @@ public class TableRebalancer {
 
     // Record the beginning of rebalance
     // We emit this metric only when the rebalance does get to this code path, i.e. excluding dry-run and downtime
-    _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, 1L);
+    if (_controllerMetrics != null) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, 1L);
+    }
     _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, currentAssignment,
         targetAssignment, rebalanceContext);
 
@@ -495,13 +497,17 @@ public class TableRebalancer {
         String errorMsg = "Caught exception while waiting for ExternalView to converge, aborting the rebalance";
         tableRebalanceLogger.warn(errorMsg, e);
         if (_tableRebalanceObserver.isStopped()) {
-          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+          if (_controllerMetrics != null) {
+            _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+          }
           return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
               "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
               tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
         }
         _tableRebalanceObserver.onError(errorMsg);
-        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        if (_controllerMetrics != null) {
+          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        }
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED,
             "Caught exception while waiting for ExternalView to converge: " + e, instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -577,7 +583,9 @@ public class TableRebalancer {
         tableRebalanceLogger.info(msg);
         // Record completion
         _tableRebalanceObserver.onSuccess(msg);
-        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        if (_controllerMetrics != null) {
+          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        }
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.DONE,
             "Success with minAvailableReplicas: " + minAvailableReplicas
                 + " (both IdealState and ExternalView should reach the target segment assignment)",
@@ -592,7 +600,9 @@ public class TableRebalancer {
       // Update the segment list as the IDEAL_STATE_CHANGE_TRIGGER should've captured the newly added / deleted segments
       allSegmentsFromIdealState = currentAssignment.keySet();
       if (_tableRebalanceObserver.isStopped()) {
-        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        if (_controllerMetrics != null) {
+          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        }
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState", instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
@@ -608,7 +618,9 @@ public class TableRebalancer {
       _tableRebalanceObserver.onTrigger(TableRebalanceObserver.Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER,
           currentAssignment, nextAssignment, rebalanceContext);
       if (_tableRebalanceObserver.isStopped()) {
-        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        if (_controllerMetrics != null) {
+          _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, -1L);
+        }
         return new RebalanceResult(rebalanceJobId, _tableRebalanceObserver.getStopStatus(),
             "Rebalance has stopped already before updating the IdealState with the next assignment",
             instancePartitionsMap, tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -142,7 +142,7 @@ public class TableRebalancer {
   // TODO: Consider making the timeoutMs below table rebalancer configurable
   private static final int TABLE_SIZE_READER_TIMEOUT_MS = 30_000;
   private static final int STREAM_PARTITION_OFFSET_READ_TIMEOUT_MS = 10_000;
-  private static final AtomicInteger _rebalanceJobCounter = new AtomicInteger(0);
+  private static final AtomicInteger REBALANCE_JOB_COUNTER = new AtomicInteger(0);
   private final HelixManager _helixManager;
   private final HelixDataAccessor _helixDataAccessor;
   private final TableRebalanceObserver _tableRebalanceObserver;
@@ -184,7 +184,7 @@ public class TableRebalancer {
     String tableNameWithType = tableConfig.getTableName();
     RebalanceResult.Status status = RebalanceResult.Status.UNKNOWN_ERROR;
     try {
-      int jobCount = _rebalanceJobCounter.incrementAndGet();
+      int jobCount = REBALANCE_JOB_COUNTER.incrementAndGet();
       if (_controllerMetrics != null) {
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, jobCount);
       }
@@ -192,7 +192,7 @@ public class TableRebalancer {
       status = result.getStatus();
       return result;
     } finally {
-      int jobCount = _rebalanceJobCounter.decrementAndGet();
+      int jobCount = REBALANCE_JOB_COUNTER.decrementAndGet();
       if (_controllerMetrics != null) {
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.TABLE_REBALANCE_IN_PROGRESS_GLOBAL, jobCount);
         _controllerMetrics.addTimedTableValue(String.format("%s.%s", tableNameWithType, status.toString()),


### PR DESCRIPTION
## Description

Add a new controller meter global metrics `pinot_controller_tableRebalanceInProgressGlobal` to keep track of the number of in progress rebalance job (i.e. excludes dry-run, downtime rebalance)

## Testing

We couldn't control the number of ongoing rebalance job in our tests (it varies when the unit tests and integration tests run in parallel). To test out the correctness of the global count, I did it manually.

Add a `Thread.sleep(30_000)` in `doRebalance`
Set a breakpoint in `doRebalance`
Initiate two table rebalance with `dryRun=true` via UI

From the debugger of the second rebalance job:
![image](https://github.com/user-attachments/assets/61cf9616-eb54-4f91-b63f-d520e3f1bbd5)

The same debugger after the first rebalance job finished:
![image](https://github.com/user-attachments/assets/19c5ae58-fd65-4eec-8692-64a0663a7b5c)

