### PR TITLE
PINOT-17: Fix baseURL for Knox Gateway compatibility

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/axios-config.ts
+++ b/pinot-controller/src/main/resources/app/utils/axios-config.ts
@@ -80,11 +80,11 @@ export const getAxiosResponseInterceptor = (): (<T>(
     return fulfilledResponseInterceptor;
 };
 
-export const baseApi = axios.create({ baseURL: '/' });
+export const baseApi = axios.create({ baseURL: location.pathname });
 baseApi.interceptors.request.use(getAxiosRequestInterceptor(), getAxiosErrorInterceptor());
 baseApi.interceptors.response.use(getAxiosResponseInterceptor(), getAxiosErrorInterceptor());
 
-export const transformApi = axios.create({baseURL: '/', transformResponse: [data => data]});
+export const transformApi = axios.create({baseURL: location.pathname, transformResponse: [data => data]});
 transformApi.interceptors.request.use(getAxiosRequestInterceptor(), getAxiosErrorInterceptor());
 transformApi.interceptors.response.use(getAxiosResponseInterceptor(), getAxiosErrorInterceptor());
 
@@ -92,6 +92,6 @@ transformApi.interceptors.response.use(getAxiosResponseInterceptor(), getAxiosEr
 // changing the handleError method of baseApi will cause current UI to break (as UI might have not handle error properly)
 // creating a new axios instance baseApiWithErrors which can be used when adding new API's
 // NOTE: It is an add-on utility and can be used in case you want to handle/show UI when API fails.
-export const baseApiWithErrors = axios.create({ baseURL: '/' });
+export const baseApiWithErrors = axios.create({ baseURL: location.pathname });
 baseApiWithErrors.interceptors.request.use(getAxiosRequestInterceptor());
 baseApiWithErrors.interceptors.response.use(getAxiosResponseInterceptor());


### PR DESCRIPTION
[PINOT-17](https://issues.apache.org/jira/browse/PINOT-17)

**Problem:**  
When Apache Pinot is deployed behind an Apache Knox Gateway, the frontend fails to correctly resolve API endpoints. This is due to the hardcoded `baseURL: '/'` in the Axios configuration, which assumes Pinot is always served from the root context. However, Knox typically proxies services under custom paths (e.g., `/gateway/default/pinot`), causing API requests to misroute and fail.

**Root Cause:**  
The hardcoded root path (`'/'`) used as the base URL in Axios does not account for the dynamic sub-path under which Pinot may be served when proxied by Knox. As a result, the browser attempts to make API calls to incorrect or non-existent paths.

**Solution:**  
Updated the Axios `baseURL` configuration to use `location.pathname` instead of a static `'/'`. This change ensures that API calls are relative to the current path under which Pinot is loaded. It makes the frontend dynamically adapt to any sub-path — including those added by Knox or other reverse proxies — without breaking API routing.

**Code Change:**  
```ts
export const baseApi = axios.create({ baseURL: location.pathname });
```

**Impact:**  
- Fixes Pinot UI accessibility when deployed behind Knox Gateway.
- Maintains existing functionality for standalone/non-Knox deployments.
- Ensures compatibility across different proxy configurations.

