### PR TITLE
Fix internal logic of pre-check minimizeDataMovement

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -192,12 +192,13 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
           }
           if (instanceAssignmentConfigConsuming.isMinimizeDataMovement()) {
             return rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.DISABLE
-                ? RebalancePreCheckerResult.warn("minimizeDataMovement is enabled in table config but it's overridden "
-                + "with disabled")
+                ? RebalancePreCheckerResult.warn(
+                "minimizeDataMovement is enabled for CONSUMING segments in table config but it's overridden "
+                    + "with disabled")
                 : RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
           }
-          return RebalancePreCheckerResult.warn("minimizeDataMovement is not enabled but instance assignment is "
-              + "allowed");
+          return RebalancePreCheckerResult.warn(
+              "minimizeDataMovement is not enabled for CONSUMING segments but instance assignment is allowed");
         }
         return RebalancePreCheckerResult.pass("Instance assignment not allowed, no need for minimizeDataMovement");
       }
@@ -221,37 +222,40 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
         if (instanceAssignmentConfigCompleted.isMinimizeDataMovement()
             && instanceAssignmentConfigConsuming.isMinimizeDataMovement()) {
           return rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.DISABLE
-              ? RebalancePreCheckerResult.warn("minimizeDataMovement is enabled in table config but it's overridden "
-              + "with disabled")
+              ? RebalancePreCheckerResult.warn(
+              "minimizeDataMovement is enabled for both COMPLETED and CONSUMING segments in table config but it's "
+                  + "overridden with disabled")
               : RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
         }
         return RebalancePreCheckerResult.warn(
-            "minimizeDataMovement may not be enabled for consuming or completed, but instance assigment is allowed "
-                + "for both");
+            "minimizeDataMovement is not enabled for either or both COMPLETED and CONSUMING segments, but instance "
+                + "assignment is allowed for both");
       } else if (instanceAssignmentConfigConsuming != null) {
         if (rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.ENABLE) {
           return RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
         }
         if (instanceAssignmentConfigConsuming.isMinimizeDataMovement()) {
           return rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.DISABLE
-              ? RebalancePreCheckerResult.warn("minimizeDataMovement is enabled in table config but it's overridden "
-              + "with disabled")
+              ? RebalancePreCheckerResult.warn(
+              "minimizeDataMovement is enabled for CONSUMING segments in table config but it's overridden with "
+                  + "disabled")
               : RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
         }
         return RebalancePreCheckerResult.warn(
-            "minimizeDataMovement is not enabled for consuming segments, but instance assignment is allowed");
+            "minimizeDataMovement is not enabled for CONSUMING segments, but instance assignment is allowed");
       } else {
         if (rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.ENABLE) {
           return RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
         }
         if (instanceAssignmentConfigCompleted.isMinimizeDataMovement()) {
           return rebalanceConfig.getMinimizeDataMovement() == RebalanceConfig.MinimizeDataMovementOptions.DISABLE
-              ? RebalancePreCheckerResult.warn("minimizeDataMovement is enabled in table config but it's overridden "
-              + "with disabled")
+              ? RebalancePreCheckerResult.warn(
+              "minimizeDataMovement is enabled for COMPLETED segments in table config but it's overridden "
+                  + "with disabled")
               : RebalancePreCheckerResult.pass("minimizeDataMovement is enabled");
         }
         return RebalancePreCheckerResult.warn(
-            "minimizeDataMovement is not enabled for completed segments, but instance assignment is allowed");
+            "minimizeDataMovement is not enabled for COMPLETED segments, but instance assignment is allowed");
       }
     } catch (IllegalStateException e) {
       LOGGER.warn("Error while trying to fetch instance assignment config, assuming minimizeDataMovement is false", e);


### PR DESCRIPTION
## Description

For table config (without `tagOverrideConfig`):
```
...
"instanceAssignmentConfigMap": {
      "COMPLETED": {
        "tagPoolConfig": {
          "tag": "DefaultTenant_OFFLINE",
          "poolBased": false,
          "numPools": 0
        },
        "replicaGroupPartitionConfig": {
        },
        "partitionSelector": "INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR",
        "minimizeDataMovement": false
      }
    },
...
```
When it's set only for `CONSUMING` or `COMPLETED`, a warning shows up even if `minimizeDataMovement=ENABLE`, which is not ture.

```
WARN: minimizeDataMovement may not enabled for consuming or completed but instance assignment is allowed for at least one
```