### PR TITLE
Allow configuring NOW() return type in the multi-stage engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -378,6 +378,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       multiStageBrokerRequestHandler =
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, _routingManager, _accessControlFactory,
               _queryQuotaManager, tableCache, _multiStageQueryThrottler, _failureDetector);
+      multiStageBrokerRequestHandler.init(_spectatorHelixManager);
     }
     TimeSeriesRequestHandler timeSeriesRequestHandler = null;
     if (StringUtils.isNotBlank(_brokerConf.getProperty(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey()))) {
@@ -442,6 +443,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       clusterConfigChangeHandler.init(_spectatorHelixManager);
     }
     _clusterConfigChangeHandlers.add(_queryQuotaManager);
+    if (multiStageBrokerRequestHandler != null) {
+      _clusterConfigChangeHandlers.add(multiStageBrokerRequestHandler);
+    }
     if (_multiStageQueryThrottler != null) {
       _clusterConfigChangeHandlers.add(_multiStageQueryThrottler);
     }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -781,6 +781,11 @@ public abstract class ClusterTest extends ControllerTest {
         sendPostRequest(controllerBaseApiUrl + "/sql", JsonUtils.objectToString(payload), headers));
   }
 
+  public void postClusterConfig(Map<String, String> clusterConfigs)
+      throws Exception {
+    sendPostRequest(getControllerBaseApiUrl() + "/cluster/configs", JsonUtils.objectToString(clusterConfigs));
+  }
+
   public List<String> getColumns(JsonNode response) {
     JsonNode resultTableJson = response.get("resultTable");
     Assert.assertNotNull(resultTableJson, "'resultTable' is null");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -256,6 +256,10 @@ public class CommonConstants {
         "pinot.beta.multistage.engine.max.server.query.threads.hardlimit.factor";
     public static final String DEFAULT_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_HARDLIMIT_FACTOR = "4";
 
+    // Multi-stage query engine operator table configs
+    public static final String MSE_OPERATOR_TABLE_PREFIX = "pinot.multistage.engine.operator.table";
+    public static final String MSE_NOW_RETURN_LONG = MSE_OPERATOR_TABLE_PREFIX + ".now.returns.long";
+
     // Preprocess throttle configs
     public static final String CONFIG_OF_MAX_SEGMENT_PREPROCESS_PARALLELISM =
         "pinot.server.max.segment.preprocess.parallelism";


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/14614 updated the return type of `NOW()` from `LONG` / `BIGINT` to `TIMESTAMP`. This was done in order to allow usage of `NOW()` with functions that expect timestamps as operands like `TIMESTAMPADD` (since the multi-stage engine is strongly typed and doesn't allow these types to be used interchangeably unlike the single-stage engine). Also, Postgres' `NOW()` function returns a timestamp type as well and we've been aiming to align the MSE behavior with Postgres.
- However, this was backward incompatible and can break usages that treat `NOW()` as a `LONG` like `WHERE longCol >= NOW()` or `SELECT NOW() - 86400000` for instance. These can be easily remediated by adding explicit casts, but the change is backward incompatible nonetheless.
- In order to allow for smoother transitions in such scenarios, this patch introduces a mechanism wherein we can configure the `PinotOperatorTable` via cluster configs without requiring any component restarts. 
- The `MultiStageBrokerRequestHandler` will react to cluster config changes and cache configs that are prefixed with `pinot.multistage.engine.operator.table`. These configs will be passed into `QueryEnvironment` (instantiated per query) which will use them while instantiating `PinotOperatorTable` (we will cache these instances keyed by the configuration). `PinotOperatorTable` can then optionally add / remove / change Pinot function signatures.
- This mechanism can be utilized in the future for other similar backward incompatible changes that we wish to make.