### PR TITLE
[typo] Fix typo in error message in ControllerConf

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -546,7 +546,7 @@ public class ControllerConf extends PinotConfiguration {
     String zkAddress = containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) ? getProperty(
         CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) : getProperty(ZK_STR);
     Preconditions.checkState(zkAddress != null,
-        "ZK address is not configured. Please configure it using the config: 'pinot.zk.str'");
+        "ZK address is not configured. Please configure it using the config: '" + ZK_STR + "'");
     return zkAddress;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -546,7 +546,7 @@ public class ControllerConf extends PinotConfiguration {
     String zkAddress = containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) ? getProperty(
         CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) : getProperty(ZK_STR);
     Preconditions.checkState(zkAddress != null,
-        "ZK address is not configured. Please configure it using the config: 'pinot.zk.server'");
+        "ZK address is not configured. Please configure it using the config: 'pinot.zk.str'");
     return zkAddress;
   }
 


### PR DESCRIPTION
This pull request includes a minor change to the error message in the `getZkStr` method of the `ControllerConf` class. The change updates the configuration key in the error message to reflect the correct property name.

* [`pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java`](diffhunk://#diff-45ef05159d9fa349a4a5f829987e258494c326e34e40fd98195e9f28972a3611L549-R549): Changed error message to use 'pinot.zk.str' instead of 'pinot.zk.server'.