### PR TITLE
Add null handling support for MV aggregation functions - COUNT, MIN, MAX, SUM, AVG, MINMAXRANGE

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -385,17 +385,17 @@ public class AggregationFunctionFactory {
           case IDSET:
             return new IdSetAggregationFunction(arguments);
           case COUNTMV:
-            return new CountMVAggregationFunction(arguments);
+            return new CountMVAggregationFunction(arguments, nullHandlingEnabled);
           case MINMV:
-            return new MinMVAggregationFunction(arguments);
+            return new MinMVAggregationFunction(arguments, nullHandlingEnabled);
           case MAXMV:
-            return new MaxMVAggregationFunction(arguments);
+            return new MaxMVAggregationFunction(arguments, nullHandlingEnabled);
           case SUMMV:
-            return new SumMVAggregationFunction(arguments);
+            return new SumMVAggregationFunction(arguments, nullHandlingEnabled);
           case AVGMV:
-            return new AvgMVAggregationFunction(arguments);
+            return new AvgMVAggregationFunction(arguments, nullHandlingEnabled);
           case MINMAXRANGEMV:
-            return new MinMaxRangeMVAggregationFunction(arguments);
+            return new MinMaxRangeMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTMV:
             return new DistinctCountMVAggregationFunction(arguments);
           case DISTINCTCOUNTBITMAPMV:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
 public class MaxAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
-  private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
+  protected static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
   public MaxAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "MAX"), nullHandlingEnabled);
@@ -148,7 +148,7 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
-  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number max) {
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number max) {
     if (max != null) {
       if (_nullHandlingEnabled) {
         Double otherMax = aggregationResultHolder.getResult();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
 public class MinAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
-  private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
+  protected static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
   public MinAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "MIN"), nullHandlingEnabled);
@@ -148,7 +148,7 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
-  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number min) {
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Number min) {
     if (min != null) {
       if (_nullHandlingEnabled) {
         Double otherMin = aggregationResultHolder.getResult();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -29,8 +29,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
 
-  public MinMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "MIN_MV"), false);
+  public MinMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "MIN_MV"), nullHandlingEnabled);
   }
 
   @Override
@@ -41,48 +41,93 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    double min = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      for (double value : valuesArray[i]) {
-        if (value < min) {
-          min = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+    Double min = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+      double innerMin = DEFAULT_VALUE;
+      for (int i = from; i < to; i++) {
+        double[] values = valuesArray[i];
+        for (double value : values) {
+          if (value < innerMin) {
+            innerMin = value;
+          }
         }
       }
-    }
-    aggregationResultHolder.setValue(min);
+      return acum == null ? innerMin : Math.min(acum, innerMin);
+    });
+
+    updateAggregationResultHolder(aggregationResultHolder, min);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      double min = groupByResultHolder.getDoubleResult(groupKey);
-      for (double value : valuesArray[i]) {
-        if (value < min) {
-          min = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int groupKey = groupKeyArray[i];
+          Double min = groupByResultHolder.getResult(groupKey);
+          for (double value : valuesArray[i]) {
+            if (min == null || value < min) {
+              min = value;
+            }
+          }
+          groupByResultHolder.setValueForKey(groupKey, min);
         }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        int groupKey = groupKeyArray[i];
+        double min = groupByResultHolder.getDoubleResult(groupKey);
+        for (double value : valuesArray[i]) {
+          if (value < min) {
+            min = value;
+          }
+        }
+        groupByResultHolder.setValueForKey(groupKey, min);
       }
-      groupByResultHolder.setValueForKey(groupKey, min);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    for (int i = 0; i < length; i++) {
-      double[] values = valuesArray[i];
-      for (int groupKey : groupKeysArray[i]) {
-        double min = groupByResultHolder.getDoubleResult(groupKey);
-        for (double value : values) {
-          if (value < min) {
-            min = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          Double min = null;
+          for (double value : valuesArray[i]) {
+            if (min == null || value < min) {
+              min = value;
+            }
+          }
+
+          for (int groupKey : groupKeysArray[i]) {
+            Double currentMin = groupByResultHolder.getResult(groupKey);
+            if (currentMin == null || (min != null && min < currentMin)) {
+              groupByResultHolder.setValueForKey(groupKey, min);
+            }
           }
         }
-        groupByResultHolder.setValueForKey(groupKey, min);
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        double[] values = valuesArray[i];
+        for (int groupKey : groupKeysArray[i]) {
+          double min = groupByResultHolder.getDoubleResult(groupKey);
+          for (double value : values) {
+            if (value < min) {
+              min = value;
+            }
+          }
+          groupByResultHolder.setValueForKey(groupKey, min);
+        }
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
 public class SumAggregationFunction extends NullableSingleInputAggregationFunction<Double, Double> {
-  private static final double DEFAULT_VALUE = 0.0;
+  protected static final double DEFAULT_VALUE = 0.0;
 
   public SumAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     this(verifySingleArgument(arguments, "SUM"), nullHandlingEnabled);
@@ -145,7 +145,7 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
     updateAggregationResultHolder(aggregationResultHolder, sum);
   }
 
-  private void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Double sum) {
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, Double sum) {
     if (sum != null) {
       if (_nullHandlingEnabled) {
         Double otherSum = aggregationResultHolder.getResult();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -29,8 +29,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
 
-  public SumMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "SUM_MV"), false);
+  public SumMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "SUM_MV"), nullHandlingEnabled);
   }
 
   @Override
@@ -41,42 +41,89 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    double sum = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      for (double value : valuesArray[i]) {
-        sum += value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+
+    Double sum;
+    sum = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+      double innerSum = 0;
+      for (int i = from; i < to; i++) {
+        for (double value : valuesArray[i]) {
+          innerSum += value;
+        }
       }
-    }
-    aggregationResultHolder.setValue(sum);
+      return acum == null ? innerSum : acum + innerSum;
+    });
+
+    updateAggregationResultHolder(aggregationResultHolder, sum);
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      double sum = groupByResultHolder.getDoubleResult(groupKey);
-      for (double value : valuesArray[i]) {
-        sum += value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int groupKey = groupKeyArray[i];
+          if (valuesArray[i].length > 0) {
+            // "i" has to be non-null here so we can use the default value as the initial value instead of null
+            double sum = DEFAULT_VALUE;
+            for (double value : valuesArray[i]) {
+              sum += value;
+            }
+            Double result = groupByResultHolder.getResult(groupKey);
+            groupByResultHolder.setValueForKey(groupKey, result == null ? sum : result + sum);
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        int groupKey = groupKeyArray[i];
+        double sum = groupByResultHolder.getDoubleResult(groupKey);
+        for (double value : valuesArray[i]) {
+          sum += value;
+        }
+        groupByResultHolder.setValueForKey(groupKey, sum);
       }
-      groupByResultHolder.setValueForKey(groupKey, sum);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[][] valuesArray = blockValSetMap.get(_expression).getDoubleValuesMV();
-    for (int i = 0; i < length; i++) {
-      double[] values = valuesArray[i];
-      for (int groupKey : groupKeysArray[i]) {
-        double sum = groupByResultHolder.getDoubleResult(groupKey);
-        for (double value : values) {
-          sum += value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    double[][] valuesArray = blockValSet.getDoubleValuesMV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          double[] values = valuesArray[i];
+          if (values.length > 0) {
+            // "i" has to be non-null here so we can use the default value as the initial value instead of null
+            double sum = DEFAULT_VALUE;
+            for (double value : values) {
+              sum += value;
+            }
+            for (int groupKey : groupKeysArray[i]) {
+              Double result = groupByResultHolder.getResult(groupKey);
+              groupByResultHolder.setValueForKey(groupKey, result == null ? sum : result + sum);
+            }
+          }
         }
-        groupByResultHolder.setValueForKey(groupKey, sum);
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        double[] values = valuesArray[i];
+        for (int groupKey : groupKeysArray[i]) {
+          double sum = groupByResultHolder.getDoubleResult(groupKey);
+          for (double value : values) {
+            sum += value;
+          }
+          groupByResultHolder.setValueForKey(groupKey, sum);
+        }
       }
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunctionTest.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class AvgMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void aggregationAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select avg_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(
+                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        )
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select avg_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(
+            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+                / 4.0))
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "2");
+  }
+
+  @Test
+  public void aggregationGroupBySVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"}
+        )
+        .whenQuery("select avg_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2;3", "k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k2"},
+            new Object[]{"1;2;3", "k1"}
+        )
+        .whenQuery("select avg_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", String.valueOf(
+            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+                / 4.0), String.valueOf(
+            (6 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+                / 4.0))
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "2", "2");
+  }
+
+  @Test
+  public void aggregationGroupByMVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select avg_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "null", "null");
+  }
+
+  @Test
+  public void aggregationGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select avg_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", String.valueOf(
+            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+                / 3.0), String.valueOf(
+            (3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+                / 3.0))
+        .whenQueryWithNullHandlingEnabled("select avg_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "1.5", "1.5");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunctionTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class CountMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void basicCountMV() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"},
+            new Object[]{"4;5;6"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"7;8;9"},
+            new Object[]{"10;11;12"}
+        )
+        .whenQuery("select count_mv(mv) from testTable")
+        .thenResultIs("LONG", String.valueOf(12));
+  }
+
+  @Test
+  public void countMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"},
+            new Object[]{"1;2"}
+        )
+        .whenQuery("select count_mv(mv) from testTable")
+        .thenResultIs("LONG", "4")
+        .whenQueryWithNullHandlingEnabled("select count_mv(mv) from testTable")
+        .thenResultIs("LONG", "2");
+  }
+
+  @Test
+  public void countMVGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2", "k1"}
+        )
+        .whenQuery("select count_mv(mv) from testTable group by sv")
+        .thenResultIs("LONG", "4")
+        .whenQueryWithNullHandlingEnabled("select count_mv(mv) from testTable group by sv")
+        .thenResultIs("LONG", "2");
+  }
+
+  @Test
+  public void countMVGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"},
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .whenQuery("select count_mv(mv1) from testTable group by mv2")
+        .thenResultIs("LONG", "4", "4")
+        .whenQueryWithNullHandlingEnabled("select count_mv(mv1) from testTable group by mv2")
+        .thenResultIs("LONG", "2", "2");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunctionTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class MaxMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void aggregationAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select max_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(
+                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        )
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select max_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "3")
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "3");
+  }
+
+  @Test
+  public void aggregationGroupBySVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"}
+        )
+        .whenQuery("select max_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2;3", "k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k2"},
+            new Object[]{"1;2;3", "k1"}
+        )
+        .whenQuery("select max_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "3", "3")
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "3", "3");
+  }
+
+  @Test
+  public void aggregationGroupByMVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select max_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "null", "null");
+  }
+
+  @Test
+  public void aggregationGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select max_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "2", "2")
+        .whenQueryWithNullHandlingEnabled("select max_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "2", "2");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunctionTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class MinMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void aggregationAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select min_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(
+                (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null))
+        )
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select min_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "1");
+  }
+
+  @Test
+  public void aggregationGroupBySVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"}
+        )
+        .whenQuery("select min_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2;3", "k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k2"},
+            new Object[]{"1;2;3", "k1"}
+        )
+        .whenQuery("select min_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", String.valueOf(
+            ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)).doubleValue()), String.valueOf(
+                ((Number) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                    null)).doubleValue()))
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "1", "1");
+  }
+
+  @Test
+  public void aggregationGroupByMVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select min_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "null", "null");
+  }
+
+  @Test
+  public void aggregationGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select min_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select min_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "1", "1");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunctionTest.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class MinMaxRangeMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void aggregationAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select min_max_range_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "0.0")
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select min_max_range_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(
+            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)))
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "2");
+  }
+
+  @Test
+  public void aggregationGroupBySVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"}
+        )
+        .whenQuery("select min_max_range_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "0")
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2;3", "k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k2"},
+            new Object[]{"1;2;3", "k1"}
+        )
+        .whenQuery("select min_max_range_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", String.valueOf(
+            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)), String.valueOf(
+            3.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)))
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "2", "2");
+  }
+
+  @Test
+  public void aggregationGroupByMVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select min_max_range_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "0", "0")
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "null", "null");
+  }
+
+  @Test
+  public void aggregationGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select min_max_range_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", String.valueOf(
+            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)), String.valueOf(
+            2.0 - 1.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)))
+        .whenQueryWithNullHandlingEnabled("select min_max_range_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "1", "1");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunctionTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+
+public class SumMVAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void aggregationAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select sum_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(
+                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                    null))
+        )
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2;3"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null"}
+        )
+        .whenQuery("select sum_mv(mv) from testTable")
+        .thenResultIs("DOUBLE", String.valueOf(
+            1 + 2 + 3 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT,
+                null)))
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable")
+        .thenResultIs("DOUBLE",
+            String.valueOf(1 + 2 + 3));
+  }
+
+  @Test
+  public void aggregationGroupBySVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1"}
+        )
+        .whenQuery("select sum_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", String.valueOf(
+            2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test
+  public void aggregationGroupBySVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv", FieldSpec.DataType.INT)
+                .addSingleValueDimension("sv", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1"},
+            new Object[]{"1;2;3", "k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k2"},
+            new Object[]{"1;2;3", "k1"}
+        )
+        .whenQuery("select sum_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", String.valueOf(
+                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(
+                6.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv) from testTable group by sv")
+        .thenResultIs("DOUBLE", "6", "6");
+  }
+
+  @Test
+  public void aggregationGroupByMVAllNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select sum_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", String.valueOf(
+                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(
+                2.0 * (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "null", "null");
+  }
+
+  @Test
+  public void aggregationGroupByMVWithNulls() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("mv1", FieldSpec.DataType.INT)
+                .addMultiValueDimension("mv2", FieldSpec.DataType.STRING)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"1;2", "k1;k2"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"null", "k1;k2"}
+        )
+        .whenQuery("select sum_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", String.valueOf(
+                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)),
+            String.valueOf(
+                3.0 + (int) FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, FieldSpec.DataType.INT, null)))
+        .whenQueryWithNullHandlingEnabled("select sum_mv(mv1) from testTable group by mv2")
+        .thenResultIs("DOUBLE", "3", "3");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FluentQueryTest.java
@@ -217,7 +217,8 @@ public class FluentQueryTest {
     /**
      * Creates one segment on the first instance (aka server) with the given content.
      * @param content the content of the segment. Each element of the array is a row. Each row is an array of objects
-     *                that should be compatible with the table definition.
+     *                that should be compatible with the table definition. Note that the values should be in the order
+     *                following the alphabetical order of the column names.
      */
     public OnFirstInstance onFirstInstance(Object[]... content) {
       return new OnFirstInstance(_tableConfig, _schema, _baseDir, false, _baseQueriesTest, _extraQueryOptions)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPair.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPair.java
@@ -45,6 +45,11 @@ public class AvgPair implements Comparable<AvgPair> {
     _count += avgPair._count;
   }
 
+  public void apply(double value) {
+    _sum += value;
+    _count++;
+  }
+
   public double getSum() {
     return _sum;
   }


### PR DESCRIPTION
- This patch adds null handling support for the most common MV aggregation functions - COUNT, MIN, MAX, SUM, AVG, MINMAXRANGE.
- It follows the same principles as in https://github.com/apache/pinot/pull/13791.