### PR TITLE
Add a parameter for thrift binary path

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -31,6 +31,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <thrift.bin.path>/usr/local/bin/thrift</thrift.bin.path>
   </properties>
 
   <build>
@@ -302,7 +303,7 @@
       <id>profile-buildthrift</id>
       <activation>
         <file>
-          <exists>/usr/local/bin/thrift</exists>
+          <exists>${thrift.bin.path}</exists>
         </file>
         <property>
           <name>buildThrift</name>
@@ -321,21 +322,21 @@
                   <target>
                     <delete dir="target/generated-sources/gen-javabean" />
                     <mkdir dir="target/generated-sources" />
-                    <exec executable="/usr/local/bin/thrift">
+                    <exec executable="${thrift.bin.path}">
                       <arg value="--gen" />
                       <arg value="java:beans" />
                       <arg value="-o" />
                       <arg value="target/generated-sources" />
                       <arg value="src/thrift/query.thrift" />
                     </exec>
-                    <exec executable="/usr/local/bin/thrift">
+                    <exec executable="${thrift.bin.path}">
                       <arg value="--gen" />
                       <arg value="java:beans" />
                       <arg value="-o" />
                       <arg value="target/generated-sources" />
                       <arg value="src/thrift/request.thrift" />
                     </exec>
-                    <exec executable="/usr/local/bin/thrift">
+                    <exec executable="${thrift.bin.path}">
                       <arg value="--gen" />
                       <arg value="java:beans" />
                       <arg value="-o" />


### PR DESCRIPTION
The thrift binary path is hard-coded to `/usr/local/bin/thrift`. In MacOS/Homebrew, thrift is installed in `/opt/homebrew/bin/thrift`.

Developers can choose the binary path with `-Dthrift.bin.path` if thrift is installed in a different path.

The default value is `/usr/local/bin/thrift`.
