### PR TITLE
[bugfix]: Fixes rebalance server status rendering

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceResponse.tsx
@@ -97,7 +97,7 @@ export const RebalanceResponse = ({ response }) => {
                 responseSectionsToShow.map((section) => {
                     if (Object.keys(response).includes(section.key)) {
                         return (
-                            <Grid item xs={12}>
+                            <Grid item xs={12} key={section.key}>
                                 <RebalanceServerResponseCard>
                                     <RebalanceServerSectionResponse key={section.key} sectionTitle={section.name} sectionData={response[section.key]} />
                                 </RebalanceServerResponseCard>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerResponses/RebalanceServerResponseLabelValue.tsx
@@ -25,7 +25,7 @@ export const RebalanceServerResponseLabelValue = (
     return (
         <Box>
             <Typography color='textSecondary' variant='caption'>{label}</Typography>
-            <Typography style={{ fontWeight: 600, whiteSpace: "pre" }} variant='body2'>{value}</Typography>
+            <Typography style={{ fontWeight: 600, whiteSpace: "pre-wrap", wordBreak: "break-all" }} variant='body2'>{value}</Typography>
         </Box>
     );
 }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
@@ -86,21 +86,36 @@ export const RebalanceServerStatusOp = (
 
     useEffect(() => {
         try {
-            if (jobSelected !== null) {
-                setRebalanceContext(JSON.parse(rebalanceServerJobs[jobSelected].REBALANCE_CONTEXT))
-                setRebalanceProgressStats(JSON.parse(rebalanceServerJobs[jobSelected].REBALANCE_PROGRESS_STATS))
+            if (jobSelected !== null && rebalanceServerJobs.length > 0) {
+                const rebalanceServerJob = rebalanceServerJobs
+                    .find(job => job.jobId === jobSelected);
+
+                if (rebalanceServerJob) {
+                    setRebalanceContext(JSON.parse(rebalanceServerJob.REBALANCE_CONTEXT));
+                    setRebalanceProgressStats(JSON.parse(rebalanceServerJob.REBALANCE_PROGRESS_STATS));
+                } else {
+                    setRebalanceContext(
+                        {
+                            message: 'Failed to load rebalance context'
+                        });
+                    setRebalanceProgressStats(
+                        {
+                            message: 'Failed to load rebalance progress stats'
+                        });
+                }
+
             }
         } catch (e) {
             setRebalanceContext(
                 {
-                    message: 'Failed to load rebalance context'
+                    message: 'Failed to load rebalance context' + e.toString()
                 });
             setRebalanceProgressStats(
                 {
-                    message: 'Failed to load rebalance progress stats'
+                    message: 'Failed to load rebalance progress stats' + e.toString()
                 });
         }
-    }, [jobSelected]);
+    }, [jobSelected, rebalanceServerJobs]);
 
     if (loading) {
         return (


### PR DESCRIPTION
### Description

Rebalance status is not rendering leading to `undefined`

### Fix

Since `rebalanceServerJobs` response is now an array, the selected rebalance server job is searched using `.find`

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/aaeccf7e-854e-43ee-a1c5-28a405acaf44" />
