### PR TITLE
Remove unused constraint when inferPartitionHint is true

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -182,9 +181,6 @@ public class QueryEnvironment {
     }
     switch (inferPartitionHint.toLowerCase()) {
       case "true":
-        Objects.requireNonNull(workerManager, "WorkerManager is required in order to infer partition hint. "
-            + "Please enable it using broker config"
-            + CommonConstants.Broker.CONFIG_OF_ENABLE_PARTITION_METADATA_MANAGER + "=true");
         return workerManager;
       case "false":
         return null;


### PR DESCRIPTION
This PR removes a problematic check when inferPartitionHint is true. The original idea was to fail when the worker manager is null in a broker and this query option is true. However, this situation is not possible anymore given that brokers always have a worker manager.

Even worse, this constraint always failed when the query was executed through a controller, given that they needed to parse the query to get the tables being used. At the same time, they never set the worker manager.

Therefore, by removing this check, we:
* Do not affect brokers
* Fix an error in controllres.