### PR TITLE
Table Rebalance: Add support for server-level segment batching

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -203,11 +203,13 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segmentRelocator.enableLocalTierMigration";
     public static final String SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY =
         "controller.segmentRelocator.rebalanceTablesSequentially";
-    public static final String SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING =
+    public static final String SEGMENT_RELOCATOR_INCLUDE_CONSUMING =
         "controller.segmentRelocator.includeConsuming";
     // Available options are: "ENABLE", "DISABLE", "DEFAULT"
-    public static final String SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT =
+    public static final String SEGMENT_RELOCATOR_MINIMIZE_DATA_MOVEMENT =
         "controller.segmentRelocator.minimizeDataMovement";
+    public static final String SEGMENT_RELOCATOR_BATCH_SIZE_PER_SERVER =
+        "controller.segmentRelocator.batchSizePerServer";
 
     public static final String REBALANCE_CHECKER_FREQUENCY_PERIOD = "controller.rebalance.checker.frequencyPeriod";
     // Because segment level validation is expensive and requires heavy ZK access, we run segment level validation
@@ -834,17 +836,22 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public boolean isSegmentRelocatorIncludingConsuming() {
-    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_INCLUDE_CONSUMING, false);
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_INCLUDE_CONSUMING, false);
   }
 
-  public Enablement getSegmentRelocatorRebalanceMinimizeDataMovement() {
-    String value = getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_MINIMIZE_DATA_MOVEMENT,
+  public Enablement getSegmentRelocatorMinimizeDataMovement() {
+    String value = getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_MINIMIZE_DATA_MOVEMENT,
         Enablement.ENABLE.name());
     try {
       return Enablement.valueOf(value.toUpperCase());
     } catch (IllegalArgumentException e) {
       return Enablement.ENABLE;
     }
+  }
+
+  public int getSegmentRelocatorBatchSizePerServer() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_BATCH_SIZE_PER_SERVER,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
   }
 
   public boolean tieredSegmentAssignmentEnabled() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -625,13 +625,13 @@ public class PinotTableRestletResource {
           + "more servers.") @DefaultValue("false") @QueryParam("lowDiskMode") boolean lowDiskMode,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime "
           + "contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
-      @ApiParam(value = "How many maximum segment adds to update in the IdealState in each step. For non-strict "
-          + "replica group based assignment, this number will be the closest possible without splitting up a single "
-          + "segment's step's replicas across steps. For strict replica group based assignment, this is treated as "
-          + "a best effort value since each partition of a replica group must be moved as a whole and at least one "
-          + "partition in a replica group should be moved. A value of Integer.MAX_VALUE is used to indicate an "
-          + "unlimited batch size, which is the non-batching behavior.")
-      @DefaultValue("2147483647") @QueryParam("batchSize") int batchSize,
+      @ApiParam(value = "How many maximum segment adds per server to update in the IdealState in each step. For "
+          + "non-strict replica group based assignment, this number will be the closest possible without splitting up "
+          + "a single segment's step's replicas across steps (so some servers may get fewer segments). For strict "
+          + "replica group based assignment, this is a per-server best effort value since each partition of a replica "
+          + "group must be moved as a whole and at least one partition in a replica group should be moved. A value of "
+          + "Integer.MAX_VALUE is used to indicate an unlimited batch size, which is the non-batching behavior.")
+      @DefaultValue("2147483647") @QueryParam("batchSizePerServer") int batchSizePerServer,
       @ApiParam(value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
       @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,
       @ApiParam(value = "Maximum time (in milliseconds) to wait for external view to converge with ideal states. "
@@ -663,7 +663,7 @@ public class PinotTableRestletResource {
     rebalanceConfig.setMinAvailableReplicas(minAvailableReplicas);
     rebalanceConfig.setLowDiskMode(lowDiskMode);
     rebalanceConfig.setBestEfforts(bestEfforts);
-    rebalanceConfig.setBatchSize(batchSize);
+    rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
     rebalanceConfig.setExternalViewCheckIntervalInMs(externalViewCheckIntervalInMs);
     rebalanceConfig.setExternalViewStabilizationTimeoutInMs(externalViewStabilizationTimeoutInMs);
     heartbeatIntervalInMs = Math.max(externalViewCheckIntervalInMs, heartbeatIntervalInMs);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -625,6 +625,13 @@ public class PinotTableRestletResource {
           + "more servers.") @DefaultValue("false") @QueryParam("lowDiskMode") boolean lowDiskMode,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime "
           + "contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
+      @ApiParam(value = "How many maximum segment adds to update in the IdealState in each step. For non-strict "
+          + "replica group based assignment, this number will be the closest possible without splitting up a single "
+          + "segment's step's replicas across steps. For strict replica group based assignment, this is treated as "
+          + "a best effort value since each partition of a replica group must be moved as a whole and at least one "
+          + "partition in a replica group should be moved. A value of Integer.MAX_VALUE is used to indicate an "
+          + "unlimited batch size, which is the non-batching behavior.")
+      @DefaultValue("2147483647") @QueryParam("batchSize") int batchSize,
       @ApiParam(value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
       @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,
       @ApiParam(value = "Maximum time (in milliseconds) to wait for external view to converge with ideal states. "
@@ -656,6 +663,7 @@ public class PinotTableRestletResource {
     rebalanceConfig.setMinAvailableReplicas(minAvailableReplicas);
     rebalanceConfig.setLowDiskMode(lowDiskMode);
     rebalanceConfig.setBestEfforts(bestEfforts);
+    rebalanceConfig.setBatchSize(batchSize);
     rebalanceConfig.setExternalViewCheckIntervalInMs(externalViewCheckIntervalInMs);
     rebalanceConfig.setExternalViewStabilizationTimeoutInMs(externalViewStabilizationTimeoutInMs);
     heartbeatIntervalInMs = Math.max(externalViewCheckIntervalInMs, heartbeatIntervalInMs);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -626,11 +626,12 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime "
           + "contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
       @ApiParam(value = "How many maximum segment adds per server to update in the IdealState in each step. For "
-          + "non-strict replica group based assignment, this number will be the closest possible without splitting up "
-          + "a single segment's step's replicas across steps (so some servers may get fewer segments). For strict "
-          + "replica group based assignment, this is a per-server best effort value since each partition of a replica "
-          + "group must be moved as a whole and at least one partition in a replica group should be moved. A value of "
-          + "-1 is used to disable batching (unlimited segments).")
+          + "non-strict replica group based assignment, this number will be capped at the batchSizePerServer value "
+          + "per rebalance step (some servers may get fewer segments). For strict replica group based assignment, "
+          + "this is a per-server best effort value since each partition of a replica group must be moved as a whole "
+          + "and at least one partition in a replica group should be moved. A value of -1 is used to disable batching "
+          + "(select as many segments as possible per incremental step in rebalance such that minAvailableReplicas is "
+          + "honored).")
       @DefaultValue("-1") @QueryParam("batchSizePerServer") int batchSizePerServer,
       @ApiParam(value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
       @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -630,8 +630,8 @@ public class PinotTableRestletResource {
           + "a single segment's step's replicas across steps (so some servers may get fewer segments). For strict "
           + "replica group based assignment, this is a per-server best effort value since each partition of a replica "
           + "group must be moved as a whole and at least one partition in a replica group should be moved. A value of "
-          + "Integer.MAX_VALUE is used to indicate an unlimited batch size, which is the non-batching behavior.")
-      @DefaultValue("2147483647") @QueryParam("batchSizePerServer") int batchSizePerServer,
+          + "-1 is used to disable batching (unlimited segments).")
+      @DefaultValue("-1") @QueryParam("batchSizePerServer") int batchSizePerServer,
       @ApiParam(value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
       @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,
       @ApiParam(value = "Maximum time (in milliseconds) to wait for external view to converge with ideal states. "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -120,7 +120,7 @@ public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
       // Uniformly spray the partitions and replicas across the instances.
       // E.g. (6 instances, 3 partitions, 4 replicas)
       // "0_0": [i0,  i1,  i2,  i3,  i4,  i5  ]
-      //         p0r0 p0r1 p0r2 p1r3 p1r0 p1r1
+      //         p0r0 p0r1 p0r2 p0r3 p1r0 p1r1
       //         p1r2 p1r3 p2r0 p2r1 p2r2 p2r3
 
       List<String> instances =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -27,10 +27,10 @@ import org.apache.pinot.spi.utils.Enablement;
 
 @ApiModel
 public class RebalanceConfig {
+  public static final int DISABLE_BATCH_SIZE_PER_SERVER = -1;
   public static final int DEFAULT_MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME = 1;
   public static final long DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS = 1000L; // 1 second
   public static final long DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS = 3600000L; // 1 hour
-  public static final int DEFAULT_BATCH_SIZE_PER_SERVER = Integer.MAX_VALUE; // unlimited batch size
 
   // Whether to rebalance table in dry-run mode
   @JsonProperty("dryRun")
@@ -97,10 +97,11 @@ public class RebalanceConfig {
   // as closest estimated upper-bound. For strict replica group based assignment, there is the additional constraint
   // to move each partitionId replica as a whole rather than splitting it up. In this case the total segment adds per
   // server may be above the threshold to accommodate a full partition. The minReplicasAvailable invariant is also
-  // maintained, so fewer segments than the batchSizePerServer may also be selected. Batching is disabled by default.
+  // maintained, so fewer segments than the batchSizePerServer may also be selected. Batching is disabled by default by
+  // setting it to -1.
   @JsonProperty("batchSizePerServer")
   @ApiModelProperty(example = "100")
-  private int _batchSizePerServer = DEFAULT_BATCH_SIZE_PER_SERVER;
+  private int _batchSizePerServer = DISABLE_BATCH_SIZE_PER_SERVER;
 
   // The check on external view can be very costly when the table has very large ideal and external states, i.e. when
   // having a huge number of segments. These two configs help reduce the cpu load on controllers, e.g. by doing the

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -226,7 +226,8 @@ public class TableRebalancer {
     boolean lowDiskMode = rebalanceConfig.isLowDiskMode();
     boolean bestEfforts = rebalanceConfig.isBestEfforts();
     int batchSizePerServer = rebalanceConfig.getBatchSizePerServer();
-    Preconditions.checkState(batchSizePerServer != 0, "TableRebalance batchSizePerServer must be > 0 or -1 to disable");
+    Preconditions.checkState(batchSizePerServer != 0 && batchSizePerServer >= -1,
+        "TableRebalance batchSizePerServer must be > 0 or -1 to disable");
     long externalViewCheckIntervalInMs = rebalanceConfig.getExternalViewCheckIntervalInMs();
     long externalViewStabilizationTimeoutInMs = rebalanceConfig.getExternalViewStabilizationTimeoutInMs();
     Enablement minimizeDataMovement = rebalanceConfig.getMinimizeDataMovement();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1608,7 +1608,7 @@ public class TableRebalancer {
       boolean anyServerExhaustedBatchSize = false;
       if (batchSizePerServer != RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER) {
         // The number of segments for a given partition, accumulates as we iterate over the assigned instances
-        Map<String, Integer> servertoNumSegmentsToBeAddedForPartitionMap = new HashMap<>();
+        Map<String, Integer> serverToNumSegmentsToBeAddedForPartitionMap = new HashMap<>();
 
         // Check if the servers of the first assignment for each unique set of assigned instances has any space left
         // to move this partition. If so, let's mark the partitions as to be moved, otherwise we mark the partition
@@ -1632,8 +1632,8 @@ public class TableRebalancer {
 
             // All segments assigned to the current instances will be moved, so track segments to be added for the given
             // server based on this
-            servertoNumSegmentsToBeAddedForPartitionMap.put(server,
-                servertoNumSegmentsToBeAddedForPartitionMap.getOrDefault(server, 0) + curAssignment.size());
+            serverToNumSegmentsToBeAddedForPartitionMap.put(server,
+                serverToNumSegmentsToBeAddedForPartitionMap.getOrDefault(server, 0) + curAssignment.size());
           }
           if (anyServerExhaustedBatchSize) {
             break;
@@ -1647,7 +1647,7 @@ public class TableRebalancer {
         // check only if segmentsAddedToServerSoFar > 0 is necessary.
         if (!anyServerExhaustedBatchSize) {
           for (Map.Entry<String, Integer> serverToNumSegmentsToAdd
-              : servertoNumSegmentsToBeAddedForPartitionMap.entrySet()) {
+              : serverToNumSegmentsToBeAddedForPartitionMap.entrySet()) {
             int segmentsAddedToServerSoFar =
                 serverToNumSegmentsAddedSoFar.getOrDefault(serverToNumSegmentsToAdd.getKey(), 0);
             if (segmentsAddedToServerSoFar > 0

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1604,7 +1604,7 @@ public class TableRebalancer {
       boolean anyServerExhaustedBatchSize = false;
       if (batchSizePerServer != RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER) {
         Map.Entry<String, Map<String, String>> firstEntry = curAssignment.entrySet().iterator().next();
-        // All partitions should be assigned to the same set of servers so it is enough to check for whether any server
+        // Each partition should be assigned to the same set of servers so it is enough to check for whether any server
         // for one segment is above the limit or not
         Map<String, String> firstEntryInstanceStateMap = firstEntry.getValue();
         SingleSegmentAssignment firstAssignment =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1686,9 +1686,9 @@ public class TableRebalancer {
       Map<String, String> instanceStateMap = assignment.getValue();
 
       int partitionId =
-          segmentPartitionIdMap.computeIntIfAbsent(segmentName, v -> partitionIdFetcher.fetch(segmentName));
-      partitionIdToCurrentAssignmentMap.putIfAbsent(partitionId, new TreeMap<>());
-      partitionIdToCurrentAssignmentMap.get(partitionId).put(segmentName, instanceStateMap);
+          segmentPartitionIdMap.computeIfAbsent(segmentName, v -> partitionIdFetcher.fetch(segmentName));
+      partitionIdToCurrentAssignmentMap.computeIfAbsent(partitionId,
+          k -> new TreeMap<>()).put(segmentName, instanceStateMap);
     }
 
     return partitionIdToCurrentAssignmentMap;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1644,14 +1644,14 @@ public class TableRebalancer {
   }
 
   private static void updateNextAssignmentForPartitionIdStrictReplicaGroup(
-      Map<String, Map<String, String>> curAssignment, Map<String, Map<String, String>> targetAssignment,
+      Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
       Map<String, Map<String, String>> nextAssignment, boolean anyServerExhaustedBatchSize, int minAvailableReplicas,
       boolean lowDiskMode, Map<String, Integer> numSegmentsToOffloadMap,
       Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap,
       Map<Set<String>, Set<String>> availableInstancesMap, Map<String, Integer> serverToNumSegmentsAddedSoFar) {
     if (anyServerExhaustedBatchSize) {
       // Exhausted the batch size for at least 1 server, just copy over the remaining segments as is
-      for (Map.Entry<String, Map<String, String>> entry : curAssignment.entrySet()) {
+      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
         String segmentName = entry.getKey();
         Map<String, String> currentInstanceStateMap = entry.getValue();
         nextAssignment.put(segmentName, currentInstanceStateMap);
@@ -1660,7 +1660,7 @@ public class TableRebalancer {
       // Process all the partitionIds even if segmentsAddedSoFar becomes larger than batchSizePerServer
       // Can only do bestEfforts w.r.t. StrictReplicaGroup since a whole partition must be moved together for
       // maintaining consistency
-      for (Map.Entry<String, Map<String, String>> entry : curAssignment.entrySet()) {
+      for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
         String segmentName = entry.getKey();
         Map<String, String> currentInstanceStateMap = entry.getValue();
         Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1647,7 +1647,7 @@ public class TableRebalancer {
       Map<String, Map<String, String>> curAssignment, Map<String, Map<String, String>> targetAssignment,
       Map<String, Map<String, String>> nextAssignment, boolean anyServerExhaustedBatchSize, int minAvailableReplicas,
       boolean lowDiskMode, Map<String, Integer> numSegmentsToOffloadMap,
-      Map<Pair<Set<String>, Set<String>>,Set<String>> assignmentMap,
+      Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap,
       Map<Set<String>, Set<String>> availableInstancesMap, Map<String, Integer> serverToNumSegmentsAddedSoFar) {
     if (anyServerExhaustedBatchSize) {
       // Exhausted the batch size for at least 1 server, just copy over the remaining segments as is

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1792,7 +1792,11 @@ public class TableRebalancer {
                 _helixManager, _partitionColumn);
           }
         } else {
-          // This how partitionId is calculated for RealtimeSegmentAssignment
+          // This how partitionId is calculated for CONSUMING segments in RealtimeSegmentAssignment
+          // TODO: Add handling for COMPLETED segments if in the future this is allowed for StrictReplicaGroup and
+          //       the partitionId calculation differs from the CONSUMING segments. For StrictRealtimeSegmentAssignment
+          //       the partitionId is mandated today. If this mandate is maintained then there may be no need to add
+          //       special handling for COMPLETED segments after all
           partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
               _helixManager, _partitionColumn);
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1791,8 +1791,8 @@ public class TableRebalancer {
                 updateNumSegmentsToOffloadMap(numSegmentsToOffloadMap, currentInstanceStateMap.keySet(), k);
                 return availableInstances;
               } else {
-                // There are other segments assigned to the same instances, check the available instances to see if adding
-                // the new assignment can still hold the minimum available replicas requirement
+                // There are other segments assigned to the same instances, check the available instances to see if
+                // adding the new assignment can still hold the minimum available replicas requirement
                 availableInstances.retainAll(currentAvailableInstances);
                 if (availableInstances.size() >= minAvailableReplicas) {
                   // New assignment can be added

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -115,6 +115,16 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "markWithWarningIcon": false
     },
     {
+        "name": "batchSizePerServer",
+        "defaultValue": -1,
+        "type": "INTEGER",
+        "label": "Batch Size Per Server",
+        "description": "Batch size of segments to add per server in each rebalance step. For non-strict replica group this serves as the maximum per server, for strict replica group since a partition is moved as a whole, this serves as best efforts. Defaults to -1 to disable batching.",
+        "isAdvancedConfig": false,
+        "isStatsGatheringConfig": false,
+        "markWithWarningIcon": false
+    },
+    {
         "name": "lowDiskMode",
         "defaultValue": false,
         "type": "BOOL",

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfig;
+import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -165,6 +167,9 @@ public class ControllerConfTest {
     Assert.assertFalse(conf.getSegmentRelocatorDowntime());
     Assert.assertEquals(conf.getSegmentRelocatorMinAvailableReplicas(), -1);
     Assert.assertTrue(conf.getSegmentRelocatorBestEfforts());
+    Assert.assertFalse(conf.isSegmentRelocatorIncludingConsuming());
+    Assert.assertEquals(conf.getSegmentRelocatorMinimizeDataMovement(), Enablement.ENABLE);
+    Assert.assertEquals(conf.getSegmentRelocatorBatchSizePerServer(), RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER);
   }
 
   @Test
@@ -175,6 +180,9 @@ public class ControllerConfTest {
     properties.put(SEGMENT_RELOCATOR_DOWNTIME, true);
     properties.put(SEGMENT_RELOCATOR_MIN_AVAILABLE_REPLICAS, -2);
     properties.put(SEGMENT_RELOCATOR_BEST_EFFORTS, true);
+    properties.put(SEGMENT_RELOCATOR_INCLUDE_CONSUMING, true);
+    properties.put(SEGMENT_RELOCATOR_MINIMIZE_DATA_MOVEMENT, "DISABLE");
+    properties.put(SEGMENT_RELOCATOR_BATCH_SIZE_PER_SERVER, 42);
 
     ControllerConf conf = new ControllerConf(properties);
     Assert.assertTrue(conf.getSegmentRelocatorReassignInstances());
@@ -182,6 +190,9 @@ public class ControllerConfTest {
     Assert.assertTrue(conf.getSegmentRelocatorDowntime());
     Assert.assertEquals(conf.getSegmentRelocatorMinAvailableReplicas(), -2);
     Assert.assertTrue(conf.getSegmentRelocatorBestEfforts());
+    Assert.assertTrue(conf.isSegmentRelocatorIncludingConsuming());
+    Assert.assertEquals(conf.getSegmentRelocatorMinimizeDataMovement(), Enablement.DISABLE);
+    Assert.assertEquals(conf.getSegmentRelocatorBatchSizePerServer(), 42);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -769,7 +769,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
   }
 
   @Test
-  public void testRebalanceBatchSizeZero()
+  public void testRebalanceBatchSizePerServerErrors()
       throws Exception {
     int numServers = 3;
     // Mock disk usage
@@ -810,10 +810,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       assertEquals(entry.getValue().size(), 1);
     }
 
-    // Rebalance should return NO_OP status since there has been no change
+    // Rebalance should throw an exception due to setting an unacceptable value for batchSizePerServer
     final RebalanceConfig rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setBatchSizePerServer(0);
     assertThrows(IllegalStateException.class, () -> tableRebalancer.rebalance(tableConfig, rebalanceConfig, null));
+
+    final RebalanceConfig rebalanceConfig2 = new RebalanceConfig();
+    rebalanceConfig2.setBatchSizePerServer(-2);
+    assertThrows(IllegalStateException.class, () -> tableRebalancer.rebalance(tableConfig, rebalanceConfig2, null));
 
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -105,649 +105,667 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
   @Test
   public void testRebalance()
       throws Exception {
-    int numServers = 3;
-    // Mock disk usage
-    Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
+    for (int batchSizePerServer : Arrays.asList(Integer.MAX_VALUE, 1)) {
+      int numServers = 3;
+      // Mock disk usage
+      Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
 
-    for (int i = 0; i < numServers; i++) {
-      String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
-      addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
-      DiskUsageInfo diskUsageInfo1 =
-          new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
-      diskUsageInfoMap.put(instanceId, diskUsageInfo1);
-    }
-
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker();
-    preChecker.init(_helixResourceManager, executorService, 1);
-    TableRebalancer tableRebalancer =
-        new TableRebalancer(_helixManager, null, null, preChecker, _helixResourceManager.getTableSizeReader());
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
-
-    // Rebalance should fail without creating the table
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
-    assertNull(rebalanceResult.getRebalanceSummaryResult());
-
-    // Rebalance with dry-run summary should fail without creating the table
-    RebalanceConfig rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
-    assertNull(rebalanceResult.getRebalanceSummaryResult());
-
-    // Create the table
-    addDummySchema(RAW_TABLE_NAME);
-    _helixResourceManager.addTable(tableConfig);
-
-    // Add the segments
-    int numSegments = 10;
-    for (int i = 0; i < numSegments; i++) {
-      _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
-    }
-    Map<String, Map<String, String>> oldSegmentAssignment =
-        _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
-
-    // Rebalance with dry-run summary should return NO_OP status
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-    RebalanceSummaryResult rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
-    assertNull(rebalanceSummaryResult.getSegmentInfo().getConsumingSegmentToBeMovedSummary());
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(), numServers);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
-
-    // Dry-run mode should not change the IdealState
-    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
-        oldSegmentAssignment);
-
-    // Rebalance should return NO_OP status
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-
-    // All servers should be assigned to the table
-    Map<InstancePartitionsType, InstancePartitions> instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    InstancePartitions instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), 1);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
-
-    // Segment assignment should not change
-    assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
-
-    // Add 3 more servers
-    int numServersToAdd = 3;
-    for (int i = 0; i < numServersToAdd; i++) {
-      String instanceId = SERVER_INSTANCE_ID_PREFIX + (numServers + i);
-      addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
-      DiskUsageInfo diskUsageInfo =
-          new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
-      diskUsageInfoMap.put(instanceId, diskUsageInfo);
-    }
-
-    ResourceUtilizationInfo.setDiskUsageInfo(diskUsageInfoMap);
-
-    // Rebalance in dry-run summary mode with added servers
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 14);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 14);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 14);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
-        numSegments * NUM_REPLICAS - 14);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
-        numServers + numServersToAdd);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
-
-    Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> serverSegmentChangeInfoMap =
-        rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo();
-    assertNotNull(serverSegmentChangeInfoMap);
-    for (int i = 0; i < numServers; i++) {
-      // Original servers should be losing some segments
-      String newServer = SERVER_INSTANCE_ID_PREFIX + i;
-      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
-      assertTrue(serverSegmentChange.getSegmentsDeleted() > 0);
-      assertTrue(serverSegmentChange.getSegmentsUnchanged() > 0);
-      assertTrue(serverSegmentChange.getTotalSegmentsBeforeRebalance() > 0);
-      assertTrue(serverSegmentChange.getTotalSegmentsAfterRebalance() > 0);
-      assertEquals(serverSegmentChange.getSegmentsAdded(), 0);
-    }
-    for (int i = 0; i < numServersToAdd; i++) {
-      // New servers should only get new segments
-      String newServer = SERVER_INSTANCE_ID_PREFIX + (numServers + i);
-      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
-      assertTrue(serverSegmentChange.getSegmentsAdded() > 0);
-      assertEquals(serverSegmentChange.getTotalSegmentsBeforeRebalance(), 0);
-      assertEquals(serverSegmentChange.getTotalSegmentsAfterRebalance(), serverSegmentChange.getSegmentsAdded());
-      assertEquals(serverSegmentChange.getSegmentsDeleted(), 0);
-      assertEquals(serverSegmentChange.getSegmentsUnchanged(), 0);
-    }
-
-    // Dry-run mode should not change the IdealState
-    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
-        oldSegmentAssignment);
-
-    // Rebalance in dry-run mode
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setPreChecks(true);
-    rebalanceConfig.setReassignInstances(true);
-
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    Map<String, RebalancePreCheckerResult> preCheckResult = rebalanceResult.getPreChecksResult();
-    assertNotNull(preCheckResult);
-    assertEquals(preCheckResult.size(), 6);
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS));
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE));
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE));
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS));
-    assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO));
-    // Sending request to servers should fail for all, so needsPreprocess should be set to "error" to indicate that a
-    // manual check is needed
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.ERROR);
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
-        "Could not determine needReload status, run needReload API manually");
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),
-        "Instance assignment not allowed, no need for minimizeDataMovement");
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertTrue(
-        preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE)
-            .getMessage()
-            .startsWith("Within threshold"));
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertTrue(
-        preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE)
-            .getMessage()
-            .startsWith("Within threshold"));
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS).getMessage(),
-        "All rebalance parameters look good");
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-        "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
-
-    // All servers should be assigned to the table
-    instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), 1);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 4,
-            SERVER_INSTANCE_ID_PREFIX + 5, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
-
-    // Segments should be moved to the new added servers
-    Map<String, Map<String, String>> newSegmentAssignment = rebalanceResult.getSegmentAssignment();
-    Map<String, IntIntPair> instanceToNumSegmentsToMoveMap =
-        SegmentAssignmentUtils.getNumSegmentsToMovePerInstance(oldSegmentAssignment, newSegmentAssignment);
-    assertEquals(instanceToNumSegmentsToMoveMap.size(), numServers + numServersToAdd);
-    for (int i = 0; i < numServersToAdd; i++) {
-      IntIntPair numSegmentsToMove = instanceToNumSegmentsToMoveMap.get(SERVER_INSTANCE_ID_PREFIX + (numServers + i));
-      assertNotNull(numSegmentsToMove);
-      assertTrue(numSegmentsToMove.leftInt() > 0);
-      assertEquals(numSegmentsToMove.rightInt(), 0);
-    }
-    for (int i = 0; i < numServers; i++) {
-      IntIntPair numSegmentsToMove = instanceToNumSegmentsToMoveMap.get(SERVER_INSTANCE_ID_PREFIX + i);
-      assertNotNull(numSegmentsToMove);
-      assertEquals(numSegmentsToMove.leftInt(), 0);
-      assertTrue(numSegmentsToMove.rightInt() > 0);
-    }
-
-    // Dry-run mode should not change the IdealState
-    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
-        oldSegmentAssignment);
-
-    // Rebalance dry-run summary with 3 min available replicas should not be impacted since actual rebalance does not
-    // occur
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setPreChecks(true);
-    rebalanceConfig.setMinAvailableReplicas(3);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceResult.getPreChecksResult());
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
-
-    // Rebalance with 3 min available replicas should fail as the table only have 3 replicas
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setMinAvailableReplicas(3);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
-
-    // IdealState should not change for FAILED rebalance
-    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
-        oldSegmentAssignment);
-
-    // Rebalance with 2 min available replicas should succeed
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setMinAvailableReplicas(2);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-
-    // Result should be the same as the result in dry-run mode
-    instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    assertEquals(instanceAssignment.get(InstancePartitionsType.OFFLINE).getPartitionToInstancesMap(),
-        instancePartitions.getPartitionToInstancesMap());
-    assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
-
-    // Update the table config to use replica-group based assignment
-    InstanceTagPoolConfig tagPoolConfig =
-        new InstanceTagPoolConfig(TagNameUtils.getOfflineTagForTenant(null), false, 0, null);
-    InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig =
-        new InstanceReplicaGroupPartitionConfig(true, 0, NUM_REPLICAS, 0, 0, 0, false, null);
-    tableConfig.setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
-        new InstanceAssignmentConfig(tagPoolConfig, null, replicaGroupPartitionConfig, null, false)));
-    _helixResourceManager.updateTableConfig(tableConfig);
-
-    // Try dry-run summary mode
-    // No need to reassign instances because instances should be automatically assigned when updating the table config
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setPreChecks(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    // Though instance partition map is set in ZK, the pre-checker is unaware of that, a warning will be thrown
-    assertEquals(
-        rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.WARN);
-    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-        "reassignInstances is disabled, replica groups may not be updated.\nOFFLINE segments - numReplicaGroups: "
-            + NUM_REPLICAS + ", numInstancesPerReplicaGroup: 0 (using as many instances as possible)");
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 11);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 11);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
-        numSegments * NUM_REPLICAS - 11);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
-        numServers + numServersToAdd);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
-
-    serverSegmentChangeInfoMap = rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo();
-    assertNotNull(serverSegmentChangeInfoMap);
-    for (int i = 0; i < numServers + numServersToAdd; i++) {
-      String newServer = SERVER_INSTANCE_ID_PREFIX + i;
-      RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
-      assertEquals(serverSegmentChange.getTotalSegmentsAfterRebalance(), 5);
-      // Ensure not all segments moved
-      assertTrue(serverSegmentChange.getSegmentsUnchanged() > 0);
-      // Ensure all segments has something assigned prior to rebalance
-      assertTrue(serverSegmentChange.getTotalSegmentsBeforeRebalance() > 0);
-    }
-
-    // Dry-run mode should not change the IdealState
-    assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
-        newSegmentAssignment);
-
-    // Try actual rebalance
-    // No need to reassign instances because instances should be automatically assigned when updating the table config
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-
-    // There should be 3 replica-groups, each with 2 servers
-    instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), NUM_REPLICAS);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
-    // [i2, i3, i4, i5, i0, i1]
-    //  r0  r1  r2  r0  r1  r2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 5));
-    assertEquals(instancePartitions.getInstances(0, 1),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 0));
-    assertEquals(instancePartitions.getInstances(0, 2),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 4, SERVER_INSTANCE_ID_PREFIX + 1));
-
-    // The assignment are based on replica-group 0 and mirrored to all the replica-groups, so server of index 0, 1, 5
-    // should have the same segments assigned, and server of index 2, 3, 4 should have the same segments assigned, each
-    // with 5 segments
-    newSegmentAssignment = rebalanceResult.getSegmentAssignment();
-    int numSegmentsOnServer0 = 0;
-    for (int i = 0; i < numSegments; i++) {
-      String segmentName = SEGMENT_NAME_PREFIX + i;
-      Map<String, String> instanceStateMap = newSegmentAssignment.get(segmentName);
-      assertEquals(instanceStateMap.size(), NUM_REPLICAS);
-      if (instanceStateMap.containsKey(SERVER_INSTANCE_ID_PREFIX + 0)) {
-        numSegmentsOnServer0++;
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 0), ONLINE);
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 1), ONLINE);
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 5), ONLINE);
-      } else {
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 2), ONLINE);
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 3), ONLINE);
-        assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 4), ONLINE);
+      for (int i = 0; i < numServers; i++) {
+        String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
+        addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
+        DiskUsageInfo diskUsageInfo1 =
+            new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
+        diskUsageInfoMap.put(instanceId, diskUsageInfo1);
       }
-    }
-    assertEquals(numSegmentsOnServer0, numSegments / 2);
 
-    // Update the table config to use non-replica-group based assignment
-    tableConfig.setInstanceAssignmentConfigMap(null);
-    _helixResourceManager.updateTableConfig(tableConfig);
+      ExecutorService executorService = Executors.newFixedThreadPool(10);
+      DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker();
+      preChecker.init(_helixResourceManager, executorService, 1);
+      TableRebalancer tableRebalancer =
+          new TableRebalancer(_helixManager, null, null, preChecker, _helixResourceManager.getTableSizeReader());
+      TableConfig tableConfig =
+          new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
 
-    // Try dry-run summary mode without reassignment to ensure that existing instance partitions are used
-    // no movement should occur
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setPreChecks(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-    assertEquals(
-        rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-        "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
-        numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
-        numServers + numServersToAdd);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
+      // Rebalance should fail without creating the table
+      RebalanceConfig rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+      assertNull(rebalanceResult.getRebalanceSummaryResult());
 
-    // Without instances reassignment, the rebalance should return status NO_OP, and the existing instance partitions
-    // should be used
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-    assertEquals(rebalanceResult.getInstanceAssignment(), instanceAssignment);
-    assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
+      // Rebalance with dry-run summary should fail without creating the table
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+      assertNull(rebalanceResult.getRebalanceSummaryResult());
 
-    // Try dry-run summary mode with reassignment
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setPreChecks(true);
-    rebalanceConfig.setReassignInstances(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    assertEquals(
-        rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
-        RebalancePreCheckerResult.PreCheckStatus.PASS);
-    assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-        "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    // No move expected since already balanced
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
-        numSegments * NUM_REPLICAS);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
-        numServers + numServersToAdd);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
+      // Create the table
+      addDummySchema(RAW_TABLE_NAME);
+      _helixResourceManager.addTable(tableConfig);
 
-    // With instances reassignment, the rebalance should return status DONE, the existing instance partitions should be
-    // removed, and the default instance partitions should be used
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setReassignInstances(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    assertNull(InstancePartitionsUtils.fetchInstancePartitions(_propertyStore,
-        InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME)));
+      // Add the segments
+      int numSegments = 10;
+      for (int i = 0; i < numSegments; i++) {
+        _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
+            SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
+      }
+      Map<String, Map<String, String>> oldSegmentAssignment =
+          _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
 
-    // All servers should be assigned to the table
-    instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), 1);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 4,
-            SERVER_INSTANCE_ID_PREFIX + 5, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
-
-    // Segment assignment should not change as it is already balanced
-    assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
-
-    // Remove the tag from the added servers
-    for (int i = 0; i < numServersToAdd; i++) {
-      _helixAdmin.removeInstanceTag(getHelixClusterName(), SERVER_INSTANCE_ID_PREFIX + (numServers + i),
+      // Rebalance with dry-run summary should return NO_OP status
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      RebalanceSummaryResult rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
+      assertNull(rebalanceSummaryResult.getSegmentInfo().getConsumingSegmentToBeMovedSummary());
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
           TagNameUtils.getOfflineTagForTenant(null));
-    }
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(), numSegments * NUM_REPLICAS);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(), numServers);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
 
-    // Try dry-run summary mode
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(true);
-    rebalanceConfig.setDowntime(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-    rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
-    assertNotNull(rebalanceSummaryResult);
-    assertNotNull(rebalanceSummaryResult.getServerInfo());
-    assertNotNull(rebalanceSummaryResult.getSegmentInfo());
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 15);
-    assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 15);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
-    assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
-    assertNotNull(rebalanceSummaryResult.getTagsInfo());
-    assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
-        TagNameUtils.getOfflineTagForTenant(null));
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 15);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
-        numSegments * NUM_REPLICAS - 15);
-    assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
-        numServers);
-    assertNotNull(rebalanceResult.getInstanceAssignment());
-    assertNotNull(rebalanceResult.getSegmentAssignment());
+      // Dry-run mode should not change the IdealState
+      assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+          oldSegmentAssignment);
 
-    // Rebalance with downtime should succeed
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDowntime(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      // Rebalance should return NO_OP status
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
 
-    // All servers with tag should be assigned to the table
-    instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), 1);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
+      // All servers should be assigned to the table
+      Map<InstancePartitionsType, InstancePartitions> instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      InstancePartitions instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), 1);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
 
-    // New segment assignment should not contain servers without tag
-    newSegmentAssignment = rebalanceResult.getSegmentAssignment();
-    for (int i = 0; i < numSegments; i++) {
-      String segmentName = SEGMENT_NAME_PREFIX + i;
-      Map<String, String> instanceStateMap = newSegmentAssignment.get(segmentName);
-      assertEquals(instanceStateMap.size(), NUM_REPLICAS);
-      for (int j = 0; j < numServersToAdd; j++) {
-        assertFalse(instanceStateMap.containsKey(SERVER_INSTANCE_ID_PREFIX + (numServers + j)));
+      // Segment assignment should not change
+      assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
+
+      // Add 3 more servers
+      int numServersToAdd = 3;
+      for (int i = 0; i < numServersToAdd; i++) {
+        String instanceId = SERVER_INSTANCE_ID_PREFIX + (numServers + i);
+        addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
+        DiskUsageInfo diskUsageInfo =
+            new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
+        diskUsageInfoMap.put(instanceId, diskUsageInfo);
       }
-    }
 
-    // Try pre-checks mode without dry-run set
-    rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setPreChecks(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
-    assertNull(rebalanceResult.getRebalanceSummaryResult());
-    assertNull(rebalanceResult.getPreChecksResult());
+      ResourceUtilizationInfo.setDiskUsageInfo(diskUsageInfoMap);
 
-    _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
+      // Rebalance in dry-run summary mode with added servers
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 14);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 14);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
+          TagNameUtils.getOfflineTagForTenant(null));
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 14);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
+          numSegments * NUM_REPLICAS - 14);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
+          numServers + numServersToAdd);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
 
-    for (int i = 0; i < numServers; i++) {
-      stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + i);
+      Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> serverSegmentChangeInfoMap =
+          rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo();
+      assertNotNull(serverSegmentChangeInfoMap);
+      for (int i = 0; i < numServers; i++) {
+        // Original servers should be losing some segments
+        String newServer = SERVER_INSTANCE_ID_PREFIX + i;
+        RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+        assertTrue(serverSegmentChange.getSegmentsDeleted() > 0);
+        assertTrue(serverSegmentChange.getSegmentsUnchanged() > 0);
+        assertTrue(serverSegmentChange.getTotalSegmentsBeforeRebalance() > 0);
+        assertTrue(serverSegmentChange.getTotalSegmentsAfterRebalance() > 0);
+        assertEquals(serverSegmentChange.getSegmentsAdded(), 0);
+      }
+      for (int i = 0; i < numServersToAdd; i++) {
+        // New servers should only get new segments
+        String newServer = SERVER_INSTANCE_ID_PREFIX + (numServers + i);
+        RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+        assertTrue(serverSegmentChange.getSegmentsAdded() > 0);
+        assertEquals(serverSegmentChange.getTotalSegmentsBeforeRebalance(), 0);
+        assertEquals(serverSegmentChange.getTotalSegmentsAfterRebalance(), serverSegmentChange.getSegmentsAdded());
+        assertEquals(serverSegmentChange.getSegmentsDeleted(), 0);
+        assertEquals(serverSegmentChange.getSegmentsUnchanged(), 0);
+      }
+
+      // Dry-run mode should not change the IdealState
+      assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+          oldSegmentAssignment);
+
+      // Rebalance in dry-run mode
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setPreChecks(true);
+      rebalanceConfig.setReassignInstances(true);
+
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      Map<String, RebalancePreCheckerResult> preCheckResult = rebalanceResult.getPreChecksResult();
+      assertNotNull(preCheckResult);
+      assertEquals(preCheckResult.size(), 6);
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS));
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT));
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE));
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE));
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS));
+      assertTrue(preCheckResult.containsKey(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO));
+      // Sending request to servers should fail for all, so needsPreprocess should be set to "error" to indicate that a
+      // manual check is needed
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.ERROR);
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.NEEDS_RELOAD_STATUS).getMessage(),
+          "Could not determine needReload status, run needReload API manually");
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.IS_MINIMIZE_DATA_MOVEMENT).getMessage(),
+          "Instance assignment not allowed, no need for minimizeDataMovement");
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertTrue(
+          preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_DURING_REBALANCE)
+              .getMessage()
+              .startsWith("Within threshold"));
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertTrue(
+          preCheckResult.get(DefaultRebalancePreChecker.DISK_UTILIZATION_AFTER_REBALANCE)
+              .getMessage()
+              .startsWith("Within threshold"));
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS).getMessage(),
+          "All rebalance parameters look good");
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertEquals(preCheckResult.get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
+          "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
+
+      // All servers should be assigned to the table
+      instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), 1);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 4,
+              SERVER_INSTANCE_ID_PREFIX + 5, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
+
+      // Segments should be moved to the new added servers
+      Map<String, Map<String, String>> newSegmentAssignment = rebalanceResult.getSegmentAssignment();
+      Map<String, IntIntPair> instanceToNumSegmentsToMoveMap =
+          SegmentAssignmentUtils.getNumSegmentsToMovePerInstance(oldSegmentAssignment, newSegmentAssignment);
+      assertEquals(instanceToNumSegmentsToMoveMap.size(), numServers + numServersToAdd);
+      for (int i = 0; i < numServersToAdd; i++) {
+        IntIntPair numSegmentsToMove = instanceToNumSegmentsToMoveMap.get(SERVER_INSTANCE_ID_PREFIX + (numServers + i));
+        assertNotNull(numSegmentsToMove);
+        assertTrue(numSegmentsToMove.leftInt() > 0);
+        assertEquals(numSegmentsToMove.rightInt(), 0);
+      }
+      for (int i = 0; i < numServers; i++) {
+        IntIntPair numSegmentsToMove = instanceToNumSegmentsToMoveMap.get(SERVER_INSTANCE_ID_PREFIX + i);
+        assertNotNull(numSegmentsToMove);
+        assertEquals(numSegmentsToMove.leftInt(), 0);
+        assertTrue(numSegmentsToMove.rightInt() > 0);
+      }
+
+      // Dry-run mode should not change the IdealState
+      assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+          oldSegmentAssignment);
+
+      // Rebalance dry-run summary with 3 min available replicas should not be impacted since actual rebalance does not
+      // occur
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setPreChecks(true);
+      rebalanceConfig.setMinAvailableReplicas(3);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 3);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+      assertNotNull(rebalanceResult.getPreChecksResult());
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
+
+      // Rebalance with 3 min available replicas should fail as the table only have 3 replicas
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setMinAvailableReplicas(3);
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+
+      // IdealState should not change for FAILED rebalance
+      assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+          oldSegmentAssignment);
+
+      // Rebalance with 2 min available replicas should succeed
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setMinAvailableReplicas(2);
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+
+      // Result should be the same as the result in dry-run mode
+      instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      assertEquals(instanceAssignment.get(InstancePartitionsType.OFFLINE).getPartitionToInstancesMap(),
+          instancePartitions.getPartitionToInstancesMap());
+      assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
+
+      // Update the table config to use replica-group based assignment
+      InstanceTagPoolConfig tagPoolConfig =
+          new InstanceTagPoolConfig(TagNameUtils.getOfflineTagForTenant(null), false, 0, null);
+      InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig =
+          new InstanceReplicaGroupPartitionConfig(true, 0, NUM_REPLICAS, 0, 0, 0, false, null);
+      tableConfig.setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+          new InstanceAssignmentConfig(tagPoolConfig, null, replicaGroupPartitionConfig, null, false)));
+      _helixResourceManager.updateTableConfig(tableConfig);
+
+      // Try dry-run summary mode
+      // No need to reassign instances because instances should be automatically assigned when updating the table config
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setPreChecks(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      // Though instance partition map is set in ZK, the pre-checker is unaware of that, a warning will be thrown
+      assertEquals(
+          rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.WARN);
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
+          "reassignInstances is disabled, replica groups may not be updated.\nOFFLINE segments - numReplicaGroups: "
+              + NUM_REPLICAS + ", numInstancesPerReplicaGroup: 0 (using as many instances as possible)");
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 11);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 11);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
+          TagNameUtils.getOfflineTagForTenant(null));
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 11);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
+          numSegments * NUM_REPLICAS - 11);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
+          numServers + numServersToAdd);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
+
+      serverSegmentChangeInfoMap = rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo();
+      assertNotNull(serverSegmentChangeInfoMap);
+      for (int i = 0; i < numServers + numServersToAdd; i++) {
+        String newServer = SERVER_INSTANCE_ID_PREFIX + i;
+        RebalanceSummaryResult.ServerSegmentChangeInfo serverSegmentChange = serverSegmentChangeInfoMap.get(newServer);
+        assertEquals(serverSegmentChange.getTotalSegmentsAfterRebalance(), 5);
+        // Ensure not all segments moved
+        assertTrue(serverSegmentChange.getSegmentsUnchanged() > 0);
+        // Ensure all segments has something assigned prior to rebalance
+        assertTrue(serverSegmentChange.getTotalSegmentsBeforeRebalance() > 0);
+      }
+
+      // Dry-run mode should not change the IdealState
+      assertEquals(_helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields(),
+          newSegmentAssignment);
+
+      // Try actual rebalance
+      // No need to reassign instances because instances should be automatically assigned when updating the table config
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+
+      // There should be 3 replica-groups, each with 2 servers
+      instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), NUM_REPLICAS);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
+      // [i2, i3, i4, i5, i0, i1]
+      //  r0  r1  r2  r0  r1  r2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 5));
+      assertEquals(instancePartitions.getInstances(0, 1),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 0));
+      assertEquals(instancePartitions.getInstances(0, 2),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 4, SERVER_INSTANCE_ID_PREFIX + 1));
+
+      // The assignment are based on replica-group 0 and mirrored to all the replica-groups, so server of index 0, 1, 5
+      // should have the same segments assigned, and server of index 2, 3, 4 should have the same segments assigned,
+      // each with 5 segments
+      newSegmentAssignment = rebalanceResult.getSegmentAssignment();
+      int numSegmentsOnServer0 = 0;
+      for (int i = 0; i < numSegments; i++) {
+        String segmentName = SEGMENT_NAME_PREFIX + i;
+        Map<String, String> instanceStateMap = newSegmentAssignment.get(segmentName);
+        assertEquals(instanceStateMap.size(), NUM_REPLICAS);
+        if (instanceStateMap.containsKey(SERVER_INSTANCE_ID_PREFIX + 0)) {
+          numSegmentsOnServer0++;
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 0), ONLINE);
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 1), ONLINE);
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 5), ONLINE);
+        } else {
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 2), ONLINE);
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 3), ONLINE);
+          assertEquals(instanceStateMap.get(SERVER_INSTANCE_ID_PREFIX + 4), ONLINE);
+        }
+      }
+      assertEquals(numSegmentsOnServer0, numSegments / 2);
+
+      // Update the table config to use non-replica-group based assignment
+      tableConfig.setInstanceAssignmentConfigMap(null);
+      _helixResourceManager.updateTableConfig(tableConfig);
+
+      // Try dry-run summary mode without reassignment to ensure that existing instance partitions are used
+      // no movement should occur
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setPreChecks(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      assertEquals(
+          rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
+          "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
+          TagNameUtils.getOfflineTagForTenant(null));
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
+          numSegments * NUM_REPLICAS);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
+          numServers + numServersToAdd);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
+
+      // Without instances reassignment, the rebalance should return status NO_OP, and the existing instance partitions
+      // should be used
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      assertEquals(rebalanceResult.getInstanceAssignment(), instanceAssignment);
+      assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
+
+      // Try dry-run summary mode with reassignment
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setPreChecks(true);
+      rebalanceConfig.setReassignInstances(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      assertEquals(
+          rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
+          RebalancePreCheckerResult.PreCheckStatus.PASS);
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
+          "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      // No move expected since already balanced
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 0);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 0);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 0);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
+          TagNameUtils.getOfflineTagForTenant(null));
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 0);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
+          numSegments * NUM_REPLICAS);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
+          numServers + numServersToAdd);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
+
+      // With instances reassignment, the rebalance should return status DONE, the existing instance partitions should
+      // be removed, and the default instance partitions should be used
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setReassignInstances(true);
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      assertNull(InstancePartitionsUtils.fetchInstancePartitions(_propertyStore,
+          InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME)));
+
+      // All servers should be assigned to the table
+      instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), 1);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 6 = 2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 3, SERVER_INSTANCE_ID_PREFIX + 4,
+              SERVER_INSTANCE_ID_PREFIX + 5, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
+
+      // Segment assignment should not change as it is already balanced
+      assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
+
+      // Remove the tag from the added servers
+      for (int i = 0; i < numServersToAdd; i++) {
+        _helixAdmin.removeInstanceTag(getHelixClusterName(), SERVER_INSTANCE_ID_PREFIX + (numServers + i),
+            TagNameUtils.getOfflineTagForTenant(null));
+      }
+
+      // Try dry-run summary mode
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setDowntime(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+      rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
+      assertNotNull(rebalanceSummaryResult);
+      assertNotNull(rebalanceSummaryResult.getServerInfo());
+      assertNotNull(rebalanceSummaryResult.getSegmentInfo());
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeMoved(), 15);
+      assertEquals(rebalanceSummaryResult.getSegmentInfo().getTotalSegmentsToBeDeleted(), 15);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getValueBeforeRebalance(), 6);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServers().getExpectedValueAfterRebalance(), 3);
+      assertEquals(rebalanceSummaryResult.getServerInfo().getNumServersGettingNewSegments(), 3);
+      assertNotNull(rebalanceSummaryResult.getTagsInfo());
+      assertEquals(rebalanceSummaryResult.getTagsInfo().size(), 1);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getTagName(),
+          TagNameUtils.getOfflineTagForTenant(null));
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsToDownload(), 15);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumSegmentsUnchanged(),
+          numSegments * NUM_REPLICAS - 15);
+      assertEquals(rebalanceSummaryResult.getTagsInfo().get(0).getNumServerParticipants(),
+          numServers);
+      assertNotNull(rebalanceResult.getInstanceAssignment());
+      assertNotNull(rebalanceResult.getSegmentAssignment());
+
+      // Rebalance with downtime should succeed
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDowntime(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+
+      // All servers with tag should be assigned to the table
+      instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), 1);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
+
+      // New segment assignment should not contain servers without tag
+      newSegmentAssignment = rebalanceResult.getSegmentAssignment();
+      for (int i = 0; i < numSegments; i++) {
+        String segmentName = SEGMENT_NAME_PREFIX + i;
+        Map<String, String> instanceStateMap = newSegmentAssignment.get(segmentName);
+        assertEquals(instanceStateMap.size(), NUM_REPLICAS);
+        for (int j = 0; j < numServersToAdd; j++) {
+          assertFalse(instanceStateMap.containsKey(SERVER_INSTANCE_ID_PREFIX + (numServers + j)));
+        }
+      }
+
+      // Try pre-checks mode without dry-run set
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setPreChecks(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+      assertNull(rebalanceResult.getRebalanceSummaryResult());
+      assertNull(rebalanceResult.getPreChecksResult());
+
+      _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
+
+      for (int i = 0; i < numServers; i++) {
+        stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + i);
+      }
+      for (int i = 0; i < numServersToAdd; i++) {
+        stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + (numServers + i));
+      }
+      executorService.shutdown();
     }
-    for (int i = 0; i < numServersToAdd; i++) {
-      stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + (numServers + i));
-    }
-    executorService.shutdown();
   }
 
   @Test(timeOut = 60000)
   public void testRebalanceStrictReplicaGroup()
       throws Exception {
-    int numServers = 3;
-    // Mock disk usage
-    Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
+    for (int batchSizePerServer : Arrays.asList(Integer.MAX_VALUE, 3)) {
+      int numServers = 3;
+      // Mock disk usage
+      Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
 
-    for (int i = 0; i < numServers; i++) {
-      String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
-      addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
-      DiskUsageInfo diskUsageInfo1 =
-          new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
-      diskUsageInfoMap.put(instanceId, diskUsageInfo1);
+      for (int i = 0; i < numServers; i++) {
+        String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
+        addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
+        DiskUsageInfo diskUsageInfo1 =
+            new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
+        diskUsageInfoMap.put(instanceId, diskUsageInfo1);
+      }
+
+      ExecutorService executorService = Executors.newFixedThreadPool(10);
+      DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker();
+      preChecker.init(_helixResourceManager, executorService, 1);
+      TableRebalancer tableRebalancer = new TableRebalancer(_helixManager, null, null, preChecker,
+          _helixResourceManager.getTableSizeReader());
+      // Set up the table with 1 replication factor and strict replica group enabled
+      TableConfig tableConfig =
+          new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(1)
+              .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
+                  false)).build();
+
+      // Create the table
+      addDummySchema(RAW_TABLE_NAME);
+      _helixResourceManager.addTable(tableConfig);
+
+      // Add the segments
+      int numSegments = 10;
+      for (int i = 0; i < numSegments; i++) {
+        _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
+            SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
+      }
+      Map<String, Map<String, String>> oldSegmentAssignment =
+          _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
+      for (Map.Entry<String, Map<String, String>> entry : oldSegmentAssignment.entrySet()) {
+        assertEquals(entry.getValue().size(), 1);
+      }
+
+      // Rebalance should return NO_OP status since there has been no change
+      RebalanceConfig rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+      // All servers should be assigned to the table
+      Map<InstancePartitionsType, InstancePartitions> instanceAssignment = rebalanceResult.getInstanceAssignment();
+      assertEquals(instanceAssignment.size(), 1);
+      InstancePartitions instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
+      assertEquals(instancePartitions.getNumReplicaGroups(), 1);
+      assertEquals(instancePartitions.getNumPartitions(), 1);
+      // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
+      assertEquals(instancePartitions.getInstances(0, 0),
+          Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
+
+      // Segment assignment should not change
+      assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
+
+      // Increase the replication factor to 3
+      tableConfig.getValidationConfig().setReplication("3");
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(false);
+      rebalanceConfig.setPreChecks(false);
+      rebalanceConfig.setReassignInstances(true);
+      rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
+      // minAvailableReplicas = -1 results in minAvailableReplicas = target replication - 1 = 2 in this case
+      rebalanceConfig.setMinAvailableReplicas(-1);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+
+      Map<String, Map<String, String>> newSegmentAssignment = rebalanceResult.getSegmentAssignment();
+      assertNotEquals(oldSegmentAssignment, newSegmentAssignment);
+      for (Map.Entry<String, Map<String, String>> entry : newSegmentAssignment.entrySet()) {
+        assertTrue(oldSegmentAssignment.containsKey(entry.getKey()));
+        assertEquals(entry.getValue().size(), 3);
+      }
+
+      _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
+
+      for (int i = 0; i < numServers; i++) {
+        stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + i);
+      }
+      executorService.shutdown();
     }
-
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    DefaultRebalancePreChecker preChecker = new DefaultRebalancePreChecker();
-    preChecker.init(_helixResourceManager, executorService, 1);
-    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager, null, null, preChecker,
-        _helixResourceManager.getTableSizeReader());
-    // Set up the table with 1 replication factor and strict replica group enabled
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(1)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
-                false)).build();
-
-    // Create the table
-    addDummySchema(RAW_TABLE_NAME);
-    _helixResourceManager.addTable(tableConfig);
-
-    // Add the segments
-    int numSegments = 10;
-    for (int i = 0; i < numSegments; i++) {
-      _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
-    }
-    Map<String, Map<String, String>> oldSegmentAssignment =
-        _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
-    for (Map.Entry<String, Map<String, String>> entry : oldSegmentAssignment.entrySet()) {
-      assertEquals(entry.getValue().size(), 1);
-    }
-
-    // Rebalance should return NO_OP status since there has been no change
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-
-    // All servers should be assigned to the table
-    Map<InstancePartitionsType, InstancePartitions> instanceAssignment = rebalanceResult.getInstanceAssignment();
-    assertEquals(instanceAssignment.size(), 1);
-    InstancePartitions instancePartitions = instanceAssignment.get(InstancePartitionsType.OFFLINE);
-    assertEquals(instancePartitions.getNumReplicaGroups(), 1);
-    assertEquals(instancePartitions.getNumPartitions(), 1);
-    // Math.abs("testTable_OFFLINE".hashCode()) % 3 = 2
-    assertEquals(instancePartitions.getInstances(0, 0),
-        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2, SERVER_INSTANCE_ID_PREFIX + 0, SERVER_INSTANCE_ID_PREFIX + 1));
-
-    // Segment assignment should not change
-    assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
-
-    // Increase the replication factor to 3
-    tableConfig.getValidationConfig().setReplication("3");
-    RebalanceConfig rebalanceConfig = new RebalanceConfig();
-    rebalanceConfig.setDryRun(false);
-    rebalanceConfig.setPreChecks(false);
-    rebalanceConfig.setReassignInstances(true);
-    // minAvailableReplicas = -1 results in minAvailableReplicas = target replication - 1 = 2 in this case
-    rebalanceConfig.setMinAvailableReplicas(-1);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
-
-    Map<String, Map<String, String>> newSegmentAssignment = rebalanceResult.getSegmentAssignment();
-    assertNotEquals(oldSegmentAssignment, newSegmentAssignment);
-    for (Map.Entry<String, Map<String, String>> entry : newSegmentAssignment.entrySet()) {
-      assertTrue(oldSegmentAssignment.containsKey(entry.getKey()));
-      assertEquals(entry.getValue().size(), 3);
-    }
-
-    _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
-
-    for (int i = 0; i < numServers; i++) {
-      stopAndDropFakeInstance(SERVER_INSTANCE_ID_PREFIX + i);
-    }
-    executorService.shutdown();
   }
 
   @Test
@@ -1134,8 +1152,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
-    // rebalance should change assignment
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
+    // rebalance should change assignment. Enable batching
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setBatchSizePerServer(2);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // check that segments have moved to tiers
@@ -1319,8 +1339,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertNotNull(rebalanceResult.getTierInstanceAssignment());
     assertNotNull(rebalanceResult.getSegmentAssignment());
 
-    // rebalance should change assignment
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
+    // rebalance should change assignment, enable batching
+    rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setBatchSizePerServer(2);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // check that segments have moved to tier a

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -410,9 +410,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       assertEquals(
           rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
           RebalancePreCheckerResult.PreCheckStatus.WARN);
-      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-          "reassignInstances is disabled, replica groups may not be updated.\nOFFLINE segments - numReplicaGroups: "
-              + NUM_REPLICAS + ", numInstancesPerReplicaGroup: 0 (using as many instances as possible)");
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO)
+              .getMessage(), "reassignInstances is disabled, replica groups may not be updated.\nOFFLINE segments "
+          + "- numReplicaGroups: " + NUM_REPLICAS + ", numInstancesPerReplicaGroup: 0 (using as many instances as "
+          + "possible)");
       rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
       assertNotNull(rebalanceSummaryResult);
       assertNotNull(rebalanceSummaryResult.getServerInfo());
@@ -508,8 +509,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       assertEquals(
           rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
           RebalancePreCheckerResult.PreCheckStatus.PASS);
-      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-          "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO)
+              .getMessage(), "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
       rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
       assertNotNull(rebalanceSummaryResult);
       assertNotNull(rebalanceSummaryResult.getServerInfo());
@@ -550,8 +551,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       assertEquals(
           rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getPreCheckStatus(),
           RebalancePreCheckerResult.PreCheckStatus.PASS);
-      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO).getMessage(),
-          "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
+      assertEquals(rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REPLICA_GROUPS_INFO)
+              .getMessage(), "OFFLINE segments - Replica Groups are not enabled, replication: " + NUM_REPLICAS);
       rebalanceSummaryResult = rebalanceResult.getRebalanceSummaryResult();
       assertNotNull(rebalanceSummaryResult);
       assertNotNull(rebalanceSummaryResult.getServerInfo());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -684,15 +684,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       throws Exception {
     for (int batchSizePerServer : Arrays.asList(RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, 3, 1)) {
       int numServers = 3;
-      // Mock disk usage
-      Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
 
       for (int i = 0; i < numServers; i++) {
         String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
         addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
-        DiskUsageInfo diskUsageInfo1 =
-            new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
-        diskUsageInfoMap.put(instanceId, diskUsageInfo1);
       }
 
       ExecutorService executorService = Executors.newFixedThreadPool(10);
@@ -773,15 +768,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
   public void testRebalanceBatchSizePerServerErrors()
       throws Exception {
     int numServers = 3;
-    // Mock disk usage
-    Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
 
     for (int i = 0; i < numServers; i++) {
       String instanceId = SERVER_INSTANCE_ID_PREFIX + i;
       addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
-      DiskUsageInfo diskUsageInfo1 =
-          new DiskUsageInfo(instanceId, "", 1000L, 500L, System.currentTimeMillis());
-      diskUsageInfoMap.put(instanceId, diskUsageInfo1);
     }
 
     ExecutorService executorService = Executors.newFixedThreadPool(10);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -659,11 +659,16 @@ public class TableRebalancerTest {
 
     // Next assignment with 2 minimum available replicas with or without strict replica-group should reach the target
     // assignment
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    boolean isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 2:
@@ -746,10 +751,12 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
@@ -757,8 +764,12 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 3:
@@ -811,7 +822,8 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target assignment
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, false,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+            false);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 2 steps:
@@ -843,15 +855,19 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
-    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
-    assertEquals(nextAssignment, targetAssignment);
+    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
+      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+    }
   }
 
   @Test
@@ -965,10 +981,12 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    boolean isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
@@ -976,8 +994,12 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 2:
@@ -1101,10 +1123,12 @@ public class TableRebalancerTest {
     // }
     //
     // The fourth assignment should reach the target assignment
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2")));
@@ -1112,7 +1136,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
@@ -1120,7 +1145,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
@@ -1128,8 +1154,12 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 3:
@@ -1205,14 +1235,15 @@ public class TableRebalancerTest {
     // The second assignment should reach the target assignment
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, true,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+            false);
     assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
     assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
     assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
     assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
     nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, false, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER, false);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 3 steps:
@@ -1263,23 +1294,28 @@ public class TableRebalancerTest {
     // }
     //
     // The third assignment should reach the target assignment
-    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
-    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
-    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
-    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
-    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
+      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, true,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
+      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
+      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
-    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
-    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
-    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
-    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
-    assertEquals(nextAssignment, targetAssignment);
+      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
+          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+    }
   }
 
   @Test
@@ -1557,11 +1593,12 @@ public class TableRebalancerTest {
 
     // Next assignment with 2 minimum available replicas with or without strict replica-group should reach the target
     // assignment after two steps. Batch size = 1, unique partitionIds
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    boolean isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       assertNotEquals(nextAssignment, targetAssignment);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -1573,18 +1610,25 @@ public class TableRebalancerTest {
           new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Next assignment with 2 minimum available replicas with our without strict replica-group should reach the target
     // assignment after one steps. Batch size = 2, unique partitionIds
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 2:
@@ -1690,10 +1734,12 @@ public class TableRebalancerTest {
     // }
     //
     // The third assignment should reach the target assignment
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
@@ -1705,7 +1751,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
       assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
@@ -1717,8 +1764,12 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
+              isStrictRealtimeSegmentAssignment);
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Target assignment 3:
@@ -1772,7 +1823,7 @@ public class TableRebalancerTest {
     // in 1 step using batchSizePerServer = 2
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, false,
-            2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+            2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER, false);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 2 steps even with
@@ -1805,19 +1856,23 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
-        2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
-    assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
-        new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-        new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
-        new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-    assertEquals(nextAssignment.get("segment__4__0__98347869999L").keySet(),
-        new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
-    assertEquals(nextAssignment, targetAssignment);
+    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
+      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
+          2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+          new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+          new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+          new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+      assertEquals(nextAssignment.get("segment__4__0__98347869999L").keySet(),
+          new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
+          2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
+          strictRealtimeSegmentAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+    }
 
     // Try assignment with overlapping partitions across segments, especially for strict replica group based.
     // Non-strict replica group based should not matter
@@ -1854,7 +1909,7 @@ public class TableRebalancerTest {
     currentAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
 
-    // Target assignment 1:
+    // Target assignment 1 with just 2 overall partitions instead of 4 unique ones:
     // {
     //   "segment__1__0__98347869999L": {
     //     "host1": "ONLINE",
@@ -1909,11 +1964,12 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after two steps. With strict replica groups it should reach the target assignment immediately since
     // the full partition must be selected for movement. Batch size = 1, unique partitionIds
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       if (!enableStrictReplicaGroup) {
         // Nothing should change, since we don't select based on partitions for non-strict replica groups
         assertNotEquals(nextAssignment, targetAssignment);
@@ -1927,9 +1983,119 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       }
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
+    }
+
+    // Target assignment 2 with just 2 unique partitions:
+    // {
+    //   "segment__1__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__3__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__4__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host5": "ONLINE"
+    //   }
+    // }
+    targetAssignment = new TreeMap<>();
+    targetAssignment.put("segment__1__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host4", "host5"), ONLINE));
+    targetAssignment.put("segment__1__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__2__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host4", "host5"), ONLINE));
+
+    // Number of segments to offload:
+    // {
+    //   "host1": 0,
+    //   "host2": 2,
+    //   "host3": 4,
+    //   "host4": -2,
+    //   "host5": -2,
+    //   "host6": -2
+    // }
+    numSegmentsToOffloadMap =
+        TableRebalancer.getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
+    assertEquals(numSegmentsToOffloadMap.size(), 6);
+    assertEquals((int) numSegmentsToOffloadMap.get("host1"), 0);
+    assertEquals((int) numSegmentsToOffloadMap.get("host2"), 2);
+    assertEquals((int) numSegmentsToOffloadMap.get("host3"), 4);
+    assertEquals((int) numSegmentsToOffloadMap.get("host4"), -2);
+    assertEquals((int) numSegmentsToOffloadMap.get("host5"), -2);
+    assertEquals((int) numSegmentsToOffloadMap.get("host6"), -2);
+
+    // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
+    // assignment after two steps. With strict replica groups it should reach the target assignment immediately since
+    // the full partition must be selected for movement. Batch size = 2, unique partitionIds
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+      Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      if (!enableStrictReplicaGroup) {
+        // Nothing should change, since we don't select based on partitions for non-strict replica groups
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host4", "host5")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      } else {
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      }
+      assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
 
     // Try an assignment with 3 unique partitions and batchSizePerServer = 1 to force strict replica group to go
@@ -1982,7 +2148,7 @@ public class TableRebalancerTest {
     currentAssignment.put("segment__3__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
 
-    // Target assignment 1:
+    // Target assignment 4:
     // {
     //   "segment__1__0__98347869999L": {
     //     "host1": "ONLINE",
@@ -2051,11 +2217,12 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after four steps. With strict replica groups it should reach the target assignment in two steps since
     // the full partition must be selected for movement. Batch size = 1, unique partitionIds
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       if (!enableStrictReplicaGroup) {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2072,7 +2239,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -2088,7 +2255,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -2104,7 +2271,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       } else {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2121,9 +2288,12 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
       }
       assertEquals(nextAssignment, targetAssignment);
+      if (enableStrictReplicaGroup) {
+        isStrictRealtimeSegmentAssignment = true;
+      }
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -2241,13 +2241,13 @@ public class TableRebalancerTest {
     //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
-    //     "host3": "ONLINE",
-    //     "host6": "ONLINE"
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE"
     //   },
     //   "segment__1__2__98347869999L": {
     //     "host1": "ONLINE",
-    //     "host2": "ONLINE",
-    //     "host3": "ONLINE"
+    //     "host3": "ONLINE",
+    //     "host6": "ONLINE"
     //   },
     //   "segment__2__0__98347869999L": {
     //     "host2": "ONLINE",
@@ -2256,13 +2256,13 @@ public class TableRebalancerTest {
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
-    //     "host4": "ONLINE",
-    //     "host7": "ONLINE"
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
     //   },
     //   "segment__2__2__98347869999L": {
     //     "host2": "ONLINE",
-    //     "host3": "ONLINE",
-    //     "host4": "ONLINE"
+    //     "host4": "ONLINE",
+    //     "host7": "ONLINE"
     //   },
     //   "segment__3__0__98347869999L": {
     //     "host1": "ONLINE",

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -659,16 +659,11 @@ public class TableRebalancerTest {
 
     // Next assignment with 2 minimum available replicas with or without strict replica-group should reach the target
     // assignment
-    boolean isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 2:
@@ -751,12 +746,10 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
@@ -764,12 +757,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 3:
@@ -822,8 +811,7 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target assignment
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, false,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-            false);
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 2 steps:
@@ -855,19 +843,15 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
-      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment, targetAssignment);
-    }
+    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+    assertEquals(nextAssignment, targetAssignment);
   }
 
   @Test
@@ -981,12 +965,10 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    boolean isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
@@ -994,12 +976,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 2:
@@ -1123,12 +1101,10 @@ public class TableRebalancerTest {
     // }
     //
     // The fourth assignment should reach the target assignment
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2")));
@@ -1136,8 +1112,7 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
@@ -1145,8 +1120,7 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
       assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host4", "host5")));
       assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host2", "host4")));
@@ -1154,12 +1128,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, true,
-              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 3:
@@ -1235,15 +1205,14 @@ public class TableRebalancerTest {
     // The second assignment should reach the target assignment
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, true,
-            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-            false);
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
     assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
     assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
     assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
     assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
     nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, false, true,
-        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER, false);
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 3 steps:
@@ -1294,28 +1263,23 @@ public class TableRebalancerTest {
     // }
     //
     // The third assignment should reach the target assignment
-    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
-      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, true,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
-      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
-      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
-      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
+    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3")));
+    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
-      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
-      assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+    assertEquals(nextAssignment.get("segment1").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment2").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
+    assertEquals(nextAssignment.get("segment3").keySet(), new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment4").keySet(), new TreeSet<>(Arrays.asList("host3", "host4")));
 
-      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
-          RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment, targetAssignment);
-    }
+    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, true,
+        RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER);
+    assertEquals(nextAssignment, targetAssignment);
   }
 
   @Test
@@ -1593,12 +1557,11 @@ public class TableRebalancerTest {
 
     // Next assignment with 2 minimum available replicas with or without strict replica-group should reach the target
     // assignment after two steps. Batch size = 1, unique partitionIds
-    boolean isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       assertNotEquals(nextAssignment, targetAssignment);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -1610,25 +1573,18 @@ public class TableRebalancerTest {
           new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Next assignment with 2 minimum available replicas with our without strict replica-group should reach the target
     // assignment after one steps. Batch size = 2, unique partitionIds
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 2:
@@ -1734,12 +1690,10 @@ public class TableRebalancerTest {
     // }
     //
     // The third assignment should reach the target assignment
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Map<String, Map<String, String>> nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
       assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
@@ -1751,8 +1705,7 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
       assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
           new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
       assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
@@ -1764,12 +1717,8 @@ public class TableRebalancerTest {
 
       nextAssignment =
           TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
-              isStrictRealtimeSegmentAssignment);
+              1, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 3:
@@ -1823,7 +1772,7 @@ public class TableRebalancerTest {
     // in 1 step using batchSizePerServer = 2
     Map<String, Map<String, String>> nextAssignment =
         TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, false, false,
-            2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER, false);
+            2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
     assertEquals(nextAssignment, targetAssignment);
 
     // Next assignment with 2 minimum available replicas with strict replica-group should finish in 2 steps even with
@@ -1856,23 +1805,19 @@ public class TableRebalancerTest {
     // }
     //
     // The second assignment should reach the target assignment
-    for (boolean strictRealtimeSegmentAssignment : Arrays.asList(false, true)) {
-      nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
-          2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
-          new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-          new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
-          new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
-      assertEquals(nextAssignment.get("segment__4__0__98347869999L").keySet(),
-          new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
-      nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
-          2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER,
-          strictRealtimeSegmentAssignment);
-      assertEquals(nextAssignment, targetAssignment);
-    }
+    nextAssignment = TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, true, false,
+        2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+    assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+        new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+        new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+        new TreeSet<>(Arrays.asList("host1", "host3", "host4")));
+    assertEquals(nextAssignment.get("segment__4__0__98347869999L").keySet(),
+        new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
+    nextAssignment = TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, true, false,
+        2, new Object2IntOpenHashMap<>(), SIMPLE_PARTITION_FETCHER);
+    assertEquals(nextAssignment, targetAssignment);
 
     // Try assignment with overlapping partitions across segments, especially for strict replica group based.
     // Non-strict replica group based should not matter
@@ -1964,12 +1909,11 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after two steps. With strict replica groups it should reach the target assignment immediately since
     // the full partition must be selected for movement. Batch size = 1, unique partitionIds
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       if (!enableStrictReplicaGroup) {
         // Nothing should change, since we don't select based on partitions for non-strict replica groups
         assertNotEquals(nextAssignment, targetAssignment);
@@ -1983,12 +1927,9 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       }
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Target assignment 2 with just 2 unique partitions:
@@ -2046,12 +1987,11 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after two steps. With strict replica groups it should reach the target assignment immediately since
     // the full partition must be selected for movement. Batch size = 2, unique partitionIds
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       if (!enableStrictReplicaGroup) {
         // Nothing should change, since we don't select based on partitions for non-strict replica groups
         assertNotEquals(nextAssignment, targetAssignment);
@@ -2065,7 +2005,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
@@ -2077,7 +2017,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       } else {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2090,12 +2030,9 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       }
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Try an assignment with 3 unique partitions and batchSizePerServer = 1 to force strict replica group to go
@@ -2217,12 +2154,11 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after four steps. With strict replica groups it should reach the target assignment in two steps since
     // the full partition must be selected for movement. Batch size = 1, unique partitionIds
-    isStrictRealtimeSegmentAssignment = false;
-    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true, true)) {
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       if (!enableStrictReplicaGroup) {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2239,7 +2175,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -2255,7 +2191,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -2271,7 +2207,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       } else {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2288,12 +2224,9 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                1, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       }
       assertEquals(nextAssignment, targetAssignment);
-      if (enableStrictReplicaGroup) {
-        isStrictRealtimeSegmentAssignment = true;
-      }
     }
 
     // Try an assignment with 3 unique partitions but with different assignments and batchSizePerServer = 1 to force
@@ -2461,12 +2394,11 @@ public class TableRebalancerTest {
     // the target assignment in two steps since the full partition must be selected for movement. Only testing this
     // assignment with isStrictRealtimeSegmentAssignment=false since the assignments usually don't differ for
     // isStrictRealtimeSegmentAssignment=true. Batch size = 1, unique partitionIds
-    isStrictRealtimeSegmentAssignment = false;
     for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
           TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       if (!enableStrictReplicaGroup) {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2489,7 +2421,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
@@ -2511,7 +2443,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       } else {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
@@ -2534,7 +2466,7 @@ public class TableRebalancerTest {
             new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
         nextAssignment =
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
-                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       }
       assertEquals(nextAssignment, targetAssignment);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -2295,5 +2295,248 @@ public class TableRebalancerTest {
         isStrictRealtimeSegmentAssignment = true;
       }
     }
+
+    // Try an assignment with 3 unique partitions but with different assignments and batchSizePerServer = 1 to force
+    // strict replica group routing only to go through 2 loops
+    // Non-strict replica group based should not matter
+    // Current assignment:
+    // {
+    //   "segment__1__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
+    //   },
+    //   "segment__1__1__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__1__2__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE"
+    //   },
+    //   "segment__2__1__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host7": "ONLINE"
+    //   },
+    //   "segment__2__2__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
+    //   },
+    //   "segment__3__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE"
+    //   },
+    //   "segment__3__1__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE"
+    //   },
+    //   "segment__3__2__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host6": "ONLINE"
+    //   }
+    // }
+    currentAssignment = new TreeMap<>();
+    currentAssignment.put("segment__1__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
+    currentAssignment.put("segment__1__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__1__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host6"), ONLINE));
+    currentAssignment.put("segment__2__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
+    currentAssignment.put("segment__2__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host7"), ONLINE));
+    currentAssignment.put("segment__3__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__3__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__3__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host6"), ONLINE));
+
+    // Target assignment 5:
+    // {
+    //   "segment__1__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__1__1__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__1__2__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__2__1__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__2__2__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
+    //   "segment__3__0__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__3__1__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   },
+    //   "segment__3__2__98347869999L": {
+    //     "host1": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host5": "ONLINE"
+    //   }
+    // }
+    targetAssignment = new TreeMap<>();
+    targetAssignment.put("segment__1__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__1__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__1__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__2__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__2__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__3__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__3__1__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__3__2__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+
+    // Number of segments to offload:
+    // {
+    //   "host1": 0,
+    //   "host2": 4,
+    //   "host3": 2,
+    //   "host4": 0,
+    //   "host5": -6,
+    //   "host6": -1,
+    //   "host7": 1
+    // }
+    numSegmentsToOffloadMap =
+        TableRebalancer.getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
+    assertEquals(numSegmentsToOffloadMap.size(), 7);
+    assertEquals((int) numSegmentsToOffloadMap.get("host1"), 0);
+    assertEquals((int) numSegmentsToOffloadMap.get("host2"), 4);
+    assertEquals((int) numSegmentsToOffloadMap.get("host3"), 2);
+    assertEquals((int) numSegmentsToOffloadMap.get("host4"), 0);
+    assertEquals((int) numSegmentsToOffloadMap.get("host5"), -6);
+    assertEquals((int) numSegmentsToOffloadMap.get("host6"), -1);
+    assertEquals((int) numSegmentsToOffloadMap.get("host7"), 1);
+
+    // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
+    // assignment after three steps if strict replica group is disabled . With strict replica groups it should reach
+    // the target assignment in two steps since the full partition must be selected for movement. Only testing this
+    // assignment with isStrictRealtimeSegmentAssignment=false since the assignments usually don't differ for
+    // isStrictRealtimeSegmentAssignment=true. Batch size = 1, unique partitionIds
+    isStrictRealtimeSegmentAssignment = false;
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+      Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+              2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      if (!enableStrictReplicaGroup) {
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host7")));
+        assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__3__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      } else {
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER, isStrictRealtimeSegmentAssignment);
+      }
+      assertEquals(nextAssignment, targetAssignment);
+    }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -2392,7 +2392,7 @@ public class TableRebalancerTest {
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after three steps if strict replica group is disabled . With strict replica groups it should reach
     // the target assignment in two steps since the full partition must be selected for movement.
-    // Batch size = 1, unique partitionIds
+    // Batch size = 2, unique partitionIds
     for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
@@ -2444,6 +2444,67 @@ public class TableRebalancerTest {
             TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
                 2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
       } else {
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__3__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+      }
+      assertEquals(nextAssignment, targetAssignment);
+    }
+
+    // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
+    // assignment after two steps if strict replica group is disabled or enabled. Batch size = 5, unique partitionIds
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+      Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+              5, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+      if (!enableStrictReplicaGroup) {
+        assertNotEquals(nextAssignment, targetAssignment);
+        assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
+        assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__3__1__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        // host5 has reached batchSizePerServer due to which this segment didn't move in the first step
+        assertEquals(nextAssignment.get("segment__3__2__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        nextAssignment =
+            TableRebalancer.getNextAssignment(nextAssignment, targetAssignment, 2, enableStrictReplicaGroup, false,
+                2, segmentToPartitionIdMap, SIMPLE_PARTITION_FETCHER);
+      } else {
+        // This would have completed in a single step for batchSizePerServer = 5 if we did not have an additional check
+        // to only add segments that exceed the batchSizePerServer if no prior segments were already assigned to a
+        // given server
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -1684,7 +1684,7 @@ public class TableRebalancerTest {
     //   },
     //   "segment__4__0__98347869999L": {
     //     "host2": "ONLINE",
-    //     "host3": "ONLINE",
+    //     "host4": "ONLINE",
     //     "host5": "ONLINE"
     //   }
     // }
@@ -1782,22 +1782,22 @@ public class TableRebalancerTest {
     // "segment4" to the target state because "host1" and "host4" might be unavailable for strict replica-group routing,
     // which breaks the minimum available replicas requirement:
     // {
-    //   "segment1": {
+    //   "segment__1__0__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
     //     "host4": "ONLINE"
     //   },
-    //   "segment2": {
+    //   "segment__2__0__98347869999L": {
     //     "host2": "ONLINE",
     //     "host3": "ONLINE",
     //     "host4": "ONLINE"
     //   },
-    //   "segment3": {
+    //   "segment__3__0__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
     //     "host4": "ONLINE"
     //   },
-    //   "segment4": {
+    //   "segment__4__0__98347869999L": {
     //     "host2": "ONLINE",
     //     "host3": "ONLINE",
     //     "host4": "ONLINE"
@@ -1828,15 +1828,15 @@ public class TableRebalancerTest {
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host3": "ONLINE",
-    //     "host4": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -1847,10 +1847,10 @@ public class TableRebalancerTest {
     currentAssignment = new TreeMap<>();
     currentAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
-    currentAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
 
@@ -1861,15 +1861,15 @@ public class TableRebalancerTest {
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host4": "ONLINE",
-    //     "host6": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -1880,10 +1880,10 @@ public class TableRebalancerTest {
     targetAssignment = new TreeMap<>();
     targetAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
-    targetAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
 
@@ -1919,10 +1919,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         nextAssignment =
@@ -1939,17 +1939,17 @@ public class TableRebalancerTest {
     //     "host4": "ONLINE",
     //     "host6": "ONLINE"
     //   },
+    //   "segment__1__1__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
+    //   },
     //   "segment__2__0__98347869999L": {
     //     "host1": "ONLINE",
     //     "host4": "ONLINE",
     //     "host5": "ONLINE"
     //   },
-    //   "segment__3__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host4": "ONLINE",
-    //     "host6": "ONLINE"
-    //   },
-    //   "segment__4__0__98347869999L": {
+    //   "segment__2__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host4": "ONLINE",
     //     "host5": "ONLINE"
@@ -1958,10 +1958,10 @@ public class TableRebalancerTest {
     targetAssignment = new TreeMap<>();
     targetAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
-    targetAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host4", "host5"), ONLINE));
     targetAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host4", "host5"), ONLINE));
     targetAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host4", "host5"), ONLINE));
 
@@ -1985,8 +1985,8 @@ public class TableRebalancerTest {
     assertEquals((int) numSegmentsToOffloadMap.get("host6"), -2);
 
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
-    // assignment after two steps. With strict replica groups it should reach the target assignment immediately since
-    // the full partition must be selected for movement. Batch size = 2, unique partitionIds
+    // assignment after three steps. With strict replica groups it should reach the target assignment in two steps since
+    // the full partition must be selected for movement. Batch size = 1, unique partitionIds
     for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
@@ -1997,10 +1997,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         nextAssignment =
@@ -2009,10 +2009,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host1", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host1", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         nextAssignment =
@@ -2022,10 +2022,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host4")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host5")));
         nextAssignment =
@@ -2045,15 +2045,15 @@ public class TableRebalancerTest {
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host3": "ONLINE",
-    //     "host4": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -2074,10 +2074,10 @@ public class TableRebalancerTest {
     currentAssignment = new TreeMap<>();
     currentAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
-    currentAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    currentAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__3__0__98347869999L",
@@ -2092,15 +2092,15 @@ public class TableRebalancerTest {
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host4": "ONLINE",
-    //     "host6": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -2121,10 +2121,10 @@ public class TableRebalancerTest {
     targetAssignment = new TreeMap<>();
     targetAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
-    targetAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__3__0__98347869999L",
@@ -2163,10 +2163,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host2", "host3")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host3", "host4")));
         assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
@@ -2179,10 +2179,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
@@ -2195,10 +2195,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
@@ -2212,10 +2212,10 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__3__0__98347869999L").keySet(),
@@ -2239,11 +2239,6 @@ public class TableRebalancerTest {
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host3": "ONLINE",
-    //     "host4": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
@@ -2253,6 +2248,11 @@ public class TableRebalancerTest {
     //     "host1": "ONLINE",
     //     "host2": "ONLINE",
     //     "host3": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host3": "ONLINE",
+    //     "host4": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -2283,12 +2283,12 @@ public class TableRebalancerTest {
     currentAssignment = new TreeMap<>();
     currentAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
-    currentAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
     currentAssignment.put("segment__1__2__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host6"), ONLINE));
+    currentAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
     currentAssignment.put("segment__2__2__98347869999L",
@@ -2307,11 +2307,6 @@ public class TableRebalancerTest {
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
     //   },
-    //   "segment__2__0__98347869999L": {
-    //     "host2": "ONLINE",
-    //     "host4": "ONLINE",
-    //     "host6": "ONLINE"
-    //   },
     //   "segment__1__1__98347869999L": {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
@@ -2321,6 +2316,11 @@ public class TableRebalancerTest {
     //     "host1": "ONLINE",
     //     "host3": "ONLINE",
     //     "host5": "ONLINE"
+    //   },
+    //   "segment__2__0__98347869999L": {
+    //     "host2": "ONLINE",
+    //     "host4": "ONLINE",
+    //     "host6": "ONLINE"
     //   },
     //   "segment__2__1__98347869999L": {
     //     "host2": "ONLINE",
@@ -2351,12 +2351,12 @@ public class TableRebalancerTest {
     targetAssignment = new TreeMap<>();
     targetAssignment.put("segment__1__0__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
-    targetAssignment.put("segment__2__0__98347869999L",
-        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__1__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
     targetAssignment.put("segment__1__2__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host3", "host5"), ONLINE));
+    targetAssignment.put("segment__2__0__98347869999L",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__2__1__98347869999L",
         SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host4", "host6"), ONLINE));
     targetAssignment.put("segment__2__2__98347869999L",
@@ -2391,9 +2391,8 @@ public class TableRebalancerTest {
 
     // Next assignment with 2 minimum available replicas without strict replica-group should reach the target
     // assignment after three steps if strict replica group is disabled . With strict replica groups it should reach
-    // the target assignment in two steps since the full partition must be selected for movement. Only testing this
-    // assignment with isStrictRealtimeSegmentAssignment=false since the assignments usually don't differ for
-    // isStrictRealtimeSegmentAssignment=true. Batch size = 1, unique partitionIds
+    // the target assignment in two steps since the full partition must be selected for movement.
+    // Batch size = 1, unique partitionIds
     for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
       Object2IntOpenHashMap<String> segmentToPartitionIdMap = new Object2IntOpenHashMap<>();
       nextAssignment =
@@ -2403,12 +2402,12 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
         assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host6")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
@@ -2425,12 +2424,12 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
         assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),
@@ -2448,12 +2447,12 @@ public class TableRebalancerTest {
         assertNotEquals(nextAssignment, targetAssignment);
         assertEquals(nextAssignment.get("segment__1__0__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
-        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
-            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__1__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
         assertEquals(nextAssignment.get("segment__1__2__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host1", "host3", "host5")));
+        assertEquals(nextAssignment.get("segment__2__0__98347869999L").keySet(),
+            new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__1__98347869999L").keySet(),
             new TreeSet<>(Arrays.asList("host2", "host4", "host6")));
         assertEquals(nextAssignment.get("segment__2__2__98347869999L").keySet(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -164,6 +164,74 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
   }
 
   @Test
+  public void testRebalanceWithBatching()
+      throws Exception {
+    populateTables();
+
+    verifyIdealState(5, NUM_SERVERS);
+
+    // setup the rebalance config
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setDryRun(false);
+    rebalanceConfig.setMinAvailableReplicas(0);
+    rebalanceConfig.setIncludeConsuming(true);
+    rebalanceConfig.setBatchSizePerServer(1);
+
+    // Add a new server
+    BaseServerStarter serverStarter1 = startOneServer(NUM_SERVERS);
+
+    // Now we trigger a rebalance operation
+    TableConfig tableConfig = _resourceManager.getTableConfig(REALTIME_TABLE_NAME);
+    RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+
+    // Check the number of replicas after rebalancing
+    int finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+
+    // Check that a replica has been added
+    assertEquals(finalReplicas, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");
+
+    waitForRebalanceToComplete(rebalanceResult, 600_000L);
+    waitForAllDocsLoaded(600_000L);
+
+    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, finalReplicas);
+
+    // Add a new server
+    BaseServerStarter serverStarter2 = startOneServer(NUM_SERVERS + 1);
+    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+
+    // Check the number of replicas after rebalancing
+    finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+
+    // Check that a replica has been added
+    assertEquals(finalReplicas, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
+
+    waitForRebalanceToComplete(rebalanceResult, 600_000L);
+    waitForAllDocsLoaded(600_000L);
+
+    // number of instances assigned can't be more than number of partitions for rf = 1
+    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, getNumKafkaPartitions());
+
+    _resourceManager.updateInstanceTags(serverStarter1.getInstanceId(), "", false);
+    _resourceManager.updateInstanceTags(serverStarter2.getInstanceId(), "", false);
+
+    rebalanceConfig.setReassignInstances(true);
+    rebalanceConfig.setDowntime(true);
+
+    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+
+    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, NUM_SERVERS);
+
+    waitForRebalanceToComplete(rebalanceResult, 600_000L);
+    waitForAllDocsLoaded(600_000L);
+
+    serverStarter1.stop();
+    serverStarter2.stop();
+    TestUtils.waitForCondition(aVoid -> _resourceManager.dropInstance(serverStarter1.getInstanceId()).isSuccessful()
+            && _resourceManager.dropInstance(serverStarter2.getInstanceId()).isSuccessful(), 60_000L,
+        "Failed to drop servers");
+  }
+
+  @Test
   public void testReload()
       throws Exception {
     pushAvroIntoKafka(_avroFiles);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -116,26 +116,29 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     TableConfig tableConfig = _resourceManager.getTableConfig(REALTIME_TABLE_NAME);
     RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of replicas after rebalancing
-    int finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    // Check the number of servers after rebalancing
+    int finalServer
 
-    // Check that a replica has been added
-    assertEquals(finalReplicas, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");
+
+    s = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+
+    // Check that a server has been added
+    assertEquals(finalServers, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");
 
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);
 
-    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, finalReplicas);
+    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, finalServers);
 
     // Add a new server
     BaseServerStarter serverStarter2 = startOneServer(NUM_SERVERS + 1);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of replicas after rebalancing
-    finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    // Check the number of servers after rebalancing
+    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
 
-    // Check that a replica has been added
-    assertEquals(finalReplicas, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
+    // Check that a server has been added
+    assertEquals(finalServers, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
 
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);
@@ -184,26 +187,26 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     TableConfig tableConfig = _resourceManager.getTableConfig(REALTIME_TABLE_NAME);
     RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of replicas after rebalancing
-    int finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    // Check the number of servers after rebalancing
+    int finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
 
-    // Check that a replica has been added
-    assertEquals(finalReplicas, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");
+    // Check that a server has been added
+    assertEquals(finalServers, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");
 
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);
 
-    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, finalReplicas);
+    verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, finalServers);
 
     // Add a new server
     BaseServerStarter serverStarter2 = startOneServer(NUM_SERVERS + 1);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of replicas after rebalancing
-    finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    // Check the number of servers after rebalancing
+    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
 
-    // Check that a replica has been added
-    assertEquals(finalReplicas, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
+    // Check that a server has been added
+    assertEquals(finalServers, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
 
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -117,9 +117,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
     // Check the number of servers after rebalancing
-    int finalServer
-
-    s = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    int finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
 
     // Check that a server has been added
     assertEquals(finalServers, NUM_SERVERS + 1, "Rebalancing didn't correctly add the new server");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -119,7 +119,6 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     // Check the number of servers after rebalancing
     int finalServer
 
-
     s = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
 
     // Check that a server has been added

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -35,8 +35,8 @@ public class PinotTableRebalancer extends PinotZKChanger {
 
   public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
       boolean includeConsuming, Enablement minimizeDataMovement, boolean bootstrap, boolean downtime,
-      int minReplicasToKeepUpForNoDowntime, boolean lowDiskMode, boolean bestEffort, long externalViewCheckIntervalInMs,
-      long externalViewStabilizationTimeoutInMs) {
+      int minReplicasToKeepUpForNoDowntime, int batchSizePerServer, boolean lowDiskMode, boolean bestEffort,
+      long externalViewCheckIntervalInMs, long externalViewStabilizationTimeoutInMs) {
     super(zkAddress, clusterName);
     _rebalanceConfig.setDryRun(dryRun);
     _rebalanceConfig.setReassignInstances(reassignInstances);
@@ -45,6 +45,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
     _rebalanceConfig.setBootstrap(bootstrap);
     _rebalanceConfig.setDowntime(downtime);
     _rebalanceConfig.setMinAvailableReplicas(minReplicasToKeepUpForNoDowntime);
+    _rebalanceConfig.setBatchSizePerServer(batchSizePerServer);
     _rebalanceConfig.setLowDiskMode(lowDiskMode);
     _rebalanceConfig.setBestEfforts(bestEffort);
     _rebalanceConfig.setExternalViewCheckIntervalInMs(externalViewCheckIntervalInMs);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -78,6 +78,11 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
           + "number of replicas allowed to be unavailable if value is negative (-1 by default)")
   private int _minAvailableReplicas = -1;
 
+  @CommandLine.Option(names = {"-batchSizePerServer"},
+      description = "Batch size per server to use to batch segments updated in IdealState per rebalance step. "
+          + "If set to -1, disables batching (-1 by default)")
+  private int _batchSizePerServer = -1;
+
   @CommandLine.Option(names = {"-lowDiskMode"}, description =
       "For no-downtime rebalance, whether to enable low disk mode during rebalance. When enabled, "
           + "segments will first be offloaded from servers, then added to servers after offload is done while "
@@ -112,8 +117,8 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
     //       the default pre-checker
     PinotTableRebalancer tableRebalancer =
         new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming,
-            _minimizeDataMovement, _bootstrap, _downtime, _minAvailableReplicas, _lowDiskMode, _bestEfforts,
-            _externalViewCheckIntervalInMs, _externalViewStabilizationTimeoutInMs);
+            _minimizeDataMovement, _bootstrap, _downtime, _minAvailableReplicas, _batchSizePerServer, _lowDiskMode,
+            _bestEfforts, _externalViewCheckIntervalInMs, _externalViewStabilizationTimeoutInMs);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);
     LOGGER
         .info("Got rebalance result: {} for table: {}", JsonUtils.objectToString(rebalanceResult), _tableNameWithType);
@@ -188,6 +193,13 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
     System.out.println(
         "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "
             + "myTable_OFFLINE -minAvailableReplicas -1");
+    System.out.println();
+
+    System.out.println(
+        "Rebalance table with batch size per server specified to enable batching.");
+    System.out.println(
+        "sh pinot-admin.sh RebalanceTable -zkAddress localhost:2191 -clusterName PinotCluster -tableName "
+            + "myTable_OFFLINE -batchSizePerServer 10");
     System.out.println();
 
     System.out.println(


### PR DESCRIPTION
This PR adds support for server-level batching (i.e. how many segment adds to batch at a server level) in Table rebalance. A new `RebalanceConfig` called `batchSizePerServer` has also been added. By default batching is disabled by setting `batchSizePerServer=Integer.MAX_VALUE`.

### Problem Statement
Today Table Rebalance performs rebalance in multiple steps. In each step, for every segment we calculate the `getNextSingleSegmentAssignment` keeping the minAvailableReplicas invariant intact as much as possible, and update the IdealState based on that. If there are a large number of segments and most of them need to be moved as part of rebalance, this can lead to a very large number of changes in the IdealState which translates to a large number of STATE_TRANSITION messages for the servers. This can also cause non-rebalance related STATE_TRANSITION messages to get backed up behind the rebalance related ones and cause delays in processing them.

### Solution
To tackle the above, this PR adds batching support at the server-level. Batching works differently for non-strict replica group based and strict replica group based:

- **Non-strict replica group:** try to add as many segments as possible based on `getNextSingleSegmentAssignment` without going over `batchSizePerServer` for any server and without splitting up the `getNextSingleSegmentAssignment` into further steps. It tracks the `segmentsAddedSoFar` in a given nextAssignment calculation for each server. It is possible to have fewer than `batchSizePerServer` for some servers if we run out of segments to add without violating the `batchSizePerServer` for any given server.
- **Strict replica group:** these need to be moved as a whole partition to keep the consistency invariant. Due to this just choosing segments at random is not possible. Instead the segments are grouped by `partitionId` and all segments of a given `partitionId` are chosen to be moved even if this violates the `batchSizePerServer`. Once this threshold is hit for a given server, no further partitions will be moved that will affect that server. Thus this batching is best efforts only.

This proposal document covers the considerations in more detail: https://docs.google.com/document/d/1Pz49QbGjs93FfeMjHJdR0DmLUPpYEDpJW9Fid9Gb3hw/edit?usp=sharing

### Testing
- Added some tests
- Tried this out manually and locally in `HybridQuickStart` for an OFFLINE table and forcing a REALTIME table to be assigned with `StrictRealtimeSegmentAssignment` and setup with strict replica group based routing config. (added some delays to processing segment state transitions to watch how the progress is made via progress stats)
- Validated that existing rebalance related tests that don't do batching pass as well
- Also tested table rebalance cancellation. With batching the existing cancellation mechanism will be more responsive, in the sense that there will be fewer IS updates in each batch, so when we cancel the rebalance job will be stopped sooner and fewer IS updates will need to complete. Just a note that cancellation does not rollback IS updates, it just stops new updates from getting added.

For changes made to UI and `RebalanceTableCommand`:
- Tested command:
```
./build/bin/pinot-admin.sh RebalanceTable -batchSizePerServer=2 -tableName=airlineStats_OFFLINE -clusterName=QuickStartCluster -zkAddress=localhost:2123 
```
- UI screenshot (also ran rebalance and validated that it picks up the `batchSizePerServer` correctly):
<img width="967" alt="Screenshot 2025-04-23 at 09 11 53" src="https://github.com/user-attachments/assets/fc116ad2-3b8f-439d-a58a-eadd491c95bb" />