### PR TITLE
Log query exceptions in query runner perf tool

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -330,6 +330,9 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
         long clientTime = response.get("totalTime").asLong();
         totalClientTime += clientTime;
         boolean hasException = !response.get("exceptions").isEmpty();
+        if (hasException) {
+          LOGGER.error("Query: {} failed with errors: {}", query, response.get("exceptions").toString());
+        }
         numExceptions += hasException ? 1 : 0;
         statisticsList.get(0).addValue(clientTime);
         if (queryStatMap != null) {
@@ -834,6 +837,9 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     long clientTime = response.get("totalTime").asLong();
     totalClientTime.getAndAdd(clientTime);
     boolean hasException = !response.get("exceptions").isEmpty();
+    if (hasException) {
+      LOGGER.error("Query: {} failed with errors: {}", query, response.get("exceptions").toString());
+    }
     numExceptions.getAndAdd(hasException ? 1 : 0);
     if (queryStatMap != null) {
       queryStatMap.computeIfAbsent(query, k -> new QueryStat()).addExecution(brokerTime, clientTime, hasException);


### PR DESCRIPTION
- Currently, if queries fail with errors in the perf `QueryRunner` tool, all we get is a log line at the end like:
```
[QueryRunner] [main] FINAL REPORT:
[QueryRunner] [main] Time Passed: 794557ms
Queries Executed: 160
Exceptions: 5
...
```
with no details on the actual errors.
- This patch logs all the query errors for better debuggability.