### PR TITLE
Helix upgrade to 1.4.3 : Additional changes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -322,6 +322,9 @@ public class HelixHelper {
    */
   public static Set<String> getOfflineInstanceFromExternalView(ExternalView resourceExternalView) {
     Set<String> instanceSet = new HashSet<String>();
+    // TODO: Checking EV alone is no longer enough to find the OFFLINE instances, need to compare with the
+    //       IdealState as that could be OFFLINE and the instance missing from EV. Perhaps delete this code since it
+    //       doesn't seem to be used
     for (String partition : resourceExternalView.getPartitionSet()) {
       Map<String, String> stateMap = resourceExternalView.getStateMap(partition);
       for (String instance : stateMap.keySet()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2781,9 +2781,13 @@ public class PinotHelixResourceManager {
     Preconditions.checkState(externalView != null, "Could not find external view for table: %s", tableNameWithType);
     Set<String> instanceSet = parseInstanceSet(idealState, segmentName, targetInstance);
     Map<String, String> externalViewStateMap = externalView.getStateMap(segmentName);
+    Map<String, String> idealStateStateMap = idealState.getInstanceStateMap(segmentName);
 
     for (String instance : instanceSet) {
-      if (externalViewStateMap == null || SegmentStateModel.OFFLINE.equals(externalViewStateMap.get(instance))) {
+      // EV can be empty for a given instance that is OFFLINE in IS, skip processing those too
+      if (externalViewStateMap == null || (SegmentStateModel.OFFLINE.equals(idealStateStateMap.get(instance))
+          && !externalViewStateMap.containsKey(instance))
+          || SegmentStateModel.OFFLINE.equals(externalViewStateMap.get(instance))) {
         LOGGER.info("Skipping resetting for segment: {} of table: {} on instance: {}", segmentName, tableNameWithType,
             instance);
       } else {
@@ -2809,13 +2813,17 @@ public class PinotHelixResourceManager {
     for (String segmentName : idealState.getPartitionSet()) {
       Set<String> instanceSet = parseInstanceSet(idealState, segmentName, targetInstance);
       Map<String, String> externalViewStateMap = externalView.getStateMap(segmentName);
+      Map<String, String> idealStateStateMap = idealState.getInstanceStateMap(segmentName);
       for (String instance : instanceSet) {
         if (errorSegmentsOnly) {
           if (externalViewStateMap != null && SegmentStateModel.ERROR.equals(externalViewStateMap.get(instance))) {
             instanceToResetSegmentsMap.computeIfAbsent(instance, i -> new HashSet<>()).add(segmentName);
           }
         } else {
-          if (externalViewStateMap == null || SegmentStateModel.OFFLINE.equals(externalViewStateMap.get(instance))) {
+          // EV can be empty for a given instance that is OFFLINE in IS, skip processing those too
+          if (externalViewStateMap == null || (SegmentStateModel.OFFLINE.equals(idealStateStateMap.get(instance))
+              && !externalViewStateMap.containsKey(instance))
+              || SegmentStateModel.OFFLINE.equals(externalViewStateMap.get(instance))) {
             instanceToSkippedSegmentsMap.computeIfAbsent(instance, i -> new HashSet<>()).add(segmentName);
           } else {
             instanceToResetSegmentsMap.computeIfAbsent(instance, i -> new HashSet<>()).add(segmentName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/PeerServerSegmentFinder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/PeerServerSegmentFinder.java
@@ -87,7 +87,7 @@ public class PeerServerSegmentFinder {
     // Find out the ONLINE servers serving the segment.
     Map<String, String> instanceStateMap = externalView.getStateMap(segmentName);
     if (instanceStateMap == null) {
-      LOGGER.warn("Failed to find segment: {} in table: {}", segmentName, tableNameWithType);
+      LOGGER.warn("Failed to find segment: {} in external view for the table: {}", segmentName, tableNameWithType);
       return;
     }
     for (Map.Entry<String, String> instanceState : instanceStateMap.entrySet()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ShowClusterInfoCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ShowClusterInfoCommand.java
@@ -166,7 +166,11 @@ public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements 
         }
 
         for (String serverName : serverStateMapFromIS.keySet()) {
-          segmentInfo._segmentStateMap.put(serverName, serverStateMapFromEV.get(serverName));
+          String evState =
+              serverStateMapFromIS.get(serverName).equals(CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE)
+                  && !serverStateMapFromEV.containsKey(serverName)
+                  ? CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE : serverStateMapFromEV.get(serverName);
+          segmentInfo._segmentStateMap.put(serverName, evState);
         }
         tableInfo.addSegmentInfo(segmentInfo);
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/VerifySegmentState.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.tools.admin.command;
 
 import com.google.common.collect.Sets;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
@@ -65,21 +67,48 @@ public class VerifySegmentState extends AbstractBaseCommand implements Command {
         Map<String, Map<String, String>> mapFieldsFromIS = resourceIdealState.getRecord().getMapFields();
         Map<String, Map<String, String>> mapFieldsFromEV = resourceExternalView.getRecord().getMapFields();
         boolean error = false;
-        if (mapFieldsFromIS.size() != mapFieldsFromEV.size()) {
-          LOGGER.info("Table: {}, idealState size: {} does NOT match external view size: {}", resourceName,
-              mapFieldsFromIS.size(), mapFieldsFromEV.size());
+        // EV may be null for a given segment if all instances of that segment are OFFLINE in IS. This is valid, so
+        // detect this scenario and update the EV size and segment list accordingly to include this case
+        int evSize = mapFieldsFromEV.size();
+        Set<String> evSegments = new HashSet<>(mapFieldsFromEV.keySet());
+        Set<String> evEmptySegmentsWithISOffline = new HashSet<>();
+        for (Map.Entry<String, Map<String, String>> idealEntry : mapFieldsFromIS.entrySet()) {
+          String segmentName = idealEntry.getKey();
+          if (!mapFieldsFromEV.containsKey(segmentName)) {
+            boolean isISAllOffline = true;
+            for (Map.Entry<String, String> instanceState : idealEntry.getValue().entrySet()) {
+              if (!CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE.equals(instanceState.getValue())) {
+                LOGGER.info("Table: {}, idealState has non-OFFLINE state: {} for instance: {} whereas EV is null for "
+                        + "given segment: {}", resourceName, instanceState.getValue(), instanceState.getKey(),
+                    segmentName);
+                isISAllOffline = false;
+                error = true;
+                break;
+              }
+            }
+            if (isISAllOffline) {
+              // We count this as a valid EV since EV can be null if all segments in IS are OFFLINE
+              evSize++;
+              evEmptySegmentsWithISOffline.add(segmentName);
+              evSegments.add(segmentName);
+            }
+          }
+        }
+
+        if (mapFieldsFromIS.size() != evSize) {
+          LOGGER.info("Table: {}, idealState size: {} does NOT match calculated external view size: {}, actual "
+                  + "external view size: {}", resourceName, mapFieldsFromIS.size(), evSize, mapFieldsFromEV.size());
           error = true;
         }
-        if (!mapFieldsFromIS.keySet().equals(mapFieldsFromEV.keySet())) {
+        if (!mapFieldsFromIS.keySet().equals(evSegments)) {
           Set<String> idealStateKeys = mapFieldsFromIS.keySet();
-          Set<String> externalViewKeys = mapFieldsFromEV.keySet();
-          Sets.SetView<String> isToEVDiff = Sets.difference(idealStateKeys, externalViewKeys);
+          Sets.SetView<String> isToEVDiff = Sets.difference(idealStateKeys, evSegments);
           for (String segmentName : isToEVDiff) {
             LOGGER.info("Segment: {} is missing in external view, ideal state: {}", segmentName,
                 mapFieldsFromIS.get(segmentName));
           }
 
-          Sets.SetView<String> evToISDiff = Sets.difference(externalViewKeys, idealStateKeys);
+          Sets.SetView<String> evToISDiff = Sets.difference(evSegments, idealStateKeys);
           for (String segmentName : evToISDiff) {
             LOGGER.error("Segment: {} is missing in ideal state, external view: {}", segmentName,
                 mapFieldsFromEV.get(segmentName));
@@ -93,14 +122,27 @@ public class VerifySegmentState extends AbstractBaseCommand implements Command {
           // try to format consistently for tool based parsing
           if (!mapFieldsFromEV.containsKey(segmentName)) {
             LOGGER
-                .info("Segment: {} idealstate: {} is MISSING in external view: {}", segmentName, segmentIdealState, "");
+                .info("Segment: {} idealstate: {} is MISSING in external view: {}, isISAllOffline: {}", segmentName,
+                    segmentIdealState, "", evEmptySegmentsWithISOffline.contains(segmentName));
           }
           Map<String, String> segmentExternalView = mapFieldsFromEV.get(segmentName);
 
-          if (!segmentIdealState.equals(segmentExternalView)) {
-            LOGGER.info("Segment: {} idealstate: {} does NOT match external view: {}", segmentName, segmentIdealState,
-                segmentExternalView);
-            error = true;
+          if (!segmentIdealState.equals(segmentExternalView) && !evEmptySegmentsWithISOffline.contains(segmentName)) {
+            LOGGER.info("Segment: {} idealstate: {} does NOT match external view: {}, checking for empty EV for "
+                    + "OFFLINE IS", segmentName, segmentIdealState, segmentExternalView);
+            for (Map.Entry<String, String> instanceToState : segmentIdealState.entrySet()) {
+              String instanceName = instanceToState.getKey();
+              String isState = instanceToState.getValue();
+              String evState = segmentExternalView == null ? null : segmentExternalView.get(instanceName);
+              if (evState == null && CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE.equals(isState)) {
+                LOGGER.info("Segment: {} ideal state: {} for instance: {} is OFFLINE, and external view is null, "
+                    + "this is valid", segmentName, isState, instanceName);
+              } else if (evState == null || !evState.equals(isState)) {
+                LOGGER.info("Segment: {} ideal state: {} for instance: {} does NOT match external view: {}",
+                    segmentName, isState, instanceName, evState);
+                error = true;
+              }
+            }
           }
         }
         LOGGER.info("{} = {}", resourceName, error ? "ERROR" : "OK");


### PR DESCRIPTION
Orignal PR for Helix upgrade to 1.4.3: https://github.com/apache/pinot/pull/15063

This PR adds on top of the above

Capturing additional changes that will be required for the Helix 1.4.3 upgrade to handle the behavior change where the ExternalView entry may be missing for OFFLINE segments. If ExternalView is OFFLINE or missing and IdealState is OFFLINE as well, we should treat this as OFFLINE

### The PR contains the following fixes so far:
- Update `TableViews::getSegmentStatuses` to use IdealState as source of truth (used to populate the Segment list in the Table UI)
- Add some handling in `PinotHelixResourceManager.java` and `ShowClusterInfoCommand.java` for OFFLINE IdealState with missing EV
- Add handling in `DebugResource`, `PinotZKChanger` and `VerifySegmentState`

### Identified some UI changes which will be tackled separately (different PR):
- In the view where we list the Tables, the table status should be updated to mark a table as GOOD (instead of UPDATING) if it has some segments that are OFFLINE in IdealState but the entry from ExternalView is missing (or OFFLINE). The `getDisplaySegmentStatus` in `Utils.tsx` will need to be modified to handle the above scenario.
- In the `SegmentDetails.tsx` page, today we only show segments that are in the ExternalView. This means that if a segment is in IdealState and OFFLINE, and missing in ExternalView, it will not be displayed. We should handle this better and also correctly show the status in this case.

### Testing done so far:

**To create the scenario of empty / null ExternalView or OFFLINE ExternalView:**
- Delete a Server / Broker from `LIVEINSTANCES` to reproduce the issue where the ExternalView becomes empty / null for segments. Updated IdealState to OFFLINE / ONLINE to test various scenarios.
- Validated that if the ExternalView shows segment in `ONLINE` state and we set the IdealState to `OFFLINE`, ExternalView will show the segment in `OFFLINE` state rather than null / empty

**Using the above to trigger various scenarios tried the following tests:**
- UI testing to ensure that changes to `TableViews::getSegmentStatuses` works to list out all the segments from IdealState. Verified that if a segment in IdealState is OFFLINE, it shows up as `GOOD` if ExternalView is `OFFLINE` or empty
- Tested `DebugResource` API for both table, segment and broker level to ensure that empty EV with OFFLINE IS is handled
- Tested `VerifySegmentState` command:
    - `./build/bin/pinot-admin.sh VerifySegmentState -clusterName=QuickStartCluster -tablePrefix=airlineStats -zkAddress=localhost:2123`
- Tested `VerifyClusterState` command (exercises the `PinotZKChanger`):
    - `./build/bin/pinot-admin.sh VerifyClusterState -clusterName=QuickStartCluster -tableName=airlineStats_OFFLINE -zkAddress=localhost:2123`

This is still a WIP

cc @Jackie-Jiang @xiangfu0 