### PR TITLE
Reduce logging spam

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -228,6 +228,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   ///     - A table not authorized to read is used
   ///     - An exception during function execution due to errors in the data
   ///       (ie a division by zero or casting an illegal string as int)
+  ///     - Query is too heavy and reaches the allowed timeout.
   ///   - The error message will be sent to the user and the error messages will be logged without stack trace.
   /// 3. With yellow error: The request failed in a way that is controlled but probably internal.
   ///   - The error message will be sent to the user and the error message will be logged with stack trace.
@@ -692,7 +693,6 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   public static boolean isYellowError(QueryException e) {
     switch (e.getErrorCode()) {
       case QUERY_SCHEDULING_TIMEOUT:
-      case EXECUTION_TIMEOUT:
       case INTERNAL:
       case UNKNOWN:
       case MERGE_RESPONSE:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -41,6 +41,7 @@ import org.apache.pinot.query.runtime.blocks.SerializedDataBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.segment.spi.memory.DataBuffer;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,9 +132,8 @@ public class GrpcSendingMailbox implements SendingMailbox {
     try {
       String msg = t != null ? t.getMessage() : "Unknown";
       // NOTE: DO NOT use onError() because it will terminate the stream, and receiver might not get the callback
-      _contentObserver.onNext(toMailboxContent(
-          ErrorMseBlock.fromException(new RuntimeException("Cancelled by sender with exception: " + msg, t)),
-          List.of()));
+      _contentObserver.onNext(toMailboxContent(ErrorMseBlock.fromException(
+          new QueryCancelledException("Cancelled by sender with exception: " + msg)), List.of()));
       _contentObserver.onCompleted();
     } catch (Exception e) {
       // Exception can be thrown if the stream is already closed, so we simply ignore it

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -41,7 +41,6 @@ import org.apache.pinot.query.runtime.blocks.SerializedDataBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.segment.spi.memory.DataBuffer;
-import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,8 +131,8 @@ public class GrpcSendingMailbox implements SendingMailbox {
     try {
       String msg = t != null ? t.getMessage() : "Unknown";
       // NOTE: DO NOT use onError() because it will terminate the stream, and receiver might not get the callback
-      _contentObserver.onNext(toMailboxContent(ErrorMseBlock.fromException(
-          new QueryCancelledException("Cancelled by sender with exception: " + msg)), List.of()));
+      _contentObserver.onNext(toMailboxContent(ErrorMseBlock.fromError(
+          QueryErrorCode.QUERY_CANCELLATION, "Cancelled by sender with exception: " + msg), List.of()));
       _contentObserver.onCompleted();
     } catch (Exception e) {
       // Exception can be thrown if the stream is already closed, so we simply ignore it

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -89,7 +89,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
       case CANCELLED:
         throw new QueryCancelledException(String.format("Mailbox: %s already cancelled from upstream", _id));
       case ERROR:
-        throw new QueryException(QueryErrorCode.ERRORED_OUT, String.format(
+        throw new QueryException(QueryErrorCode.INTERNAL, String.format(
             "Mailbox: %s already errored out (received error block before)", _id));
       case TIMEOUT:
         throw new QueryException(QueryErrorCode.EXECUTION_TIMEOUT,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -28,6 +28,8 @@ import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.segment.spi.memory.DataBuffer;
 import org.apache.pinot.spi.exception.QueryCancelledException;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.QueryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,9 +89,10 @@ public class InMemorySendingMailbox implements SendingMailbox {
       case CANCELLED:
         throw new QueryCancelledException(String.format("Mailbox: %s already cancelled from upstream", _id));
       case ERROR:
-        throw new RuntimeException(String.format("Mailbox: %s already errored out (received error block before)", _id));
+        throw new QueryException(QueryErrorCode.ERRORED_OUT, String.format(
+            "Mailbox: %s already errored out (received error block before)", _id));
       case TIMEOUT:
-        throw new TimeoutException(
+        throw new QueryException(QueryErrorCode.EXECUTION_TIMEOUT,
             String.format("Timed out adding block into mailbox: %s with timeout: %dms", _id, timeoutMs));
       case EARLY_TERMINATED:
         _isEarlyTerminated = true;
@@ -114,8 +117,8 @@ public class InMemorySendingMailbox implements SendingMailbox {
       _receivingMailbox = _mailboxService.getReceivingMailbox(_id);
     }
     _receivingMailbox.setErrorBlock(
-        ErrorMseBlock.fromException(new RuntimeException("Cancelled by sender with exception: " + t.getMessage(), t)),
-        Collections.emptyList());
+        ErrorMseBlock.fromException(new QueryCancelledException(
+            "Cancelled by sender with exception: " + t.getMessage())), Collections.emptyList());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.proto.Mailbox.MailboxStatus;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
-import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,8 +114,8 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
     LOGGER.warn("Error on receiver side", t);
     if (_mailbox != null) {
       _mailbox.setErrorBlock(
-          ErrorMseBlock.fromException(new QueryCancelledException(
-              "Cancelled by sender with exception: " + t.getMessage())), Collections.emptyList());
+          ErrorMseBlock.fromException(new RuntimeException("Cancelled by sender", t)),
+          Collections.emptyList());
     } else {
       LOGGER.error("Got error before mailbox is set up", t);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.proto.Mailbox.MailboxStatus;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,8 +115,8 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
     LOGGER.warn("Error on receiver side", t);
     if (_mailbox != null) {
       _mailbox.setErrorBlock(
-          ErrorMseBlock.fromException(new RuntimeException("Cancelled by sender", t)),
-          Collections.emptyList());
+          ErrorMseBlock.fromException(new QueryCancelledException(
+              "Cancelled by sender with exception: " + t.getMessage())), Collections.emptyList());
     } else {
       LOGGER.error("Got error before mailbox is set up", t);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
+import javax.validation.constraints.NotNull;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -50,12 +51,16 @@ public class ErrorMseBlock implements MseBlock.Eos {
     } else {
       errorCode = QueryErrorCode.UNKNOWN;
     }
-    String errorMessage = errorCode.isIncludeStackTrace() ? DataBlockUtils.extractErrorMsg(e) : e.getMessage();
+    String errorMessage = shouldIncludeStackTrace(errorCode) ? DataBlockUtils.extractErrorMsg(e) : e.getMessage();
     return new ErrorMseBlock(Collections.singletonMap(errorCode, errorMessage));
   }
 
   public static ErrorMseBlock fromError(QueryErrorCode errorCode, String errorMessage) {
     return new ErrorMseBlock(Collections.singletonMap(errorCode, errorMessage));
+  }
+
+  private static boolean shouldIncludeStackTrace(@NotNull QueryErrorCode errorCode) {
+    return QueryErrorCode.UNKNOWN.equals(errorCode);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
@@ -42,7 +42,6 @@ public class ErrorMseBlock implements MseBlock.Eos {
   }
 
   public static ErrorMseBlock fromException(Exception e) {
-    String errorMessage = DataBlockUtils.extractErrorMsg(e);
     QueryErrorCode errorCode;
     if (e instanceof QueryException) {
       errorCode = ((QueryException) e).getErrorCode();
@@ -51,6 +50,7 @@ public class ErrorMseBlock implements MseBlock.Eos {
     } else {
       errorCode = QueryErrorCode.UNKNOWN;
     }
+    String errorMessage = errorCode.isIncludeStackTrace() ? DataBlockUtils.extractErrorMsg(e) : e.getMessage();
     return new ErrorMseBlock(Collections.singletonMap(errorCode, errorMessage));
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
@@ -54,6 +54,10 @@ public class ErrorMseBlock implements MseBlock.Eos {
     return new ErrorMseBlock(Collections.singletonMap(errorCode, errorMessage));
   }
 
+  public static ErrorMseBlock fromError(QueryErrorCode errorCode, String errorMessage) {
+    return new ErrorMseBlock(Collections.singletonMap(errorCode, errorMessage));
+  }
+
   @Override
   public boolean isError() {
     return true;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -225,7 +225,7 @@ public class MailboxSendOperator extends MultiStageOperator {
     } catch (Exception e) {
       ErrorMseBlock errorBlock = ErrorMseBlock.fromException(e);
       try {
-        LOGGER.error("Exception while transferring data on opChain: {}", _context.getId(), e);
+        LOGGER.error("Exception while transferring data on opChain: {}", _context.getId());
         sendEos(errorBlock);
       } catch (Exception e2) {
         LOGGER.error("Exception while sending error block.", e2);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -57,7 +57,6 @@ public enum QueryErrorCode {
   UNKNOWN_COLUMN(710, "UnknownColumnError"),
   ///  Error while planning the query. For example, trying to run a colocated join on non-colocated tables.
   QUERY_PLANNING(720, "QueryPlanningError"),
-  ///  Query already errored out.
   UNKNOWN(1000, "UnknownError");
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -154,14 +154,4 @@ public enum QueryErrorCode {
         return false;
     }
   }
-
-  public boolean isIncludeStackTrace() {
-    switch (this) {
-      case INTERNAL:
-      case UNKNOWN:
-        return true;
-      default:
-        return false;
-    }
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -57,6 +57,8 @@ public enum QueryErrorCode {
   UNKNOWN_COLUMN(710, "UnknownColumnError"),
   ///  Error while planning the query. For example, trying to run a colocated join on non-colocated tables.
   QUERY_PLANNING(720, "QueryPlanningError"),
+  ///  Query already errored out.
+  ERRORED_OUT(800, "ErroredOutError"),
   UNKNOWN(1000, "UnknownError");
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 
@@ -148,6 +150,16 @@ public enum QueryErrorCode {
       case TABLE_DOES_NOT_EXIST:
       case TABLE_IS_DISABLED:
       case UNKNOWN_COLUMN:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public boolean isIncludeStackTrace() {
+    switch (this) {
+      case INTERNAL:
+      case UNKNOWN:
         return true;
       default:
         return false;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -58,7 +58,6 @@ public enum QueryErrorCode {
   ///  Error while planning the query. For example, trying to run a colocated join on non-colocated tables.
   QUERY_PLANNING(720, "QueryPlanningError"),
   ///  Query already errored out.
-  ERRORED_OUT(800, "ErroredOutError"),
   UNKNOWN(1000, "UnknownError");
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 


### PR DESCRIPTION
This PR aims to reduce how we spam the logs under certain query error scenarios, usually including big stack traces that are either irrelevant or redundant.

Main changes include:

- Consider `EXECUTION_TIMEOUT` a _Green error_ instead of a _Yellow_ one. That way the broker will not log its own stack trace, which is irrelevant when the timeout took place in one or several servers.
- Stage cancellation catches are now re-thrown as `QueryCancelledException` and server will decide not to print the stack trace again when that's the type of exception catched. That way in a timeout, the only stage that will actually log the stack trace is the one that really timed out and parent stages will stop printing redundant info.