### PR TITLE
Fix and clean-up upsert and dedup config

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -262,7 +262,8 @@ public class TableConfigSerDeTest {
     }
     {
       // with dedup config - without metadata ttl and metadata time column
-      DedupConfig dedupConfig = new DedupConfig(true, HashFunction.MD5);
+      DedupConfig dedupConfig = new DedupConfig();
+      dedupConfig.setHashFunction(HashFunction.MD5);
       TableConfig tableConfig = tableConfigBuilder.setDedupConfig(dedupConfig).build();
       // Serialize then de-serialize
       checkTableConfigWithDedupConfigWithoutTTL(
@@ -272,7 +273,10 @@ public class TableConfigSerDeTest {
     }
     {
       // with dedup config - with metadata ttl and metadata time column
-      DedupConfig dedupConfig = new DedupConfig(true, HashFunction.MD5, null, null, 10, "dedupTimeColumn", false);
+      DedupConfig dedupConfig = new DedupConfig();
+      dedupConfig.setHashFunction(HashFunction.MD5);
+      dedupConfig.setMetadataTTL(10);
+      dedupConfig.setDedupTimeColumn("dedupTimeColumn");
       TableConfig tableConfig = tableConfigBuilder.setDedupConfig(dedupConfig).build();
       // Serialize then de-serialize
       checkTableConfigWithDedupConfigWithTTL(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class));

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -91,14 +91,17 @@ public class TableConfigTest {
     ingestionConfig.setRowTimeValueCheck(true);
     ingestionConfig.setSegmentTimeValueCheck(false);
 
+    DedupConfig dedupConfig = new DedupConfig();
+    dedupConfig.setHashFunction(HashFunction.MD5);
+
     TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(RAW_TABLE_NAME)
         .setAggregateMetrics(true)
         .setRetentionTimeValue("5")
         .setRetentionTimeUnit("DAYS")
         .setNumReplicas(2)
-        .setDedupConfig(new DedupConfig(true, HashFunction.MD5))
         .setIngestionConfig(ingestionConfig)
+        .setDedupConfig(dedupConfig)
         .setQueryConfig(new QueryConfig(2000L, true, false, Collections.emptyMap(), 100_000L, 100_000L))
         .setTierConfigList(List.of(new TierConfig("name", "type", null, null, "storageType", null, null, null)))
         .build();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2546,7 +2546,7 @@ public class PinotHelixResourceManager {
           InstancePartitionsUtils.fetchOrComputeInstancePartitions(_helixZkManager, tableConfig,
               InstancePartitionsType.OFFLINE));
     }
-    if (tableConfig.getUpsertMode() != UpsertConfig.Mode.NONE) {
+    if (tableConfig.isUpsertEnabled()) {
       // In an upsert enabled LLC realtime table, all segments of the same partition are collocated on the same server
       // -- consuming or completed. So it is fine to use CONSUMING as the InstancePartitionsType.
       return Collections.singletonMap(InstancePartitionsType.CONSUMING,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -86,6 +86,7 @@ public class RebalanceConfig {
   // Whether to run Minimal Data Movement Algorithm, overriding the minimizeDataMovement flag in table config. If set
   // to default, the minimizeDataMovement flag in table config will be used to determine whether to run the Minimal
   // Data Movement Algorithm.
+  // TODO: Replace this with Enablement
   @ApiModel
   public enum MinimizeDataMovementOptions {
     ENABLE, DISABLE, DEFAULT

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -54,6 +54,7 @@ import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.ConsumptionRateLimiter;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.dedup.DedupContext;
 import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
@@ -63,6 +64,7 @@ import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.V1Constants;
@@ -74,7 +76,6 @@ import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.CompletionConfig;
-import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentZKPropsConfig;
@@ -761,7 +762,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         //   persisted.
         // Take upsert snapshot before starting consuming events
         if (_partitionUpsertMetadataManager != null) {
-          if (_tableConfig.getUpsertMetadataTTL() > 0) {
+          if (_partitionUpsertMetadataManager.getContext().getMetadataTTL() > 0) {
             // If upsertMetadataTTL is enabled, we will remove expired primary keys from upsertMetadata
             // AFTER taking a snapshot. Taking the snapshot first is crucial to capture the final
             // state of each key before it exits the TTL window. Out-of-TTL segments are skipped in
@@ -779,7 +780,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           }
         }
 
-        if (_partitionDedupMetadataManager != null && _tableConfig.getDedupMetadataTTL() > 0) {
+        if (_partitionDedupMetadataManager != null
+            && _partitionDedupMetadataManager.getContext().getMetadataTTL() > 0) {
           _partitionDedupMetadataManager.removeExpiredPrimaryKeys();
         }
 
@@ -1662,27 +1664,24 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     // Start new realtime segment
     String consumerDir = realtimeTableDataManager.getConsumerDir();
-    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
-        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType)
-            .setSegmentName(_segmentNameStr)
-            .setStreamName(streamTopic).setSchema(_schema).setTimeColumnName(timeColumnName)
-            .setCapacity(_segmentMaxRowCount).setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
-            .setSegmentZKMetadata(segmentZKMetadata)
-            .setOffHeap(_isOffHeap).setMemoryManager(_memoryManager)
-            .setStatsHistory(realtimeTableDataManager.getStatsHistory())
-            .setAggregateMetrics(indexingConfig.isAggregateMetrics())
-            .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
-            .setDefaultNullHandlingEnabled(_defaultNullHandlingEnabled)
-            .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
-            .setUpsertConsistencyMode(tableConfig.getUpsertConsistencyMode())
-            .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
-            .setUpsertComparisonColumns(tableConfig.getUpsertComparisonColumns())
-            .setUpsertDeleteRecordColumn(tableConfig.getUpsertDeleteRecordColumn())
-            .setUpsertOutOfOrderRecordColumn(tableConfig.getOutOfOrderRecordColumn())
-            .setUpsertDropOutOfOrderRecord(tableConfig.isDropOutOfOrderRecord())
-            .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
-            .setDedupTimeColumn(tableConfig.getDedupTimeColumn())
-            .setFieldConfigList(tableConfig.getFieldConfigList());
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder = new RealtimeSegmentConfig.Builder(indexLoadingConfig)
+        .setTableNameWithType(_tableNameWithType)
+        .setSegmentName(_segmentNameStr)
+        .setStreamName(streamTopic)
+        .setSchema(_schema)
+        .setTimeColumnName(timeColumnName)
+        .setCapacity(_segmentMaxRowCount)
+        .setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
+        .setSegmentZKMetadata(segmentZKMetadata)
+        .setOffHeap(_isOffHeap)
+        .setMemoryManager(_memoryManager)
+        .setStatsHistory(realtimeTableDataManager.getStatsHistory())
+        .setAggregateMetrics(indexingConfig.isAggregateMetrics())
+        .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
+        .setDefaultNullHandlingEnabled(_defaultNullHandlingEnabled)
+        .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
+        .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
+        .setConsumerDir(consumerDir);
 
     // Create message decoder
     Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema);
@@ -1761,8 +1760,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
-  @VisibleForTesting
-  ParallelSegmentConsumptionPolicy getParallelConsumptionPolicy() {
+  private ParallelSegmentConsumptionPolicy getParallelConsumptionPolicy() {
     IngestionConfig ingestionConfig = _tableConfig.getIngestionConfig();
     ParallelSegmentConsumptionPolicy parallelSegmentConsumptionPolicy = null;
     boolean pauseless = false;
@@ -1782,19 +1780,18 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     //   - For pauseless tables, allow consumption during build, but disallow consumption during download
     //   - For non-pauseless tables, disallow consumption during build and download
     //     TODO: Revisit the non-pauseless handling
-    if (_realtimeTableDataManager.isDedupEnabled()) {
-      DedupConfig dedupConfig = _tableConfig.getDedupConfig();
-      assert dedupConfig != null;
-      if (dedupConfig.isAllowDedupConsumptionDuringCommit()) {
+    if (_partitionUpsertMetadataManager != null) {
+      UpsertContext upsertContext = _partitionUpsertMetadataManager.getContext();
+      if (upsertContext.isAllowPartialUpsertConsumptionDuringCommit()
+          || upsertContext.getUpsertMode() != UpsertConfig.Mode.PARTIAL) {
         return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
       }
       return pauseless ? ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY
           : ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS;
     }
-    if (_realtimeTableDataManager.isPartialUpsertEnabled()) {
-      UpsertConfig upsertConfig = _tableConfig.getUpsertConfig();
-      assert upsertConfig != null;
-      if (upsertConfig.isAllowPartialUpsertConsumptionDuringCommit()) {
+    if (_partitionDedupMetadataManager != null) {
+      DedupContext dedupContext = _partitionDedupMetadataManager.getContext();
+      if (dedupContext.isAllowDedupConsumptionDuringCommit()) {
         return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
       }
       return pauseless ? ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -227,7 +227,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       RealtimeTableDataManager rtdm = (RealtimeTableDataManager) tableDataManager;
       TableUpsertMetadataManager tumm = rtdm.getTableUpsertMetadataManager();
       boolean isUsingConsistencyMode =
-          rtdm.getTableUpsertMetadataManager().getUpsertConsistencyMode() != UpsertConfig.ConsistencyMode.NONE;
+          rtdm.getTableUpsertMetadataManager().getContext().getConsistencyMode() != UpsertConfig.ConsistencyMode.NONE;
       if (isUsingConsistencyMode) {
         tumm.lockForSegmentContexts();
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -50,12 +50,8 @@ import org.apache.pinot.segment.local.segment.creator.Fixtures;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
-import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
-import org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -112,15 +108,6 @@ public class RealtimeSegmentDataManagerTest {
     when(statsHistory.getEstimatedAvgColSize(anyString())).thenReturn(32);
     when(tableDataManager.getStatsHistory()).thenReturn(statsHistory);
     when(tableDataManager.getConsumerDir()).thenReturn(TEMP_DIR.getAbsolutePath() + "/consumerDir");
-    if (tableConfig.isUpsertEnabled()) {
-      when(tableDataManager.isUpsertEnabled()).thenReturn(true);
-      if (tableConfig.getUpsertConfig().getMode() == UpsertConfig.Mode.PARTIAL) {
-        when(tableDataManager.isPartialUpsertEnabled()).thenReturn(true);
-      }
-    }
-    if (tableConfig.isDedupEnabled()) {
-      when(tableDataManager.isDedupEnabled()).thenReturn(true);
-    }
     return tableDataManager;
   }
 
@@ -767,6 +754,8 @@ public class RealtimeSegmentDataManagerTest {
       throws Exception {
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getInstanceDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
+    when(instanceDataManagerConfig.getUpsertConfig()).thenReturn(new PinotConfiguration());
+    when(instanceDataManagerConfig.getDedupConfig()).thenReturn(new PinotConfiguration());
     TableDataManagerProvider tableDataManagerProvider = new DefaultTableDataManagerProvider();
     tableDataManagerProvider.init(instanceDataManagerConfig, mock(HelixManager.class), new SegmentLocks(), null);
     TableConfig tableConfig = createTableConfig();
@@ -856,60 +845,6 @@ public class RealtimeSegmentDataManagerTest {
           FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
       Assert.assertEquals(segmentDataManager.getSegment().getSegmentMetadata().getTotalDocs(),
           FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
-    }
-  }
-
-  @Test
-  public void testParallelSegmentConsumptionPolicy()
-      throws Exception {
-    // no partial upsert or dedup enabled.
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager()) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
-    }
-
-    // enable dedup
-    TableConfig tableConfig = createTableConfig();
-    DedupConfig dedupConfig = new DedupConfig(true, HashFunction.NONE);
-    dedupConfig.setAllowDedupConsumptionDuringCommit(true);
-    tableConfig.setDedupConfig(dedupConfig);
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
-        null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
-    }
-    dedupConfig.setAllowDedupConsumptionDuringCommit(false);
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
-        null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
-    }
-
-    // enable partial upsert
-    tableConfig = createTableConfig();
-    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
-    upsertConfig.setAllowPartialUpsertConsumptionDuringCommit(true);
-    tableConfig.setUpsertConfig(upsertConfig);
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
-        null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
-    }
-    upsertConfig.setAllowPartialUpsertConsumptionDuringCommit(false);
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
-        null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.DISALLOW_ALWAYS);
-    }
-
-    // enable full upsert
-    tableConfig = createTableConfig();
-    upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
-    tableConfig.setUpsertConfig(upsertConfig);
-    try (FakeRealtimeSegmentDataManager realtimeSegmentDataManager = createFakeSegmentManager(false, new TimeSupplier(),
-        null, null, tableConfig)) {
-      Assert.assertEquals(realtimeSegmentDataManager.getParallelConsumptionPolicy(),
-          ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.plan.maker;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
@@ -34,6 +33,7 @@ import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -62,6 +62,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -128,10 +129,15 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     ServerMetrics.register(mock(ServerMetrics.class));
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    UpsertContext upsertContext =
-        new UpsertContext.Builder().setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-            .setPrimaryKeyColumns(Collections.singletonList("column6"))
-            .setComparisonColumns(Collections.singletonList("daysSinceEpoch")).setTableIndexDir(INDEX_DIR).build();
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(INDEX_DIR);
+    UpsertContext upsertContext = new UpsertContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(List.of("column6"))
+        .setComparisonColumns(List.of("daysSinceEpoch"))
+        .build();
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, upsertContext);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(upsertMetadataManager,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesBitmapTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesBitmapTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.queries;
 
-import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImplTestUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -34,7 +33,6 @@ import static org.testng.Assert.assertTrue;
 /**
  * Queries test for FUNNEL_COUNT queries.
  */
-@SuppressWarnings("rawtypes")
 public class FunnelCountQueriesBitmapTest extends BaseFunnelCountQueriesTest {
 
   @Override
@@ -60,9 +58,7 @@ public class FunnelCountQueriesBitmapTest extends BaseFunnelCountQueriesTest {
   @Override
   protected IndexSegment buildSegment(List<GenericRow> records)
       throws Exception {
-    MutableSegment mutableSegment =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false);
+    MutableSegment mutableSegment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA);
     for (GenericRow record : records) {
       mutableSegment.index(record, null);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesPartitionedTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesPartitionedTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.queries;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImplTestUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -34,7 +33,6 @@ import static org.testng.Assert.assertTrue;
 /**
  * Queries test for FUNNEL_COUNT queries.
  */
-@SuppressWarnings("rawtypes")
 public class FunnelCountQueriesPartitionedTest extends BaseFunnelCountQueriesTest {
 
   @Override
@@ -60,9 +58,7 @@ public class FunnelCountQueriesPartitionedTest extends BaseFunnelCountQueriesTes
   @Override
   protected IndexSegment buildSegment(List<GenericRow> records)
       throws Exception {
-    MutableSegment mutableSegment =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false);
+    MutableSegment mutableSegment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA);
     for (GenericRow record : records) {
       mutableSegment.index(record, null);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesSetTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.queries;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImplTestUtils;
@@ -60,9 +59,7 @@ public class FunnelCountQueriesSetTest extends BaseFunnelCountQueriesTest {
   @Override
   protected IndexSegment buildSegment(List<GenericRow> records)
       throws Exception {
-    MutableSegment mutableSegment =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false);
+    MutableSegment mutableSegment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA);
     for (GenericRow record : records) {
       mutableSegment.index(record, null);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesThetaSketchTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FunnelCountQueriesThetaSketchTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.queries;
 
-import java.util.Collections;
 import java.util.List;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImplTestUtils;
@@ -34,7 +33,6 @@ import static org.testng.Assert.assertTrue;
 /**
  * Queries test for FUNNEL_COUNT queries.
  */
-@SuppressWarnings("rawtypes")
 public class FunnelCountQueriesThetaSketchTest extends BaseFunnelCountQueriesTest {
 
   @Override
@@ -55,9 +53,7 @@ public class FunnelCountQueriesThetaSketchTest extends BaseFunnelCountQueriesTes
   @Override
   protected IndexSegment buildSegment(List<GenericRow> records)
       throws Exception {
-    MutableSegment mutableSegment =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false);
+    MutableSegment mutableSegment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA);
     for (GenericRow record : records) {
       mutableSegment.index(record, null);
     }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -48,7 +48,6 @@ import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
@@ -62,6 +61,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -439,7 +439,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
     if (upsertConfig == null) {
       upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
-      upsertConfig.setEnableSnapshot(true);
+      upsertConfig.setSnapshot(Enablement.ENABLE);
     }
     if (kafkaTopicName == null) {
       kafkaTopicName = getKafkaTopic();
@@ -479,7 +479,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
             new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
         .setSegmentPartitionConfig(new SegmentPartitionConfig(columnPartitionConfigMap))
         .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(primaryKeyColumn, 1))
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
+        .setDedupConfig(new DedupConfig()).build();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DedupIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DedupIntegrationTest.java
@@ -27,13 +27,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -96,8 +96,9 @@ public class DedupIntegrationTest extends BaseClusterIntegrationTestSet {
     Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
     columnPartitionConfigMap.put(primaryKeyColumn, new ColumnPartitionConfig("Murmur", numPartitions));
 
-    DedupConfig dedupConfig =
-        new DedupConfig(true, HashFunction.NONE, null, new HashMap<>(), 30, getTimeColumnName(), true);
+    DedupConfig dedupConfig = new DedupConfig();
+    dedupConfig.setMetadataTTL(30);
+    dedupConfig.setPreload(Enablement.ENABLE);
     return new TableConfigBuilder(TableType.REALTIME).setTableName("DedupTableWithReplicas_REALTIME")
         .setTimeColumnName(getTimeColumnName()).setFieldConfigList(getFieldConfigs()).setNumReplicas(2)
         .setSegmentVersion(getSegmentVersion()).setLoadMode(getLoadMode()).setTaskConfig(getTaskConfig())

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DedupPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/DedupPreloadIntegrationTest.java
@@ -25,11 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.segment.local.dedup.TableDedupMetadataManagerFactory;
-import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -37,7 +34,8 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
@@ -77,11 +75,10 @@ public class DedupPreloadIntegrationTest extends BaseClusterIntegrationTestSet {
 
   @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
-    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads",
-        "1");
-    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
-        HelixInstanceDataManagerConfig.DEDUP_CONFIG_PREFIX,
-        TableDedupMetadataManagerFactory.DEDUP_DEFAULT_ENABLE_PRELOAD), "true");
+    serverConf.setProperty(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads", "1");
+    serverConf.setProperty(Joiner.on(".")
+        .join(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX, Server.Dedup.CONFIG_PREFIX,
+            Server.Dedup.DEFAULT_ENABLE_PRELOAD), "true");
   }
 
   @AfterClass
@@ -153,7 +150,8 @@ public class DedupPreloadIntegrationTest extends BaseClusterIntegrationTestSet {
     Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
     columnPartitionConfigMap.put(primaryKeyColumn, new ColumnPartitionConfig("Murmur", numPartitions));
 
-    DedupConfig dedupConfig = new DedupConfig(true, HashFunction.NONE, null, null, 0, null, true);
+    DedupConfig dedupConfig = new DedupConfig();
+    dedupConfig.setPreload(Enablement.ENABLE);
 
     return new TableConfigBuilder(TableType.REALTIME).setTableName(getTableName())
         .setTimeColumnName(getTimeColumnName()).setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas())

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -291,9 +291,10 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     addSchema(_schema);
     _tableConfig = createUpsertTableConfig(_avroFiles.get(0), PRIMARY_KEY_COL, null, getNumKafkaPartitions());
     _tableConfig.getValidationConfig().setDeletedSegmentsRetentionPeriod(null);
-    _tableConfig.getUpsertConfig().setMode(UpsertConfig.Mode.PARTIAL);
-    _tableConfig.getUpsertConfig().setPartialUpsertStrategies(new HashMap<>());
-    _tableConfig.getUpsertConfig().setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
+    UpsertConfig upsertConfig = _tableConfig.getUpsertConfig();
+    assert upsertConfig != null;
+    upsertConfig.setMode(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     _tableConfig.getIndexingConfig().setNullHandlingEnabled(true);
 
     addTableConfig(_tableConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -39,9 +39,7 @@ import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.data.manager.realtime.SegmentBuildTimeLeaseExtender;
 import org.apache.pinot.integration.tests.models.DummyTableUpsertMetadataManager;
-import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
-import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -49,7 +47,8 @@ import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
@@ -392,9 +391,9 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTest {
   public void testDefaultMetadataManagerClass()
       throws Exception {
     PinotConfiguration serverConf = getServerConf(NUM_SERVERS);
-    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
-            HelixInstanceDataManagerConfig.UPSERT_CONFIG_PREFIX,
-            TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_METADATA_MANAGER_CLASS),
+    serverConf.setProperty(Joiner.on(".")
+            .join(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX, Server.Upsert.CONFIG_PREFIX,
+                Server.Upsert.DEFAULT_METADATA_MANAGER_CLASS),
         DummyTableUpsertMetadataManager.class.getName());
     BaseServerStarter serverStarter = startOneServer(serverConf);
 
@@ -446,7 +445,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTest {
     String tableName = "gameScoresWithCompaction";
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setDeleteRecordColumn(DELETE_COL);
-    upsertConfig.setEnableSnapshot(true);
+    upsertConfig.setSnapshot(Enablement.ENABLE);
     TableConfig tableConfig = setUpTable(tableName, kafkaTopicName, upsertConfig);
     tableConfig.setTaskConfig(getCompactionTaskConfig());
     updateTableConfig(tableConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -28,17 +28,15 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.client.ExecutionStats;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.helix.HelixHelper;
-import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
-import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
@@ -104,14 +102,14 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
 
   @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
-    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads",
+    serverConf.setProperty(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads",
         "1");
-    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
-        HelixInstanceDataManagerConfig.UPSERT_CONFIG_PREFIX,
-        TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_ENABLE_SNAPSHOT), "true");
-    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
-        HelixInstanceDataManagerConfig.UPSERT_CONFIG_PREFIX,
-        TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_ENABLE_PRELOAD), "true");
+    serverConf.setProperty(Joiner.on(".")
+        .join(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX, Server.Upsert.CONFIG_PREFIX,
+            Server.Upsert.DEFAULT_ENABLE_SNAPSHOT), "true");
+    serverConf.setProperty(Joiner.on(".")
+        .join(Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX, Server.Upsert.CONFIG_PREFIX,
+            Server.Upsert.DEFAULT_ENABLE_PRELOAD), "true");
   }
 
   @AfterClass
@@ -223,7 +221,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
     TestUtils.waitForCondition(aVoid -> {
       for (BaseServerStarter serverStarter : _serverStarters) {
-        String segmentDir = serverStarter.getConfig().getProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR);
+        String segmentDir = serverStarter.getConfig().getProperty(Server.CONFIG_OF_INSTANCE_DATA_DIR);
         File[] files = new File(segmentDir, realtimeTableName).listFiles((dir, name) -> name.startsWith(rawTableName));
         assertNotNull(files);
         for (File file : files) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pinot.integration.tests.models;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.upsert.BasePartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager;
@@ -34,37 +32,15 @@ import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
-import org.apache.pinot.spi.config.table.HashFunction;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class DummyTableUpsertMetadataManager extends BaseTableUpsertMetadataManager {
 
-  private TableConfig _tableConfig;
-  private Schema _schema;
-
-  public DummyTableUpsertMetadataManager() {
-    super();
-  }
-
-  @Override
-  public void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager) {
-    super.init(tableConfig, schema, tableDataManager);
-    _tableConfig = tableConfig;
-    _schema = schema;
-  }
-
   @Override
   public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    UpsertContext context = new UpsertContext.Builder().setTableConfig(_tableConfig).setSchema(_schema)
-        .setPrimaryKeyColumns(_schema.getPrimaryKeyColumns())
-        .setComparisonColumns(Collections.singletonList(_tableConfig.getValidationConfig().getTimeColumnName()))
-        .setHashFunction(HashFunction.NONE).setTableIndexDir(new File("/tmp/tableIndexDirDummy")).build();
-
-    return new DummyPartitionUpsertMetadataManager("dummy", partitionId, context);
+    return new DummyPartitionUpsertMetadataManager("dummy", partitionId, _context);
   }
 
   @Override

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -47,6 +47,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -323,13 +324,14 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, UpsertCompactionTask.SNAPSHOT);
     if (validDocIdsType.equals(ValidDocIdsType.SNAPSHOT.toString())) {
       UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
-      Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
-      Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
-          "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = "
-              + "%s", validDocIdsType));
+      assert upsertConfig != null;
+      // NOTE: Allow snapshot to be DEFAULT because it might be enabled at server level.
+      Preconditions.checkState(upsertConfig.getSnapshot() != Enablement.DISABLE,
+          "'snapshot' from UpsertConfig must not be 'DISABLE' for UpsertCompactionTask with validDocIdsType = %s",
+          validDocIdsType);
     } else if (validDocIdsType.equals(ValidDocIdsType.IN_MEMORY_WITH_DELETE.toString())) {
       UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
-      Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
+      assert upsertConfig != null;
       Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(), String.format(
           "deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdsType = %s",
           validDocIdsType));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -42,7 +42,6 @@ import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
@@ -108,9 +107,10 @@ public class MergeRollupTaskGeneratorTest {
             .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).build();
     assertFalse(MergeRollupTaskGenerator.validate(tableConfig, MinionConstants.MergeRollupTask.TASK_TYPE));
 
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName(TIME_COLUMN_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.MD5)).build();
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN_NAME)
+        .setDedupConfig(new DedupConfig())
+        .build();
     assertFalse(MergeRollupTaskGenerator.validate(tableConfig, MinionConstants.MergeRollupTask.TASK_TYPE));
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -322,7 +323,7 @@ public class UpsertCompactionTaskGeneratorTest {
         ImmutableMap.of("bufferTimePeriod", "5d", "invalidRecordsThresholdPercent", "1", "invalidRecordsThresholdCount",
             "1");
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
-    upsertConfig.setEnableSnapshot(true);
+    upsertConfig.setSnapshot(Enablement.ENABLE);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
         .setUpsertConfig(upsertConfig)
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -97,6 +97,11 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
   }
 
   @Override
+  public DedupContext getContext() {
+    return _context;
+  }
+
+  @Override
   public boolean checkRecordPresentOrUpdate(PrimaryKey pk, IndexSegment indexSegment) {
     throw new UnsupportedOperationException(
         "checkRecordPresentOrUpdate(PrimaryKey pk, IndexSegment indexSegment) is " + "deprecated!");

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java
@@ -19,18 +19,17 @@
 package org.apache.pinot.segment.local.dedup;
 
 import com.google.common.base.Preconditions;
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Server.Dedup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,20 +39,22 @@ public abstract class BaseTableDedupMetadataManager implements TableDedupMetadat
 
   protected final Map<Integer, PartitionDedupMetadataManager> _partitionMetadataManagerMap = new ConcurrentHashMap<>();
   protected String _tableNameWithType;
-  protected DedupContext _dedupContext;
-  private boolean _enablePreload;
+  protected DedupContext _context;
 
   @Override
-  public void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager,
-      ServerMetrics serverMetrics) {
+  public void init(PinotConfiguration instanceDedupConfig, TableConfig tableConfig, Schema schema,
+      TableDataManager tableDataManager) {
     _tableNameWithType = tableConfig.getTableName();
+
+    Preconditions.checkArgument(tableConfig.isDedupEnabled(), "Dedup must be enabled for table: %s",
+        _tableNameWithType);
+    DedupConfig dedupConfig = tableConfig.getDedupConfig();
+    assert dedupConfig != null;
 
     List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
     Preconditions.checkArgument(!CollectionUtils.isEmpty(primaryKeyColumns),
         "Primary key columns must be configured for dedup enabled table: %s", _tableNameWithType);
 
-    DedupConfig dedupConfig = tableConfig.getDedupConfig();
-    Preconditions.checkArgument(dedupConfig != null, "Dedup must be enabled for table: %s", _tableNameWithType);
     double metadataTTL = dedupConfig.getMetadataTTL();
     String dedupTimeColumn = dedupConfig.getDedupTimeColumn();
     if (dedupTimeColumn == null) {
@@ -61,33 +62,42 @@ public abstract class BaseTableDedupMetadataManager implements TableDedupMetadat
     }
     if (metadataTTL > 0) {
       Preconditions.checkArgument(dedupTimeColumn != null,
-          "When metadataTTL is configured, metadata time column or time column must be configured for "
-              + "dedup enabled table: %s", _tableNameWithType);
+          "When metadataTTL is configured, metadata time column or time column must be configured for dedup enabled "
+              + "table: %s", _tableNameWithType);
     }
-    _enablePreload = dedupConfig.isEnablePreload() && tableDataManager.getSegmentPreloadExecutor() != null;
-    HashFunction hashFunction = dedupConfig.getHashFunction();
-    File tableIndexDir = tableDataManager.getTableDataDir();
-    DedupContext.Builder dedupContextBuider = new DedupContext.Builder();
-    dedupContextBuider.setTableConfig(tableConfig).setSchema(schema).setPrimaryKeyColumns(primaryKeyColumns)
-        .setHashFunction(hashFunction).setEnablePreload(_enablePreload).setMetadataTTL(metadataTTL)
-        .setDedupTimeColumn(dedupTimeColumn).setTableIndexDir(tableIndexDir).setTableDataManager(tableDataManager);
-    _dedupContext = dedupContextBuider.build();
-    LOGGER.info(
-        "Initialized {} for table: {} with primary key columns: {}, hash function: {}, enable preload: {}, metadata "
-            + "TTL: {}, dedup time column: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
-        primaryKeyColumns, hashFunction, _enablePreload, metadataTTL, dedupTimeColumn, tableIndexDir);
+
+    boolean enablePreload =
+        dedupConfig.getPreload().isEnabled(() -> instanceDedupConfig.getProperty(Dedup.DEFAULT_ENABLE_PRELOAD, false));
+    if (enablePreload) {
+      if (tableDataManager.getSegmentPreloadExecutor() == null) {
+        LOGGER.warn("Preload cannot be enabled without segment preload executor for table: {}", _tableNameWithType);
+        enablePreload = false;
+      }
+    }
+
+    // NOTE: This field doesn't follow enablement override, and always enabled if enabled at instance level.
+    boolean allowDedupConsumptionDuringCommit = dedupConfig.isAllowDedupConsumptionDuringCommit();
+    if (!allowDedupConsumptionDuringCommit) {
+      allowDedupConsumptionDuringCommit =
+          instanceDedupConfig.getProperty(Dedup.DEFAULT_ALLOW_DEDUP_CONSUMPTION_DURING_COMMIT, false);
+    }
+
+    _context = new DedupContext.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(primaryKeyColumns)
+        .setHashFunction(dedupConfig.getHashFunction())
+        .setMetadataTTL(metadataTTL)
+        .setDedupTimeColumn(dedupTimeColumn)
+        .setEnablePreload(enablePreload)
+        .setMetadataManagerConfigs(dedupConfig.getMetadataManagerConfigs())
+        .setAllowDedupConsumptionDuringCommit(allowDedupConsumptionDuringCommit)
+        .build();
+    LOGGER.info("Initialized {} for table: {} with: {}", getClass().getSimpleName(), _tableNameWithType, _context);
 
     initCustomVariables();
   }
-
-  public PartitionDedupMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap.computeIfAbsent(partitionId, this::createPartitionDedupMetadataManager);
-  }
-
-  /**
-   * Create PartitionDedupMetadataManager for given partition id.
-   */
-  abstract protected PartitionDedupMetadataManager createPartitionDedupMetadataManager(Integer partitionId);
 
   /**
    * Can be overridden to initialize custom variables after other variables are set
@@ -96,8 +106,24 @@ public abstract class BaseTableDedupMetadataManager implements TableDedupMetadat
   }
 
   @Override
+  public PartitionDedupMetadataManager getOrCreatePartitionManager(int partitionId) {
+    return _partitionMetadataManagerMap.computeIfAbsent(partitionId, this::createPartitionDedupMetadataManager);
+  }
+
+  /**
+   * Create PartitionDedupMetadataManager for given partition id.
+   */
+  protected abstract PartitionDedupMetadataManager createPartitionDedupMetadataManager(Integer partitionId);
+
+  @Override
+  public DedupContext getContext() {
+    return _context;
+  }
+
+  @Deprecated
+  @Override
   public boolean isEnablePreload() {
-    return _enablePreload;
+    return _context.isPreloadEnabled();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
@@ -26,6 +26,9 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 public interface PartitionDedupMetadataManager extends Closeable {
+
+  DedupContext getContext();
+
   /**
    * Initializes the dedup metadata for the given immutable segment.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManager.java
@@ -19,23 +19,28 @@
 package org.apache.pinot.segment.local.dedup;
 
 import java.io.Closeable;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public interface TableDedupMetadataManager extends Closeable {
   /**
    * Initialize TableDedupMetadataManager.
    */
-  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics);
+  void init(PinotConfiguration instanceUpsertConfig, TableConfig tableConfig, Schema schema,
+      TableDataManager tableDataManager);
 
   /**
    * Create a new PartitionDedupMetadataManager if not present already, otherwise return existing one.
    */
   PartitionDedupMetadataManager getOrCreatePartitionManager(int partitionId);
 
+  DedupContext getContext();
+
+  /// @deprecated Use {@link #getContext()} instead.
+  @Deprecated
   boolean isEnablePreload();
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManagerFactory.java
@@ -19,14 +19,13 @@
 package org.apache.pinot.segment.local.dedup;
 
 import com.google.common.base.Preconditions;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Server.Dedup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,39 +35,20 @@ public class TableDedupMetadataManagerFactory {
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableDedupMetadataManagerFactory.class);
-  public static final String DEDUP_DEFAULT_METADATA_MANAGER_CLASS = "default.metadata.manager.class";
-  public static final String DEDUP_DEFAULT_ENABLE_PRELOAD = "default.enable.preload";
 
-  public static final String DEDUP_DEFAULT_ALLOW_DEDUP_CONSUMPTION_DURING_COMMIT =
-      "default.allow.dedup.consumption.during.commit";
-
-  public static TableDedupMetadataManager create(TableConfig tableConfig, Schema schema,
-      TableDataManager tableDataManager, ServerMetrics serverMetrics,
-      @Nullable PinotConfiguration instanceDedupConfig) {
+  public static TableDedupMetadataManager create(PinotConfiguration instanceDedupConfig, TableConfig tableConfig,
+      Schema schema, TableDataManager tableDataManager) {
     String tableNameWithType = tableConfig.getTableName();
+    Preconditions.checkArgument(tableConfig.isDedupEnabled(), "Dedup must be enabled for table: %s", tableNameWithType);
     DedupConfig dedupConfig = tableConfig.getDedupConfig();
-    Preconditions.checkArgument(dedupConfig != null, "Must provide dedup config for table: %s", tableNameWithType);
+    assert dedupConfig != null;
 
     TableDedupMetadataManager metadataManager;
     String metadataManagerClass = dedupConfig.getMetadataManagerClass();
-
-    if (instanceDedupConfig != null) {
-      if (metadataManagerClass == null) {
-        metadataManagerClass = instanceDedupConfig.getProperty(DEDUP_DEFAULT_METADATA_MANAGER_CLASS);
-      }
-
-      // Server level config honoured only when table level config is not set to true
-      if (!dedupConfig.isEnablePreload()) {
-        dedupConfig.setEnablePreload(
-            Boolean.parseBoolean(instanceDedupConfig.getProperty(DEDUP_DEFAULT_ENABLE_PRELOAD, "false")));
-      }
-      // server level config honoured only when table level config is not set to true
-      if (!dedupConfig.isAllowDedupConsumptionDuringCommit()) {
-        dedupConfig.setAllowDedupConsumptionDuringCommit(Boolean.parseBoolean(
-            instanceDedupConfig.getProperty(DEDUP_DEFAULT_ALLOW_DEDUP_CONSUMPTION_DURING_COMMIT, "false")));
-      }
+    if (metadataManagerClass == null) {
+      metadataManagerClass = instanceDedupConfig.getProperty(Dedup.DEFAULT_METADATA_MANAGER_CLASS);
     }
-    if (StringUtils.isNotEmpty(metadataManagerClass)) {
+    if (StringUtils.isNotBlank(metadataManagerClass)) {
       LOGGER.info("Creating TableDedupMetadataManager with class: {} for table: {}", metadataManagerClass,
           tableNameWithType);
       try {
@@ -83,8 +63,7 @@ public class TableDedupMetadataManagerFactory {
       LOGGER.info("Creating ConcurrentMapTableDedupMetadataManager for table: {}", tableNameWithType);
       metadataManager = new ConcurrentMapTableDedupMetadataManager();
     }
-
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics);
+    metadataManager.init(instanceDedupConfig, tableConfig, schema, tableDataManager);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -68,6 +68,7 @@ import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProvide
 import org.apache.pinot.segment.local.upsert.ComparisonColumns;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.RecordInfo;
+import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.local.utils.FixedIntArrayOffHeapIdMap;
 import org.apache.pinot.segment.local.utils.IdMap;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
@@ -172,11 +173,12 @@ public class MutableSegmentImpl implements MutableSegment {
   private final String _dedupTimeColumn;
 
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
-  private final UpsertConfig.ConsistencyMode _upsertConsistencyMode;
   private final List<String> _upsertComparisonColumns;
   private final String _deleteRecordColumn;
-  private final String _upsertOutOfOrderRecordColumn;
   private final boolean _upsertDropOutOfOrderRecord;
+  private final String _upsertOutOfOrderRecordColumn;
+  private final UpsertConfig.ConsistencyMode _upsertConsistencyMode;
+
   // The valid doc ids are maintained locally instead of in the upsert metadata manager because:
   // 1. There is only one consuming segment per partition, the committed segments do not need to modify the valid doc
   //    ids for the consuming segment.
@@ -394,23 +396,20 @@ public class MutableSegmentImpl implements MutableSegment {
     }
 
     _partitionDedupMetadataManager = config.getPartitionDedupMetadataManager();
-    if (_partitionDedupMetadataManager != null) {
-      _dedupTimeColumn = config.getDedupTimeColumn() == null ? _timeColumnName : config.getDedupTimeColumn();
-    } else {
-      _dedupTimeColumn = null;
-    }
+    _dedupTimeColumn =
+        _partitionDedupMetadataManager != null ? _partitionDedupMetadataManager.getContext().getDedupTimeColumn()
+            : null;
 
     _partitionUpsertMetadataManager = config.getPartitionUpsertMetadataManager();
-    _upsertConsistencyMode = config.getUpsertConsistencyMode();
     if (_partitionUpsertMetadataManager != null) {
       Preconditions.checkState(!isAggregateMetricsEnabled(),
           "Metrics aggregation and upsert cannot be enabled together");
-      List<String> upsertComparisonColumns = config.getUpsertComparisonColumns();
-      _upsertComparisonColumns =
-          upsertComparisonColumns != null ? upsertComparisonColumns : Collections.singletonList(_timeColumnName);
-      _deleteRecordColumn = config.getUpsertDeleteRecordColumn();
-      _upsertOutOfOrderRecordColumn = config.getUpsertOutOfOrderRecordColumn();
-      _upsertDropOutOfOrderRecord = config.isUpsertDropOutOfOrderRecord();
+      UpsertContext upsertContext = _partitionUpsertMetadataManager.getContext();
+      _upsertComparisonColumns = upsertContext.getComparisonColumns();
+      _deleteRecordColumn = upsertContext.getDeleteRecordColumn();
+      _upsertDropOutOfOrderRecord = upsertContext.isDropOutOfOrderRecord();
+      _upsertOutOfOrderRecordColumn = upsertContext.getOutOfOrderRecordColumn();
+      _upsertConsistencyMode = upsertContext.getConsistencyMode();
       _validDocIds = new ThreadSafeMutableRoaringBitmap();
       if (_deleteRecordColumn != null) {
         _queryableDocIds = new ThreadSafeMutableRoaringBitmap();
@@ -420,10 +419,11 @@ public class MutableSegmentImpl implements MutableSegment {
     } else {
       _upsertComparisonColumns = null;
       _deleteRecordColumn = null;
+      _upsertDropOutOfOrderRecord = false;
+      _upsertOutOfOrderRecordColumn = null;
+      _upsertConsistencyMode = null;
       _validDocIds = null;
       _queryableDocIds = null;
-      _upsertOutOfOrderRecordColumn = null;
-      _upsertDropOutOfOrderRecord = false;
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -180,15 +180,18 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
     RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsHistoryFile);
 
     // Initialize mutable segment with configurations
-    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
-        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType)
-            .setSegmentName(_segmentName).setStreamName(_streamConfig.getTopicName())
-            .setSegmentZKMetadata(_segmentZKMetadata).setStatsHistory(statsHistory).setSchema(_schema)
-            .setCapacity(capacity).setAvgNumMultiValues(avgNumMultiValues)
-            .setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
-            .setFieldConfigList(_tableConfig.getFieldConfigList()).setConsumerDir(_resourceDataDir.getAbsolutePath())
-            .setMemoryManager(
-                new MmapMemoryManager(FileUtils.getTempDirectory().getAbsolutePath(), _segmentName, null));
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder = new RealtimeSegmentConfig.Builder(indexLoadingConfig)
+        .setTableNameWithType(_tableNameWithType)
+        .setSegmentName(_segmentName)
+        .setStreamName(_streamConfig.getTopicName())
+        .setSchema(_schema)
+        .setCapacity(capacity)
+        .setAvgNumMultiValues(avgNumMultiValues)
+        .setSegmentZKMetadata(_segmentZKMetadata)
+        .setOffHeap(indexLoadingConfig.isRealtimeOffHeapAllocation())
+        .setMemoryManager(new MmapMemoryManager(FileUtils.getTempDirectory().getAbsolutePath(), _segmentName, null))
+        .setStatsHistory(statsHistory)
+        .setConsumerDir(_resourceDataDir.getAbsolutePath());
 
     setPartitionParameters(realtimeSegmentConfigBuilder, _tableConfig.getIndexingConfig().getSegmentPartitionConfig());
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -176,6 +176,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   }
 
   @Override
+  public UpsertContext getContext() {
+    return _context;
+  }
+
+  @Override
   public List<String> getPrimaryKeyColumns() {
     return _primaryKeyColumns;
   }
@@ -853,6 +858,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // overlap of valid docs among segments with snapshots is required by the preloading to work correctly.
     Set<ImmutableSegmentImpl> segmentsWithoutSnapshot = new HashSet<>();
     TableDataManager tableDataManager = _context.getTableDataManager();
+    Preconditions.checkNotNull(tableDataManager, "Taking snapshot requires tableDataManager");
     boolean isSegmentSkipped = false;
     for (IndexSegment segment : _trackedSegments) {
       if (!(segment instanceof ImmutableSegmentImpl)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -47,9 +47,10 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
 
   @Override
   public BasePartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap.computeIfAbsent(partitionId, k -> _enableDeletedKeysCompactionConsistency
-        ? new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context)
-        : new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
+    return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
+        k -> _context.isEnableDeletedKeysCompactionConsistency()
+            ? new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(_tableNameWithType, k, _context)
+            : new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
   }
 
   @Override
@@ -92,7 +93,8 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public void setSegmentContexts(List<SegmentContext> segmentContexts, Map<String, String> queryOptions) {
     // Get queryableDocIds bitmaps from partitionMetadataManagers if any consistency mode is used.
     // Otherwise, get queryableDocIds bitmaps as kept by the segment objects directly as before.
-    if (_consistencyMode == UpsertConfig.ConsistencyMode.NONE || QueryOptionsUtils.isSkipUpsertView(queryOptions)) {
+    if (_context.getConsistencyMode() == UpsertConfig.ConsistencyMode.NONE || QueryOptionsUtils.isSkipUpsertView(
+        queryOptions)) {
       for (SegmentContext segmentContext : segmentContexts) {
         IndexSegment segment = segmentContext.getIndexSegment();
         segmentContext.setQueryableDocIdsSnapshot(UpsertUtils.getQueryableDocIdsSnapshotFromSegment(segment));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.upsert;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
 import org.apache.pinot.segment.local.upsert.merger.PartialUpsertMerger;
@@ -45,7 +44,6 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public class PartialUpsertHandler {
   private final List<String> _primaryKeyColumns;
   private final List<String> _comparisonColumns;
-  private final TreeMap<String, FieldSpec> _fieldSpecMap;
   private final PartialUpsertMerger _partialUpsertMerger;
 
   private final Map<String, Object> _defaultNullValues = new HashMap<>();
@@ -53,7 +51,6 @@ public class PartialUpsertHandler {
   public PartialUpsertHandler(Schema schema, List<String> comparisonColumns, UpsertConfig upsertConfig) {
     _primaryKeyColumns = schema.getPrimaryKeyColumns();
     _comparisonColumns = comparisonColumns;
-    _fieldSpecMap = schema.getFieldSpecMap();
     _partialUpsertMerger =
         PartialUpsertMergerFactory.getPartialUpsertMerger(_primaryKeyColumns, comparisonColumns, upsertConfig);
     // cache default null values to handle null merger results

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -55,6 +55,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 @ThreadSafe
 public interface PartitionUpsertMetadataManager extends Closeable {
 
+  UpsertContext getContext();
+
   /**
    * Returns the primary key columns.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -37,14 +38,23 @@ import org.apache.pinot.spi.data.Schema;
 @ThreadSafe
 public interface TableUpsertMetadataManager extends Closeable {
 
-  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager);
+  void init(PinotConfiguration instanceUpsertConfig, TableConfig tableConfig, Schema schema,
+      TableDataManager tableDataManager);
 
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
+  UpsertContext getContext();
+
+  /// @deprecated Use {@link #getContext()} instead.
+  @Deprecated
   UpsertConfig.Mode getUpsertMode();
 
+  /// @deprecated Use {@link #getContext()} instead.
+  @Deprecated
   UpsertConfig.ConsistencyMode getUpsertConsistencyMode();
 
+  /// @deprecated Use {@link #getContext()} instead.
+  @Deprecated
   boolean isEnablePreload();
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -21,8 +21,10 @@ package org.apache.pinot.segment.local.upsert;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -34,46 +36,64 @@ public class UpsertContext {
   private final TableConfig _tableConfig;
   private final Schema _schema;
   private final List<String> _primaryKeyColumns;
-  private final List<String> _comparisonColumns;
-  private final String _deleteRecordColumn;
   private final HashFunction _hashFunction;
+  private final List<String> _comparisonColumns;
+  @Nullable
   private final PartialUpsertHandler _partialUpsertHandler;
+  @Nullable
+  private final String _deleteRecordColumn;
+  private final boolean _dropOutOfOrderRecord;
+  @Nullable
+  private final String _outOfOrderRecordColumn;
   private final boolean _enableSnapshot;
   private final boolean _enablePreload;
   private final double _metadataTTL;
   private final double _deletedKeysTTL;
+  private final boolean _enableDeletedKeysCompactionConsistency;
   private final UpsertConfig.ConsistencyMode _consistencyMode;
   private final long _upsertViewRefreshIntervalMs;
   private final long _newSegmentTrackingTimeMs;
-  private final File _tableIndexDir;
-  private final boolean _dropOutOfOrderRecord;
-  private final boolean _enableDeletedKeysCompactionConsistency;
+  @Nullable
+  private final Map<String, String> _metadataManagerConfigs;
+
+  /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
+  @Deprecated
+  private final boolean _allowPartialUpsertConsumptionDuringCommit;
+
+  /// Can be null if the context is not created from server.
+  @Nullable
   private final TableDataManager _tableDataManager;
+  private final File _tableIndexDir;
 
   private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
-      List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
-      @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
-      double metadataTTL, double deletedKeysTTL, UpsertConfig.ConsistencyMode consistencyMode,
-      long upsertViewRefreshIntervalMs, long newSegmentTrackingTimeMs, File tableIndexDir, boolean dropOutOfOrderRecord,
-      boolean enableDeletedKeysCompactionConsistency, @Nullable TableDataManager tableDataManager) {
+      HashFunction hashFunction, List<String> comparisonColumns, @Nullable PartialUpsertHandler partialUpsertHandler,
+      @Nullable String deleteRecordColumn, boolean dropOutOfOrderRecord, @Nullable String outOfOrderRecordColumn,
+      boolean enableSnapshot, boolean enablePreload, double metadataTTL, double deletedKeysTTL,
+      boolean enableDeletedKeysCompactionConsistency, UpsertConfig.ConsistencyMode consistencyMode,
+      long upsertViewRefreshIntervalMs, long newSegmentTrackingTimeMs,
+      @Nullable Map<String, String> metadataManagerConfigs, boolean allowPartialUpsertConsumptionDuringCommit,
+      @Nullable TableDataManager tableDataManager, File tableIndexDir) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
-    _comparisonColumns = comparisonColumns;
-    _deleteRecordColumn = deleteRecordColumn;
     _hashFunction = hashFunction;
+    _comparisonColumns = comparisonColumns;
     _partialUpsertHandler = partialUpsertHandler;
+    _deleteRecordColumn = deleteRecordColumn;
+    _dropOutOfOrderRecord = dropOutOfOrderRecord;
+    _outOfOrderRecordColumn = outOfOrderRecordColumn;
     _enableSnapshot = enableSnapshot;
     _enablePreload = enablePreload;
     _metadataTTL = metadataTTL;
     _deletedKeysTTL = deletedKeysTTL;
+    _enableDeletedKeysCompactionConsistency = enableDeletedKeysCompactionConsistency;
     _consistencyMode = consistencyMode;
     _upsertViewRefreshIntervalMs = upsertViewRefreshIntervalMs;
     _newSegmentTrackingTimeMs = newSegmentTrackingTimeMs;
-    _tableIndexDir = tableIndexDir;
-    _dropOutOfOrderRecord = dropOutOfOrderRecord;
-    _enableDeletedKeysCompactionConsistency = enableDeletedKeysCompactionConsistency;
+    _metadataManagerConfigs = metadataManagerConfigs;
+    _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
     _tableDataManager = tableDataManager;
+    _tableIndexDir = tableIndexDir;
   }
 
   public TableConfig getTableConfig() {
@@ -88,20 +108,35 @@ public class UpsertContext {
     return _primaryKeyColumns;
   }
 
-  public List<String> getComparisonColumns() {
-    return _comparisonColumns;
-  }
-
-  public String getDeleteRecordColumn() {
-    return _deleteRecordColumn;
-  }
-
   public HashFunction getHashFunction() {
     return _hashFunction;
   }
 
+  public List<String> getComparisonColumns() {
+    return _comparisonColumns;
+  }
+
+  @Nullable
   public PartialUpsertHandler getPartialUpsertHandler() {
     return _partialUpsertHandler;
+  }
+
+  public UpsertConfig.Mode getUpsertMode() {
+    return _partialUpsertHandler == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
+  }
+
+  @Nullable
+  public String getDeleteRecordColumn() {
+    return _deleteRecordColumn;
+  }
+
+  public boolean isDropOutOfOrderRecord() {
+    return _dropOutOfOrderRecord;
+  }
+
+  @Nullable
+  public String getOutOfOrderRecordColumn() {
+    return _outOfOrderRecordColumn;
   }
 
   public boolean isSnapshotEnabled() {
@@ -120,6 +155,10 @@ public class UpsertContext {
     return _deletedKeysTTL;
   }
 
+  public boolean isEnableDeletedKeysCompactionConsistency() {
+    return _enableDeletedKeysCompactionConsistency;
+  }
+
   public UpsertConfig.ConsistencyMode getConsistencyMode() {
     return _consistencyMode;
   }
@@ -132,41 +171,72 @@ public class UpsertContext {
     return _newSegmentTrackingTimeMs;
   }
 
+  @Nullable
+  public Map<String, String> getMetadataManagerConfigs() {
+    return _metadataManagerConfigs;
+  }
+
+  @Deprecated
+  public boolean isAllowPartialUpsertConsumptionDuringCommit() {
+    return _allowPartialUpsertConsumptionDuringCommit;
+  }
+
+  @Nullable
+  public TableDataManager getTableDataManager() {
+    return _tableDataManager;
+  }
+
   public File getTableIndexDir() {
     return _tableIndexDir;
   }
 
-  public boolean isDropOutOfOrderRecord() {
-    return _dropOutOfOrderRecord;
-  }
-
-  public boolean isEnableDeletedKeysCompactionConsistency() {
-    return _enableDeletedKeysCompactionConsistency;
-  }
-
-  public TableDataManager getTableDataManager() {
-    return _tableDataManager;
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("primaryKeyColumns", _primaryKeyColumns)
+        .append("hashFunction", _hashFunction)
+        .append("comparisonColumns", _comparisonColumns)
+        .append("mode", getUpsertMode())
+        .append("deleteRecordColumn", _deleteRecordColumn)
+        .append("dropOutOfOrderRecord", _dropOutOfOrderRecord)
+        .append("outOfOrderRecordColumn", _outOfOrderRecordColumn)
+        .append("enableSnapshot", _enableSnapshot)
+        .append("enablePreload", _enablePreload)
+        .append("metadataTTL", _metadataTTL)
+        .append("deletedKeysTTL", _deletedKeysTTL)
+        .append("enableDeletedKeysCompactionConsistency", _enableDeletedKeysCompactionConsistency)
+        .append("consistencyMode", _consistencyMode)
+        .append("upsertViewRefreshIntervalMs", _upsertViewRefreshIntervalMs)
+        .append("newSegmentTrackingTimeMs", _newSegmentTrackingTimeMs)
+        .append("metadataManagerConfigs", _metadataManagerConfigs)
+        .append("allowPartialUpsertConsumptionDuringCommit", _allowPartialUpsertConsumptionDuringCommit)
+        .append("tableIndexDir", _tableIndexDir)
+        .toString();
   }
 
   public static class Builder {
     private TableConfig _tableConfig;
     private Schema _schema;
     private List<String> _primaryKeyColumns;
-    private List<String> _comparisonColumns;
-    private String _deleteRecordColumn;
     private HashFunction _hashFunction = HashFunction.NONE;
+    private List<String> _comparisonColumns;
     private PartialUpsertHandler _partialUpsertHandler;
+    private String _deleteRecordColumn;
+    private boolean _dropOutOfOrderRecord;
+    private String _outOfOrderRecordColumn;
     private boolean _enableSnapshot;
     private boolean _enablePreload;
     private double _metadataTTL;
     private double _deletedKeysTTL;
-    private UpsertConfig.ConsistencyMode _consistencyMode;
+    private boolean _enableDeletedKeysCompactionConsistency;
+    private UpsertConfig.ConsistencyMode _consistencyMode = UpsertConfig.ConsistencyMode.NONE;
     private long _upsertViewRefreshIntervalMs;
     private long _newSegmentTrackingTimeMs;
-    private File _tableIndexDir;
-    private boolean _dropOutOfOrderRecord;
-    private boolean _enableDeletedKeysCompactionConsistency;
+    private Map<String, String> _metadataManagerConfigs;
+    @Deprecated
+    private boolean _allowPartialUpsertConsumptionDuringCommit;
     private TableDataManager _tableDataManager;
+    private File _tableIndexDir;
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -183,8 +253,18 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setHashFunction(HashFunction hashFunction) {
+      _hashFunction = hashFunction;
+      return this;
+    }
+
     public Builder setComparisonColumns(List<String> comparisonColumns) {
       _comparisonColumns = comparisonColumns;
+      return this;
+    }
+
+    public Builder setPartialUpsertHandler(PartialUpsertHandler partialUpsertHandler) {
+      _partialUpsertHandler = partialUpsertHandler;
       return this;
     }
 
@@ -193,13 +273,13 @@ public class UpsertContext {
       return this;
     }
 
-    public Builder setHashFunction(HashFunction hashFunction) {
-      _hashFunction = hashFunction;
+    public Builder setDropOutOfOrderRecord(boolean dropOutOfOrderRecord) {
+      _dropOutOfOrderRecord = dropOutOfOrderRecord;
       return this;
     }
 
-    public Builder setPartialUpsertHandler(PartialUpsertHandler partialUpsertHandler) {
-      _partialUpsertHandler = partialUpsertHandler;
+    public Builder setOutOfOrderRecordColumn(String outOfOrderRecordColumn) {
+      _outOfOrderRecordColumn = outOfOrderRecordColumn;
       return this;
     }
 
@@ -223,6 +303,11 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setEnableDeletedKeysCompactionConsistency(boolean enableDeletedKeysCompactionConsistency) {
+      _enableDeletedKeysCompactionConsistency = enableDeletedKeysCompactionConsistency;
+      return this;
+    }
+
     public Builder setConsistencyMode(UpsertConfig.ConsistencyMode consistencyMode) {
       _consistencyMode = consistencyMode;
       return this;
@@ -238,18 +323,14 @@ public class UpsertContext {
       return this;
     }
 
-    public Builder setTableIndexDir(File tableIndexDir) {
-      _tableIndexDir = tableIndexDir;
+    public Builder setMetadataManagerConfigs(Map<String, String> metadataManagerConfigs) {
+      _metadataManagerConfigs = metadataManagerConfigs;
       return this;
     }
 
-    public Builder setDropOutOfOrderRecord(boolean dropOutOfOrderRecord) {
-      _dropOutOfOrderRecord = dropOutOfOrderRecord;
-      return this;
-    }
-
-    public Builder setEnableDeletedKeysCompactionConsistency(boolean enableDeletedKeysCompactionConsistency) {
-      _enableDeletedKeysCompactionConsistency = enableDeletedKeysCompactionConsistency;
+    @Deprecated
+    public Builder setAllowPartialUpsertConsumptionDuringCommit(boolean allowPartialUpsertConsumptionDuringCommit) {
+      _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
       return this;
     }
 
@@ -258,17 +339,27 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setTableIndexDir(File tableIndexDir) {
+      _tableIndexDir = tableIndexDir;
+      return this;
+    }
+
     public UpsertContext build() {
       Preconditions.checkState(_tableConfig != null, "Table config must be set");
       Preconditions.checkState(_schema != null, "Schema must be set");
       Preconditions.checkState(CollectionUtils.isNotEmpty(_primaryKeyColumns), "Primary key columns must be set");
-      Preconditions.checkState(CollectionUtils.isNotEmpty(_comparisonColumns), "Comparison columns must be set");
       Preconditions.checkState(_hashFunction != null, "Hash function must be set");
-      Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
-      return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
-          _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
-          _consistencyMode, _upsertViewRefreshIntervalMs, _newSegmentTrackingTimeMs, _tableIndexDir,
-          _dropOutOfOrderRecord, _enableDeletedKeysCompactionConsistency, _tableDataManager);
+      Preconditions.checkState(CollectionUtils.isNotEmpty(_comparisonColumns), "Comparison columns must be set");
+      Preconditions.checkState(_consistencyMode != null, "Consistency mode must be set");
+      if (_tableIndexDir == null) {
+        Preconditions.checkState(_tableDataManager != null, "Either table data manager or table index dir must be set");
+        _tableIndexDir = _tableDataManager.getTableDataDir();
+      }
+      return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _hashFunction, _comparisonColumns,
+          _partialUpsertHandler, _deleteRecordColumn, _dropOutOfOrderRecord, _outOfOrderRecordColumn, _enableSnapshot,
+          _enablePreload, _metadataTTL, _deletedKeysTTL, _enableDeletedKeysCompactionConsistency, _consistencyMode,
+          _upsertViewRefreshIntervalMs, _newSegmentTrackingTimeMs, _metadataManagerConfigs,
+          _allowPartialUpsertConsumptionDuringCommit, _tableDataManager, _tableIndexDir);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertColumnarMerger.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertColumnarMerger.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.segment.local.upsert.merger;
 
-import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
 import org.apache.pinot.segment.local.upsert.merger.columnar.ForceOverwriteMerger;
 import org.apache.pinot.segment.local.upsert.merger.columnar.OverwriteMerger;
@@ -46,9 +46,10 @@ public class PartialUpsertColumnarMerger extends BasePartialUpsertMerger {
     _defaultColumnValueMerger =
         PartialUpsertColumnMergerFactory.getMerger(upsertConfig.getDefaultPartialUpsertStrategy());
     Map<String, UpsertConfig.Strategy> partialUpsertStrategies = upsertConfig.getPartialUpsertStrategies();
-    Preconditions.checkArgument(partialUpsertStrategies != null, "Partial upsert strategies must be configured");
-    for (Map.Entry<String, UpsertConfig.Strategy> entry : partialUpsertStrategies.entrySet()) {
-      _column2Mergers.put(entry.getKey(), PartialUpsertColumnMergerFactory.getMerger(entry.getValue()));
+    if (MapUtils.isNotEmpty(partialUpsertStrategies)) {
+      for (Map.Entry<String, UpsertConfig.Strategy> entry : partialUpsertStrategies.entrySet()) {
+        _column2Mergers.put(entry.getKey(), PartialUpsertColumnMergerFactory.getMerger(entry.getValue()));
+      }
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -87,6 +87,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.DataSizeUtils;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
@@ -729,10 +730,9 @@ public final class TableConfigUtils {
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();
-      Preconditions.checkState(outOfOrderRecordColumn == null || !upsertConfig.isDropOutOfOrderRecord(),
-          "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
-
       if (outOfOrderRecordColumn != null) {
+        Preconditions.checkState(!Boolean.TRUE.equals(upsertConfig.isDropOutOfOrderRecord()),
+            "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
         FieldSpec fieldSpec = schema.getFieldSpecFor(outOfOrderRecordColumn);
         Preconditions.checkState(
             fieldSpec != null && fieldSpec.isSingleValueField() && fieldSpec.getDataType() == DataType.BOOLEAN,
@@ -744,17 +744,18 @@ public final class TableConfigUtils {
         Preconditions.checkState(upsertConfig.getMetadataTTL() == 0,
             "enableDeletedKeysCompactionConsistency and metadataTTL shouldn't exist together for upsert table");
 
-        // enableDeletedKeysCompactionConsistency shouldn't exist with enablePreload
-        Preconditions.checkState(!upsertConfig.isEnablePreload(),
-            "enableDeletedKeysCompactionConsistency and enablePreload shouldn't exist together for upsert table");
+        // enableDeletedKeysCompactionConsistency shouldn't exist with preload enabled
+        Preconditions.checkState(upsertConfig.getPreload() != Enablement.ENABLE,
+            "enableDeletedKeysCompactionConsistency and preload shouldn't exist together for upsert table");
 
         // enableDeletedKeysCompactionConsistency should exist with deletedKeysTTL
         Preconditions.checkState(upsertConfig.getDeletedKeysTTL() > 0,
             "enableDeletedKeysCompactionConsistency should exist with deletedKeysTTL for upsert table");
 
-        // enableDeletedKeysCompactionConsistency should exist with enableSnapshot
-        Preconditions.checkState(upsertConfig.isEnableSnapshot(),
-            "enableDeletedKeysCompactionConsistency should exist with enableSnapshot for upsert table");
+        // enableDeletedKeysCompactionConsistency should exist with snapshot enabled
+        // NOTE: Allow snapshot to be DEFAULT because it might be enabled at server level.
+        Preconditions.checkState(upsertConfig.getSnapshot() != Enablement.DISABLE,
+            "enableDeletedKeysCompactionConsistency should exist with snapshot for upsert table");
 
         // enableDeletedKeysCompactionConsistency should exist with UpsertCompactionTask / UpsertCompactMergeTask
         TableTaskConfig taskConfig = tableConfig.getTaskConfig();
@@ -802,7 +803,9 @@ public final class TableConfigUtils {
     }
 
     if (upsertConfig.getMetadataTTL() > 0) {
-      Preconditions.checkState(upsertConfig.isEnableSnapshot(), "Upsert TTL must have snapshot enabled");
+      // NOTE: Allow snapshot to be DEFAULT because it might be enabled at server level.
+      Preconditions.checkState(upsertConfig.getSnapshot() != Enablement.DISABLE,
+          "Upsert TTL must have snapshot enabled");
     }
 
     if (upsertConfig.getDeletedKeysTTL() > 0) {
@@ -904,7 +907,7 @@ public final class TableConfigUtils {
     if (StringUtils.isNotBlank(partialUpsertMergerClass)) {
       Preconditions.checkState(MapUtils.isEmpty(partialUpsertStrategies),
           "If partialUpsertMergerClass is provided then partialUpsertStrategies should be empty");
-    } else {
+    } else if (MapUtils.isNotEmpty(partialUpsertStrategies)) {
       List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
       // validate partial upsert column mergers
       for (Map.Entry<String, UpsertConfig.Strategy> entry : partialUpsertStrategies.entrySet()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithTTLTest.java
@@ -62,11 +62,15 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
   public void setUpContextBuilder()
       throws IOException {
     FileUtils.forceMkdir(TEMP_DIR);
-    _dedupContextBuilder = new DedupContext.Builder();
-    _dedupContextBuilder.setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-        .setPrimaryKeyColumns(List.of("primaryKeyColumn")).setMetadataTTL(METADATA_TTL)
-        .setDedupTimeColumn(DEDUP_TIME_COLUMN_NAME).setTableIndexDir(mock(File.class))
-        .setTableDataManager(mock(TableDataManager.class)).setTableIndexDir(TEMP_DIR);
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(TEMP_DIR);
+    _dedupContextBuilder = new DedupContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(List.of("primaryKeyColumn"))
+        .setMetadataTTL(METADATA_TTL)
+        .setDedupTimeColumn(DEDUP_TIME_COLUMN_NAME);
   }
 
   @AfterMethod
@@ -76,11 +80,17 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithTTLTest {
 
   @Test
   public void creatingMetadataManagerThrowsExceptions() {
-    DedupContext.Builder dedupContextBuider = new DedupContext.Builder();
-    dedupContextBuider.setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-        .setPrimaryKeyColumns(List.of("primaryKeyColumn")).setHashFunction(HashFunction.NONE).setMetadataTTL(1)
-        .setDedupTimeColumn(null).setTableIndexDir(mock(File.class)).setTableDataManager(mock(TableDataManager.class));
-    DedupContext dedupContext = dedupContextBuider.build();
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(TEMP_DIR);
+    DedupContext dedupContext = new DedupContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(List.of("primaryKeyColumn"))
+        .setHashFunction(HashFunction.NONE)
+        .setMetadataTTL(1)
+        .setDedupTimeColumn(null)
+        .build();
     assertThrows(IllegalArgumentException.class,
         () -> new ConcurrentMapPartitionDedupMetadataManager(DedupTestUtils.REALTIME_TABLE_NAME, 0, dedupContext));
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 
@@ -54,10 +55,13 @@ public class ConcurrentMapPartitionDedupMetadataManagerWithoutTTLTest {
   public void setUpContextBuilder()
       throws IOException {
     FileUtils.forceMkdir(TEMP_DIR);
-    _dedupContextBuilder = new DedupContext.Builder();
-    _dedupContextBuilder.setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-        .setPrimaryKeyColumns(List.of("primaryKeyColumn")).setTableIndexDir(mock(File.class))
-        .setTableDataManager(mock(TableDataManager.class)).setTableIndexDir(TEMP_DIR);
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(TEMP_DIR);
+    _dedupContextBuilder = new DedupContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(List.of("primaryKeyColumn"));
   }
 
   @AfterMethod

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManagerFactoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/TableDedupMetadataManagerFactoryTest.java
@@ -20,50 +20,74 @@ package org.apache.pinot.segment.local.dedup;
 
 import com.google.common.collect.Lists;
 import java.io.File;
-import java.util.Collections;
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Server.Dedup;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
 
 
 public class TableDedupMetadataManagerFactoryTest {
+
   @Test
-  public void testEnablePreload() {
-    DedupConfig dedupConfig =
-        new DedupConfig(true, HashFunction.MD5, null, Collections.emptyMap(), 10, "timeCol", true);
-    Schema schema =
-        new Schema.SchemaBuilder().setSchemaName("mytable").addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+  public void testEnablePreload()
+      throws IOException {
+    DedupConfig dedupConfig = new DedupConfig();
+    dedupConfig.setMetadataTTL(10);
+    dedupConfig.setDedupTimeColumn("timeCol");
+    dedupConfig.setPreload(Enablement.ENABLE);
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("mytable")
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .setPrimaryKeyColumns(Lists.newArrayList("myCol"))
+        .build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("mytable").setDedupConfig(dedupConfig).build();
 
     // Preloading is not enabled as there is no preloading thread.
+    PinotConfiguration instanceDedupConfig = new PinotConfiguration();
     TableDataManager tableDataManager = mock(TableDataManager.class);
     when(tableDataManager.getTableDataDir()).thenReturn(new File("mytable"));
     when(tableDataManager.getSegmentPreloadExecutor()).thenReturn(null);
-    TableDedupMetadataManager tableDedupMetadataManager =
-        TableDedupMetadataManagerFactory.create(tableConfig, schema, tableDataManager, null, null);
-    assertNotNull(tableDedupMetadataManager);
-    assertFalse(tableDedupMetadataManager.isEnablePreload());
+    verifyPreloadEnabled(instanceDedupConfig, tableConfig, schema, tableDataManager, false);
 
     // Enabled as enablePreload is true and there is preloading thread.
     tableDataManager = mock(TableDataManager.class);
     when(tableDataManager.getTableDataDir()).thenReturn(new File("mytable"));
     when(tableDataManager.getSegmentPreloadExecutor()).thenReturn(mock(ExecutorService.class));
-    tableDedupMetadataManager = TableDedupMetadataManagerFactory.create(tableConfig, schema, tableDataManager, null,
-        null);
-    assertNotNull(tableDedupMetadataManager);
+    verifyPreloadEnabled(instanceDedupConfig, tableConfig, schema, tableDataManager, true);
+
+    // Disabled via instance level config
+    dedupConfig.setPreload(Enablement.DEFAULT);
+    verifyPreloadEnabled(instanceDedupConfig, tableConfig, schema, tableDataManager, false);
+
+    // Enabled via instance level config
+    instanceDedupConfig.setProperty(Dedup.DEFAULT_ENABLE_PRELOAD, true);
+    verifyPreloadEnabled(instanceDedupConfig, tableConfig, schema, tableDataManager, true);
+
+    // Disabled via table level config override
+    dedupConfig.setPreload(Enablement.DISABLE);
+    instanceDedupConfig.setProperty(Dedup.DEFAULT_ENABLE_PRELOAD, false);
+  }
+
+  private void verifyPreloadEnabled(PinotConfiguration instanceDedupConfig, TableConfig tableConfig, Schema schema,
+      TableDataManager tableDataManager, boolean expected)
+      throws IOException {
+    try (TableDedupMetadataManager tableDedupMetadataManager = TableDedupMetadataManagerFactory.create(
+        instanceDedupConfig, tableConfig, schema, tableDataManager)) {
+      assertEquals(tableDedupMetadataManager.getContext().isPreloadEnabled(), expected);
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentEntriesAboveThresholdTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentEntriesAboveThresholdTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
@@ -130,10 +129,7 @@ public class MutableSegmentEntriesAboveThresholdTest implements PinotBuffersAfte
 
     _schema = config.getSchema();
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(_schema, "testSegment");
-    return MutableSegmentImplTestUtils
-        .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-            Collections.emptyMap(),
-            false, false, null, null, null, null, null, null, Collections.emptyList());
+    return MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.indexsegment.mutable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
@@ -83,9 +82,7 @@ public class MutableSegmentImplTest {
 
     _schema = config.getSchema();
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(_schema, "testSegment");
-    _mutableSegmentImpl = MutableSegmentImplTestUtils
-        .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-            false);
+    _mutableSegmentImpl = MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema);
     _lastIngestionTimeMs = System.currentTimeMillis();
     StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs, new GenericRow());
     _startTimeMs = System.currentTimeMillis();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.indexsegment.mutable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -38,6 +37,7 @@ import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -87,13 +87,10 @@ public class MutableSegmentImplUpsertComparisonColTest implements PinotBuffersAf
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     TableUpsertMetadataManager tableUpsertMetadataManager =
-        TableUpsertMetadataManagerFactory.create(_tableConfig, null);
-    tableUpsertMetadataManager.init(_tableConfig, _schema, _tableDataManager);
+        TableUpsertMetadataManagerFactory.create(new PinotConfiguration(), _tableConfig, _schema, _tableDataManager);
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
-    _mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false, true, upsertConfig, "secondsSinceEpoch", _partitionUpsertMetadataManager,
-            null, null);
+    _mutableSegmentImpl = MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, true, "secondsSinceEpoch",
+        _partitionUpsertMetadataManager, null);
     GenericRow reuse = new GenericRow();
     try (RecordReader recordReader = RecordReaderFactory.getRecordReader(FileFormat.JSON, jsonFile,
         _schema.getColumnNames(), null)) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -618,7 +618,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(LONG_COLUMN1), StandardIndexes.inverted(), IndexConfig.ENABLED)
             .setIndex(Sets.newHashSet(STRING_COLUMN1), StandardIndexes.text(), textIndexConfig)
             .setIndex(Sets.newHashSet(STRING_COLUMN1), StandardIndexes.dictionary(), dictionaryIndexConfig)
-            .setFieldConfigList(fieldConfigList).setSegmentZKMetadata(getSegmentZKMetadata(segmentName))
+            .setSegmentZKMetadata(getSegmentZKMetadata(segmentName))
             .setOffHeap(true).setMemoryManager(new DirectMemoryManager(segmentName))
             .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.EmptyIndexSegment;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
@@ -195,10 +196,18 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest
 
   @BeforeMethod
   public void setUpContextBuilder() {
-    _contextBuilder = new UpsertContext.Builder().setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-        .setPrimaryKeyColumns(PRIMARY_KEY_COLUMNS).setComparisonColumns(COMPARISON_COLUMNS)
-        .setEnableDeletedKeysCompactionConsistency(true).setTableIndexDir(INDEX_DIR).setEnableSnapshot(true)
-        .setDeleteRecordColumn(DELETE_RECORD_COLUMN).setDeletedKeysTTL(20);
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(INDEX_DIR);
+    _contextBuilder = new UpsertContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(PRIMARY_KEY_COLUMNS)
+        .setComparisonColumns(COMPARISON_COLUMNS)
+        .setDeleteRecordColumn(DELETE_RECORD_COLUMN)
+        .setEnableSnapshot(true)
+        .setDeletedKeysTTL(20)
+        .setEnableDeletedKeysCompactionConsistency(true);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.EmptyIndexSegment;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
@@ -94,8 +95,14 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   @BeforeMethod
   public void setUpContextBuilder() {
-    _contextBuilder = new UpsertContext.Builder().setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
-        .setPrimaryKeyColumns(PRIMARY_KEY_COLUMNS).setComparisonColumns(COMPARISON_COLUMNS).setTableIndexDir(INDEX_DIR);
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    when(tableDataManager.getTableDataDir()).thenReturn(INDEX_DIR);
+    _contextBuilder = new UpsertContext.Builder()
+        .setTableConfig(mock(TableConfig.class))
+        .setSchema(mock(Schema.class))
+        .setTableDataManager(tableDataManager)
+        .setPrimaryKeyColumns(PRIMARY_KEY_COLUMNS)
+        .setComparisonColumns(COMPARISON_COLUMNS);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -121,7 +121,7 @@ public class PartialUpsertHandlerTest {
           when(mockReader.isNull(1)).thenReturn(isPreviousNull);
           when(mockReader.getValue(1)).thenReturn(previousValue);
         })) {
-      UpsertConfig upsertConfig = new UpsertConfig();
+      UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
       upsertConfig.setPartialUpsertStrategies(partialUpsertStrategies);
       upsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.IGNORE);
       PartialUpsertHandler handler =
@@ -154,7 +154,7 @@ public class PartialUpsertHandlerTest {
         .addDateTime("hoursSinceEpoch", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
         .setPrimaryKeyColumns(Arrays.asList("pk")).build();
 
-    UpsertConfig upsertConfig = new UpsertConfig();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
     upsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     upsertConfig.setPartialUpsertMergerClass("org.apache.pinot.segment.local.upsert.CustomPartialUpsertRowMerger");
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerFactoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerFactoryTest.java
@@ -27,7 +27,8 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class PartialUpsertMergerFactoryTest {
@@ -39,7 +40,7 @@ public class PartialUpsertMergerFactoryTest {
         .addDateTime("hoursSinceEpoch", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
         .setPrimaryKeyColumns(Arrays.asList("pk")).build();
 
-    UpsertConfig upsertConfig = new UpsertConfig();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
     Map<String, UpsertConfig.Strategy> partialUpsertStrategies = new HashMap<>();
     partialUpsertStrategies.put("field1", UpsertConfig.Strategy.OVERWRITE);
     upsertConfig.setPartialUpsertStrategies(partialUpsertStrategies);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPreloadUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPreloadUtilsTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.Enablement;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -76,10 +77,10 @@ public class SegmentPreloadUtilsTest {
 
     // Setup mocks for TableConfig and Schema.
     TableConfig tableConfig = mock(TableConfig.class);
-    UpsertConfig upsertConfig = new UpsertConfig();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setComparisonColumn("ts");
-    upsertConfig.setEnablePreload(true);
-    upsertConfig.setEnableSnapshot(true);
+    upsertConfig.setSnapshot(Enablement.ENABLE);
+    upsertConfig.setPreload(Enablement.ENABLE);
     when(tableConfig.getUpsertConfig()).thenReturn(upsertConfig);
     when(tableConfig.getTableName()).thenReturn(realtimeTableName);
     Schema schema = mock(Schema.class);

--- a/pinot-segment-local/src/test/resources/data/test_dedup_data.json
+++ b/pinot-segment-local/src/test/resources/data/test_dedup_data.json
@@ -3,24 +3,24 @@
     "event_id": "aa",
     "description" : "first",
     "dedupTime": 5000,
-    "secondsSinceEpoch": 5000
+    "secondsSinceEpoch": 1514765000
   },
   {
     "event_id": "bb",
     "description" : "first",
     "dedupTime": 6000,
-    "secondsSinceEpoch": 1000
+    "secondsSinceEpoch": 1514761000
   },
   {
     "event_id": "aa",
     "description" : "second",
     "dedupTime": 3000,
-    "secondsSinceEpoch": 5500
+    "secondsSinceEpoch": 1514765500
   },
   {
     "event_id": "bb",
     "description" : "second",
     "dedupTime": 1000,
-    "secondsSinceEpoch": 7000
+    "secondsSinceEpoch": 1514767000
   }
 ]

--- a/pinot-segment-local/src/test/resources/data/test_dedup_schema.json
+++ b/pinot-segment-local/src/test/resources/data/test_dedup_schema.json
@@ -1,5 +1,5 @@
 {
-  "schemaName": "test_pinot_table",
+  "schemaName": "testTable",
   "dimensionFieldSpecs": [
     {
       "name": "event_id",

--- a/pinot-segment-local/src/test/resources/data/test_upsert_schema.json
+++ b/pinot-segment-local/src/test/resources/data/test_upsert_schema.json
@@ -1,5 +1,5 @@
 {
-  "schemaName": "test_pinot_table",
+  "schemaName": "testTable",
   "dimensionFieldSpecs": [
     {
       "name": "event_id",
@@ -14,12 +14,14 @@
       "dataType": "LONG"
     }
   ],
-  "timeFieldSpec": {
-    "incomingGranularitySpec": {
+  "dateTimeFieldSpecs": [
+    {
       "name": "secondsSinceEpoch",
       "dataType": "LONG",
-      "timeType": "SECONDS"
+      "defaultNullValue": 1514764800,
+      "format": "EPOCH|SECONDS",
+      "granularity": "1:SECONDS"
     }
-  },
+  ],
   "primaryKeyColumns": ["event_id"]
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
@@ -18,33 +18,49 @@
  */
 package org.apache.pinot.spi.config.table;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.base.Preconditions;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.utils.Enablement;
 
 
 public class DedupConfig extends BaseJsonConfig {
+  // TODO: Consider removing this field. It should always be true when DedupConfig is present.
   @JsonPropertyDescription("Whether dedup is enabled or not.")
-  private final boolean _dedupEnabled;
+  private boolean _dedupEnabled = true;
+
   @JsonPropertyDescription("Function to hash the primary key.")
-  private final HashFunction _hashFunction;
-  @JsonPropertyDescription("Custom class for dedup metadata manager. If not specified, the default implementation "
-      + "ConcurrentMapTableDedupMetadataManager will be used.")
-  private final String _metadataManagerClass;
-  @JsonPropertyDescription("Custom configs for dedup metadata manager.")
-  private final Map<String, String> _metadataManagerConfigs;
+  private HashFunction _hashFunction = HashFunction.NONE;
+
   @JsonPropertyDescription("When larger than 0, use it for dedup metadata cleanup, it uses the same unit as the "
       + "dedup time column. The metadata will be cleaned up when the dedup time is older than the current time "
       + "minus metadata TTL. Notice that the metadata may not be cleaned up immediately after the TTL, it depends on "
       + "the cleanup schedule.")
-  private final double _metadataTTL;
+  private double _metadataTTL;
+
   @JsonPropertyDescription("Time column used to calculate dedup metadata TTL. When it is not specified, the time column"
       + " from the table config will be used.")
-  private final String _dedupTimeColumn;
+  @Nullable
+  private String _dedupTimeColumn;
 
-  @JsonPropertyDescription("Whether to preload segments for fast dedup metadata recovery")
+  @JsonPropertyDescription("Whether to preload segments for fast dedup metadata recovery. Available values are "
+      + "ENABLE, DISABLE and DEFAULT (use instance level default behavior).")
+  private Enablement _preload = Enablement.DEFAULT;
+
+  @JsonPropertyDescription("Custom class for dedup metadata manager. If not specified, the default implementation "
+      + "ConcurrentMapTableDedupMetadataManager will be used.")
+  @Nullable
+  private String _metadataManagerClass;
+
+  @JsonPropertyDescription("Custom configs for dedup metadata manager.")
+  @Nullable
+  private Map<String, String> _metadataManagerConfigs;
+
+  /// @deprecated use {@link #_preload} instead. This is kept here for backward compatibility.
+  @Deprecated
+  @JsonPropertyDescription("Whether to preload segments for fast dedup metadata recovery.")
   private boolean _enablePreload;
 
   /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
@@ -52,58 +68,100 @@ public class DedupConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to pause dedup table's partition consumption during commit")
   private boolean _allowDedupConsumptionDuringCommit;
 
-  public DedupConfig(@JsonProperty(value = "dedupEnabled", required = true) boolean dedupEnabled,
-      @JsonProperty(value = "hashFunction") HashFunction hashFunction) {
-    this(dedupEnabled, hashFunction, null, null, 0, null, false);
+  public DedupConfig() {
   }
 
-  @JsonCreator
-  public DedupConfig(@JsonProperty(value = "dedupEnabled", required = true) boolean dedupEnabled,
-      @JsonProperty(value = "hashFunction") HashFunction hashFunction,
-      @JsonProperty(value = "metadataManagerClass") String metadataManagerClass,
-      @JsonProperty(value = "metadataManagerConfigs") Map<String, String> metadataManagerConfigs,
-      @JsonProperty(value = "metadataTTL") double metadataTTL,
-      @JsonProperty(value = "dedupTimeColumn") String dedupTimeColumn,
-      @JsonProperty(value = "enablePreload") boolean enablePreload) {
+  @Deprecated
+  public DedupConfig(boolean dedupEnabled, @Nullable HashFunction hashFunction) {
     _dedupEnabled = dedupEnabled;
-    _hashFunction = hashFunction == null ? HashFunction.NONE : hashFunction;
+    _hashFunction = hashFunction != null ? hashFunction : HashFunction.NONE;
+  }
+
+  @Deprecated
+  public DedupConfig(boolean dedupEnabled, @Nullable HashFunction hashFunction, @Nullable String metadataManagerClass,
+      @Nullable Map<String, String> metadataManagerConfigs, double metadataTTL, @Nullable String dedupTimeColumn,
+      @Nullable boolean enablePreload) {
+    _dedupEnabled = dedupEnabled;
+    _hashFunction = hashFunction != null ? hashFunction : HashFunction.NONE;
     _metadataManagerClass = metadataManagerClass;
     _metadataManagerConfigs = metadataManagerConfigs;
     _metadataTTL = metadataTTL;
     _dedupTimeColumn = dedupTimeColumn;
-    _enablePreload = enablePreload;
-  }
-
-  public HashFunction getHashFunction() {
-    return _hashFunction;
+    _preload = enablePreload ? Enablement.ENABLE : Enablement.DEFAULT;
   }
 
   public boolean isDedupEnabled() {
     return _dedupEnabled;
   }
 
-  public String getMetadataManagerClass() {
-    return _metadataManagerClass;
+  public void setDedupEnabled(boolean dedupEnabled) {
+    _dedupEnabled = dedupEnabled;
   }
 
-  public Map<String, String> getMetadataManagerConfigs() {
-    return _metadataManagerConfigs;
+  public HashFunction getHashFunction() {
+    return _hashFunction;
+  }
+
+  public void setHashFunction(HashFunction hashFunction) {
+    Preconditions.checkArgument(hashFunction != null, "Hash function cannot be null");
+    _hashFunction = hashFunction;
   }
 
   public double getMetadataTTL() {
     return _metadataTTL;
   }
 
+  public void setMetadataTTL(double metadataTTL) {
+    _metadataTTL = metadataTTL;
+  }
+
+  @Nullable
   public String getDedupTimeColumn() {
     return _dedupTimeColumn;
   }
 
+  public void setDedupTimeColumn(@Nullable String dedupTimeColumn) {
+    _dedupTimeColumn = dedupTimeColumn;
+  }
+
+  public Enablement getPreload() {
+    return _preload;
+  }
+
+  public void setPreload(Enablement preload) {
+    Preconditions.checkArgument(preload != null, "Preload cannot be null, must be one of ENABLE, DISABLE or DEFAULT");
+    _preload = preload;
+  }
+
+  @Nullable
+  public String getMetadataManagerClass() {
+    return _metadataManagerClass;
+  }
+
+  public void setMetadataManagerClass(@Nullable String metadataManagerClass) {
+    _metadataManagerClass = metadataManagerClass;
+  }
+
+  @Nullable
+  public Map<String, String> getMetadataManagerConfigs() {
+    return _metadataManagerConfigs;
+  }
+
+  public void setMetadataManagerConfigs(@Nullable Map<String, String> metadataManagerConfigs) {
+    _metadataManagerConfigs = metadataManagerConfigs;
+  }
+
+  @Deprecated
   public boolean isEnablePreload() {
     return _enablePreload;
   }
 
+  @Deprecated
   public void setEnablePreload(boolean enablePreload) {
     _enablePreload = enablePreload;
+    if (enablePreload) {
+      _preload = Enablement.ENABLE;
+    }
   }
 
   @Deprecated

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -332,6 +332,11 @@ public class TableConfig extends BaseJsonConfig {
     _upsertConfig = upsertConfig;
   }
 
+  @JsonIgnore
+  public boolean isUpsertEnabled() {
+    return _upsertConfig != null && _upsertConfig.getMode() != UpsertConfig.Mode.NONE;
+  }
+
   @Nullable
   public DedupConfig getDedupConfig() {
     return _dedupConfig;
@@ -375,57 +380,10 @@ public class TableConfig extends BaseJsonConfig {
     _tierConfigsList = tierConfigsList;
   }
 
+  @Deprecated
   @JsonIgnore
   public UpsertConfig.Mode getUpsertMode() {
     return _upsertConfig == null ? UpsertConfig.Mode.NONE : _upsertConfig.getMode();
-  }
-
-  @JsonIgnore
-  public boolean isUpsertEnabled() {
-    return _upsertConfig != null && _upsertConfig.getMode() != UpsertConfig.Mode.NONE;
-  }
-
-  @JsonIgnore
-  public UpsertConfig.ConsistencyMode getUpsertConsistencyMode() {
-    return _upsertConfig == null ? UpsertConfig.ConsistencyMode.NONE : _upsertConfig.getConsistencyMode();
-  }
-
-  @JsonIgnore
-  @Nullable
-  public List<String> getUpsertComparisonColumns() {
-    return _upsertConfig == null ? null : _upsertConfig.getComparisonColumns();
-  }
-
-  @JsonIgnore
-  public double getUpsertMetadataTTL() {
-    return _upsertConfig == null ? 0 : _upsertConfig.getMetadataTTL();
-  }
-
-  @JsonIgnore
-  public String getDedupTimeColumn() {
-    return _dedupConfig == null ? null : _dedupConfig.getDedupTimeColumn();
-  }
-
-  @JsonIgnore
-  public double getDedupMetadataTTL() {
-    return _dedupConfig == null ? 0 : _dedupConfig.getMetadataTTL();
-  }
-
-  @JsonIgnore
-  @Nullable
-  public String getUpsertDeleteRecordColumn() {
-    return _upsertConfig == null ? null : _upsertConfig.getDeleteRecordColumn();
-  }
-
-  @JsonIgnore
-  @Nullable
-  public String getOutOfOrderRecordColumn() {
-    return _upsertConfig == null ? null : _upsertConfig.getOutOfOrderRecordColumn();
-  }
-
-  @JsonIgnore
-  public boolean isDropOutOfOrderRecord() {
-    return _upsertConfig != null && _upsertConfig.isDropOutOfOrderRecord();
   }
 
   @JsonProperty(TUNER_CONFIG_LIST_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1096,6 +1096,31 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY =
         "pinot.server.environmentProvider.factory";
     public static final String ENVIRONMENT_PROVIDER_CLASS_NAME = "pinot.server.environmentProvider.className";
+
+    /// All the keys should be prefixed with {@link #INSTANCE_DATA_MANAGER_CONFIG_PREFIX}
+    public static class Upsert {
+      public static final String CONFIG_PREFIX = "upsert";
+      public static final String DEFAULT_METADATA_MANAGER_CLASS = "default.metadata.manager.class";
+      public static final String DEFAULT_ENABLE_SNAPSHOT = "default.enable.snapshot";
+      public static final String DEFAULT_ENABLE_PRELOAD = "default.enable.preload";
+
+      /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
+      @Deprecated
+      public static final String DEFAULT_ALLOW_PARTIAL_UPSERT_CONSUMPTION_DURING_COMMIT =
+          "default.allow.partial.upsert.consumption.during.commit";
+    }
+
+    /// All the keys should be prefixed with {@link #INSTANCE_DATA_MANAGER_CONFIG_PREFIX}
+    public static class Dedup {
+      public static final String CONFIG_PREFIX = "dedup";
+      public static final String DEFAULT_METADATA_MANAGER_CLASS = "default.metadata.manager.class";
+      public static final String DEFAULT_ENABLE_PRELOAD = "default.enable.preload";
+
+      /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
+      @Deprecated
+      public static final String DEFAULT_ALLOW_DEDUP_CONSUMPTION_DURING_COMMIT =
+          "default.allow.dedup.consumption.during.commit";
+    }
   }
 
   public static class Controller {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Enablement.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Enablement.java
@@ -16,10 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.segment.local.dedup;
+package org.apache.pinot.spi.utils;
 
-class ConcurrentMapTableDedupMetadataManager extends BaseTableDedupMetadataManager {
-  protected PartitionDedupMetadataManager createPartitionDedupMetadataManager(Integer partitionId) {
-    return new ConcurrentMapPartitionDedupMetadataManager(_tableNameWithType, partitionId, _context);
+import java.util.function.BooleanSupplier;
+
+
+/**
+ * This enum is used to represent the enablement status of a feature.
+ * It can be used to enable, disable, or use the default instance level enablement of a feature.
+ */
+public enum Enablement {
+  ENABLE,   // Enable a feature
+  DISABLE,  // Disable a feature
+  DEFAULT;  // Use the default enablement of the feature
+
+  public boolean isEnabled(boolean defaultValue) {
+    if (this == ENABLE) {
+      return true;
+    }
+    if (this == DISABLE) {
+      return false;
+    }
+    return defaultValue;
+  }
+
+  public boolean isEnabled(BooleanSupplier defaultValueSupplier) {
+    if (this == ENABLE) {
+      return true;
+    }
+    if (this == DISABLE) {
+      return false;
+    }
+    return defaultValueSupplier.getAsBoolean();
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
@@ -40,11 +40,11 @@ public class UpsertConfigTest {
     assertEquals(upsertConfig1.getHashFunction(), HashFunction.MURMUR3);
 
     UpsertConfig upsertConfig2 = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
-    Map<String, UpsertConfig.Strategy> partialUpsertStratgies = new HashMap<>();
-    partialUpsertStratgies.put("myCol", UpsertConfig.Strategy.INCREMENT);
-    upsertConfig2.setPartialUpsertStrategies(partialUpsertStratgies);
+    Map<String, UpsertConfig.Strategy> partialUpsertStrategies = new HashMap<>();
+    partialUpsertStrategies.put("myCol", UpsertConfig.Strategy.INCREMENT);
+    upsertConfig2.setPartialUpsertStrategies(partialUpsertStrategies);
     upsertConfig2.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
-    assertEquals(upsertConfig2.getPartialUpsertStrategies(), partialUpsertStratgies);
+    assertEquals(upsertConfig2.getPartialUpsertStrategies(), partialUpsertStrategies);
   }
 
   @Test


### PR DESCRIPTION
Bugfixes:
- Introduce `Enablement` enum with value `ENABLE`, `DISABLE` and `DEFAULT` to control the enablement of a feature. For `DEFAULT` enablement, use the default config from upper level (e.g. instance level)
- Introduce `snapshot` and `preload` field as `Enablement` into `UpsertConfig` and `DedupConfig` so that the value can be properly overridden. Currently there is no way to disable at table level when instance level is enabled
- Always read properties from `UpsertContext` and `DedupContext` to avoid the inconsistency of server level override and config change

Cleanups:
- Simplify the constructor for upsert/dedup related configs
- Re-order some fields/methods for readability
- Unify the metadata manager creation logic for upsert/dedup
- Move some constants to `CommonConstants`

Incompatible:
- Several method signatures are changed

Release note:
- `enableSnapshot` and `enablePreload` are deprecated and replaced with `snapshot` and `preload`