### PR TITLE
set tables for controller task scheduling

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.minion;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -811,7 +812,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   protected void processTables(List<String> tableNamesWithType, Properties taskProperties) {
     TaskSchedulingContext context = new TaskSchedulingContext()
         .setLeader(true)
-        .setTriggeredBy(CommonConstants.TaskTriggers.CRON_TRIGGER.name());
+        .setTriggeredBy(CommonConstants.TaskTriggers.CRON_TRIGGER.name())
+        .setTablesToSchedule(ImmutableSet.copyOf(tableNamesWithType));
     // cron schedule
     scheduleTasks(context);
   }


### PR DESCRIPTION
Bug fix for https://github.com/apache/pinot/issues/15592.

If not set `setTablesToSchedule()`, the all controllers will generate tasks for all tables, which causes the minions to do lots of duplicated work. 
