### PR TITLE
Codecov tests

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -230,6 +230,17 @@ jobs:
           token: 3cb787e5-09a8-4b23-8856-06410b11455f
           fail_ci_if_error: false
           verbose: true
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        continue-on-error: true
+        timeout-minutes: 5
+        with:
+          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          name: codecov-integration-tests
+          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          fail_ci_if_error: false
+          verbose: true
       - name: Custom Integration Test
         if : ${{ matrix.testset == 1 }}
         env:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -150,6 +150,15 @@ jobs:
           token: 3cb787e5-09a8-4b23-8856-06410b11455f
           fail_ci_if_error: false
           verbose: true
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          name: codecov-unit-tests
+          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          fail_ci_if_error: false
+          verbose: true
 
   integration-test:
     if: github.repository == 'apache/pinot'
@@ -242,6 +251,15 @@ jobs:
         uses: codecov/codecov-action@v5
         continue-on-error: true
         timeout-minutes: 5
+        with:
+          flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          name: codecov-custom-integration-tests
+          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          fail_ci_if_error: false
+          verbose: true
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
         with:
           flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-custom-integration-tests

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -80,17 +80,7 @@ jobs:
         testset: [ 1, 2 ]
         java: [ 11, 21 ]
         distribution: [ "temurin" ]
-        skip_bytebuffer: [false]
-        include:
-          - java: 21
-            testset: 1
-            distribution: "temurin"
-            skip_bytebuffer: true
-          - java: 21
-            testset: 2
-            distribution: "temurin"
-            skip_bytebuffer: true
-    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
+    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -133,7 +123,6 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: false
           RUN_TEST_SET: ${{ matrix.testset }}
-          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -156,7 +145,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}},skip-bytebuffers-${{matrix.skip_bytebuffer}}
+          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
           token: 3cb787e5-09a8-4b23-8856-06410b11455f
           fail_ci_if_error: false
@@ -172,17 +161,7 @@ jobs:
         testset: [ 1, 2 ]
         java: [ 11, 21 ]
         distribution: [ "temurin" ]
-        skip_bytebuffer: [false]
-        include:
-          - java: 21
-            testset: 1
-            distribution: "temurin"
-            skip_bytebuffer: true
-          - java: 21
-            testset: 2
-            distribution: "temurin"
-            skip_bytebuffer: true
-    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
+    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -219,7 +198,6 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           RUN_TEST_SET: ${{ matrix.testset }}
-          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -237,7 +215,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}},skip-bytebuffers-${{matrix.skip_bytebuffer}}
+          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-integration-tests
           token: 3cb787e5-09a8-4b23-8856-06410b11455f
           fail_ci_if_error: false
@@ -392,12 +370,7 @@ jobs:
       matrix:
         java: [ 11, 21 ]
         distribution: [ "temurin" ]
-        skip_bytebuffer: [false]
-        include:
-          - java: 21
-            distribution: "temurin"
-            skip_bytebuffer: true
-    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with skip bytebuffers:${{matrix.skip_bytebuffer}}
+    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -417,6 +390,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Quickstart on JDK ${{ matrix.java }}
-        env:
-          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
         run: .github/workflows/scripts/.pinot_quickstart.sh

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -153,6 +153,7 @@ jobs:
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
+        timeout-minutes: 5
         with:
           flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
@@ -260,6 +261,7 @@ jobs:
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
+        timeout-minutes: 5
         with:
           flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-custom-integration-tests

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
       - name: Upload test results to Codecov
@@ -157,7 +157,7 @@ jobs:
         with:
           flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
 
@@ -227,7 +227,7 @@ jobs:
         with:
           flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-integration-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
       - name: Upload test results to Codecov
@@ -238,7 +238,7 @@ jobs:
         with:
           flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-integration-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
       - name: Custom Integration Test
@@ -266,7 +266,7 @@ jobs:
         with:
           flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-custom-integration-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
       - name: Upload test results to Codecov
@@ -276,7 +276,7 @@ jobs:
         with:
           flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-custom-integration-tests
-          token: 3cb787e5-09a8-4b23-8856-06410b11455f
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
 

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21 ]
+        java: [ 11, 21, 24 ]
         distribution: [ "temurin" ]
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -168,7 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21 ]
+        java: [ 11, 21, 24 ]
         distribution: [ "temurin" ]
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -386,7 +386,7 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 21 ]
+        java: [ 11, 21, 24 ]
         distribution: [ "temurin" ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21, 24 ]
+        java: [ 11, 21 ]
         distribution: [ "temurin" ]
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -169,7 +169,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21, 24 ]
+        java: [ 11, 21 ]
         distribution: [ "temurin" ]
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -399,7 +399,7 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 21, 24 ]
+        java: [ 11, 21 ]
         distribution: [ "temurin" ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:


### PR DESCRIPTION
This PR changes github actions in two ways:
1. Removes the skip bytebuffer tests we introduced more than a year ago to increase our confidence in our alternative to LArray buffers. We have been using our alternative in all JVMs for a while and recently we completely removed LArray buffer dependency, so it doesn't seem we need to test in this mode anymore.
2. Uploads test results to codecov. This is a new feature in codecov described in https://docs.codecov.com/docs/test-analytics.