### PR TITLE
Fix MIN_MAX_RANGE aggregation function behavior when all input values are null

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -65,6 +66,7 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
 
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     MinMaxRangePair minMax = new MinMaxRangePair();
+    AtomicBoolean empty = new AtomicBoolean(true);
 
     if (blockValSet.getValueType() != DataType.BYTES) {
       double[] doubleValues = blockValSet.getDoubleValuesSV();
@@ -72,6 +74,7 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
         for (int i = from; i < to; i++) {
           double value = doubleValues[i];
           minMax.apply(value);
+          empty.set(false);
         }
       });
     } else {
@@ -81,10 +84,13 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
         for (int i = from; i < to; i++) {
           MinMaxRangePair minMaxRangePair = ObjectSerDeUtils.MIN_MAX_RANGE_PAIR_SER_DE.deserialize(bytesValues[i]);
           minMax.apply(minMaxRangePair);
+          empty.set(false);
         }
       });
     }
-    setAggregationResult(aggregationResultHolder, minMax.getMin(), minMax.getMax());
+    if (!empty.get()) {
+      setAggregationResult(aggregationResultHolder, minMax.getMin(), minMax.getMax());
+    }
   }
 
   protected void setAggregationResult(AggregationResultHolder aggregationResultHolder, double min, double max) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
@@ -81,6 +81,21 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
   }
 
   @Test(dataProvider = "scenarios")
+  void aggrWithAllNulls(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true)
+        .onFirstInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select minmaxrange(myField) from testTable")
+        .thenResultIs("DOUBLE", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(DataTypeScenario scenario) {
     scenario.getDeclaringTable(false)
         .onFirstInstance("myField",


### PR DESCRIPTION
- Currently, the `MIN_MAX_RANGE` aggregation function returns `-Infinity` when null handling is enabled and all input values are null.
- This is incorrect and the function should return `null` in such cases. This patch fixes the issue. 
- Note that the bug only applies to pure aggregations and not group by / keyed aggregations (which already returned `null` in such scenarios).