### PR TITLE
reverse MSE case-insensitive capabilities

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1540,7 +1540,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertTrue(result > 0);
   }
 
-  @Test
+  @Test(enabled = false) // disabled until we figure out how to make MSE case-insensitive without breaking compatibility
   public void testCaseInsensitiveNamesAgainstController() throws Exception {
     String query = "select ACTualELAPsedTIMe from mYtABLE where actUALelAPSedTIMe > 0 limit 1";
     JsonNode jsonNode = postQueryToController(query);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3358,7 +3358,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     testQuery(pinotQuery, h2Query);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
+  //@Test(dataProvider = "useBothQueryEngines")
+  // disabled for MSE until we figure out how to make it case-insensitive without breaking compatibility
+  @Test(dataProvider = "useV1QueryEngine")
   public void testCaseSensitivity(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -125,10 +125,11 @@ public class QueryEnvironment {
     _catalog = new PinotCatalog(config.getTableCache(), database);
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false, database, _catalog);
     Properties connectionConfigProperties = new Properties();
-    connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.toString(
+    /*connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.toString(
         config.getTableCache() == null
             ? !CommonConstants.Helix.DEFAULT_ENABLE_CASE_INSENSITIVE
-            : !config.getTableCache().isIgnoreCase()));
+            : !config.getTableCache().isIgnoreCase()));*/
+    connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
     CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(connectionConfigProperties);
     _config = Frameworks.newConfigBuilder().traitDefs().operatorTable(PinotOperatorTable.instance())
         .defaultSchema(rootSchema.plus()).sqlToRelConverterConfig(PinotRuleUtils.PINOT_SQL_TO_REL_CONFIG).build();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -290,7 +290,8 @@ public final class RelToPlanNodeConverter {
   }
 
   private TableScanNode convertPinotLogicalTableScan(PinotLogicalTableScan node) {
-    String tableName = _tableCache.getActualTableName(getTableNameFromTableScan(node));
+    //String tableName = _tableCache.getActualTableName(getTableNameFromTableScan(node));
+    String tableName = getTableNameFromTableScan(node);
     List<RelDataTypeField> fields = node.getRowType().getFieldList();
     List<String> columns = new ArrayList<>(fields.size());
     for (RelDataTypeField field : fields) {


### PR DESCRIPTION
Recently Multi Stage Engine [has been updated](https://github.com/apache/pinot/pull/14830) to support the `enable.case.insensitive=true` configuration and ignore case for table and field identifiers.

However, this introduced some backward compatibility breaks as stated [here](https://github.com/apache/pinot/pull/14830/#issuecomment-2788228861) when user named tables as `*_realtime` or `*_offline`.

Until we figure out a way to configure Calcite to ignore case but ignore the REALTIME/OFFLINE suffix, we rather revert the change and make MSE always case-sensitive again.