### PR TITLE
Move Query Execution Planning to TableExecutionInfo in SSE 

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -19,20 +19,39 @@
 package org.apache.pinot.core.query.executor;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.metrics.ServerQueryPhase;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.core.query.pruner.SegmentPrunerService;
+import org.apache.pinot.core.query.pruner.SegmentPrunerStatistics;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class SingleTableExecutionInfo implements TableExecutionInfo {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SingleTableExecutionInfo.class);
+
   private final TableDataManager _tableDataManager;
   private final List<SegmentDataManager> _segmentDataManagers;
   private final List<IndexSegment> _indexSegments;
@@ -41,7 +60,85 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
   private final List<String> _optionalSegments;
   private final List<String> _notAcquiredSegments;
 
-  public SingleTableExecutionInfo(TableDataManager tableDataManager, List<SegmentDataManager> segmentDataManagers,
+  public static SingleTableExecutionInfo create(InstanceDataManager instanceDataManager, String tableNameWithType,
+      List<String> segmentsToQuery, List<String> optionalSegments, QueryContext queryContext) {
+    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableNameWithType);
+    if (tableDataManager == null) {
+      throw new NoSuchElementException(tableNameWithType);
+    }
+
+    List<String> notAcquiredSegments = new ArrayList<>();
+    List<SegmentDataManager> segmentDataManagers;
+    List<IndexSegment> indexSegments;
+    Map<IndexSegment, SegmentContext> providedSegmentContexts = null;
+
+    if (!isUpsertTable(tableDataManager)) {
+      segmentDataManagers = tableDataManager.acquireSegments(segmentsToQuery, optionalSegments, notAcquiredSegments);
+      indexSegments = new ArrayList<>(segmentDataManagers.size());
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+        indexSegments.add(segmentDataManager.getSegment());
+      }
+    } else {
+      RealtimeTableDataManager rtdm = (RealtimeTableDataManager) tableDataManager;
+      TableUpsertMetadataManager tumm = rtdm.getTableUpsertMetadataManager();
+      boolean isUsingConsistencyMode =
+          rtdm.getTableUpsertMetadataManager().getContext().getConsistencyMode() != UpsertConfig.ConsistencyMode.NONE;
+      if (isUsingConsistencyMode) {
+        tumm.lockForSegmentContexts();
+      }
+      try {
+        Set<String> allSegmentsToQuery = new HashSet<>(segmentsToQuery);
+        if (optionalSegments == null) {
+          optionalSegments = new ArrayList<>();
+        } else {
+          allSegmentsToQuery.addAll(optionalSegments);
+        }
+        for (String segmentName : tumm.getNewlyAddedSegments()) {
+          if (!allSegmentsToQuery.contains(segmentName)) {
+            optionalSegments.add(segmentName);
+          }
+        }
+        segmentDataManagers = tableDataManager.acquireSegments(segmentsToQuery, optionalSegments, notAcquiredSegments);
+        indexSegments = new ArrayList<>(segmentDataManagers.size());
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          if (segmentDataManager.hasMultiSegments()) {
+            indexSegments.addAll(segmentDataManager.getSegments());
+          } else {
+            indexSegments.add(segmentDataManager.getSegment());
+          }
+        }
+        if (isUsingConsistencyMode) {
+          List<SegmentContext> segmentContexts =
+              tableDataManager.getSegmentContexts(indexSegments, queryContext.getQueryOptions());
+          providedSegmentContexts = new HashMap<>(segmentContexts.size());
+          for (SegmentContext sc : segmentContexts) {
+            providedSegmentContexts.put(sc.getIndexSegment(), sc);
+          }
+        }
+      } finally {
+        if (isUsingConsistencyMode) {
+          tumm.unlockForSegmentContexts();
+        }
+      }
+    }
+
+    return new SingleTableExecutionInfo(tableDataManager, segmentDataManagers, indexSegments, providedSegmentContexts,
+        segmentsToQuery, optionalSegments, notAcquiredSegments);
+  }
+
+  private static boolean isUpsertTable(TableDataManager tableDataManager) {
+    // For upsert table, the server can start to process newly added segments before brokers can add those segments
+    // into their routing tables, like newly created consuming segment or newly uploaded segments. We should include
+    // those segments in the list of segments for query to process on the server, otherwise, the query will see less
+    // than expected valid docs from the upsert table.
+    if (tableDataManager instanceof RealtimeTableDataManager) {
+      RealtimeTableDataManager rtdm = (RealtimeTableDataManager) tableDataManager;
+      return rtdm.isUpsertEnabled();
+    }
+    return false;
+  }
+
+  private SingleTableExecutionInfo(TableDataManager tableDataManager, List<SegmentDataManager> segmentDataManagers,
       List<IndexSegment> indexSegments, Map<IndexSegment, SegmentContext> providedSegmentContexts,
       List<String> segmentsToQuery, List<String> optionalSegments, List<String> notAcquiredSegments) {
     _tableDataManager = tableDataManager;
@@ -52,6 +149,12 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
     _optionalSegments = optionalSegments;
     _notAcquiredSegments = notAcquiredSegments;
   }
+
+  @Override
+  public boolean hasRealtime() {
+    return _tableDataManager instanceof RealtimeTableDataManager;
+  }
+
 
   public TableDataManager getTableDataManager() {
     return _tableDataManager;
@@ -84,6 +187,7 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
     return new ArrayList<>(_indexSegments);
   }
 
+  @Nullable
   @Override
   public Map<IndexSegment, SegmentContext> getProvidedSegmentContexts() {
     return _providedSegmentContexts;
@@ -106,6 +210,11 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
   public List<String> getMissingSegments() {
     return _notAcquiredSegments.stream().filter(segmentName -> !_tableDataManager.isSegmentDeletedRecently(segmentName))
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public int getNumSegmentsAcquired() {
+    return _segmentDataManagers.size();
   }
 
   @Override
@@ -150,12 +259,47 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
   }
 
   @Override
-  public int getNumSegmentsAcquired() {
-    return _segmentDataManagers.size();
+  public SelectedSegmentsInfo getSelectedSegmentsInfo(QueryContext queryContext, TimerContext timerContext,
+      ExecutorService executorService, SegmentPrunerService segmentPrunerService) {
+    List<IndexSegment> indexSegments = getCopyOfIndexSegments();
+    Map<IndexSegment, SegmentContext> providedSegmentContexts = getProvidedSegmentContexts();
+
+    // Compute total docs for the table before pruning the segments
+    long numTotalDocs = 0;
+    for (IndexSegment indexSegment : indexSegments) {
+      numTotalDocs += indexSegment.getSegmentMetadata().getTotalDocs();
+    }
+
+    SegmentPrunerStatistics prunerStats = new SegmentPrunerStatistics();
+    List<IndexSegment> selectedSegments =
+        selectSegments(indexSegments, queryContext, timerContext, executorService, segmentPrunerService, prunerStats);
+
+    int numTotalSegments = indexSegments.size();
+    int numSelectedSegments = selectedSegments.size();
+    LOGGER.debug("Matched {} segments after pruning", numSelectedSegments);
+    List<SegmentContext> selectedSegmentContexts;
+    if (providedSegmentContexts == null) {
+      selectedSegmentContexts = getSegmentContexts(selectedSegments, queryContext.getQueryOptions());
+    } else {
+      selectedSegmentContexts = new ArrayList<>(selectedSegments.size());
+      selectedSegments.forEach(s -> selectedSegmentContexts.add(providedSegmentContexts.get(s)));
+    }
+    return new SelectedSegmentsInfo(indexSegments, numTotalDocs, prunerStats, numTotalSegments, numSelectedSegments,
+        selectedSegmentContexts);
   }
 
-  @Override
-  public boolean isRealtime() {
-    return _tableDataManager instanceof RealtimeTableDataManager;
+  private List<IndexSegment> selectSegments(List<IndexSegment> indexSegments, QueryContext queryContext,
+      TimerContext timerContext, ExecutorService executorService, SegmentPrunerService segmentPrunerService,
+      SegmentPrunerStatistics prunerStats) {
+    List<IndexSegment> selectedSegments;
+    if ((queryContext.getFilter() != null && queryContext.getFilter().isConstantFalse()) || (
+        queryContext.getHavingFilter() != null && queryContext.getHavingFilter().isConstantFalse())) {
+      selectedSegments = Collections.emptyList();
+    } else {
+      TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
+      selectedSegments = segmentPrunerService.prune(indexSegments, queryContext, prunerStats, executorService);
+      segmentPruneTimer.stopAndRecord();
+    }
+    return selectedSegments;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
@@ -59,12 +60,12 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
   private final List<String> _optionalSegments;
   private final List<String> _notAcquiredSegments;
 
-  @Nullable
   public static SingleTableExecutionInfo create(InstanceDataManager instanceDataManager, String tableNameWithType,
-      List<String> segmentsToQuery, List<String> optionalSegments, QueryContext queryContext) {
+      List<String> segmentsToQuery, List<String> optionalSegments, QueryContext queryContext)
+      throws TableNotFoundException {
     TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableNameWithType);
     if (tableDataManager == null) {
-      return null;
+      throw new TableNotFoundException(tableNameWithType);
     }
 
     List<String> notAcquiredSegments = new ArrayList<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.executor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+
+
+public class SingleTableExecutionInfo implements TableExecutionInfo {
+  private final TableDataManager _tableDataManager;
+  private final List<SegmentDataManager> _segmentDataManagers;
+  private final List<IndexSegment> _indexSegments;
+  private final Map<IndexSegment, SegmentContext> _providedSegmentContexts;
+  private final List<String> _segmentsToQuery;
+  private final List<String> _optionalSegments;
+  private final List<String> _notAcquiredSegments;
+
+  public SingleTableExecutionInfo(TableDataManager tableDataManager, List<SegmentDataManager> segmentDataManagers,
+      List<IndexSegment> indexSegments, Map<IndexSegment, SegmentContext> providedSegmentContexts,
+      List<String> segmentsToQuery, List<String> optionalSegments, List<String> notAcquiredSegments) {
+    _tableDataManager = tableDataManager;
+    _segmentDataManagers = segmentDataManagers;
+    _indexSegments = indexSegments;
+    _providedSegmentContexts = providedSegmentContexts;
+    _segmentsToQuery = segmentsToQuery;
+    _optionalSegments = optionalSegments;
+    _notAcquiredSegments = notAcquiredSegments;
+  }
+
+  public TableDataManager getTableDataManager() {
+    return _tableDataManager;
+  }
+
+  public List<SegmentDataManager> getSegmentDataManagers() {
+    return _segmentDataManagers;
+  }
+
+  @Override
+  public void releaseSegmentDataManagers() {
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      _tableDataManager.releaseSegment(segmentDataManager);
+    }
+  }
+
+  @Override
+  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+      Map<String, String> queryOptions) {
+    return _tableDataManager.getSegmentContexts(selectedSegments, queryOptions);
+  }
+
+  @Override
+  public List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @Override
+  public List<IndexSegment> getCopyOfIndexSegments() {
+    return new ArrayList<>(_indexSegments);
+  }
+
+  @Override
+  public Map<IndexSegment, SegmentContext> getProvidedSegmentContexts() {
+    return _providedSegmentContexts;
+  }
+
+  public List<String> getSegmentsToQuery() {
+    return _segmentsToQuery;
+  }
+
+  public List<String> getOptionalSegments() {
+    return _optionalSegments;
+  }
+
+  @Override
+  public List<String> getNotAcquiredSegments() {
+    return _notAcquiredSegments;
+  }
+
+  @Override
+  public List<String> getMissingSegments() {
+    return _notAcquiredSegments.stream().filter(segmentName -> !_tableDataManager.isSegmentDeletedRecently(segmentName))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public ConsumingSegmentsInfo getConsumingSegmentsInfo() {
+    int numConsumingSegmentsQueried = 0;
+    long minIndexTimeMs = 0;
+    long minIngestionTimeMs = 0;
+    long maxEndTimeMs = 0;
+    if (_tableDataManager instanceof RealtimeTableDataManager) {
+      minIndexTimeMs = Long.MAX_VALUE;
+      minIngestionTimeMs = Long.MAX_VALUE;
+      maxEndTimeMs = Long.MIN_VALUE;
+      for (IndexSegment indexSegment : _indexSegments) {
+        SegmentMetadata segmentMetadata = indexSegment.getSegmentMetadata();
+        if (indexSegment instanceof MutableSegment) {
+          numConsumingSegmentsQueried += 1;
+          long indexTimeMs = segmentMetadata.getLastIndexedTimestamp();
+          if (indexTimeMs > 0) {
+            minIndexTimeMs = Math.min(minIndexTimeMs, indexTimeMs);
+          }
+          long ingestionTimeMs =
+              ((RealtimeTableDataManager) _tableDataManager).getPartitionIngestionTimeMs(indexSegment.getSegmentName());
+          if (ingestionTimeMs > 0) {
+            minIngestionTimeMs = Math.min(minIngestionTimeMs, ingestionTimeMs);
+          }
+        } else if (indexSegment instanceof ImmutableSegment) {
+          long indexCreationTime = segmentMetadata.getIndexCreationTime();
+          if (indexCreationTime > 0) {
+            maxEndTimeMs = Math.max(maxEndTimeMs, indexCreationTime);
+          } else {
+            // NOTE: the endTime may be totally inaccurate based on the value added in the timeColumn
+            long endTime = segmentMetadata.getEndTime();
+            if (endTime > 0) {
+              maxEndTimeMs = Math.max(maxEndTimeMs, endTime);
+            }
+          }
+        }
+      }
+    }
+
+    return new ConsumingSegmentsInfo(numConsumingSegmentsQueried, minIndexTimeMs, minIngestionTimeMs, maxEndTimeMs);
+  }
+
+  @Override
+  public int getNumSegmentsAcquired() {
+    return _segmentDataManagers.size();
+  }
+
+  @Override
+  public boolean isRealtime() {
+    return _tableDataManager instanceof RealtimeTableDataManager;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
@@ -45,12 +45,6 @@ public interface TableExecutionInfo {
   List<IndexSegment> getIndexSegments();
 
   /**
-   * Get a copy of the index segments for a table referenced in the query as some functions may mutate the list.
-   * @return A copy of the list of index segments for the table
-   */
-  List<IndexSegment> getCopyOfIndexSegments();
-
-  /**
    * Get the SegmentContext for all the index segments.
    * @return A map of index segments to their SegmentContext
    */
@@ -109,10 +103,6 @@ public interface TableExecutionInfo {
   /**
    * Get the selected segments and segment contexts for a table referenced in a query. The information is gathered
    * in a SelectSegmentsInfo object.
-   * @param queryContext
-   * @param timerContext
-   * @param executorService
-   * @param segmentPrunerService
    * @return A SelectSegmentsInfo object containing the selected segments and segment contexts
    */
   SelectedSegmentsInfo getSelectedSegmentsInfo(QueryContext queryContext, TimerContext timerContext,
@@ -176,12 +166,12 @@ public interface TableExecutionInfo {
    * number of segments selected and the number of total documents.
    */
   class SelectedSegmentsInfo {
-    public List<IndexSegment> _indexSegments;
-    public long _numTotalDocs;
-    public SegmentPrunerStatistics _prunerStats;
-    public int _numTotalSegments;
-    public int _numSelectedSegments;
-    public List<SegmentContext> _selectedSegmentContexts;
+    private List<IndexSegment> _indexSegments;
+    private long _numTotalDocs;
+    private SegmentPrunerStatistics _prunerStats;
+    private int _numTotalSegments;
+    private int _numSelectedSegments;
+    private List<SegmentContext> _selectedSegmentContexts;
 
     public SelectedSegmentsInfo(List<IndexSegment> indexSegments, long numTotalDocs,
         SegmentPrunerStatistics prunerStats, int numTotalSegments, int numSelectedSegments,
@@ -192,6 +182,30 @@ public interface TableExecutionInfo {
       _numTotalSegments = numTotalSegments;
       _numSelectedSegments = numSelectedSegments;
       _selectedSegmentContexts = selectedSegmentContexts;
+    }
+
+    public List<IndexSegment> getIndexSegments() {
+      return _indexSegments;
+    }
+
+    public long getNumTotalDocs() {
+      return _numTotalDocs;
+    }
+
+    public SegmentPrunerStatistics getPrunerStats() {
+      return _prunerStats;
+    }
+
+    public int getNumTotalSegments() {
+      return _numTotalSegments;
+    }
+
+    public int getNumSelectedSegments() {
+      return _numSelectedSegments;
+    }
+
+    public List<SegmentContext> getSelectedSegmentContexts() {
+      return _selectedSegmentContexts;
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.executor;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+
+
+public interface TableExecutionInfo {
+  boolean isRealtime();
+
+  class ConsumingSegmentsInfo {
+    private final int _numConsumingSegmentsQueried;
+    private final long _minIndexTimeMs;
+    private final long _minIngestionTimeMs;
+    private final long _maxEndTimeMs;
+
+    public ConsumingSegmentsInfo(int numConsumingSegmentsQueried, long minIndexTimeMs, long minIngestionTimeMs,
+        long maxEndTimeMs) {
+      _numConsumingSegmentsQueried = numConsumingSegmentsQueried;
+      _minIndexTimeMs = minIndexTimeMs;
+      _minIngestionTimeMs = minIngestionTimeMs;
+      _maxEndTimeMs = maxEndTimeMs;
+    }
+
+    long getMinConsumingFreshnessTimeMs() {
+      long minConsumingFreshnessTimeMs = 0;
+      if (getMinIngestionTimeMs() != Long.MAX_VALUE) {
+        minConsumingFreshnessTimeMs = getMinIngestionTimeMs();
+      } else if (getMinIndexTimeMs() != Long.MAX_VALUE) {
+        minConsumingFreshnessTimeMs = getMinIndexTimeMs();
+      } else if (getMaxEndTimeMs() != Long.MIN_VALUE) {
+        minConsumingFreshnessTimeMs = getMaxEndTimeMs();
+      }
+      return minConsumingFreshnessTimeMs;
+    }
+
+    public int getNumConsumingSegmentsQueried() {
+      return _numConsumingSegmentsQueried;
+    }
+
+    public long getMinIndexTimeMs() {
+      return _minIndexTimeMs;
+    }
+
+    public long getMinIngestionTimeMs() {
+      return _minIngestionTimeMs;
+    }
+
+    public long getMaxEndTimeMs() {
+      return _maxEndTimeMs;
+    }
+  }
+
+  List<IndexSegment> getIndexSegments();
+
+  List<IndexSegment> getCopyOfIndexSegments();
+
+  Map<IndexSegment, SegmentContext> getProvidedSegmentContexts();
+
+  List<String> getSegmentsToQuery();
+
+  List<String> getOptionalSegments();
+
+  List<SegmentDataManager> getSegmentDataManagers();
+
+  void releaseSegmentDataManagers();
+
+  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments, Map<String, String> queryOptions);
+
+  List<String> getNotAcquiredSegments();
+
+  List<String> getMissingSegments();
+
+  ConsumingSegmentsInfo getConsumingSegmentsInfo();
+
+  int getNumSegmentsAcquired();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
@@ -20,14 +20,114 @@ package org.apache.pinot.core.query.executor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.query.pruner.SegmentPrunerService;
+import org.apache.pinot.core.query.pruner.SegmentPrunerStatistics;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 
 
 public interface TableExecutionInfo {
-  boolean isRealtime();
+  /**
+   * Check if consuming segments are being queried.
+   * @return true if consuming segments are being queried, false otherwise
+   */
+  boolean hasRealtime();
 
+  /**
+   * Get the index segments for a table referenced in the query.
+   * @return A list of index segments for the table
+   */
+  List<IndexSegment> getIndexSegments();
+
+  /**
+   * Get a copy of the index segments for a table referenced in the query as some functions may mutate the list.
+   * @return A copy of the list of index segments for the table
+   */
+  List<IndexSegment> getCopyOfIndexSegments();
+
+  /**
+   * Get the SegmentContext for all the index segments.
+   * @return A map of index segments to their SegmentContext
+   */
+  @Nullable
+  Map<IndexSegment, SegmentContext> getProvidedSegmentContexts();
+
+  /**
+   * List of segment names to query.
+   * @return A list of segment names to query
+   */
+  List<String> getSegmentsToQuery();
+
+  /**
+   * List of optional segments to query.
+   * @return A list of optional segments to query
+   */
+  List<String> getOptionalSegments();
+
+  /**
+   * Get the list of segment data managers for the segments that are being queried.
+   * @return A list of segment data managers for the segments that are being queried
+   */
+  List<SegmentDataManager> getSegmentDataManagers();
+
+  /**
+   * Release the lock acquired on the segment data managers.
+   */
+  void releaseSegmentDataManagers();
+
+  /**
+   * Get the list of SegmentContexts for the index segments selected in getSelectedSegmentsInfo.
+   * @param selectedSegments A list of index segments selected in getSelectedSegmentsInfo
+   * @param queryOptions A map of query options
+   * @return A list of SegmentContexts for the index segments selected in getSelectedSegmentsInfo
+   */
+  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments, Map<String, String> queryOptions);
+
+  /**
+   * Get the list of segments that are not acquired.
+   * @return A list of segments that are not acquired
+   */
+  List<String> getNotAcquiredSegments();
+
+  /**
+   * Get the list of segments that are missing.
+   * @return A list of segments that are missing
+   */
+  List<String> getMissingSegments();
+
+  /**
+   * Get the number of segments acquired.
+   * @return The number of segments acquired
+   */
+  int getNumSegmentsAcquired();
+
+  /**
+   * Get the selected segments and segment contexts for a table referenced in a query. The information is gathered
+   * in a SelectSegmentsInfo object.
+   * @param queryContext
+   * @param timerContext
+   * @param executorService
+   * @param segmentPrunerService
+   * @return A SelectSegmentsInfo object containing the selected segments and segment contexts
+   */
+  SelectedSegmentsInfo getSelectedSegmentsInfo(QueryContext queryContext, TimerContext timerContext,
+      ExecutorService executorService, SegmentPrunerService segmentPrunerService);
+
+  /**
+   * Generate metadata about the consuming segments queried.
+   * @return A ConsumingSegmentsInfo object containing the metadata about the consuming segments queried
+   */
+  ConsumingSegmentsInfo getConsumingSegmentsInfo();
+
+  /**
+   * If consuming segments are being queried, this class contains the information about the consuming segments such as
+   * the number of segments queried, the min index time, the min ingestion time and the max end time.
+   */
   class ConsumingSegmentsInfo {
     private final int _numConsumingSegmentsQueried;
     private final long _minIndexTimeMs;
@@ -71,27 +171,27 @@ public interface TableExecutionInfo {
     }
   }
 
-  List<IndexSegment> getIndexSegments();
+  /**
+   * This class contains the information about the selected segments such as the number of segments queried, the
+   * number of segments selected and the number of total documents.
+   */
+  class SelectedSegmentsInfo {
+    public List<IndexSegment> _indexSegments;
+    public long _numTotalDocs;
+    public SegmentPrunerStatistics _prunerStats;
+    public int _numTotalSegments;
+    public int _numSelectedSegments;
+    public List<SegmentContext> _selectedSegmentContexts;
 
-  List<IndexSegment> getCopyOfIndexSegments();
-
-  Map<IndexSegment, SegmentContext> getProvidedSegmentContexts();
-
-  List<String> getSegmentsToQuery();
-
-  List<String> getOptionalSegments();
-
-  List<SegmentDataManager> getSegmentDataManagers();
-
-  void releaseSegmentDataManagers();
-
-  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments, Map<String, String> queryOptions);
-
-  List<String> getNotAcquiredSegments();
-
-  List<String> getMissingSegments();
-
-  ConsumingSegmentsInfo getConsumingSegmentsInfo();
-
-  int getNumSegmentsAcquired();
+    public SelectedSegmentsInfo(List<IndexSegment> indexSegments, long numTotalDocs,
+        SegmentPrunerStatistics prunerStats, int numTotalSegments, int numSelectedSegments,
+        List<SegmentContext> selectedSegmentContexts) {
+      _indexSegments = indexSegments;
+      _numTotalDocs = numTotalDocs;
+      _prunerStats = prunerStats;
+      _numTotalSegments = numTotalSegments;
+      _numSelectedSegments = numSelectedSegments;
+      _selectedSegmentContexts = selectedSegmentContexts;
+    }
+  }
 }


### PR DESCRIPTION
The SSE Query Executor class - `ServerQueryExecutorV1Impl` processes a single table using a single `TableDataManager`. LogicalTable feature (#15558  ) requires the executor to process multiple tables. 

In preparation for this change, table processing has been moved to `SingleTableExecutionInfo`. This class processes all the metadata associated with a single table. `ServerQueryExecutorV1Impl` delegates processing using an interface `TableExecutionInfo`. In the future a new implementation will be added to process a list of tables. 

Operations such as calculating `ConsumingSegmentInfo` and selecting/pruning/getting contexts are specific to a table. So these operations have been moved to `TableExecutionInfo`. In the future, these operations will be appropriately aggregated across a list of tables.

A proof-of-concept of how a list of tables will be processed is in #15151 

Close #15559 