### PR TITLE
Add a config to skip updating dedup metadata for non-default tier segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.core.data.manager.provider.TableDataManagerProvider;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -142,8 +143,8 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   }
 
   @Override
-  public void addSegment(ImmutableSegment immutableSegment) {
-    super.addSegment(immutableSegment);
+  public void addSegment(ImmutableSegment immutableSegment, @Nullable SegmentZKMetadata zkMetadata) {
+    super.addSegment(immutableSegment, zkMetadata);
     String segmentName = immutableSegment.getSegmentName();
     if (loadLookupTable()) {
       _logger.info("Successfully loaded lookup table after adding segment: {}", segmentName);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -94,10 +94,26 @@ public interface TableDataManager {
 
   /**
    * Adds a loaded immutable segment into the table.
+   * See {@link #addSegment(ImmutableSegment, SegmentZKMetadata)} for details.
+   */
+  @VisibleForTesting
+  default void addSegment(ImmutableSegment immutableSegment) {
+    addSegment(immutableSegment, null);
+  }
+
+  /**
+   * Adds a loaded immutable segment into the table.
+   * <p>If one segment already exists with the same name, replaces it with the new one.
+   * <p>Ensures that reference count of the old segment (if replaced) is reduced by 1, so that the last user of the old
+   * segment (or the calling thread, if there are none) remove the segment.
+   * <p>The new segment is added with reference count of 1, so that is never removed until a drop command comes through.
+   * <p>Segment ZK metadata might not be available when replacing a CONSUMING segment with the locally sealed one or
+   * invoked from tests.
+   *
    * NOTE: This method is not designed to be directly used by the production code, but can be handy to set up tests.
    */
   @VisibleForTesting
-  void addSegment(ImmutableSegment immutableSegment);
+  void addSegment(ImmutableSegment immutableSegment, @Nullable SegmentZKMetadata zkMetadata);
 
   /**
    * Adds an ONLINE segment into a table.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java
@@ -75,6 +75,9 @@ public abstract class BaseTableDedupMetadataManager implements TableDedupMetadat
       }
     }
 
+    boolean ignoreNonDefaultTiers = dedupConfig.getIgnoreNonDefaultTiers()
+        .isEnabled(() -> instanceDedupConfig.getProperty(Dedup.DEFAULT_IGNORE_NON_DEFAULT_TIERS, false));
+
     // NOTE: This field doesn't follow enablement override, and always enabled if enabled at instance level.
     boolean allowDedupConsumptionDuringCommit = dedupConfig.isAllowDedupConsumptionDuringCommit();
     if (!allowDedupConsumptionDuringCommit) {
@@ -91,6 +94,7 @@ public abstract class BaseTableDedupMetadataManager implements TableDedupMetadat
         .setMetadataTTL(metadataTTL)
         .setDedupTimeColumn(dedupTimeColumn)
         .setEnablePreload(enablePreload)
+        .setIgnoreNonDefaultTiers(ignoreNonDefaultTiers)
         .setMetadataManagerConfigs(dedupConfig.getMetadataManagerConfigs())
         .setAllowDedupConsumptionDuringCommit(allowDedupConsumptionDuringCommit)
         .build();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java
@@ -40,6 +40,7 @@ public class DedupContext {
   @Nullable
   private final String _dedupTimeColumn;
   private final boolean _enablePreload;
+  private final boolean _ignoreNonDefaultTiers;
   @Nullable
   private final Map<String, String> _metadataManagerConfigs;
 
@@ -54,8 +55,8 @@ public class DedupContext {
 
   private DedupContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
       HashFunction hashFunction, double metadataTTL, @Nullable String dedupTimeColumn, boolean enablePreload,
-      @Nullable Map<String, String> metadataManagerConfigs, boolean allowDedupConsumptionDuringCommit,
-      @Nullable TableDataManager tableDataManager, File tableIndexDir) {
+      boolean ignoreNonDefaultTiers, @Nullable Map<String, String> metadataManagerConfigs,
+      boolean allowDedupConsumptionDuringCommit, @Nullable TableDataManager tableDataManager, File tableIndexDir) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
@@ -63,6 +64,7 @@ public class DedupContext {
     _metadataTTL = metadataTTL;
     _dedupTimeColumn = dedupTimeColumn;
     _enablePreload = enablePreload;
+    _ignoreNonDefaultTiers = ignoreNonDefaultTiers;
     _metadataManagerConfigs = metadataManagerConfigs;
     _allowDedupConsumptionDuringCommit = allowDedupConsumptionDuringCommit;
     _tableDataManager = tableDataManager;
@@ -98,6 +100,10 @@ public class DedupContext {
     return _enablePreload;
   }
 
+  public boolean isIgnoreNonDefaultTiers() {
+    return _ignoreNonDefaultTiers;
+  }
+
   @Nullable
   public Map<String, String> getMetadataManagerConfigs() {
     return _metadataManagerConfigs;
@@ -125,6 +131,7 @@ public class DedupContext {
         .append("metadataTTL", _metadataTTL)
         .append("dedupTimeColumn", _dedupTimeColumn)
         .append("enablePreload", _enablePreload)
+        .append("ignoreNonDefaultTiers", _ignoreNonDefaultTiers)
         .append("metadataManagerConfigs", _metadataManagerConfigs)
         .append("allowDedupConsumptionDuringCommit", _allowDedupConsumptionDuringCommit)
         .append("tableIndexDir", _tableIndexDir)
@@ -139,6 +146,7 @@ public class DedupContext {
     private double _metadataTTL;
     private String _dedupTimeColumn;
     private boolean _enablePreload;
+    private boolean _ignoreNonDefaultTiers;
     private Map<String, String> _metadataManagerConfigs;
     @Deprecated
     private boolean _allowDedupConsumptionDuringCommit;
@@ -180,6 +188,11 @@ public class DedupContext {
       return this;
     }
 
+    public Builder setIgnoreNonDefaultTiers(boolean ignoreNonDefaultTiers) {
+      _ignoreNonDefaultTiers = ignoreNonDefaultTiers;
+      return this;
+    }
+
     public Builder setMetadataManagerConfigs(Map<String, String> metadataManagerConfigs) {
       _metadataManagerConfigs = metadataManagerConfigs;
       return this;
@@ -211,8 +224,8 @@ public class DedupContext {
         _tableIndexDir = _tableDataManager.getTableDataDir();
       }
       return new DedupContext(_tableConfig, _schema, _primaryKeyColumns, _hashFunction, _metadataTTL, _dedupTimeColumn,
-          _enablePreload, _metadataManagerConfigs, _allowDedupConsumptionDuringCommit, _tableDataManager,
-          _tableIndexDir);
+          _enablePreload, _ignoreNonDefaultTiers, _metadataManagerConfigs, _allowDedupConsumptionDuringCommit,
+          _tableDataManager, _tableIndexDir);
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
@@ -49,6 +49,9 @@ public class DedupConfig extends BaseJsonConfig {
       + "ENABLE, DISABLE and DEFAULT (use instance level default behavior).")
   private Enablement _preload = Enablement.DEFAULT;
 
+  @JsonPropertyDescription("Whether to ignore segments from non-default tiers when constructing dedup metadata.")
+  private Enablement _ignoreNonDefaultTiers = Enablement.DEFAULT;
+
   @JsonPropertyDescription("Custom class for dedup metadata manager. If not specified, the default implementation "
       + "ConcurrentMapTableDedupMetadataManager will be used.")
   @Nullable
@@ -131,6 +134,16 @@ public class DedupConfig extends BaseJsonConfig {
   public void setPreload(Enablement preload) {
     Preconditions.checkArgument(preload != null, "Preload cannot be null, must be one of ENABLE, DISABLE or DEFAULT");
     _preload = preload;
+  }
+
+  public Enablement getIgnoreNonDefaultTiers() {
+    return _ignoreNonDefaultTiers;
+  }
+
+  public void setIgnoreNonDefaultTiers(Enablement ignoreNonDefaultTiers) {
+    Preconditions.checkArgument(ignoreNonDefaultTiers != null,
+        "Ignore non-default tiers cannot be null, must be one of ENABLE, DISABLE or DEFAULT");
+    _ignoreNonDefaultTiers = ignoreNonDefaultTiers;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1115,6 +1115,7 @@ public class CommonConstants {
       public static final String CONFIG_PREFIX = "dedup";
       public static final String DEFAULT_METADATA_MANAGER_CLASS = "default.metadata.manager.class";
       public static final String DEFAULT_ENABLE_PRELOAD = "default.enable.preload";
+      public static final String DEFAULT_IGNORE_NON_DEFAULT_TIERS = "default.ignore.non.default.tiers";
 
       /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
       @Deprecated


### PR DESCRIPTION
For dedup-enabled table, when segments are moved to the cold tier, usually they are out of the metadata TTL thus we can skip updating the dedup metadata for it to reduce the overhead of metadata construction.

New added config:
- Table level under `dedupConfig`: `ignoreNonDefaultTiers`: `ENABLE`, `DISABLE`, or `DEFAULT` (default, use instance level config)
- Instance level: `pinot.server.instance.dedup.default.ignore.non.default.tiers`

TODO:
- [ ] Add test for this new feature #15577 
- [ ] Ensure minion tasks honor this new config to skip processing tier segments #15578 
- [ ] Revisit if this flag also applies to upsert