### PR TITLE
Metrics that Tracks the Progress of each Table Rebalance Job

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -48,6 +48,15 @@ rules:
     table: "$2$4"
     tableType: "$5"
     taskType: "$6"
+# Gauge for rebalanceJobId and tableNameWithType
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableRebalanceJobProgressPercent\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
+  name: "pinot_controller_tableRebalanceJobProgressPercent_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    jobId: "$5"
   # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs which use table name, table type and another string for status / taskType
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
   name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$6"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -49,7 +49,7 @@ rules:
     tableType: "$5"
     taskType: "$6"
 # Gauge for rebalanceJobId and tableNameWithType
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(tableRebalanceJobAddingProgressPercent|tableRebalanceJobDeletingProgressPercent)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(tableRebalanceJobAdditionProgressPercent|tableRebalanceJobDeletionProgressPercent)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
   name: "pinot_controller_$1_$7"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -49,14 +49,14 @@ rules:
     tableType: "$5"
     taskType: "$6"
 # Gauge for rebalanceJobId and tableNameWithType
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableRebalanceJobProgressPercent\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
-  name: "pinot_controller_tableRebalanceJobProgressPercent_$6"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(tableRebalanceJobAddingProgressPercent|tableRebalanceJobDeletingProgressPercent)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
+  name: "pinot_controller_$1_$7"
   cache: true
   labels:
-    database: "$2"
-    table: "$1$3"
-    tableType: "$4"
-    jobId: "$5"
+    database: "$3"
+    table: "$2$4"
+    tableType: "$5"
+    jobId: "$6"
   # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs which use table name, table type and another string for status / taskType
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
   name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$6"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -49,14 +49,14 @@ rules:
     tableType: "$5"
     taskType: "$6"
 # Gauge for rebalanceJobId and tableNameWithType
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(tableRebalanceJobAdditionProgressPercent|tableRebalanceJobDeletionProgressPercent)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
-  name: "pinot_controller_$1_$7"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableRebalanceJobProgressPercent\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([0-9a-fA-F-]+)\"><>(\\w+)"
+  name: "pinot_controller_tableRebalanceJobProgressPercent_$6"
   cache: true
   labels:
-    database: "$3"
-    table: "$2$4"
-    tableType: "$5"
-    jobId: "$6"
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    jobId: "$5"
   # Special handling for timers like cronSchedulerJobExecutionTimeMs and tableRebalanceExecutionTimeMs which use table name, table type and another string for status / taskType
 - pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
   name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$6"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -219,8 +219,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   DEEP_STORE_WRITE_OPS_IN_PROGRESS("deepStoreWriteOpsInProgress", true),
 
   // The progress of a certain table rebalance job of a table
-  TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT("percent", false),
-  TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT("percent", false);
+  TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false);
 
 
   private final String _gaugeName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -219,7 +219,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   DEEP_STORE_WRITE_OPS_IN_PROGRESS("deepStoreWriteOpsInProgress", true),
 
   // The progress of a certain table rebalance job of a table
-  TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false);
+  TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT("percent", false),
+  TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT("percent", false);
 
 
   private final String _gaugeName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -216,7 +216,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Bytes to be written to deep store
   DEEP_STORE_WRITE_BYTES_IN_PROGRESS("deepStoreWriteBytesInProgress", true),
   // Count of deep store segment writes that are currently in progress
-  DEEP_STORE_WRITE_OPS_IN_PROGRESS("deepStoreWriteOpsInProgress", true);
+  DEEP_STORE_WRITE_OPS_IN_PROGRESS("deepStoreWriteOpsInProgress", true),
+
+  // The progress of a certain table rebalance job of a table
+  TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false);
+
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -219,8 +219,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   DEEP_STORE_WRITE_OPS_IN_PROGRESS("deepStoreWriteOpsInProgress", true),
 
   // The progress of a certain table rebalance job of a table
-  TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT("percent", false),
-  TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT("percent", false);
+  TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT("percent", false),
+  TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT("percent", false);
 
 
   private final String _gaugeName;

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -178,10 +178,11 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
             String.format("%s.%s", ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC, TaskState.IN_PROGRESS));
         assertGaugeExportedCorrectly(ControllerGauge.TASK_STATUS.getGaugeName(),
             ExportedLabels.JOBSTATUS_CONTROLLER_TASKTYPE, EXPORTED_METRIC_PREFIX);
-      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT) {
+      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT
+          || controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT) {
         addGaugeWithLabels(controllerGauge,
             String.format("%s.%s", TABLE_NAME_WITH_TYPE, REBALANCE_JOB_ID));
-        assertGaugeExportedCorrectly(ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT.getGaugeName(),
+        assertGaugeExportedCorrectly(controllerGauge.getGaugeName(),
             ExportedLabels.JOBID_TABLENAME_TABLETYPE, EXPORTED_METRIC_PREFIX);
       } else {
         addGaugeWithLabels(controllerGauge, TABLE_NAME_WITH_TYPE);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -178,8 +178,7 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
             String.format("%s.%s", ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC, TaskState.IN_PROGRESS));
         assertGaugeExportedCorrectly(ControllerGauge.TASK_STATUS.getGaugeName(),
             ExportedLabels.JOBSTATUS_CONTROLLER_TASKTYPE, EXPORTED_METRIC_PREFIX);
-      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT
-          || controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT) {
+      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT) {
         addGaugeWithLabels(controllerGauge,
             String.format("%s.%s", TABLE_NAME_WITH_TYPE, REBALANCE_JOB_ID));
         assertGaugeExportedCorrectly(controllerGauge.getGaugeName(),

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -178,8 +178,8 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
             String.format("%s.%s", ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC, TaskState.IN_PROGRESS));
         assertGaugeExportedCorrectly(ControllerGauge.TASK_STATUS.getGaugeName(),
             ExportedLabels.JOBSTATUS_CONTROLLER_TASKTYPE, EXPORTED_METRIC_PREFIX);
-      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT
-          || controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT) {
+      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT
+          || controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT) {
         addGaugeWithLabels(controllerGauge,
             String.format("%s.%s", TABLE_NAME_WITH_TYPE, REBALANCE_JOB_ID));
         assertGaugeExportedCorrectly(controllerGauge.getGaugeName(),

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -178,6 +178,11 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
             String.format("%s.%s", ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC, TaskState.IN_PROGRESS));
         assertGaugeExportedCorrectly(ControllerGauge.TASK_STATUS.getGaugeName(),
             ExportedLabels.JOBSTATUS_CONTROLLER_TASKTYPE, EXPORTED_METRIC_PREFIX);
+      } else if (controllerGauge == ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT) {
+        addGaugeWithLabels(controllerGauge,
+            String.format("%s.%s", TABLE_NAME_WITH_TYPE, REBALANCE_JOB_ID));
+        assertGaugeExportedCorrectly(ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT.getGaugeName(),
+            ExportedLabels.JOBID_TABLENAME_TABLETYPE, EXPORTED_METRIC_PREFIX);
       } else {
         addGaugeWithLabels(controllerGauge, TABLE_NAME_WITH_TYPE);
         assertGaugeExportedCorrectly(controllerGauge.getGaugeName(), ExportedLabels.TABLENAME_TABLETYPE,

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PinotPrometheusMetricsTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -68,6 +69,7 @@ public abstract class PinotPrometheusMetricsTest {
   protected static final String PARTITION_GROUP_ID = "partitionGroupId";
   protected static final String CLIENT_ID =
       String.format("%s-%s-%s", TABLE_NAME_WITH_TYPE, KAFKA_TOPIC, PARTITION_GROUP_ID);
+  protected static final String REBALANCE_JOB_ID = UUID.randomUUID().toString();
 
   protected HttpClient _httpClient;
 
@@ -336,6 +338,9 @@ public abstract class PinotPrometheusMetricsTest {
     public static final List<String> TASKTYPE_TABLENAME_TABLETYPE =
         List.of(TASKTYPE, ExportedLabelValues.MINION_TASK_SEGMENT_IMPORT, TABLE, ExportedLabelValues.TABLENAME,
             TABLETYPE, TABLETYPE_REALTIME);
+
+    public static final List<String> JOBID_TABLENAME_TABLETYPE =
+        List.of(JOBID, REBALANCE_JOB_ID, TABLE, ExportedLabelValues.TABLENAME, TABLETYPE, TABLETYPE_REALTIME);
   }
 
   public static class ExportedLabelKeys {
@@ -348,6 +353,7 @@ public abstract class PinotPrometheusMetricsTest {
     public static final String PERIODIC_TASK = "periodicTask";
     public static final String STATUS = "status";
     public static final String DATABASE = "database";
+    public static final String JOBID = "jobId";
   }
 
   public static class ExportedLabelValues {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -243,16 +243,14 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
    * @param overallProgress the latest overall progress
    */
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
+    long progressPercent = 100 - (long) TableRebalanceProgressStats.calculatePercentageChange(
+        overallProgress._totalSegmentsToBeAdded + overallProgress._totalSegmentsToBeDeleted,
+        overallProgress._totalRemainingSegmentsToBeAdded + overallProgress._totalRemainingSegmentsToBeDeleted
+            + overallProgress._totalRemainingSegmentsToConverge);
     // Using the original job ID to group rebalance retries together with the same label
-    long additionProgressPercent = 100 - (long) overallProgress._percentageRemainingSegmentsToBeAdded;
-    long deletionProgressPercent = 100 - (long) overallProgress._percentageRemainingSegmentsToBeDeleted;
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
-        ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT,
-        additionProgressPercent < 0 ? 0 : additionProgressPercent);
-
-    _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
-        ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT,
-        deletionProgressPercent < 0 ? 0 : deletionProgressPercent);
+        ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT,
+        progressPercent < 0 ? 0 : progressPercent);
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -245,8 +245,12 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
     // Using the original job ID to group rebalance retries together with the same label
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
-        ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT,
+        ControllerGauge.TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT,
         (long) overallProgress._percentageRemainingSegmentsToBeAdded * 100);
+
+    _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
+        ControllerGauge.TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT,
+        (long) overallProgress._percentageRemainingSegmentsToBeDeleted * 100);
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -244,7 +244,7 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
    * @param overallProgress the latest overall progress
    */
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
-    _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getJobId(),
+    _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
         ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT,
         (long) overallProgress._percentageRemainingSegmentsToBeAdded * 100);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -244,13 +244,15 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
    */
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
     // Using the original job ID to group rebalance retries together with the same label
+    long additionProgressPercent = 100 - (long) overallProgress._percentageRemainingSegmentsToBeAdded;
+    long deletionProgressPercent = 100 - (long) overallProgress._percentageRemainingSegmentsToBeDeleted;
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
         ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT,
-        (long) overallProgress._percentageRemainingSegmentsToBeAdded);
+        additionProgressPercent < 0 ? 0 : additionProgressPercent);
 
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
         ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT,
-        (long) overallProgress._percentageRemainingSegmentsToBeDeleted);
+        deletionProgressPercent < 0 ? 0 : deletionProgressPercent);
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -238,6 +238,11 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
     return _numUpdatesToZk;
   }
 
+  /**
+   * Emits the rebalance progress in percent to the metrics. Uses the percentage of remaining segments to be added as
+   * the indicator of the overall progress.
+   * @param overallProgress the latest overall progress
+   */
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getJobId(),
         ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -242,7 +242,9 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
    * Emits the rebalance progress in percent to the metrics. Uses the percentage of remaining segments to be added as
    * the indicator of the overall progress.
    * Notice that for some jobs, the metrics may not be exactly accurate and would not be 100% when the job is done.
-   * (e.g. when `lowDiskMode=false`, the job finishes without waiting for `totalRemainingSegmentsToBeDeleted` become 0)
+   * (e.g. when `lowDiskMode=false`, the job finishes without waiting for `totalRemainingSegmentsToBeDeleted` become
+   * 0, or when `bestEffort=true` the job finishes without waiting for both `totalRemainingSegmentsToBeAdded`,
+   * `totalRemainingSegmentsToBeDeleted`, and `totalRemainingSegmentsToConverge` become 0)
    * Therefore `emitProgressMetricDone()` should be called to emit the final progress as the time job exits.
    * @param overallProgress the latest overall progress
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -145,7 +145,6 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
             Trigger.NEXT_ASSINGMENT_CALCULATION_TRIGGER, _tableRebalanceProgressStats);
         if (!_tableRebalanceProgressStats.getRebalanceProgressStatsCurrentStep().equals(latestProgress)) {
           _tableRebalanceProgressStats.setRebalanceProgressStatsCurrentStep(latestProgress);
-          emitProgressMetric(latestProgress);
           trackStatsInZk();
           updatedStatsInZk = true;
         }
@@ -244,6 +243,7 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
    * @param overallProgress the latest overall progress
    */
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
+    // Using the original job ID to group rebalance retries together with the same label
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
         ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT,
         (long) overallProgress._percentageRemainingSegmentsToBeAdded * 100);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -245,12 +245,12 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
   private void emitProgressMetric(TableRebalanceProgressStats.RebalanceProgressStats overallProgress) {
     // Using the original job ID to group rebalance retries together with the same label
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
-        ControllerGauge.TABLE_REBALANCE_JOB_ADDING_PROGRESS_PERCENT,
-        (long) overallProgress._percentageRemainingSegmentsToBeAdded * 100);
+        ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT,
+        (long) overallProgress._percentageRemainingSegmentsToBeAdded);
 
     _controllerMetrics.setValueOfTableGauge(_tableNameWithType + "." + _tableRebalanceContext.getOriginalJobId(),
-        ControllerGauge.TABLE_REBALANCE_JOB_DELETING_PROGRESS_PERCENT,
-        (long) overallProgress._percentageRemainingSegmentsToBeDeleted * 100);
+        ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT,
+        (long) overallProgress._percentageRemainingSegmentsToBeDeleted);
   }
 
   @VisibleForTesting
@@ -314,6 +314,11 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
           tableNameWithType, e);
     }
     return jobMetadata;
+  }
+
+  @VisibleForTesting
+  TableRebalanceProgressStats getTableRebalanceProgressStats() {
+    return _tableRebalanceProgressStats;
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -93,18 +93,16 @@ public class TestZkBasedTableRebalanceObserver {
 
   private void checkProgressPercentMetrics(ControllerMetrics controllerMetrics,
       ZkBasedTableRebalanceObserver observer) {
-    Long additionGaugeValue = controllerMetrics.getGaugeValue(
-        ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
-    Long deletionGaugeValue = controllerMetrics.getGaugeValue(
-        ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
-    assertNotNull(additionGaugeValue);
-    assertNotNull(deletionGaugeValue);
-    long additionProgressRemained = (long) observer.getTableRebalanceProgressStats()
-        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeAdded;
-    long deletionProgressRemained = (long) observer.getTableRebalanceProgressStats()
-        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeDeleted;
-    assertEquals(additionGaugeValue, additionProgressRemained > 100 ? 0 : 100 - additionProgressRemained);
-    assertEquals(deletionGaugeValue, deletionProgressRemained > 100 ? 0 : 100 - deletionProgressRemained);
+    Long progressGaugeValue = controllerMetrics.getGaugeValue(
+        ControllerGauge.TABLE_REBALANCE_JOB_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
+    assertNotNull(progressGaugeValue);
+    TableRebalanceProgressStats.RebalanceProgressStats overallProgress =
+        observer.getTableRebalanceProgressStats().getRebalanceProgressStatsOverall();
+    long progressRemained = (long) TableRebalanceProgressStats.calculatePercentageChange(
+        overallProgress._totalSegmentsToBeAdded + overallProgress._totalSegmentsToBeDeleted,
+        overallProgress._totalRemainingSegmentsToBeAdded + overallProgress._totalRemainingSegmentsToBeDeleted
+            + overallProgress._totalRemainingSegmentsToConverge);
+    assertEquals(progressGaugeValue, progressRemained > 100 ? 0 : 100 - progressRemained);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -96,9 +96,9 @@ public class TestZkBasedTableRebalanceObserver {
         ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
     Long deletionProgress = controllerMetrics.getGaugeValue(
         ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
-    assertEquals(additionProgress, (long) observer.getTableRebalanceProgressStats()
+    assertEquals(additionProgress, 100 - (long) observer.getTableRebalanceProgressStats()
         .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeAdded);
-    assertEquals(deletionProgress, (long) observer.getTableRebalanceProgressStats()
+    assertEquals(deletionProgress, 100 - (long) observer.getTableRebalanceProgressStats()
         .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeDeleted);
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -38,6 +38,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -92,14 +93,18 @@ public class TestZkBasedTableRebalanceObserver {
 
   private void checkProgressPercentMetrics(ControllerMetrics controllerMetrics,
       ZkBasedTableRebalanceObserver observer) {
-    Long additionProgress = controllerMetrics.getGaugeValue(
+    Long additionGaugeValue = controllerMetrics.getGaugeValue(
         ControllerGauge.TABLE_REBALANCE_JOB_ADDITION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
-    Long deletionProgress = controllerMetrics.getGaugeValue(
+    Long deletionGaugeValue = controllerMetrics.getGaugeValue(
         ControllerGauge.TABLE_REBALANCE_JOB_DELETION_PROGRESS_PERCENT.getGaugeName() + ".dummy.testZkObserverTracking");
-    assertEquals(additionProgress, 100 - (long) observer.getTableRebalanceProgressStats()
-        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeAdded);
-    assertEquals(deletionProgress, 100 - (long) observer.getTableRebalanceProgressStats()
-        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeDeleted);
+    assertNotNull(additionGaugeValue);
+    assertNotNull(deletionGaugeValue);
+    long additionProgressRemained = (long) observer.getTableRebalanceProgressStats()
+        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeAdded;
+    long deletionProgressRemained = (long) observer.getTableRebalanceProgressStats()
+        .getRebalanceProgressStatsOverall()._percentageRemainingSegmentsToBeDeleted;
+    assertEquals(additionGaugeValue, additionProgressRemained > 100 ? 0 : 100 - additionProgressRemained);
+    assertEquals(deletionGaugeValue, deletionProgressRemained > 100 ? 0 : 100 - deletionProgressRemained);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -98,10 +98,10 @@ public class TestZkBasedTableRebalanceObserver {
     assertNotNull(progressGaugeValue);
     TableRebalanceProgressStats.RebalanceProgressStats overallProgress =
         observer.getTableRebalanceProgressStats().getRebalanceProgressStatsOverall();
-    long progressRemained = (long) TableRebalanceProgressStats.calculatePercentageChange(
+    long progressRemained = (long) Math.ceil(TableRebalanceProgressStats.calculatePercentageChange(
         overallProgress._totalSegmentsToBeAdded + overallProgress._totalSegmentsToBeDeleted,
         overallProgress._totalRemainingSegmentsToBeAdded + overallProgress._totalRemainingSegmentsToBeDeleted
-            + overallProgress._totalRemainingSegmentsToConverge);
+            + overallProgress._totalRemainingSegmentsToConverge));
     assertEquals(progressGaugeValue, progressRemained > 100 ? 0 : 100 - progressRemained);
   }
 


### PR DESCRIPTION
## Description

Add a new controller gauge metrics `pinot_controller_tableRebalanceJobProgressPercent` to expose the progress in percent for each rebalance job that has a `TableRebalanceObserver`

The percentage is of how many the segments to be added remain.

The metric has labels `jobId`, `database`, `table`, and `tableType`.

