### PR TITLE
[multistage] Bug Fixes / Refactoring Based on E2E Physical Optimizer Test

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategy.java
@@ -59,5 +59,9 @@ public enum ExchangeStrategy {
   /**
    * Each stream will send data to all receiving streams.
    */
-  BROADCAST_EXCHANGE
+  BROADCAST_EXCHANGE,
+  /**
+   * Records are sent randomly from a given worker in the sender to some worker in the receiver.
+   */
+  RANDOM_EXCHANGE
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelNode.java
@@ -105,7 +105,7 @@ public interface PRelNode {
   }
 
   default PRelNode with(List<PRelNode> newInputs) {
-    return with(getNodeId(), newInputs, getPinotDataDistributionOrThrow());
+    return with(getNodeId(), newInputs, getPinotDataDistribution());
   }
 
   default PRelNode asLeafStage() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PinotDataDistribution.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PinotDataDistribution.java
@@ -163,10 +163,8 @@ public class PinotDataDistribution {
     }
     Set<HashDistributionDesc> newHashDesc = new HashSet<>();
     for (HashDistributionDesc desc : _hashDistributionDesc) {
-      HashDistributionDesc newDescs = desc.apply(mapping);
-      if (newDescs != null) {
-        newHashDesc.add(newDescs);
-      }
+      Set<HashDistributionDesc> newDescs = desc.apply(mapping);
+      newHashDesc.addAll(newDescs);
     }
     RelDistribution.Type newType = _type;
     if (newType == RelDistribution.Type.HASH_DISTRIBUTED && newHashDesc.isEmpty()) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/RelToPRelConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/RelToPRelConverter.java
@@ -45,10 +45,7 @@ import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalTableScan;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalUnion;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalValues;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalWindow;
-import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRule;
 import org.apache.pinot.query.planner.physical.v2.opt.PhysicalOptRuleSet;
-import org.apache.pinot.query.planner.physical.v2.opt.RuleExecutor;
-import org.apache.pinot.query.planner.physical.v2.opt.RuleExecutors;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,11 +66,9 @@ public class RelToPRelConverter {
     // Step-2: Assign traits
     rootPRelNode = TraitAssignment.assign(rootPRelNode, context);
     // Step-3: Run physical optimizer rules.
-    var ruleAndExecutorList = PhysicalOptRuleSet.create(context, tableCache);
-    for (var ruleAndExecutor : ruleAndExecutorList) {
-      PRelOptRule rule = ruleAndExecutor.getLeft();
-      RuleExecutor executor = RuleExecutors.create(ruleAndExecutor.getRight(), rule, context);
-      rootPRelNode = executor.execute(rootPRelNode);
+    var pRelTransformers = PhysicalOptRuleSet.create(context, tableCache);
+    for (var pRelTransformer : pRelTransformers) {
+      rootPRelNode = pRelTransformer.execute(rootPRelNode);
     }
     return rootPRelNode;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/mapping/DistMappingGenerator.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/mapping/DistMappingGenerator.java
@@ -59,7 +59,7 @@ public class DistMappingGenerator {
       PinotDistMapping mapping = new PinotDistMapping(source.getRowType().getFieldCount());
       List<Integer> groupSet = aggregate.getGroupSet().asList();
       for (int j = 0; j < groupSet.size(); j++) {
-        mapping.set(groupSet.get(j), j);
+        mapping.add(groupSet.get(j), j);
       }
       return mapping;
     } else if (destination instanceof Join) {
@@ -72,7 +72,7 @@ public class DistMappingGenerator {
       }
       PinotDistMapping mapping = new PinotDistMapping(source.getRowType().getFieldCount());
       for (int i = 0; i < mapping.getSourceCount(); i++) {
-        mapping.set(i, i + leftFieldCount);
+        mapping.add(i, i + leftFieldCount);
       }
       return mapping;
     } else if (destination instanceof Filter) {
@@ -100,7 +100,7 @@ public class DistMappingGenerator {
     for (RexNode rexNode : project.getProjects()) {
       if (rexNode instanceof RexInputRef) {
         RexInputRef rexInputRef = (RexInputRef) rexNode;
-        mapping.set(rexInputRef.getIndex(), indexInCurrentRelNode);
+        mapping.add(rexInputRef.getIndex(), indexInCurrentRelNode);
       }
       indexInCurrentRelNode++;
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/mapping/PinotDistMapping.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/mapping/PinotDistMapping.java
@@ -19,11 +19,16 @@
 package org.apache.pinot.query.planner.physical.v2.mapping;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.commons.collections4.CollectionUtils;
 
 
 /**
@@ -31,21 +36,20 @@ import java.util.Map;
  * RelNode pair and is used to track how input fields are mapped to output fields.
  */
 public class PinotDistMapping {
-  private static final int DEFAULT_MAPPING_VALUE = -1;
   private final int _sourceCount;
-  private final Map<Integer, Integer> _sourceToTargetMapping = new HashMap<>();
+  private final Map<Integer, List<Integer>> _sourceToTargetMapping = new HashMap<>();
 
   public PinotDistMapping(int sourceCount) {
     _sourceCount = sourceCount;
     for (int i = 0; i < sourceCount; i++) {
-      _sourceToTargetMapping.put(i, DEFAULT_MAPPING_VALUE);
+      _sourceToTargetMapping.put(i, new ArrayList<>());
     }
   }
 
   public static PinotDistMapping identity(int sourceCount) {
     PinotDistMapping mapping = new PinotDistMapping(sourceCount);
     for (int i = 0; i < sourceCount; i++) {
-      mapping.set(i, i);
+      mapping.add(i, i);
     }
     return mapping;
   }
@@ -54,29 +58,57 @@ public class PinotDistMapping {
     return _sourceCount;
   }
 
-  public int getTarget(int source) {
+  public List<Integer> getTargets(int source) {
     Preconditions.checkArgument(source >= 0 && source < _sourceCount, "Invalid source index: %s", source);
-    Integer target = _sourceToTargetMapping.get(source);
-    return target == null ? DEFAULT_MAPPING_VALUE : target;
+    List<Integer> target = _sourceToTargetMapping.get(source);
+    return target == null ? List.of() : target;
   }
 
-  public void set(int source, int target) {
+  public void add(int source, int target) {
     Preconditions.checkArgument(source >= 0 && source < _sourceCount, "Invalid source index: %s", source);
-    _sourceToTargetMapping.put(source, target);
+    _sourceToTargetMapping.computeIfAbsent(source, (x) -> new ArrayList<>()).add(target);
   }
 
-  public List<Integer> getMappedKeys(List<Integer> existingKeys) {
-    List<Integer> result = new ArrayList<>(existingKeys.size());
-    for (int key : existingKeys) {
-      Integer mappedKey = _sourceToTargetMapping.get(key);
-      Preconditions.checkArgument(mappedKey != null,
-          "Key %s not found in mapping with source count: %s", key, _sourceCount);
-      if (mappedKey != DEFAULT_MAPPING_VALUE) {
-        result.add(mappedKey);
-      } else {
-        return Collections.emptyList();
-      }
-    }
+  public List<List<Integer>> getMappedKeys(List<Integer> existingKeys) {
+    List<List<Integer>> result = new ArrayList<>();
+    computeAllMappings(0, existingKeys, this, new ArrayDeque<>(), result);
     return result;
+  }
+
+  public static RelCollation apply(RelCollation relCollation, PinotDistMapping mapping) {
+    if (relCollation.getKeys().isEmpty()) {
+      return relCollation;
+    }
+    List<RelFieldCollation> newFieldCollations = new ArrayList<>();
+    for (RelFieldCollation fieldCollation : relCollation.getFieldCollations()) {
+      List<Integer> newFieldIndices = mapping.getTargets(fieldCollation.getFieldIndex());
+      if (CollectionUtils.isEmpty(newFieldIndices)) {
+        break;
+      }
+      newFieldCollations.add(fieldCollation.withFieldIndex(newFieldIndices.get(0)));
+    }
+    return RelCollations.of(newFieldCollations);
+  }
+
+  /**
+   * Consider a node that is partitioned on the key: [1]. If there's a project node on top of this, with project
+   * expressions as: [RexInputRef#0, RexInputRef#1, RexInputRef#1], then the project node will have two hash
+   * distribution descriptors: [1] and [2]. This method computes all such mappings for the given key indexes.
+   * <p>
+   *   This is a common occurrence in Calcite plans.
+   * </p>
+   */
+  public static void computeAllMappings(int index, List<Integer> currentKey, PinotDistMapping mapping,
+      Deque<Integer> runningKey, List<List<Integer>> newKeysSink) {
+    if (index == currentKey.size()) {
+      newKeysSink.add(new ArrayList<>(runningKey));
+      return;
+    }
+    List<Integer> possibilities = mapping.getTargets(currentKey.get(index));
+    for (int currentKeyPossibility : possibilities) {
+      runningKey.addLast(currentKeyPossibility);
+      computeAllMappings(index + 1, currentKey, mapping, runningKey, newKeysSink);
+      runningKey.removeLast();
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
@@ -113,4 +113,20 @@ public class PhysicalAggregate extends Aggregate implements PRelNode {
         getAggCallList(), _nodeId, _pRelInputs.get(0), _pinotDataDistribution, true, _aggType, _leafReturnFinalResult,
         _collations, _limit);
   }
+
+  public AggregateNode.AggType getAggType() {
+    return _aggType;
+  }
+
+  public boolean isLeafReturnFinalResult() {
+    return _leafReturnFinalResult;
+  }
+
+  public List<RelFieldCollation> getCollations() {
+    return _collations;
+  }
+
+  public int getLimit() {
+    return _limit;
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalExchange.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalExchange.java
@@ -22,13 +22,17 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.Exchange;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTrait;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTraitDef;
 import org.apache.pinot.query.planner.physical.v2.ExchangeStrategy;
 import org.apache.pinot.query.planner.physical.v2.PRelNode;
 import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
@@ -73,10 +77,11 @@ public class PhysicalExchange extends Exchange implements PRelNode {
    */
   private final RelCollation _relCollation;
 
-  public PhysicalExchange(RelOptCluster cluster, RelDistribution distribution,
-      int nodeId, PRelNode input, @Nullable PinotDataDistribution pinotDataDistribution,
-      List<Integer> distributionKeys, ExchangeStrategy exchangeStrategy, @Nullable RelCollation relCollation) {
-    super(cluster, EMPTY_TRAIT_SET, input.unwrap(), distribution);
+  public PhysicalExchange(int nodeId, PRelNode input, @Nullable PinotDataDistribution pinotDataDistribution,
+      List<Integer> distributionKeys, ExchangeStrategy exchangeStrategy, @Nullable RelCollation relCollation,
+      PinotExecStrategyTrait execStrategyTrait) {
+    super(input.unwrap().getCluster(), EMPTY_TRAIT_SET.plus(execStrategyTrait), input.unwrap(),
+        getRelDistribution(exchangeStrategy, distributionKeys));
     _nodeId = nodeId;
     _pRelInputs = Collections.singletonList(input);
     _pinotDataDistribution = pinotDataDistribution;
@@ -89,8 +94,8 @@ public class PhysicalExchange extends Exchange implements PRelNode {
   public Exchange copy(RelTraitSet traitSet, RelNode newInput, RelDistribution newDistribution) {
     Preconditions.checkState(newInput instanceof PRelNode, "Expected input of PhysicalExchange to be a PRelNode");
     Preconditions.checkState(traitSet.isEmpty(), "Expected empty trait set for PhysicalExchange");
-    return new PhysicalExchange(getCluster(), newDistribution, _nodeId, (PRelNode) newInput, _pinotDataDistribution,
-        _distributionKeys, _exchangeStrategy, _relCollation);
+    return new PhysicalExchange(_nodeId, (PRelNode) newInput, _pinotDataDistribution, _distributionKeys,
+        _exchangeStrategy, _relCollation, PinotExecStrategyTrait.getDefaultExecStrategy());
   }
 
   @Override
@@ -119,9 +124,63 @@ public class PhysicalExchange extends Exchange implements PRelNode {
     return false;
   }
 
+  public List<Integer> getDistributionKeys() {
+    return _distributionKeys;
+  }
+
+  public ExchangeStrategy getExchangeStrategy() {
+    return _exchangeStrategy;
+  }
+
+  public RelCollation getRelCollation() {
+    return _relCollation;
+  }
+
+  public PinotExecStrategyTrait getExecStrategy() {
+    PinotExecStrategyTrait trait = traitSet.getTrait(PinotExecStrategyTraitDef.INSTANCE);
+    if (trait == null) {
+      return PinotExecStrategyTrait.getDefaultExecStrategy();
+    }
+    return trait;
+  }
+
+  public PinotRelExchangeType getRelExchangeType() {
+    PinotExecStrategyTrait trait = traitSet.getTrait(PinotExecStrategyTraitDef.INSTANCE);
+    if (trait == null) {
+      return PinotExecStrategyTrait.getDefaultExecStrategy().getType();
+    }
+    return trait.getType();
+  }
+
   @Override
   public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
-    return new PhysicalExchange(getCluster(), getDistribution(), newNodeId, newInputs.get(0), newDistribution,
-        _distributionKeys, _exchangeStrategy, _relCollation);
+    return new PhysicalExchange(newNodeId, newInputs.get(0), newDistribution, _distributionKeys, _exchangeStrategy,
+        _relCollation, PinotExecStrategyTrait.getDefaultExecStrategy());
+  }
+
+  @Override public RelWriter explainTerms(RelWriter pw) {
+    return pw.item("input", input)
+        .item("exchangeStrategy", _exchangeStrategy)
+        .item("distKeys", _distributionKeys)
+        .item("execStrategy", getRelExchangeType())
+        .item("collation", _relCollation);
+  }
+
+  private static RelDistribution getRelDistribution(ExchangeStrategy exchangeStrategy, List<Integer> keys) {
+    switch (exchangeStrategy) {
+      case IDENTITY_EXCHANGE:
+      case PARTITIONING_EXCHANGE:
+      case SUB_PARTITIONING_HASH_EXCHANGE:
+      case COALESCING_PARTITIONING_EXCHANGE:
+        return RelDistributions.hash(keys);
+      case BROADCAST_EXCHANGE:
+        return RelDistributions.BROADCAST_DISTRIBUTED;
+      case SINGLETON_EXCHANGE:
+        return RelDistributions.SINGLETON;
+      case SUB_PARTITIONING_RR_EXCHANGE:
+        return RelDistributions.ROUND_ROBIN_DISTRIBUTED;
+      default:
+        throw new IllegalStateException(String.format("Unexpected exchange strategy: %s", exchangeStrategy));
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PRelOptRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PRelOptRule.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.physical.v2.opt;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.query.planner.physical.v2.PRelNode;
 
 
@@ -42,5 +43,10 @@ public abstract class PRelOptRule {
    */
   public PRelNode onDone(PRelNode currentNode) {
     return currentNode;
+  }
+
+  @Nullable
+  public PRelNode getParentNode(PRelOptRuleCall call) {
+    return call._parents.isEmpty() ? null : call._parents.getLast();
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageAggregateRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageAggregateRule.java
@@ -59,7 +59,7 @@ public class LeafStageAggregateRule extends PRelOptRule {
     if (!(currentNode.unwrap() instanceof Aggregate)) {
       return false;
     }
-    if (!isProjectFilterOrScan(currentNode.getPRelInput(0).unwrap())) {
+    if (!currentNode.getPRelInput(0).isLeafStage() || !isProjectFilterOrScan(currentNode.getPRelInput(0).unwrap())) {
       return false;
     }
     // ==> We have: "aggregate (non-leaf stage) > project|filter|table-scan (leaf-stage)"
@@ -80,7 +80,7 @@ public class LeafStageAggregateRule extends PRelOptRule {
         currentNode.unwrap(), null);
     PinotDataDistribution derivedDistribution = currentNode.getPRelInput(0).getPinotDataDistributionOrThrow()
         .apply(mapping);
-    return currentNode.with(currentNode.getPRelInputs(), derivedDistribution);
+    return currentNode.with(currentNode.getPRelInputs(), derivedDistribution).asLeafStage();
   }
 
   private static boolean isPartitionedByHintPresent(PhysicalAggregate aggRel) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/mapping/PinotDistMappingTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/mapping/PinotDistMappingTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.physical.v2.mapping;
 
+import java.util.Collections;
 import java.util.List;
 import org.testng.annotations.Test;
 
@@ -31,7 +32,7 @@ public class PinotDistMappingTest {
     PinotDistMapping mapping = PinotDistMapping.identity(10);
     assertEquals(mapping.getSourceCount(), 10);
     for (int i = 0; i < 10; i++) {
-      assertEquals(mapping.getTarget(i), i);
+      assertEquals(mapping.getTargets(i), List.of(i));
     }
     // Test getMappedKeys always returns the same values as the input.
     List<List<Integer>> testKeys = List.of(
@@ -42,7 +43,7 @@ public class PinotDistMappingTest {
         List.of(4, 2, 9)
     );
     for (List<Integer> keys : testKeys) {
-      assertEquals(mapping.getMappedKeys(keys), keys);
+      assertEquals(mapping.getMappedKeys(keys), List.of(keys));
     }
   }
 
@@ -50,10 +51,10 @@ public class PinotDistMappingTest {
   public void testOutOfBoundsSource() {
     // When the passed source index is out of bounds wrt the sourceCount in the mapping, we should get an exception.
     PinotDistMapping mapping = new PinotDistMapping(5);
-    assertThrows(IllegalArgumentException.class, () -> mapping.getTarget(-1));
-    assertThrows(IllegalArgumentException.class, () -> mapping.getTarget(5));
-    assertThrows(IllegalArgumentException.class, () -> mapping.set(-1, 2));
-    assertThrows(IllegalArgumentException.class, () -> mapping.set(5, 2));
+    assertThrows(IllegalArgumentException.class, () -> mapping.getTargets(-1));
+    assertThrows(IllegalArgumentException.class, () -> mapping.getTargets(5));
+    assertThrows(IllegalArgumentException.class, () -> mapping.add(-1, 2));
+    assertThrows(IllegalArgumentException.class, () -> mapping.add(5, 2));
     assertThrows(IllegalArgumentException.class, () -> mapping.getMappedKeys(List.of(5)));
   }
 
@@ -61,25 +62,25 @@ public class PinotDistMappingTest {
   public void testSet() {
     // Test setting a mapping value.
     PinotDistMapping mapping = new PinotDistMapping(5);
-    mapping.set(0, 2);
-    assertEquals(mapping.getTarget(0), 2);
-    assertEquals(mapping.getTarget(1), -1);
-    assertEquals(mapping.getTarget(2), -1);
-    assertEquals(mapping.getTarget(3), -1);
-    assertEquals(mapping.getTarget(4), -1);
+    mapping.add(0, 2);
+    assertEquals(mapping.getTargets(0), List.of(2));
+    assertEquals(mapping.getTargets(1), Collections.emptyList());
+    assertEquals(mapping.getTargets(2), Collections.emptyList());
+    assertEquals(mapping.getTargets(3), Collections.emptyList());
+    assertEquals(mapping.getTargets(4), Collections.emptyList());
 
     // Test setting multiple mapping values.
-    mapping.set(1, 3);
-    mapping.set(2, 4);
-    assertEquals(mapping.getTarget(0), 2);
-    assertEquals(mapping.getTarget(1), 3);
-    assertEquals(mapping.getTarget(2), 4);
-    assertEquals(mapping.getTarget(3), -1);
-    assertEquals(mapping.getTarget(4), -1);
+    mapping.add(1, 3);
+    mapping.add(2, 4);
+    assertEquals(mapping.getTargets(0), List.of(2));
+    assertEquals(mapping.getTargets(1), List.of(3));
+    assertEquals(mapping.getTargets(2), List.of(4));
+    assertEquals(mapping.getTargets(3), Collections.emptyList());
+    assertEquals(mapping.getTargets(4), Collections.emptyList());
 
     // Test setting a mapping value to an invalid index.
-    assertThrows(IllegalArgumentException.class, () -> mapping.set(-1, 2));
-    assertThrows(IllegalArgumentException.class, () -> mapping.set(5, 2));
+    assertThrows(IllegalArgumentException.class, () -> mapping.add(-1, 2));
+    assertThrows(IllegalArgumentException.class, () -> mapping.add(5, 2));
   }
 
   @Test
@@ -87,27 +88,47 @@ public class PinotDistMappingTest {
     {
       // Test when all passed keys are mapped.
       PinotDistMapping mapping = new PinotDistMapping(5);
-      mapping.set(0, 2);
-      mapping.set(1, 3);
-      mapping.set(2, 4);
+      mapping.add(0, 2);
+      mapping.add(1, 3);
+      mapping.add(2, 4);
       List<Integer> keys = List.of(0, 1, 2);
-      List<Integer> expectedMappedKeys = List.of(2, 3, 4);
+      List<List<Integer>> expectedMappedKeys = List.of(List.of(2, 3, 4));
+      assertEquals(mapping.getMappedKeys(keys), expectedMappedKeys);
+    }
+    {
+      // Test when a key is mapped to multiple targets
+      PinotDistMapping mapping = new PinotDistMapping(5);
+      mapping.add(0, 2);
+      mapping.add(1, 3);
+      mapping.add(1, 4);
+      List<Integer> keys = List.of(0, 1);
+      List<List<Integer>> expectedMappedKeys = List.of(List.of(2, 3), List.of(2, 4));
       assertEquals(mapping.getMappedKeys(keys), expectedMappedKeys);
     }
     {
       // Test when one of the keys is not mapped
       PinotDistMapping mapping = new PinotDistMapping(5);
-      mapping.set(0, 2);
-      mapping.set(1, 3);
+      mapping.add(0, 2);
+      mapping.add(1, 3);
       List<Integer> keys = List.of(0, 1, 2);
-      List<Integer> expectedMappedKeys = List.of();
+      List<List<Integer>> expectedMappedKeys = List.of();
+      assertEquals(mapping.getMappedKeys(keys), expectedMappedKeys);
+    }
+    {
+      // Test when passed keys are empty
+      PinotDistMapping mapping = new PinotDistMapping(5);
+      mapping.add(0, 2);
+      mapping.add(1, 3);
+      mapping.add(1, 4);
+      List<Integer> keys = List.of();
+      List<List<Integer>> expectedMappedKeys = List.of(List.of());
       assertEquals(mapping.getMappedKeys(keys), expectedMappedKeys);
     }
     {
       // Test getting mapped keys with an invalid key.
       PinotDistMapping mapping = new PinotDistMapping(5);
-      mapping.set(0, 2);
-      mapping.set(1, 3);
+      mapping.add(0, 2);
+      mapping.add(1, 3);
       List<Integer> keys = List.of(0, 1, 5);
       assertThrows(IllegalArgumentException.class, () -> mapping.getMappedKeys(keys));
     }


### PR DESCRIPTION
**Note:** This does NOT touch any reachable code path so expected to be a safe change. We are building the physical optimizer behind a flag to begin with since the changes involved are significant.

### Summary

I am about done with the first version of the Physical Optimizer change. While getting it running I found some bugs so this PR fixes some of them. These are summarized below.

#### Support Mapping Source to Multiple Targets in PinotDistMapping

Calcite quite commonly generates projects, where the same input reference exists multiple times. It looks something as follows. If we only allow a source to map to at most 1 target, we were dropping distribution descriptors which was leading to some unnecessary shuffles in some sample queries as shown below.

Hence, I have changed PinotDistMapping to instead be of the form `Map<Integer, List<Integer>>`. Moreover, while computing new hash descriptors for a node, I now compute all possible mappings. For instance, if a node is partitioned on `$1` and we have a project such as the one show below, then the Project node is partitioned by both `col2` and `col21`.

```
          "\n              PhysicalProject(col1=[$0], col2=[$1], col21=[$1])",
```

Example query where this feature helps in getting rid of even more shuffles:

```
SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT col1, col2 FROM a WHERE col2 IN (SELECT col2 FROM a WHERE col3 = 'foo') AND col2 NOT IN (SELECT col2 FROM a WHERE col3 = 'bar') AND col2 IN (SELECT col2 FROM a WHERE col3 = 'lorem')
```

#### Remove Semi-Join Dynamic Filtering Temporarily

This will be handled through a separate rule. To keep our scope low, I have removed support for it for now. 

#### Switch to Transformers instead of Rule Executors at Top Level

The `RelToPRelConverter` should execute transformers, which are the more generic type, rather than rule executors.

#### Trait Assignment Update

We should first set the right distribution. If it is broadcast, then we don't need to set any trait on the left and we can leave it Random (we'll change this to Any later. see: F3 in the tracker)