### PR TITLE
Ensure allocator is applied to accepted connections in QueryServer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
@@ -131,8 +131,10 @@ public class QueryServer {
       metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_POOLED_THREADLOCALCACHE, metric::numThreadLocalCaches);
       metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_POOLED_CHUNK_SIZE, metric::chunkSize);
       _channel = (ServerSocketChannel) serverBootstrap.group(_bossGroup, _workerGroup).channel(_channelClass)
-          .option(ChannelOption.SO_BACKLOG, 128).childOption(ChannelOption.SO_KEEPALIVE, true)
+          .option(ChannelOption.SO_BACKLOG, 128)
+          .childOption(ChannelOption.SO_KEEPALIVE, true)
           .option(ChannelOption.ALLOCATOR, bufAllocatorWithLimits)
+          .childOption(ChannelOption.ALLOCATOR, bufAllocatorWithLimits)
           .childHandler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) {


### PR DESCRIPTION
This fixes a misconfiguration where `bufAllocatorWithLimits` was set using `.option(ChannelOption.ALLOCATOR, ...)` but not applied via `.childOption(ChannelOption.ALLOCATOR, ...)`.

Setting the allocator with .option(...) only affects the parent listening socket, not the child channels (i.e., accepted connections), which are the ones handling actual query traffic and consuming most of the memory.

As a result, metrics such as usedDirectMemory were not accurately reflecting the direct memory usage from accepted connections. By applying the allocator to .childOption(...) as well, we ensure that:

All connections use the intended allocator with enforced limits

Memory metrics now include the buffers allocated for accepted channels