### PR TITLE
Fix filtered aggregate expression hint override logic for compound filters

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -380,8 +380,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       for (Pair<AggregationFunction, FilterContext> filteredAggregationFunction : filtAggrFuns) {
         FilterContext right = filteredAggregationFunction.getRight();
         if (right != null) {
-          Predicate predicate = right.getPredicate();
-          predicate.setLhs(overrideWithExpressionHints(predicate.getLhs(), indexSegment, expressionOverrideHints));
+          overrideWithExpressionHints(right, indexSegment, expressionOverrideHints);
         }
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampIndexMseTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampIndexMseTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests.custom;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +35,8 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 
 public class TimestampIndexMseTest extends BaseClusterIntegrationTest implements ExplainIntegrationTestTrait {
@@ -105,6 +108,16 @@ public class TimestampIndexMseTest extends BaseClusterIntegrationTest implements
             + "              Project(columns=[[]])\n"
             + "                DocIdSet(maxDocs=[120000])\n"
             + "                  FilterMatchEntireSegment(numDocs=[115545])\n");
+  }
+
+  @Test
+  public void timestampIndexCompoundAggregateFilter()
+      throws Exception {
+    JsonNode result = postQuery(
+        "SELECT DATE_TRUNC('SECOND', ArrTime), SUM(CASE WHEN ArrTime < now() THEN 2 ELSE 0 END) FILTER (WHERE "
+            + "AirlineID > 0 AND DayOfMonth = 1) FROM mytable GROUP BY DATE_TRUNC('SECOND', ArrTime) LIMIT 100");
+    assertNoError(result);
+    assertEquals(result.get("numRowsResultSet").asInt(), 4);
   }
 
   @Test


### PR DESCRIPTION
- Currently, a filtered aggregate with a compound filter like `SUM(x) FILTER (WHERE y > 100 AND y < 100)` fails with an NPE like:
```
java.lang.NullPointerException: Cannot invoke "org.apache.pinot.common.request.context.predicate.Predicate.getLhs()" because "predic
ate" is null
        at org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.rewriteQueryContextWithHints(InstancePlanMakerImplV2.java:384) ~
[startree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.makeSegmentPlanNode(InstancePlanMakerImplV2.java:303) ~[startree
-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.makeStreamingSegmentPlanNode(InstancePlanMakerImplV2.java:357) ~
[startree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.makeStreamingInstancePlan(InstancePlanMakerImplV2.java:341) ~[st
artree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.planCombineQuery(ServerQueryExecutorV1Impl.java:688) ~[sta
rtree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.executeQuery(ServerQueryExecutorV1Impl.java:731) ~[startre
e-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.execute(ServerQueryExecutorV1Impl.java:714) ~[startree-pin
ot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.executeInternal(ServerQueryExecutorV1Impl.java:446) ~[star
tree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.executeInternal(ServerQueryExecutorV1Impl.java:317) ~[star
tree-pinot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.execute(ServerQueryExecutorV1Impl.java:144) ~[startree-pin
ot-all-1.4.0-ST.38-jar-with-dependencies.jar:1.4.0-ST.38-6daa00d9c7072acbeeba512281c73d66385369cf]
```
- This is because the `FilterContext` class can have `null` predicates for compound filters like `AND`, `OR`, `NOT` - these filters have non-null children filters instead. There was already a helper method for recursively adding the expression override hints to such filters, but its usage was missed in this filtered aggregation context. This patch simply updates the logic to use that helper method.