### PR TITLE
Add a button to view consuming segments info directly in table UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/ConsumingSegmentsTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/ConsumingSegmentsTable.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import React from 'react';
 import { Typography, List, ListItem, ListItemText } from '@material-ui/core';
 import CustomizedTables from '../components/Table';

--- a/pinot-controller/src/main/resources/app/components/ConsumingSegmentsTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/ConsumingSegmentsTable.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Typography, List, ListItem, ListItemText } from '@material-ui/core';
+import CustomizedTables from '../components/Table';
+import type { ConsumingSegmentsInfo } from 'Models';
+
+type Props = {
+  info: ConsumingSegmentsInfo;
+};
+
+const ConsumingSegmentsTable: React.FC<Props> = ({ info }) => {
+  const segmentMap = info?._segmentToConsumingInfoMap ?? {};
+  const entries = Object.entries(segmentMap);
+
+  if (entries.length === 0) {
+    return <Typography>No consuming segment data available.</Typography>;
+  }
+
+  const columns = [
+    'Segment Name',
+    'Server Details',
+    'Max Partition Offset Lag',
+    'Max Partition Availability Lag (ms)',
+  ];
+
+  const records = entries
+    .map(([segment, infos]) => {
+      const list = infos ?? [];
+      if (list.length === 0) {
+        return null;
+      }
+      let segmentMaxOffsetLag = 0;
+      let segmentMaxAvailabilityLag = 0;
+
+      const serverDetails = list.map((item) => {
+        const lags = Object.values(item.partitionOffsetInfo?.recordsLagMap ?? {});
+        const avails = Object.values(item.partitionOffsetInfo?.availabilityLagMsMap ?? {});
+        const serverLag = lags
+          .filter((lag) => lag != null && Number(lag) > -1)
+          .reduce((max, lag) => Math.max(max, Number(lag)), 0);
+        const serverAvail = avails
+          .filter((av) => av != null && Number(av) > -1)
+          .reduce((max, av) => Math.max(max, Number(av)), 0);
+        segmentMaxOffsetLag = Math.max(segmentMaxOffsetLag, serverLag);
+        segmentMaxAvailabilityLag = Math.max(segmentMaxAvailabilityLag, serverAvail);
+        return {
+          serverName: item.serverName,
+          consumerState: item.consumerState,
+          lag: serverLag,
+          availabilityMs: serverAvail,
+        };
+      });
+      if (serverDetails.length === 0) {
+        return null;
+      }
+      return [
+        segment,
+        {
+          customRenderer: (
+            <List dense disablePadding style={{ width: '100%' }}>
+              {serverDetails.map((detail, idx) => (
+                <ListItem key={idx} dense disableGutters style={{ padding: '2px 0' }}>
+                  <ListItemText
+                    primary={`${detail.serverName}: ${detail.consumerState}`}
+                    secondary={`Lag: ${detail.lag}, Availability: ${detail.availabilityMs}ms`}
+                    primaryTypographyProps={{ variant: 'body2', style: { fontWeight: 500 } }}
+                    secondaryTypographyProps={{ variant: 'caption', color: 'textSecondary' }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          ),
+        },
+        segmentMaxOffsetLag,
+        segmentMaxAvailabilityLag,
+      ];
+    })
+    .filter(Boolean) as any[];
+
+  if (records.length === 0) {
+    return <Typography>Consuming segment data found, but no server details available.</Typography>;
+  }
+
+  return (
+    <CustomizedTables
+      title="Consuming Segments Summary"
+      data={{ columns, records }}
+      showSearchBox={true}
+    />
+  );
+};
+
+export default ConsumingSegmentsTable;

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -128,6 +128,31 @@ declare module 'Models' {
 
   export type QuerySchemas = Array<string>;
 
+  /**
+   * Information about a consuming segment on a server
+   */
+  export interface ConsumingInfo {
+    serverName: string;
+    consumerState: string;
+    lastConsumedTimestamp: number;
+    partitionToOffsetMap: Record<string, string>;
+    partitionOffsetInfo: {
+      currentOffsetsMap: Record<string, string>;
+      latestUpstreamOffsetMap: Record<string, string>;
+      recordsLagMap: Record<string, string>;
+      availabilityLagMsMap: Record<string, string>;
+    };
+  }
+
+  /**
+   * Consuming segments information for a table
+   */
+  export interface ConsumingSegmentsInfo {
+    serversFailingToRespond: number;
+    serversUnparsableRespond: number;
+    _segmentToConsumingInfoMap: Record<string, ConsumingInfo[]>;
+  }
+
   export type TableSchema = {
     dimensionFieldSpecs: Array<schema>;
     metricFieldSpecs?: Array<schema>;

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -794,7 +794,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
                     const columns = [
                       'Segment Name',
                       'Server Details',
-                      'Total Segment Lag',
+                      'Max Partition Offset Lag',
                       'Max Partition Availability Lag (ms)',
                     ];
                     const records = [];

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -784,9 +784,11 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
             disableBackdropClick
           >
             {loadingConsumingSegments ? (
-              <Typography>Loading consuming segments info...</Typography>
+              <Box display="flex" justifyContent="center">
+                <CircularProgress />
+              </Box>
             ) : consumingSegmentsInfo ? (
-              <Box style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+              <Box style={{ height: '100%', overflowY: 'auto' }}>
                 <Typography><strong>Servers Failing To Respond:</strong> {consumingSegmentsInfo.serversFailingToRespond || 'N/A'}</Typography>
                 <Typography><strong>Servers Unparsable Respond:</strong> {consumingSegmentsInfo.serversUnparsableRespond || 'N/A'}</Typography>
                 <Box mt={2}>

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -45,10 +45,12 @@ import {
   SegmentDebugDetails,
   QuerySchemas,
   TableType,
-  InstanceState, SegmentMetadata,
+  InstanceState,
+  SegmentMetadata,
   SchemaInfo,
   SegmentStatusInfo,
-  ServerToSegmentsCount
+  ServerToSegmentsCount,
+  ConsumingSegmentsInfo
 } from 'Models';
 
 const headers = {
@@ -109,6 +111,11 @@ export const getServerToSegmentsCount = (name: string, tableType: TableType, ver
 
 export const getSegmentsStatus = (name: string): Promise<AxiosResponse<SegmentStatusInfo[]>> =>
   baseApi.get(`/tables/${name}/segmentsStatus`);
+
+// Fetch consuming segments information for a table
+// API: GET /tables/{tableName}/consumingSegmentsInfo
+export const getConsumingSegmentsInfo = (name: string): Promise<AxiosResponse<ConsumingSegmentsInfo>> =>
+  baseApi.get(`/tables/${name}/consumingSegmentsInfo`);
 
 export const getInstances = (): Promise<AxiosResponse<Instances>> =>
   baseApi.get('/instances');

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -108,6 +108,7 @@ import {
   getTaskRuntimeConfig,
   getSchemaInfo,
   getSegmentsStatus,
+  getConsumingSegmentsInfo,
   getServerToSegmentsCount
 } from '../requests';
 import { baseApi } from './axios-config';
@@ -431,7 +432,14 @@ const getAllSchemaDetails = async (schemaList) => {
     columns: allSchemaDetailsColumnHeader,
     records: schemaDetails
   };
-}
+};
+
+// Fetch consuming segments info for a given table
+// API: /tables/{tableName}/consumingSegmentsInfo
+// Expected Output: ConsumingSegmentsInfo
+const getConsumingSegmentsInfoData = (tableName) => {
+  return getConsumingSegmentsInfo(tableName).then(({ data }) => data);
+};
 
 const allTableDetailsColumnHeader = [
   'Table Name',
@@ -1389,5 +1397,6 @@ export default {
   updateUser,
   getAuthUserNameFromAccessToken,
   getAuthUserEmailFromAccessToken,
-  fetchServerToSegmentsCountData
+  fetchServerToSegmentsCountData,
+  getConsumingSegmentsInfoData
 };


### PR DESCRIPTION
This patch introduces a new UI feature in the Pinot Controller web interface that allows users to view consuming segment information directly from the table details page. It adds a "View Consuming Segments" button, which opens a modal displaying detailed consuming segment data.

**Key Changes:**

- **UI Enhancements:**
  - Added a "View Consuming Segments" button to the table details page.
  - Implemented a modal dialog to display consuming segment information upon button click.

- **Type Definitions:**
  - Introduced `ConsumingInfo` and `ConsumingSegmentsInfo` interfaces in `types.d.ts` to define the structure of consuming segment data.

- **Data Fetching:**
  - Implemented logic to fetch consuming segment information using `PinotMethodUtils.getConsumingSegmentsInfoData`.
  - Added error handling to manage fetch failures gracefully.

**Benefits:**

- Provides users with immediate access to consuming segment details without navigating away from the table details page.
- Enhances the observability and debugging capabilities within the Pinot Controller UI.

This enhancement streamlines the user experience by providing quick access to critical segment information, aiding in monitoring and troubleshooting efforts. 

![Screenshot 2025-04-23 at 9 22 21 PM](https://github.com/user-attachments/assets/a8946dbd-86e6-4a24-9725-5fda574a9272)
![Screenshot 2025-04-23 at 9 22 26 PM](https://github.com/user-attachments/assets/5c231e84-1b00-4a30-afaa-96b0c6877c90)
