### PR TITLE
Fix multi-stage case insensitiveness

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -370,7 +370,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       // multi-stage request handler uses both Netty and GRPC ports.
       // worker requires both the "Netty port" for protocol transport; and "GRPC port" for mailbox transport.
       // TODO: decouple protocol and engine selection.
-      queryDispatcher = createQueryDispatcher(_brokerConf);
+      queryDispatcher = createQueryDispatcher(_brokerConf, tableCache);
       multiStageBrokerRequestHandler =
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, _routingManager, _accessControlFactory,
               _queryQuotaManager, tableCache, _multiStageQueryThrottler, _failureDetector);
@@ -522,11 +522,11 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected void registerExtraComponents(BrokerAdminApiApplication brokerAdminApplication) {
   }
 
-  private QueryDispatcher createQueryDispatcher(PinotConfiguration brokerConf) {
+  private QueryDispatcher createQueryDispatcher(PinotConfiguration brokerConf, TableCache tableCache) {
     String hostname = _brokerConf.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME);
     int port = Integer.parseInt(_brokerConf.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT));
-    return new QueryDispatcher(new MailboxService(hostname, port, _brokerConf), _failureDetector);
+    return new QueryDispatcher(new MailboxService(hostname, port, _brokerConf), tableCache, _failureDetector);
   }
 
   private void updateInstanceConfigAndBrokerResourceIfNeeded() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -118,7 +118,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     super(config, brokerId, routingManager, accessControlFactory, queryQuotaManager, tableCache);
     String hostname = config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME);
     int port = Integer.parseInt(config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT));
-    _workerManager = new WorkerManager(_brokerId, hostname, port, _routingManager);
+    _workerManager = new WorkerManager(_brokerId, hostname, port, tableCache, _routingManager);
     TlsConfig tlsConfig = config.getProperty(
         CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_TLS_ENABLED,
         CommonConstants.Helix.DEFAULT_MULTI_STAGE_ENGINE_TLS_ENABLED) ? TlsUtils.extractTlsConfig(config,
@@ -126,8 +126,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     failureDetector.registerUnhealthyServerRetrier(this::retryUnhealthyServer);
     _queryDispatcher =
-        new QueryDispatcher(new MailboxService(hostname, port, config, tlsConfig), failureDetector, tlsConfig,
-            this.isQueryCancellationEnabled());
+        new QueryDispatcher(new MailboxService(hostname, port, config, tlsConfig), tableCache, failureDetector,
+            tlsConfig, this.isQueryCancellationEnabled());
     LOGGER.info("Initialized MultiStageBrokerRequestHandler on host: {}, port: {} with broker id: {}, timeout: {}ms, "
             + "query log max length: {}, query log max rate: {}, query cancellation enabled: {}", hostname, port,
         _brokerId, _brokerTimeoutMs, _queryLogger.getMaxQueryLengthToLog(), _queryLogger.getLogRateLimit(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1540,7 +1540,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertTrue(result > 0);
   }
 
-  @Test
+  @Test(enabled = false) // disabled until we figure out how to make MSE case-insensitive without breaking compatibility
   public void testCaseInsensitiveNamesAgainstController() throws Exception {
     String query = "select ACTualELAPsedTIMe from mYtABLE where actUALelAPSedTIMe > 0 limit 1";
     JsonNode jsonNode = postQueryToController(query);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1540,7 +1540,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     assertTrue(result > 0);
   }
 
-  @Test(enabled = false) // disabled until we figure out how to make MSE case-insensitive without breaking compatibility
+  @Test
   public void testCaseInsensitiveNamesAgainstController() throws Exception {
     String query = "select ACTualELAPsedTIMe from mYtABLE where actUALelAPSedTIMe > 0 limit 1";
     JsonNode jsonNode = postQueryToController(query);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3358,7 +3358,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     testQuery(pinotQuery, h2Query);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
+  //@Test(dataProvider = "useBothQueryEngines")
+  // disabled for MSE until we figure out how to make it case-insensitive without breaking compatibility
+  @Test(dataProvider = "useV1QueryEngine")
   public void testCaseSensitivity(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3358,9 +3358,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     testQuery(pinotQuery, h2Query);
   }
 
-  //@Test(dataProvider = "useBothQueryEngines")
-  // disabled for MSE until we figure out how to make it case-insensitive without breaking compatibility
-  @Test(dataProvider = "useV1QueryEngine")
+  @Test(dataProvider = "useBothQueryEngines")
   public void testCaseSensitivity(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -125,10 +125,11 @@ public class QueryEnvironment {
     _catalog = new PinotCatalog(config.getTableCache(), database);
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false, database, _catalog);
     Properties connectionConfigProperties = new Properties();
-    connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.toString(
+    /*connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.toString(
         config.getTableCache() == null
             ? !CommonConstants.Helix.DEFAULT_ENABLE_CASE_INSENSITIVE
-            : !config.getTableCache().isIgnoreCase()));
+            : !config.getTableCache().isIgnoreCase()));*/
+    connectionConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
     CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(connectionConfigProperties);
     _config = Frameworks.newConfigBuilder().traitDefs().operatorTable(PinotOperatorTable.instance())
         .defaultSchema(rootSchema.plus()).sqlToRelConverterConfig(PinotRuleUtils.PINOT_SQL_TO_REL_CONFIG).build();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -290,7 +290,8 @@ public final class RelToPlanNodeConverter {
   }
 
   private TableScanNode convertPinotLogicalTableScan(PinotLogicalTableScan node) {
-    String tableName = _tableCache.getActualTableName(getTableNameFromTableScan(node));
+    //String tableName = _tableCache.getActualTableName(getTableNameFromTableScan(node));
+    String tableName = getTableNameFromTableScan(node);
     List<RelDataTypeField> fields = node.getRowType().getFieldList();
     List<String> columns = new ArrayList<>(fields.size());
     for (RelDataTypeField field : fields) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -35,6 +35,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.calcite.rel.rules.ImmutableTableOptions;
 import org.apache.pinot.calcite.rel.rules.TableOptions;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.ServerRouteInfo;
@@ -72,12 +73,15 @@ public class WorkerManager {
   private final String _instanceId;
   private final String _hostName;
   private final int _port;
+  private final TableCache _tableCache;
   private final RoutingManager _routingManager;
 
-  public WorkerManager(String instanceId, String hostName, int port, RoutingManager routingManager) {
+  public WorkerManager(String instanceId, String hostName, int port, TableCache tableCache,
+      RoutingManager routingManager) {
     _instanceId = instanceId;
     _hostName = hostName;
     _port = port;
+    _tableCache = tableCache;
     _routingManager = routingManager;
   }
 
@@ -386,6 +390,7 @@ public class WorkerManager {
   private void assignWorkersToNonPartitionedLeafFragment(DispatchablePlanMetadata metadata,
       DispatchablePlanContext context) {
     String tableName = metadata.getScannedTables().get(0);
+    tableName = _tableCache.getActualTableName(tableName);
     Map<String, RoutingTable> routingTableMap = getRoutingTable(tableName, context.getRequestId());
     Preconditions.checkState(!routingTableMap.isEmpty(), "Unable to find routing entries for table: %s", tableName);
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -307,7 +307,7 @@ public class QueryEnvironmentTestBase {
     RoutingManager routingManager = factory.buildRoutingManager(partitionInfoMap);
     TableCache tableCache = factory.buildTableCache();
     return new QueryEnvironment(CommonConstants.DEFAULT_DATABASE, tableCache,
-        new WorkerManager("Broker_localhost", "localhost", reducerPort, routingManager));
+        new WorkerManager("Broker_localhost", "localhost", reducerPort, tableCache, routingManager));
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.plan;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
@@ -40,6 +41,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 public class OpChainExecutionContext {
 
   private final MailboxService _mailboxService;
+  private final TableCache _tableCache;
   private final long _requestId;
   private final long _deadlineMs;
   private final Map<String, String> _opChainMetadata;
@@ -57,11 +59,12 @@ public class OpChainExecutionContext {
   private final boolean _sendStats;
 
 
-  public OpChainExecutionContext(MailboxService mailboxService, long requestId, long deadlineMs,
+  public OpChainExecutionContext(MailboxService mailboxService, TableCache tableCache, long requestId, long deadlineMs,
       Map<String, String> opChainMetadata, StageMetadata stageMetadata, WorkerMetadata workerMetadata,
       @Nullable PipelineBreakerResult pipelineBreakerResult, @Nullable ThreadExecutionContext parentContext,
       boolean sendStats) {
     _mailboxService = mailboxService;
+    _tableCache = tableCache;
     _requestId = requestId;
     _deadlineMs = deadlineMs;
     _opChainMetadata = Collections.unmodifiableMap(opChainMetadata);
@@ -78,6 +81,10 @@ public class OpChainExecutionContext {
 
   public MailboxService getMailboxService() {
     return _mailboxService;
+  }
+
+  public TableCache getTableCache() {
+    return _tableCache;
   }
 
   public long getRequestId() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
@@ -67,7 +68,7 @@ public class PipelineBreakerExecutor {
    */
   @Nullable
   public static PipelineBreakerResult executePipelineBreakers(OpChainSchedulerService scheduler,
-      MailboxService mailboxService, WorkerMetadata workerMetadata, StagePlan stagePlan,
+      MailboxService mailboxService, TableCache tableCache, WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> opChainMetadata, long requestId, long deadlineMs,
       @Nullable ThreadExecutionContext parentContext, boolean sendStats) {
     PipelineBreakerContext pipelineBreakerContext = new PipelineBreakerContext();
@@ -78,7 +79,7 @@ public class PipelineBreakerExecutor {
         //     OpChain receive-mail callbacks.
         // see also: MailboxIdUtils TODOs, de-couple mailbox id from query information
         OpChainExecutionContext opChainExecutionContext =
-            new OpChainExecutionContext(mailboxService, requestId, deadlineMs, opChainMetadata,
+            new OpChainExecutionContext(mailboxService, tableCache, requestId, deadlineMs, opChainMetadata,
                 stagePlan.getStageMetadata(), workerMetadata, null, parentContext, sendStats);
         return execute(scheduler, pipelineBreakerContext, opChainExecutionContext);
       } catch (Exception e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -148,6 +148,7 @@ public class ServerPlanRequestUtils {
       PinotQuery pinotQuery, InstanceDataManager instanceDataManager) {
     StageMetadata stageMetadata = executionContext.getStageMetadata();
     String rawTableName = TableNameBuilder.extractRawTableName(stageMetadata.getTableName());
+    rawTableName = executionContext.getTableCache().getActualTableName(rawTableName);
     Map<String, List<String>> tableSegmentsMap = executionContext.getWorkerMetadata().getTableSegmentsMap();
     assert tableSegmentsMap != null;
     TimeBoundaryInfo timeBoundary = stageMetadata.getTimeBoundary();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.query.routing.StagePlan;
 import org.apache.pinot.query.routing.WorkerMetadata;
@@ -60,8 +61,9 @@ public class QueryServerEnclosure {
     runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, "Server_localhost");
     runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _queryRunnerPort);
     InstanceDataManager instanceDataManager = factory.buildInstanceDataManager();
+    HelixManager helixManager = factory.buildHelixManager();
     _queryRunner = new QueryRunner();
-    _queryRunner.init(new PinotConfiguration(runnerConfig), instanceDataManager, null, () -> true);
+    _queryRunner.init(new PinotConfiguration(runnerConfig), helixManager, instanceDataManager, null, () -> true);
   }
 
   public int getPort() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.StageMetadata;
@@ -42,6 +43,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -75,11 +77,13 @@ public class OpChainSchedulerServiceTest {
 
   private OpChain getChain(MultiStageOperator operator) {
     MailboxService mailboxService = mock(MailboxService.class);
+    TableCache tableCache = mock(TableCache.class);
     when(mailboxService.getHostname()).thenReturn("localhost");
     when(mailboxService.getPort()).thenReturn(1234);
+    when(tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
     WorkerMetadata workerMetadata = new WorkerMetadata(0, ImmutableMap.of(), ImmutableMap.of());
     OpChainExecutionContext context =
-        new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, ImmutableMap.of(),
+        new OpChainExecutionContext(mailboxService, tableCache, 123L, Long.MAX_VALUE, ImmutableMap.of(),
             new StageMetadata(0, ImmutableList.of(workerMetadata), ImmutableMap.of()), workerMetadata, null, null,
             true);
     return new OpChain(context, operator);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -49,6 +50,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -69,6 +71,8 @@ public class MailboxReceiveOperatorTest {
   private AutoCloseable _mocks;
   @Mock
   private MailboxService _mailboxService;
+  @Mock
+  private TableCache _tableCache;
   @Mock
   private ReceivingMailbox _mailbox1;
   @Mock
@@ -92,6 +96,7 @@ public class MailboxReceiveOperatorTest {
     when(_mailboxService.getPort()).thenReturn(1234);
     when(_mailbox1.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
     when(_mailbox2.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
+    when(_tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterMethod
@@ -279,7 +284,8 @@ public class MailboxReceiveOperatorTest {
 
   private MailboxReceiveOperator getOperator(StageMetadata stageMetadata, RelDistribution.Type distributionType,
       long deadlineMs) {
-    OpChainExecutionContext context = OperatorTestUtil.getOpChainContext(_mailboxService, deadlineMs, stageMetadata);
+    OpChainExecutionContext context = OperatorTestUtil.getOpChainContext(
+        _mailboxService, _tableCache, deadlineMs, stageMetadata);
     MailboxReceiveNode node = mock(MailboxReceiveNode.class);
     when(node.getDistributionType()).thenReturn(distributionType);
     when(node.getSenderStageId()).thenReturn(1);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -53,6 +54,8 @@ public class MailboxSendOperatorTest {
   @Mock
   private MailboxService _mailboxService;
   @Mock
+  private TableCache _tableCache;
+  @Mock
   private MultiStageOperator _input;
   @Mock
   private BlockExchange _exchange;
@@ -64,6 +67,8 @@ public class MailboxSendOperatorTest {
     when(_mailboxService.getPort()).thenReturn(1234);
 
     when(_input.calculateStats()).thenReturn(MultiStageQueryStats.emptyStats(1));
+
+    when(_tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterMethod
@@ -196,8 +201,8 @@ public class MailboxSendOperatorTest {
     WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
     StageMetadata stageMetadata = new StageMetadata(SENDER_STAGE_ID, List.of(workerMetadata), Map.of());
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService, 123L, Long.MAX_VALUE, Map.of(), stageMetadata, workerMetadata,
-            null, null, true);
+        new OpChainExecutionContext(_mailboxService, _tableCache, 123L, Long.MAX_VALUE, Map.of(), stageMetadata,
+            workerMetadata, null, null, true);
     return new MailboxSendOperator(context, _input, statMap -> _exchange);
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -42,6 +43,7 @@ import org.apache.pinot.segment.spi.memory.DataBuffer;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.Assert;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,9 +109,9 @@ public class OperatorTestUtil {
     return new ReceivingMailbox.MseBlockWithStats(SuccessMseBlock.INSTANCE, serializedStats);
   }
 
-  public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, long deadlineMs,
-      StageMetadata stageMetadata) {
-    return new OpChainExecutionContext(mailboxService, 0, deadlineMs, ImmutableMap.of(), stageMetadata,
+  public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, TableCache tableCache,
+      long deadlineMs, StageMetadata stageMetadata) {
+    return new OpChainExecutionContext(mailboxService, tableCache, 0, deadlineMs, ImmutableMap.of(), stageMetadata,
         stageMetadata.getWorkerMetadataList().get(0), null, null, true);
   }
 
@@ -129,10 +131,12 @@ public class OperatorTestUtil {
     MailboxService mailboxService = mock(MailboxService.class);
     when(mailboxService.getHostname()).thenReturn("localhost");
     when(mailboxService.getPort()).thenReturn(1234);
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
     WorkerMetadata workerMetadata = new WorkerMetadata(0, ImmutableMap.of(), ImmutableMap.of());
     StageMetadata stageMetadata = new StageMetadata(0, ImmutableList.of(workerMetadata), ImmutableMap.of());
-    OpChainExecutionContext opChainExecutionContext = new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE,
-        opChainMetadata, stageMetadata, workerMetadata, null, null, true);
+    OpChainExecutionContext opChainExecutionContext = new OpChainExecutionContext(mailboxService, tableCache, 123L,
+        Long.MAX_VALUE, opChainMetadata, stageMetadata, workerMetadata, null, null, true);
 
     StagePlan stagePlan = new StagePlan(null, stageMetadata);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -50,6 +51,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -71,6 +73,8 @@ public class SortedMailboxReceiveOperatorTest {
   private AutoCloseable _mocks;
   @Mock
   private MailboxService _mailboxService;
+  @Mock
+  private TableCache _tableCache;
   @Mock
   private ReceivingMailbox _mailbox1;
   @Mock
@@ -94,6 +98,7 @@ public class SortedMailboxReceiveOperatorTest {
     when(_mailboxService.getPort()).thenReturn(1234);
     when(_mailbox1.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
     when(_mailbox2.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
+    when(_tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterMethod
@@ -254,7 +259,8 @@ public class SortedMailboxReceiveOperatorTest {
 
   private SortedMailboxReceiveOperator getOperator(StageMetadata stageMetadata, RelDistribution.Type distributionType,
       DataSchema resultSchema, List<RelFieldCollation> collations, long deadlineMs) {
-    OpChainExecutionContext context = OperatorTestUtil.getOpChainContext(_mailboxService, deadlineMs, stageMetadata);
+    OpChainExecutionContext context = OperatorTestUtil.getOpChainContext(
+        _mailboxService, _tableCache, deadlineMs, stageMetadata);
     MailboxReceiveNode node = mock(MailboxReceiveNode.class);
     when(node.getDistributionType()).thenReturn(distributionType);
     when(node.getSenderStageId()).thenReturn(1);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -59,6 +60,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 
@@ -81,6 +83,8 @@ public class PipelineBreakerExecutorTest {
   @Mock
   private MailboxService _mailboxService;
   @Mock
+  private TableCache _tableCache;
+  @Mock
   private ReceivingMailbox _mailbox1;
   @Mock
   private ReceivingMailbox _mailbox2;
@@ -95,6 +99,8 @@ public class PipelineBreakerExecutorTest {
     when(_mailbox1.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
     when(_mailbox2.getId()).thenReturn("mailbox2");
     when(_mailbox2.getStatMap()).thenReturn(new StatMap<>(ReceivingMailbox.StatKey.class));
+
+    when(_tableCache.getActualTableName(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterMethod
@@ -105,10 +111,10 @@ public class PipelineBreakerExecutorTest {
 
   @Nullable
   public static PipelineBreakerResult executePipelineBreakers(OpChainSchedulerService scheduler,
-      MailboxService mailboxService, WorkerMetadata workerMetadata, StagePlan stagePlan,
+      MailboxService mailboxService, TableCache tableCache, WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> opChainMetadata, long requestId, long deadlineMs) {
-    return PipelineBreakerExecutor.executePipelineBreakers(scheduler, mailboxService, workerMetadata, stagePlan,
-        opChainMetadata, requestId, deadlineMs, null, true);
+    return PipelineBreakerExecutor.executePipelineBreakers(scheduler, mailboxService, tableCache, workerMetadata,
+        stagePlan, opChainMetadata, requestId, deadlineMs, null, true);
   }
 
   @AfterClass
@@ -132,7 +138,7 @@ public class PipelineBreakerExecutorTest {
         OperatorTestUtil.eosWithStats(OperatorTestUtil.getDummyStats(1).serialize()));
 
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, Long.MAX_VALUE);
 
     // then
@@ -171,7 +177,7 @@ public class PipelineBreakerExecutorTest {
         OperatorTestUtil.eosWithStats(OperatorTestUtil.getDummyStats(2).serialize()));
 
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, Long.MAX_VALUE);
 
     // then
@@ -199,7 +205,7 @@ public class PipelineBreakerExecutorTest {
 
     // when
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, Long.MAX_VALUE);
 
     // then
@@ -227,7 +233,7 @@ public class PipelineBreakerExecutorTest {
     });
 
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, System.currentTimeMillis() + 100);
 
     // then
@@ -262,7 +268,7 @@ public class PipelineBreakerExecutorTest {
         OperatorTestUtil.eosWithStats(List.of()));
 
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, Long.MAX_VALUE);
 
     // then
@@ -297,7 +303,7 @@ public class PipelineBreakerExecutorTest {
         OperatorTestUtil.eosWithStats(List.of()));
 
     PipelineBreakerResult pipelineBreakerResult =
-        executePipelineBreakers(_scheduler, _mailboxService, _workerMetadata, stagePlan,
+        executePipelineBreakers(_scheduler, _mailboxService, _tableCache, _workerMetadata, stagePlan,
             ImmutableMap.of(), 0, Long.MAX_VALUE);
 
     // then

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -95,6 +96,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   protected String _reducerHostname;
   protected int _reducerPort;
   protected MailboxService _mailboxService;
+  protected TableCache _tableCache;
   protected QueryEnvironment _queryEnvironment;
   protected Map<QueryServerInstance, QueryServerEnclosure> _servers = new HashMap<>();
 
@@ -161,7 +163,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     }
     // exception will be propagated through for assert purpose on runtime error
     return QueryDispatcher.runReducer(requestId, dispatchableSubPlan, timeoutMs, Collections.emptyMap(),
-        _mailboxService);
+        _mailboxService, _tableCache);
   }
 
   protected List<CompletableFuture<?>> processDistributedStagePlans(DispatchableSubPlan dispatchableSubPlan,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.failuredetector.FailureDetector;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.query.QueryEnvironment;
@@ -77,7 +78,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(1, portList.get(0), portList.get(1),
         QueryEnvironmentTestBase.TABLE_SCHEMAS, QueryEnvironmentTestBase.SERVER1_SEGMENTS,
         QueryEnvironmentTestBase.SERVER2_SEGMENTS, null);
-    _queryDispatcher = new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class));
+    _queryDispatcher = new QueryDispatcher(
+        Mockito.mock(MailboxService.class), Mockito.mock(TableCache.class), Mockito.mock(FailureDetector.class));
   }
 
   @BeforeMethod

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixManager;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -132,6 +135,13 @@ public class MockInstanceDataManagerFactory {
       when(instanceDataManager.getTableDataManager(e.getKey())).thenReturn(e.getValue());
     }
     return instanceDataManager;
+  }
+
+  public HelixManager buildHelixManager() {
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    return helixManager;
   }
 
   public Map<String, Schema> getRegisteredSchemaMap() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -134,7 +134,7 @@ public class ServerInstance {
 
     if (serverConf.isMultiStageServerEnabled()) {
       LOGGER.info("Initializing Multi-stage query engine");
-      _workerQueryServer = new WorkerQueryServer(serverConf.getPinotConfig(), _instanceDataManager,
+      _workerQueryServer = new WorkerQueryServer(serverConf.getPinotConfig(), _helixManager, _instanceDataManager,
           serverConf.isMultiStageEngineTlsEnabled() ? tlsConfig : null, sendStatsPredicate);
     } else {
       _workerQueryServer = null;

--- a/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.server.worker;
 
 import javax.annotation.Nullable;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.query.runtime.QueryRunner;
@@ -35,13 +36,13 @@ public class WorkerQueryServer {
 
   private final QueryServer _queryWorkerService;
 
-  public WorkerQueryServer(PinotConfiguration configuration, InstanceDataManager instanceDataManager,
-      @Nullable TlsConfig tlsConfig, SendStatsPredicate sendStats) {
+  public WorkerQueryServer(PinotConfiguration configuration, HelixManager helixManager,
+      InstanceDataManager instanceDataManager, @Nullable TlsConfig tlsConfig, SendStatsPredicate sendStats) {
     _configuration = toWorkerQueryConfig(configuration);
     _queryServicePort = _configuration.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_SERVER_PORT,
         CommonConstants.MultiStageQueryRunner.DEFAULT_QUERY_SERVER_PORT);
     QueryRunner queryRunner = new QueryRunner();
-    queryRunner.init(_configuration, instanceDataManager, tlsConfig, sendStats::getSendStats);
+    queryRunner.init(_configuration, helixManager, instanceDataManager, tlsConfig, sendStats::getSendStats);
     _queryWorkerService = new QueryServer(_queryServicePort, queryRunner, tlsConfig, configuration);
   }
 


### PR DESCRIPTION
As stated [here](https://github.com/apache/pinot/pull/15565), MSE additions to make it case-insensitive were not backwards compatible.

However this fix has been merged since January, so just reverse it was not recommended.

This PR fixes how MSE handles case-insensitiveness using some nasty hacks: for table resolution it uses the already existing TableCache.getActualTableName method like SSE and, the worst part, to make column identifiers case-insensitive relies in Java Reflection to override a private member. This is required because Apache Calcite built-in support for case-insensitiveness is too radical and transforms everything to lower-case internally, leading to the mentioned backward compatibility issue.