### PR TITLE
[ui][refactor] New API util - FetchRebalanceTableJobs

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
@@ -28,19 +28,7 @@ import {RebalanceServerResponseCard} from "./RebalanceServer/RebalanceServerResp
 import CustomizedTables from "../../Table";
 import Utils from "../../../utils/Utils";
 import PinotMethodUtils from "../../../utils/PinotMethodUtils";
-
-type RebalanceTableSegmentJob = {
-    jobId: string;
-    messageCount: number;
-    submissionTimeMs: number;
-    jobType: string;
-    tableName: string;
-    REBALANCE_PROGRESS_STATS: string;
-    REBALANCE_CONTEXT: string;
-}
-export type RebalanceTableSegmentJobs = {
-    [key: string]: RebalanceTableSegmentJob;
-}
+import {RebalanceTableSegmentJob} from "Models";
 
 type RebalanceServerStatusOpProps = {
     tableName: string;
@@ -59,15 +47,9 @@ export const RebalanceServerStatusOp = (
     useEffect(() => {
         setLoading(true);
         PinotMethodUtils
-            .fetchTableJobs(tableName, "TABLE_REBALANCE")
+            .fetchRebalanceTableJobs(tableName)
             .then(jobs => {
-                if (jobs.error) {
-                    return;
-                }
-                const sortedJobs: RebalanceTableSegmentJob[] = Object.keys(jobs as RebalanceTableSegmentJobs)
-                    .map(jobId => jobs[jobId] as RebalanceTableSegmentJob)
-                    .sort((j1, j2) => j1.submissionTimeMs < j2.submissionTimeMs ? 1 : -1);
-                setRebalanceServerJobs(sortedJobs);
+                setRebalanceServerJobs(jobs)
             })
             .finally(() => setLoading(false));
     }, []);

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -258,6 +258,20 @@ declare module 'Models' {
       tableName: string
     }
   }
+
+  type RebalanceTableSegmentJob = {
+    jobId: string;
+    messageCount: number;
+    submissionTimeMs: number;
+    jobType: string;
+    tableName: string;
+    REBALANCE_PROGRESS_STATS: string;
+    REBALANCE_CONTEXT: string;
+  }
+
+  export type RebalanceTableSegmentJobs = {
+    [key: string]: RebalanceTableSegmentJob;
+  }
   
   export interface TaskRuntimeConfig {
     ConcurrentTasksPerWorker: string,

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -45,7 +45,7 @@ import { SegmentStatusRenderer } from '../components/SegmentStatusRenderer';
 import Skeleton from '@material-ui/lab/Skeleton';
 import NotFound from '../components/NotFound';
 import {
-  RebalanceServerStatusOp, RebalanceTableSegmentJobs
+  RebalanceServerStatusOp
 } from "../components/Homepage/Operations/RebalanceServerStatusOp";
 
 const useStyles = makeStyles((theme) => ({

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -19,7 +19,16 @@
 
 import jwtDecode from "jwt-decode";
 import { get, each, isEqual, isArray, keys, union } from 'lodash';
-import { DataTable, InstanceType, SchemaInfo, SegmentMetadata, SqlException, SQLResult } from 'Models';
+import {
+  DataTable,
+  InstanceType,
+  RebalanceTableSegmentJob,
+  RebalanceTableSegmentJobs,
+  SchemaInfo,
+  SegmentMetadata,
+  SqlException,
+  SQLResult
+} from 'Models';
 import moment from 'moment';
 import {
   getTenants,
@@ -966,6 +975,18 @@ const fetchTableJobs = async (tableName: string, jobTypes?: string) => {
   return response.data;
 }
 
+const fetchRebalanceTableJobs = async (tableName: string): Promise<RebalanceTableSegmentJob[]> => {
+  const response = await getTableJobs(tableName, "TABLE_REBALANCE");
+  if (response.data.error) {
+    return [];
+  }
+
+  const rebalanceTableSegmentJobs: RebalanceTableSegmentJob[] = Object.keys(response.data as RebalanceTableSegmentJobs)
+      .map(jobId => response.data[jobId] as RebalanceTableSegmentJob)
+      .sort((j1, j2) => j1.submissionTimeMs < j2.submissionTimeMs ? 1 : -1);
+  return rebalanceTableSegmentJobs;
+}
+
 const fetchSegmentReloadStatus = async (jobId: string) => {
   const response = await getSegmentReloadStatus(jobId);
   
@@ -1309,6 +1330,7 @@ export default {
   getAllPeriodicTaskNames,
   getAllTaskTypes,
   fetchTableJobs,
+  fetchRebalanceTableJobs,
   fetchSegmentReloadStatus,
   getTaskTypeDebugData,
   getTableData,


### PR DESCRIPTION
In follow up to PR #15554 

This PR creates a new PinotMethodUtil named `fetchRebalanceTableJobs` that fetches the rebalance jobs and sorts them based on descending order of date time