### PR TITLE
Set cluster.tenant.isolation.enable to true in ControllerTest's default controller config

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -228,6 +228,7 @@ public class ControllerTest {
     properties.put(ControllerConf.DISABLE_GROOVY, false);
     properties.put(ControllerConf.CONSOLE_SWAGGER_ENABLE, false);
     properties.put(CommonConstants.CONFIG_OF_TIMEZONE, "UTC");
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, true);
     overrideControllerConf(properties);
     return properties;
   }


### PR DESCRIPTION
## Description

Today `cluster.tenant.isolation.enable` in controller config is default to `true` https://github.com/apache/pinot/blob/6c0215834bf3e6203d1246bbb0b49e01b369b6d4/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java#L831

In `ControllerTest`, the default controller config it uses does not explicitly set this. Tests are going to fail in the future once the default value of `cluster.tenant.isolation.enable` changes.