### PR TITLE
Dynamic timeout for EV convergence in table rebalance

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -239,10 +239,6 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
     return _tableRebalanceContext;
   }
 
-  public TableRebalanceProgressStats.RebalanceProgressStats getOverallStats() {
-    return _tableRebalanceProgressStats.getRebalanceProgressStatsOverall();
-  }
-
   private void trackStatsInZk() {
     Map<String, String> jobMetadata =
         createJobMetadata(_tableNameWithType, _rebalanceJobId, _tableRebalanceProgressStats, _tableRebalanceContext);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -239,6 +239,10 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
     return _tableRebalanceContext;
   }
 
+  public TableRebalanceProgressStats.RebalanceProgressStats getOverallStats() {
+    return _tableRebalanceProgressStats.getRebalanceProgressStatsOverall();
+  }
+
   private void trackStatsInZk() {
     Map<String, String> jobMetadata =
         createJobMetadata(_tableNameWithType, _rebalanceJobId, _tableRebalanceProgressStats, _tableRebalanceContext);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -1299,8 +1299,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 1);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 1);
       }
     }
 
@@ -1309,8 +1310,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
       }
     }
 
@@ -1321,8 +1323,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
       }
     }
 
@@ -1332,8 +1335,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
       }
     }
 
@@ -1344,8 +1348,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 2);
       }
     }
 
@@ -1356,8 +1361,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertFalse(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 1);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 1);
       }
     }
 
@@ -1368,8 +1374,9 @@ public class TableRebalancerTest {
       for (boolean bestEfforts : falseAndTrue) {
         assertTrue(TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates,
             idealStateSegmentStates, lowDiskMode, bestEfforts, null));
-        assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
-            idealStateSegmentStates, lowDiskMode, bestEfforts, null), 0);
+        assertEquals(
+            TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
+                idealStateSegmentStates, lowDiskMode, bestEfforts, null), 0);
       }
     }
 
@@ -1381,12 +1388,12 @@ public class TableRebalancerTest {
       assertTrue(
           TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
               false, bestEfforts, null));
-      assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
+      assertEquals(TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
           idealStateSegmentStates, false, bestEfforts, null), 0);
       assertFalse(
           TableRebalancer.isExternalViewConverged(offlineTableName, externalViewSegmentStates, idealStateSegmentStates,
               true, bestEfforts, null));
-      assertEquals(TableRebalancer.getNumRemainingSegmentsToProcess(offlineTableName, externalViewSegmentStates,
+      assertEquals(TableRebalancer.getNumRemainingSegmentReplicasToProcess(offlineTableName, externalViewSegmentStates,
           idealStateSegmentStates, true, bestEfforts, null), 3);
     }
 


### PR DESCRIPTION
## Description
It is usually difficult to decide the timeout (`externalViewStabilizationTimeoutInMs`). Consequently, some larger tables fail to finish a rebalance job because they take longer than normal and need to be manually re-triggered.

## Change in PR
This PR tracks the number of remaining segments to process in the current EV-IS convergence, and checks this number each time the timeout has been reached. If the number is lower than last time it checked, another new session for timeout is granted to carry out the EV-IS convergence, otherwise the timeout exception is thrown as what it does now.

For job with `lowDiskMode=true`, the number is the sum of remaining segments to be added, added but not in the same state as IdealState, and to be deleted. For `lowDiskMode=false` it's the number of remaining segments to be added, and added but not in the same state as IdealState, as the convergence check only look for these segments.

For job with `bestEfforts=true`, we do not grant any extra new timeout session after the first one (i.e. it checks if EV-IS converges in `externalViewStabilizationTimeoutInMs`, if not converged at the end it still moves on anyway)

## Issue
~~This change only applies to rebalance jobs triggered from controller API, other rebalance jobs like the periodic `segmentRelocator` does not have `ZkBasedTableRebalanceObserver` passed to the `TableRebalancer` and thus no progress is tracked so as to enable the dynamic timeout.~~

^ This has been solved by switching to not using `ZkBasedTableRebalanceObserver` to get the number of remaining segments.

## Manual Testing
Using a local setup, a table with 2000 segments and replicated by 2 on 2 servers. Rebalance to the other 2 servers with `minAvailableReplica=-1`, set `externalViewStabilizationTimeoutInMs=15000`
Server side has a `Thread.sleep((long) (Math.random() * 4_000) + 1_000);` for OFFLINE -> ONLINE transition (`onBecomeOnlineFromOffline`) to simulate the load.

Cherry picked the metrics from [this PR](https://github.com/apache/pinot/pull/15650) and observe the progress

### Rebalance succeed (timeout session extended)

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/aaf0555c-4f92-466e-9b31-358224f257f1" />

Also check the log:
```2025/05/02 16:13:20.700 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Start rebalancing with dryRun: true, preChecks: false, reassignInstances: true, includeConsuming: true, bootstrap: false, downtime: false, minReplicasToKeepUpForNoDowntime: -1, enableStrictReplicaGroup: false, lowDiskMode: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 15000, minimizeDataMovement: ENABLE
2025/05/02 16:13:20.702 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Processing instance partitions
2025/05/02 16:13:20.702 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] OFFLINE instance assignment is not allowed, using default instance partitions for table: jhow_OFFLINE
2025/05/02 16:13:20.704 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Calculating the target assignment
2025/05/02 16:13:20.737 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] instancePartitionsUnchanged: true, tierInstancePartitionsUnchanged: true, segmentAssignmentUnchanged: false
2025/05/02 16:13:20.737 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Fetching the table size
2025/05/02 16:13:20.796 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Fetched the table size details
2025/05/02 16:13:20.796 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Calculating rebalance summary
2025/05/02 16:13:20.799 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Calculated rebalance summary
2025/05/02 16:13:20.799 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [grizzly-http-server-8] Rebalancing in dry-run mode, returning the target assignment
2025/05/02 16:13:20.801 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Start rebalancing with dryRun: false, preChecks: false, reassignInstances: true, includeConsuming: true, bootstrap: false, downtime: false, minReplicasToKeepUpForNoDowntime: -1, enableStrictReplicaGroup: false, lowDiskMode: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 15000, minimizeDataMovement: ENABLE
2025/05/02 16:13:20.802 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Processing instance partitions
2025/05/02 16:13:20.802 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] OFFLINE instance assignment is not allowed, using default instance partitions for table: jhow_OFFLINE
2025/05/02 16:13:20.803 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Calculating the target assignment
2025/05/02 16:13:20.816 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] instancePartitionsUnchanged: true, tierInstancePartitionsUnchanged: true, segmentAssignmentUnchanged: false
2025/05/02 16:13:20.816 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Fetching the table size
2025/05/02 16:13:20.862 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Fetched the table size details
2025/05/02 16:13:20.862 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Calculating rebalance summary
2025/05/02 16:13:20.864 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Calculated rebalance summary
2025/05/02 16:13:20.878 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Rebalancing with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 15000
2025/05/02 16:13:20.878 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Waiting for ExternalView to converge, 1000 segments to monitor in current step
2025/05/02 16:13:20.881 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] ExternalView converged in 3ms, with 0 extensions
2025/05/02 16:13:20.911 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Got the next assignment with number of segments to be added/removed for each instance: {Server_100.114.242.49_8003=<1000,0>, Server_100.114.242.49_8098=<0,1000>}
2025/05/02 16:13:20.946 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Successfully updated the IdealState
2025/05/02 16:13:20.946 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Waiting for ExternalView to converge, 1000 segments to monitor in current step
2025/05/02 16:13:20.955 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Remaining 1000 segments to be processed.
2025/05/02 16:13:36.141 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 920 segments to be processed.
2025/05/02 16:13:51.338 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 801 segments to be processed.
2025/05/02 16:14:06.531 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 698 segments to be processed.
2025/05/02 16:14:21.749 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 594 segments to be processed.
2025/05/02 16:14:36.956 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 480 segments to be processed.
2025/05/02 16:14:52.157 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 364 segments to be processed.
2025/05/02 16:15:07.389 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 261 segments to be processed.
2025/05/02 16:15:22.616 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 152 segments to be processed.
2025/05/02 16:15:37.812 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 39 segments to be processed.
2025/05/02 16:15:42.883 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] ExternalView converged in 141937ms, with 9 extensions
2025/05/02 16:15:42.895 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Got the next assignment with number of segments to be added/removed for each instance: {Server_100.114.242.49_8002=<0,1000>, Server_100.114.242.49_8004=<1000,0>}
2025/05/02 16:15:42.923 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Successfully updated the IdealState
2025/05/02 16:15:42.923 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Waiting for ExternalView to converge, 1000 segments to monitor in current step
2025/05/02 16:15:42.930 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Remaining 1000 segments to be processed.
2025/05/02 16:15:58.155 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 920 segments to be processed.
2025/05/02 16:16:13.346 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 800 segments to be processed.
2025/05/02 16:16:28.532 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 695 segments to be processed.
2025/05/02 16:16:43.736 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 599 segments to be processed.
2025/05/02 16:16:58.933 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 480 segments to be processed.
2025/05/02 16:17:14.144 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 365 segments to be processed.
2025/05/02 16:17:29.386 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 257 segments to be processed.
2025/05/02 16:17:44.601 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 151 segments to be processed.
2025/05/02 16:17:59.795 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Extending EV stabilization timeout for another 15000ms, remaining 40 segments to be processed.
2025/05/02 16:18:04.893 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] ExternalView converged in 141970ms, with 9 extensions
2025/05/02 16:18:04.895 INFO [TableRebalancer-jhow_OFFLINE-b646148f-18de-4bdd-a79d-d5cfa6a10359] [jersey-server-managed-async-executor-0] Finished rebalancing with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: false in 284092 ms.
```

### Rebalance timeout and failed (timeout session did not extended)

Make it `Thread.sleep((long) (Math.random() * 4_000) + 14_000);` for OFFLINE -> ONLINE transition (`onBecomeOnlineFromOffline`) to simulate the heavier load.
Again rebalance with `externalViewStabilizationTimeoutInMs=15000`, expect a timeout:

<img width="976" alt="image" src="https://github.com/user-attachments/assets/dd586f3f-171e-41e2-8bf9-bfc5b04066c0" />


```
2025/05/02 16:00:08.461 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Start rebalancing with dryRun: true, preChecks: false, reassignInstances: true, includeConsuming: true, bootstrap: false, downtime: false, minReplicasToKeepUpForNoDowntime: -1, enableStrictReplicaGroup: false, lowDiskMode: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 5000, minimizeDataMovement: ENABLE
2025/05/02 16:00:08.463 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Processing instance partitions
2025/05/02 16:00:08.464 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] OFFLINE instance assignment is not allowed, using default instance partitions for table: jhow_OFFLINE
2025/05/02 16:00:08.466 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Calculating the target assignment
2025/05/02 16:00:08.479 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] instancePartitionsUnchanged: true, tierInstancePartitionsUnchanged: true, segmentAssignmentUnchanged: false
2025/05/02 16:00:08.479 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Fetching the table size
2025/05/02 16:00:08.544 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Fetched the table size details
2025/05/02 16:00:08.544 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Calculating rebalance summary
2025/05/02 16:00:08.546 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Calculated rebalance summary
2025/05/02 16:00:08.546 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [grizzly-http-server-10] Rebalancing in dry-run mode, returning the target assignment
2025/05/02 16:00:08.548 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Start rebalancing with dryRun: false, preChecks: false, reassignInstances: true, includeConsuming: true, bootstrap: false, downtime: false, minReplicasToKeepUpForNoDowntime: -1, enableStrictReplicaGroup: false, lowDiskMode: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 5000, minimizeDataMovement: ENABLE
2025/05/02 16:00:08.549 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Processing instance partitions
2025/05/02 16:00:08.549 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] OFFLINE instance assignment is not allowed, using default instance partitions for table: jhow_OFFLINE
2025/05/02 16:00:08.550 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Calculating the target assignment
2025/05/02 16:00:08.557 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] instancePartitionsUnchanged: true, tierInstancePartitionsUnchanged: true, segmentAssignmentUnchanged: false
2025/05/02 16:00:08.557 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Fetching the table size
2025/05/02 16:00:08.600 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Fetched the table size details
2025/05/02 16:00:08.600 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Calculating rebalance summary
2025/05/02 16:00:08.602 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Calculated rebalance summary
2025/05/02 16:00:08.618 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Rebalancing with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: false, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 5000
2025/05/02 16:00:08.618 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Waiting for ExternalView to converge, 1000 segments to monitor in current step
2025/05/02 16:00:08.621 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] ExternalView converged
2025/05/02 16:00:08.642 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Got the next assignment with number of segments to be added/removed for each instance: {Server_100.114.242.49_8002=<1000,0>, Server_100.114.242.49_8004=<0,1000>}
2025/05/02 16:00:08.657 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Successfully updated the IdealState
2025/05/02 16:00:08.657 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Waiting for ExternalView to converge, 1000 segments to monitor in current step
2025/05/02 16:00:08.667 INFO [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Remaining 1000 segments to be processed.
2025/05/02 16:00:13.725 WARN [TableRebalancer-jhow_OFFLINE-5ac1938a-24fc-420c-85fb-c3c38b8645a9] [jersey-server-managed-async-executor-0] Caught exception while waiting for ExternalView to converge, aborting the rebalance: ExternalView has not made progress for the last 5000ms, timeout after spending 5068ms waiting (0 extensions)
```

### Rebalance timeout and failed due to force commit while rebalancing (timeout session did not extend)

Using a local setup, a table with 10 consuming segments and replicated by 2 on 2 servers. Rebalance to the other 2 servers with `minAvailableReplica=-1`, set `externalViewStabilizationTimeoutInMs=30000`

Set `Thread.sleep((long) (Math.random() * 10_000) + 10_000);` for OFFLINE -> ONLINE transition, CONSUMING -> ONLINE transition, OFFLINE -> CONSUMING transition.

After the rebalance started, sent a forceCommit request to change the consuming segments ideal states on the fly.

![image](https://github.com/user-attachments/assets/19485a56-081b-4790-925c-a533edf0a856)

Notice that the progress dropped because some converged CONSUMING segments got their ideal states change to ONLINE. And it resulted in a timeout. Even though servers are making progress, but the "net progress" was not moving forward and thus the job was timeout.

The same job could complete without forceCommit:

![image](https://github.com/user-attachments/assets/c6f1a01e-eb29-4a2a-aae6-d73347213171)

### Rebalance with `bestEfforts=true` and EV-IS does not make progress

```
...
2025/05/06 14:28:29.925 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Rebalancing with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: true, externalViewCheckIntervalInMs: 1000, externalViewStabilizationTimeoutInMs: 15000
2025/05/06 14:28:29.925 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Starting EV-IS convergence check loop, 1000 segments to monitor in current step
2025/05/06 14:28:29.927 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] ExternalView converged in 2ms, with 0 extensions
2025/05/06 14:28:29.935 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Got the next assignment with number of segments to be added/removed for each instance: {Server_100.114.242.49_8002=<1000,0>, Server_100.114.242.49_8004=<0,1000>}
2025/05/06 14:28:29.947 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Successfully updated the IdealState
2025/05/06 14:28:29.947 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Starting EV-IS convergence check loop, 1000 segments to monitor in current step
2025/05/06 14:28:29.955 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Remaining 1000 segments to be processed.
2025/05/06 14:28:45.133 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Extending EV stabilization timeout for another 15000ms, remaining 920 segments to be processed. (Extension count: 1)
2025/05/06 14:29:00.324 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Extending EV stabilization timeout for another 15000ms, remaining 800 segments to be processed. (Extension count: 2)
2025/05/06 14:29:15.506 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Extending EV stabilization timeout for another 15000ms, remaining 695 segments to be processed. (Extension count: 3)
2025/05/06 14:29:30.661 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Extending EV stabilization timeout for another 15000ms, remaining 640 segments to be processed. (Extension count: 4)
2025/05/06 14:29:45.809 WARN [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] ExternalView has not made progress for the last 15000ms, stop waiting after spending 75862ms waiting (4 extensions), continuing the rebalance (best-efforts)
2025/05/06 14:29:45.826 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Got the next assignment with number of segments to be added/removed for each instance: {Server_100.114.242.49_8003=<0,1000>, Server_100.114.242.49_8098=<1000,0>}
2025/05/06 14:29:45.837 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Successfully updated the IdealState
2025/05/06 14:29:45.837 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Starting EV-IS convergence check loop, 1000 segments to monitor in current step
2025/05/06 14:29:45.845 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Remaining 1640 segments to be processed.
2025/05/06 14:30:01.002 WARN [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] ExternalView has not made progress for the last 15000ms, stop waiting after spending 15165ms waiting (0 extensions), continuing the rebalance (best-efforts)
2025/05/06 14:30:01.003 INFO [TableRebalancer-jhow_OFFLINE-68b5cab3-dba2-402b-90e1-50e70201718d] [jersey-server-managed-async-executor-3] Finished rebalancing with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: true in 91141 ms.
```