### PR TITLE
Refactor query compilation to be able to stop it at different steps

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -222,8 +222,8 @@ public class PinotQueryResource {
         new QueryEnvironment(database, _pinotHelixResourceManager.getTableCache(), null);
     List<String> tableNames;
 
-    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
-      tableNames = new ArrayList<>(compiledQuery.getTableNames());
+    try (QueryEnvironment.RelationalQuery relQuery = queryEnvironment.relational(query)) {
+      tableNames = new ArrayList<>(relQuery.getTableNames());
     } catch (QueryException e) {
       if (e.getErrorCode() != QueryErrorCode.UNKNOWN) {
         throw e;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
@@ -81,8 +81,8 @@ public class ParserUtils {
     if (useMSE) {
       QueryEnvironment queryEnvironment = new QueryEnvironment(database, tableCache, null);
       RelRoot root;
-      try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
-        root = compiledQuery.getRelRoot();
+      try (QueryEnvironment.OptimizedQuery optimizedQuery = queryEnvironment.optimize(query)) {
+        root = optimizedQuery.getRelRoot();
       } catch (Exception ignored) {
         root = null;
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -105,7 +105,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   protected QueryEnvironment.QueryPlannerResult planQuery(String sql) {
     long requestId = REQUEST_ID_GEN.getAndIncrement();
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
-    try (QueryEnvironment.CompiledQuery compiledQuery = _queryEnvironment.compile(sql, sqlNodeAndOptions)) {
+    try (QueryEnvironment.OptimizedQuery compiledQuery = _queryEnvironment.optimize(sql, sqlNodeAndOptions)) {
       return compiledQuery.planQuery(requestId);
     }
   }
@@ -118,7 +118,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     long requestId = REQUEST_ID_GEN.getAndIncrement();
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
     QueryEnvironment.QueryPlannerResult queryPlannerResult;
-    try (QueryEnvironment.CompiledQuery compiledQuery = _queryEnvironment.compile(sql, sqlNodeAndOptions)) {
+    try (QueryEnvironment.OptimizedQuery compiledQuery = _queryEnvironment.optimize(sql, sqlNodeAndOptions)) {
       queryPlannerResult = compiledQuery.planQuery(requestId);
     }
     DispatchableSubPlan dispatchableSubPlan = queryPlannerResult.getQueryPlan();


### PR DESCRIPTION
Some weeks ago, I modified QueryEnvironment to include a new class called CompiledQuery. This class contains the result of parsing, validating, transforming into RelNode and then optimizing the query.

Today, I'm splitting this process into some extra steps: validation, to relation and optimization. These steps were already there, but calling them individually was impossible. This isn't ideal since we may want to stop the process in the middle or continue after applying some changes. The clearest case is PinotQueryResource.getTableNames(), which needed to optimize the query just to get the used tables. That optimization process there is not necessary (at least assuming queries are not written in such a way that whole tables can be statically pruned), and in this PR, we are using the relational model without optimizations to list the tables. This should accelerate queries when executed from the controller instead of directly attacking the brokers.