### PR TITLE
Modify parser to support type aliases like LONG for BIGINT in MSE

### DIFF
--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -44,6 +44,10 @@ data: {
     keywords: [
       "FILE"
       "ARCHIVE"
+      "BIG_DECIMAL"
+      "BYTES"
+      "LONG"
+      "STRING"
     ]
 
     # List of non-reserved keywords to add;
@@ -51,6 +55,10 @@ data: {
     nonReservedKeywordsToAdd: [
       "FILE"
       "ARCHIVE"
+      "BIG_DECIMAL"
+      "BYTES"
+      "LONG"
+      "STRING"
       # Pinot allows using DEFAULT as the catalog name
       "DEFAULT_"
       # Pinot allows using DATETIME as column name

--- a/pinot-common/src/main/codegen/templates/Parser.jj
+++ b/pinot-common/src/main/codegen/templates/Parser.jj
@@ -5899,7 +5899,10 @@ SqlTypeNameSpec SqlTypeName1(Span s) :
     |
         <SMALLINT> { s.add(this); sqlTypeName = SqlTypeName.SMALLINT; }
     |
-        <BIGINT> { s.add(this); sqlTypeName = SqlTypeName.BIGINT; }
+        // <BIGINT> { s.add(this); sqlTypeName = SqlTypeName.BIGINT; }
+        // PINOT CUSTOMIZATION START
+        ( <BIGINT> | <LONG> ) { s.add(this); sqlTypeName = SqlTypeName.BIGINT; }
+        // PINOT CUSTOMIZATION END
     |
         <REAL> { s.add(this); sqlTypeName = SqlTypeName.REAL; }
     |
@@ -5932,7 +5935,10 @@ SqlTypeNameSpec SqlTypeName2(Span s) :
             { sqlTypeName = SqlTypeName.BINARY; }
         )
     |
-        <VARBINARY> { s.add(this); sqlTypeName = SqlTypeName.VARBINARY; }
+        // <VARBINARY> { s.add(this); sqlTypeName = SqlTypeName.VARBINARY; }
+        // PINOT CUSTOMIZATION START
+        (<VARBINARY> | <BYTES>) { s.add(this); sqlTypeName = SqlTypeName.VARBINARY; }
+        // PINOT CUSTOMIZATION END
     )
     precision = PrecisionOpt()
     {
@@ -5949,7 +5955,10 @@ SqlTypeNameSpec SqlTypeName3(Span s) :
 }
 {
     (
-        (<DECIMAL> | <DEC> | <NUMERIC>) { s.add(this); sqlTypeName = SqlTypeName.DECIMAL; }
+        // (<DECIMAL> | <DEC> | <NUMERIC>) { s.add(this); sqlTypeName = SqlTypeName.DECIMAL; }
+        // PINOT CUSTOMIZATION START
+        (<DECIMAL> | <DEC> | <NUMERIC> | <BIG_DECIMAL>) { s.add(this); sqlTypeName = SqlTypeName.DECIMAL; }
+        // PINOT CUSTOMIZATION END
     |
         <ANY> { s.add(this); sqlTypeName = SqlTypeName.ANY; }
     )
@@ -6155,7 +6164,10 @@ SqlTypeNameSpec CharacterTypeName(Span s) :
             { sqlTypeName = SqlTypeName.CHAR; }
         )
     |
-        <VARCHAR> { s.add(this); sqlTypeName = SqlTypeName.VARCHAR; }
+        // <VARCHAR> { s.add(this); sqlTypeName = SqlTypeName.VARCHAR; }
+        // PINOT CUSTOMIZATION START
+        (<VARCHAR> | <STRING>) { s.add(this); sqlTypeName = SqlTypeName.VARCHAR; }
+        // PINOT CUSTOMIZATION END
     )
     precision = PrecisionOpt()
     [

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
@@ -26,10 +26,7 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 
-import static org.apache.pinot.common.utils.PinotDataType.DOUBLE;
-import static org.apache.pinot.common.utils.PinotDataType.INTEGER;
-import static org.apache.pinot.common.utils.PinotDataType.LONG;
-import static org.apache.pinot.common.utils.PinotDataType.STRING;
+import static org.apache.pinot.common.utils.PinotDataType.*;
 
 
 /**
@@ -48,12 +45,25 @@ public class DataTypeConversionFunctions {
       PinotDataType sourceType = PinotDataType.getSingleValueType(clazz);
       String transformed = targetTypeLiteral.toUpperCase();
       PinotDataType targetDataType;
-      if ("INT".equals(transformed)) {
-        targetDataType = INTEGER;
-      } else if ("VARCHAR".equals(transformed)) {
-        targetDataType = STRING;
-      } else {
-        targetDataType = PinotDataType.valueOf(transformed);
+      switch (transformed) {
+        case "BIGINT":
+          targetDataType = LONG;
+          break;
+        case "DECIMAL":
+          targetDataType = BIG_DECIMAL;
+          break;
+        case "INT":
+          targetDataType = INTEGER;
+          break;
+        case "VARBINARY":
+          targetDataType = BYTES;
+          break;
+        case "VARCHAR":
+          targetDataType = STRING;
+          break;
+        default:
+          targetDataType = PinotDataType.valueOf(transformed);
+          break;
       }
       if (sourceType == STRING && (targetDataType == INTEGER || targetDataType == LONG)) {
         if (String.valueOf(value).contains(".")) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1776,7 +1776,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "column1");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
-        "STRING");
+        "VARCHAR");
 
     pinotQuery = compileToPinotQuery("SELECT CAST(column1 AS varchar) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -57,11 +57,16 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (castFormatTransformFunction instanceof LiteralTransformFunction) {
       String targetType = ((LiteralTransformFunction) castFormatTransformFunction).getStringLiteral().toUpperCase();
       switch (targetType) {
+        case "BYTES":
+        case "VARBINARY":
+          _resultMetadata = sourceSV ? BYTES_SV_NO_DICTIONARY_METADATA : BYTES_MV_NO_DICTIONARY_METADATA;
+          break;
         case "INT":
         case "INTEGER":
           _resultMetadata = sourceSV ? INT_SV_NO_DICTIONARY_METADATA : INT_MV_NO_DICTIONARY_METADATA;
           break;
         case "LONG":
+        case "BIGINT":
           _resultMetadata = sourceSV ? LONG_SV_NO_DICTIONARY_METADATA : LONG_MV_NO_DICTIONARY_METADATA;
           break;
         case "FLOAT":

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -281,6 +281,19 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     query = "SELECT CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay "
         + "FROM mytable";
     testQuery(query);
+
+    // Test CAST
+    query =
+        "SELECT SUM(CAST(CAST(ArrTime AS VARCHAR) AS LONG)) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = "
+            + "'DL'";
+    testQuery(query);
+    query =
+        "SELECT CAST(CAST(ArrTime AS STRING) AS BIGINT) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = 'DL' "
+            + "ORDER BY ArrTime DESC";
+    h2Query =
+        "SELECT CAST(CAST(ArrTime AS VARCHAR) AS BIGINT) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = "
+            + "'DL' ORDER BY ArrTime DESC";
+    testQuery(query, h2Query);
   }
 
   private void testHardcodedQueriesV2()
@@ -308,18 +321,6 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   private void testHardCodedQueriesV1()
       throws Exception {
-    String query;
-    String h2Query;
-    // TODO: move to common when multistage support CAST AS 'LONG', for now it must use: CAST AS BIGINT
-    query =
-        "SELECT SUM(CAST(CAST(ArrTime AS varchar) AS LONG)) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = "
-            + "'DL'";
-    testQuery(query);
-    query =
-        "SELECT CAST(CAST(ArrTime AS varchar) AS LONG) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = 'DL' "
-            + "ORDER BY ArrTime DESC";
-    testQuery(query);
-
     // Non-Standard SQL syntax:
     // IN_ID_SET
     {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JmxMetricsIntegrationTest.java
@@ -114,19 +114,8 @@ public class JmxMetricsIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Run some queries that are known to not work as is with the multi-stage query engine
 
-    // Type differences
-    // STRING is VARCHAR in v2
-    JsonNode response = postQuery("SELECT CAST(ArrTime AS STRING) FROM mytable");
-    assertFalse(response.get("resultTable").get("rows").isEmpty());
-    // LONG is BIGINT in v2
-    response = postQuery("SELECT CAST(ArrTime AS LONG) FROM mytable");
-    assertFalse(response.get("resultTable").get("rows").isEmpty());
-    // FLOAT_ARRAY is FLOAT ARRAY in v2
-    response = postQuery("SELECT CAST(DivAirportIDs AS FLOAT_ARRAY) FROM mytable");
-    assertFalse(response.get("resultTable").get("rows").isEmpty());
-
     // MV column requires ARRAY_TO_MV wrapper to be used in filter predicates
-    response = postQuery("SELECT COUNT(*) FROM mytable WHERE DivAirports = 'JFK'");
+    JsonNode response = postQuery("SELECT COUNT(*) FROM mytable WHERE DivAirports = 'JFK'");
     assertFalse(response.get("resultTable").get("rows").isEmpty());
 
     // Unsupported function
@@ -138,20 +127,20 @@ public class JmxMetricsIntegrationTest extends BaseClusterIntegrationTestSet {
     response = postQuery("SELECT AirTime, AirTime FROM mytable ORDER BY AirTime");
     assertFalse(response.get("resultTable").get("rows").isEmpty());
 
-    assertEquals((Long) MBEAN_SERVER.getAttribute(queriesGlobalMetric, "Count"), initialQueryCount + 8L);
+    assertEquals((Long) MBEAN_SERVER.getAttribute(queriesGlobalMetric, "Count"), initialQueryCount + 5L);
 
     AtomicLong multiStageMigrationMetricValue = new AtomicLong();
     TestUtils.waitForCondition((aVoid) -> {
       try {
         multiStageMigrationMetricValue.set((Long) MBEAN_SERVER.getAttribute(multiStageMigrationMetric, "Count"));
-        return multiStageMigrationMetricValue.get() == 6L;
+        return multiStageMigrationMetricValue.get() == 3L;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
     }, 5000, "Expected value of MBean 'pinot.broker.singleStageQueriesInvalidMultiStage' to be: "
-        + 6L + "; actual value: " + multiStageMigrationMetricValue.get());
+        + 3L + "; actual value: " + multiStageMigrationMetricValue.get());
 
-    assertEquals((Long) MBEAN_SERVER.getAttribute(multiStageMigrationMetric, "Count"), 6L);
+    assertEquals((Long) MBEAN_SERVER.getAttribute(multiStageMigrationMetric, "Count"), 3L);
   }
 
   @Test(dataProvider = "useBothQueryEngines")

--- a/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
+++ b/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
@@ -37,6 +37,11 @@
         "sql": "SELECT CAST(floatCol AS DOUBLE) * 1e100, CAST(intCol AS BIGINT) * 2000000000, CAST(longCol AS DOUBLE) * 1e100, CAST(boolCol AS INT) FROM {tbl}"
       },
       {
+        "sql": "SELECT CAST(intCol AS LONG) * 2000000000, CAST(longCol AS STRING), CAST(doubleCol AS BIG_DECIMAL), CAST(x'ab' AS BYTES) FROM {tbl}",
+        "h2Sql": "SELECT CAST(intCol AS BIGINT) * 2000000000, CAST(longCol AS VARCHAR), CAST(doubleCol AS DECIMAL), CAST(x'ab' AS VARBINARY) FROM {tbl}",
+        "comments": "use aliases for types - LONG for BIGINT, STRING for VARCHAR, BIG_DECIMAL for DECIMAL, BYTES for VARBINARY"
+      },
+      {
         "sql": "SELECT CAST(a.floatCol AS DOUBLE) * 1e100, CAST(a.intCol AS BIGINT) * 2000000000, CAST(b.longCol AS FLOAT) * 1e20, CAST(a.boolCol AS INT) FROM {tbl} AS a JOIN {tbl} AS b ON a.intCol = b.intCol WHERE a.boolCol = true"
       },
       {


### PR DESCRIPTION
- This patch updates the parser to support the following type aliases:
  - `BIG_DECIMAL` for `DECIMAL`
  - `BYTES` for `VARBINARY`
  - `LONG` for `BIGINT`
  - `STRING` for `VARCHAR`
- This has been a long standing incompatibility between Pinot's two query engines (SSE and MSE) - https://docs.pinot.apache.org/reference/troubleshooting/troubleshoot-multi-stage-query-engine#different-type-names.
- Types like `BIGINT`, `VARBINARY`, `VARCHAR` aren't actual Pinot types - they're Calcite SQL types that map to Pinot types (https://docs.pinot.apache.org/configuration-reference/schema#data-types) and usages in functions like `CAST` are the only place they're exposed to users.
- For consistency, this patch also makes changes so that SSE can support syntax like `CAST(intCol AS BIGINT)` (and all the other aliases).