### PR TITLE
ASOF JOIN

### DIFF
--- a/pinot-common/src/main/proto/plan.proto
+++ b/pinot-common/src/main/proto/plan.proto
@@ -84,11 +84,14 @@ enum JoinType {
   FULL = 3;
   SEMI = 4;
   ANTI = 5;
+  ASOF = 6;
+  LEFT_ASOF = 7;
 }
 
 enum JoinStrategy {
   HASH = 0;
   LOOKUP = 1;
+  AS_OF = 2;
 }
 
 message JoinNode {
@@ -97,6 +100,7 @@ message JoinNode {
   repeated int32 rightKeys = 3;
   repeated Expression nonEquiConditions = 4;
   JoinStrategy joinStrategy = 5;
+  Expression matchCondition = 6;
 }
 
 enum ExchangeType {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
@@ -102,7 +102,9 @@ public class PlanNodeDeserializer {
     return new JoinNode(protoNode.getStageId(), extractDataSchema(protoNode), extractNodeHint(protoNode),
         extractInputs(protoNode), convertJoinType(protoJoinNode.getJoinType()), protoJoinNode.getLeftKeysList(),
         protoJoinNode.getRightKeysList(), convertExpressions(protoJoinNode.getNonEquiConditionsList()),
-        convertJoinStrategy(protoJoinNode.getJoinStrategy()));
+        convertJoinStrategy(protoJoinNode.getJoinStrategy()),
+        protoJoinNode.hasMatchCondition() ? ProtoExpressionToRexExpression.convertExpression(
+            protoJoinNode.getMatchCondition()) : null);
   }
 
   private static MailboxReceiveNode deserializeMailboxReceiveNode(Plan.PlanNode protoNode) {
@@ -284,6 +286,10 @@ public class PlanNodeDeserializer {
         return JoinRelType.SEMI;
       case ANTI:
         return JoinRelType.ANTI;
+      case ASOF:
+        return JoinRelType.ASOF;
+      case LEFT_ASOF:
+        return JoinRelType.LEFT_ASOF;
       default:
         throw new IllegalStateException("Unsupported JoinType: " + joinType);
     }
@@ -295,6 +301,8 @@ public class PlanNodeDeserializer {
         return JoinNode.JoinStrategy.HASH;
       case LOOKUP:
         return JoinNode.JoinStrategy.LOOKUP;
+      case AS_OF:
+        return JoinNode.JoinStrategy.ASOF;
       default:
         throw new IllegalStateException("Unsupported JoinStrategy: " + joinStrategy);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AsofJoinOperator.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+public class AsofJoinOperator extends BaseJoinOperator {
+  private static final String EXPLAIN_NAME = "ASOF_JOIN";
+
+  // The right table is a map from the hash key (columns in the ON join condition) to a sorted map of match key
+  // (column in the MATCH_CONDITION) to rows.
+  private final Map<Object, NavigableMap<Comparable<?>, Object[]>> _rightTable;
+  private final KeySelector<?> _leftKeySelector;
+  private final KeySelector<?> _rightKeySelector;
+  private final MatchConditionType _matchConditionType;
+  private final int _leftMatchKeyIndex;
+  private final int _rightMatchKeyIndex;
+
+  public AsofJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
+      MultiStageOperator rightInput, JoinNode node) {
+    super(context, leftInput, leftSchema, rightInput, node);
+    Preconditions.checkState(node.getNonEquiConditions().isEmpty(),
+        "ASOF_JOIN operator cannot have non-equi join keys");
+    Preconditions.checkState(node.getMatchCondition() != null, "ASOF_JOIN operator must have a match condition");
+    _rightTable = new HashMap<>();
+
+    _leftKeySelector = KeySelectorFactory.getKeySelector(node.getLeftKeys());
+    _rightKeySelector = KeySelectorFactory.getKeySelector(node.getRightKeys());
+
+    RexExpression matchCondition = node.getMatchCondition();
+    Preconditions.checkState(matchCondition instanceof RexExpression.FunctionCall,
+        "ASOF_JOIN operator only supports function call match condition");
+
+    try {
+      _matchConditionType =
+          MatchConditionType.valueOf(((RexExpression.FunctionCall) matchCondition).getFunctionName().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new UnsupportedOperationException("Unsupported match condition: " + matchCondition);
+    }
+    List<RexExpression> matchKeys = ((RexExpression.FunctionCall) matchCondition).getFunctionOperands();
+    // TODO: Add support for MATCH_CONDITION containing two columns of different types. In that case, there would be
+    //       a CAST RexExpression.FunctionCall on top of the RexExpression.InputRef, and we'd need to add the
+    //       appropriate type casts to make sure that the Comparable based comparisons in this class don't throw
+    //       ClassCastException.
+    Preconditions.checkState(
+        matchKeys.size() == 2 && matchKeys.get(0) instanceof RexExpression.InputRef
+            && matchKeys.get(1) instanceof RexExpression.InputRef,
+        "ASOF_JOIN operator only supports match conditions with a comparison between two columns of the same type");
+    _leftMatchKeyIndex = ((RexExpression.InputRef) matchKeys.get(0)).getIndex();
+    _rightMatchKeyIndex = ((RexExpression.InputRef) matchKeys.get(1)).getIndex() - leftSchema.size();
+  }
+
+  @Override
+  protected void addRowsToRightTable(List<Object[]> rows) {
+    for (Object[] row : rows) {
+      Comparable<?> matchKey = (Comparable<?>) row[_rightMatchKeyIndex];
+      if (matchKey == null) {
+        // Skip rows with null match keys because they cannot be matched with any left rows
+        continue;
+      }
+      Object hashKey = _rightKeySelector.getKey(row);
+      // Results need not be deterministic if there are "ties" based on the match key in an ASOF JOIN, so it's okay to
+      // only keep the last row with the same hash key and match key.
+      _rightTable.computeIfAbsent(hashKey, k -> new TreeMap<>()).put(matchKey, row);
+    }
+  }
+
+  @Override
+  protected void finishBuildingRightTable() {
+    // no-op
+  }
+
+  @Override
+  protected List<Object[]> buildJoinedRows(MseBlock.Data leftBlock) {
+    List<Object[]> rows = new ArrayList<>();
+    for (Object[] leftRow : leftBlock.asRowHeap().getRows()) {
+      Comparable<?> matchKey = (Comparable<?>) leftRow[_leftMatchKeyIndex];
+      if (matchKey == null) {
+        // Rows with null match keys cannot be matched with any right rows
+        if (needUnmatchedLeftRows()) {
+          rows.add(joinRow(leftRow, null));
+        }
+        continue;
+      }
+      Object hashKey = _leftKeySelector.getKey(leftRow);
+      NavigableMap<Comparable<?>, Object[]> rightRows = _rightTable.get(hashKey);
+      if (rightRows == null) {
+        if (needUnmatchedLeftRows()) {
+          rows.add(joinRow(leftRow, null));
+        }
+      } else {
+        Object[] rightRow = closestMatch(matchKey, rightRows);
+        if (rightRow == null) {
+          if (needUnmatchedLeftRows()) {
+            rows.add(joinRow(leftRow, null));
+          }
+        } else {
+          rows.add(joinRow(leftRow, rightRow));
+        }
+      }
+    }
+    return rows;
+  }
+
+  @Nullable
+  private Object[] closestMatch(Comparable<?> matchKey, NavigableMap<Comparable<?>, Object[]> rightRows) {
+    switch (_matchConditionType) {
+      case GREATER_THAN: {
+        // Find the closest right row that is less than the left row (compared by their match keys from the match
+        // condition).
+        Map.Entry<Comparable<?>, Object[]> closestMatch = rightRows.lowerEntry(matchKey);
+        return closestMatch == null ? null : closestMatch.getValue();
+      }
+      case GREATER_THAN_OR_EQUAL: {
+        // Find the closest right row that is less than or equal to the left row (compared by their match keys from
+        // the match condition).
+        Map.Entry<Comparable<?>, Object[]> closestMatch = rightRows.floorEntry(matchKey);
+        return closestMatch == null ? null : closestMatch.getValue();
+      }
+      case LESS_THAN: {
+        // Find the closest right row that is greater than the left row (compared by their match keys from the match
+        // condition).
+        Map.Entry<Comparable<?>, Object[]> closestMatch = rightRows.higherEntry(matchKey);
+        return closestMatch == null ? null : closestMatch.getValue();
+      }
+      case LESS_THAN_OR_EQUAL: {
+        // Find the closest right row that is greater than or equal to the left row (compared by their match keys from
+        // the match condition).
+        Map.Entry<Comparable<?>, Object[]> closestMatch = rightRows.ceilingEntry(matchKey);
+        return closestMatch == null ? null : closestMatch.getValue();
+      }
+      default:
+        throw new IllegalArgumentException("Unsupported match condition type: " + _matchConditionType);
+    }
+  }
+
+  @Override
+  protected List<Object[]> buildNonMatchRightRows() {
+    // There's only ASOF JOIN and LEFT ASOF JOIN; RIGHT ASOF JOIN is not a thing
+    throw new UnsupportedOperationException("ASOF JOIN does not support unmatched right rows");
+  }
+
+  @Nullable
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  private enum MatchConditionType {
+    GREATER_THAN,
+    GREATER_THAN_OR_EQUAL,
+    LESS_THAN,
+    LESS_THAN_OR_EQUAL
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.query.runtime.operator.join.LongLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LookupTable;
 import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 
 
 /**
@@ -93,44 +92,15 @@ public class HashJoinOperator extends BaseJoinOperator {
   }
 
   @Override
-  protected void buildRightTable() {
-    LOGGER.trace("Building hash table for join operator");
-    long startTime = System.currentTimeMillis();
-    int numRows = 0;
-    MseBlock rightBlock = _rightInput.nextBlock();
-    while (rightBlock.isData()) {
-      MseBlock.Data dataBlock = (MseBlock.Data) rightBlock;
-      List<Object[]> rows = dataBlock.asRowHeap().getRows();
-      // Row based overflow check.
-      if (rows.size() + numRows > _maxRowsInJoin) {
-        if (_joinOverflowMode == JoinOverFlowMode.THROW) {
-          throwForJoinRowLimitExceeded(
-              "Cannot build in memory hash table for join operator, reached number of rows limit: " + _maxRowsInJoin);
-        } else {
-          // Just fill up the buffer.
-          int remainingRows = _maxRowsInJoin - numRows;
-          rows = rows.subList(0, remainingRows);
-          _statMap.merge(StatKey.MAX_ROWS_IN_JOIN_REACHED, true);
-          // setting only the rightTableOperator to be early terminated and awaits EOS block next.
-          _rightInput.earlyTerminate();
-        }
-      }
-      for (Object[] row : rows) {
-        _rightTable.addRow(_rightKeySelector.getKey(row), row);
-      }
-      numRows += rows.size();
-      sampleAndCheckInterruption();
-      rightBlock = _rightInput.nextBlock();
+  protected void addRowsToRightTable(List<Object[]> rows) {
+    for (Object[] row : rows) {
+      _rightTable.addRow(_rightKeySelector.getKey(row), row);
     }
-    MseBlock.Eos eosBlock = (MseBlock.Eos) rightBlock;
-    if (eosBlock.isError()) {
-      _eos = eosBlock;
-    } else {
-      _rightTable.finish();
-      _isRightTableBuilt = true;
-    }
-    _statMap.merge(StatKey.TIME_BUILDING_HASH_TABLE_MS, System.currentTimeMillis() - startTime);
-    LOGGER.trace("Finished building hash table for join operator");
+  }
+
+  @Override
+  protected void finishBuildingRightTable() {
+    _rightTable.finish();
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -37,6 +37,7 @@ import org.apache.pinot.query.planner.plannode.TableScanNode;
 import org.apache.pinot.query.planner.plannode.ValueNode;
 import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.apache.pinot.query.runtime.operator.AggregateOperator;
+import org.apache.pinot.query.runtime.operator.AsofJoinOperator;
 import org.apache.pinot.query.runtime.operator.FilterOperator;
 import org.apache.pinot.query.runtime.operator.HashJoinOperator;
 import org.apache.pinot.query.runtime.operator.IntersectAllOperator;
@@ -180,16 +181,20 @@ public class PlanNodeToOpChain {
       PlanNode right = inputs.get(1);
       MultiStageOperator rightOperator = visit(right, context);
       JoinNode.JoinStrategy joinStrategy = node.getJoinStrategy();
-      if (joinStrategy == JoinNode.JoinStrategy.HASH) {
-        if (node.getLeftKeys().isEmpty()) {
-          // TODO: Consider adding non-equi as a separate join strategy.
-          return new NonEquiJoinOperator(context, leftOperator, left.getDataSchema(), rightOperator, node);
-        } else {
-          return new HashJoinOperator(context, leftOperator, left.getDataSchema(), rightOperator, node);
-        }
-      } else {
-        assert joinStrategy == JoinNode.JoinStrategy.LOOKUP;
-        return new LookupJoinOperator(context, leftOperator, rightOperator, node);
+      switch (joinStrategy) {
+        case HASH:
+          if (node.getLeftKeys().isEmpty()) {
+            // TODO: Consider adding non-equi as a separate join strategy.
+            return new NonEquiJoinOperator(context, leftOperator, left.getDataSchema(), rightOperator, node);
+          } else {
+            return new HashJoinOperator(context, leftOperator, left.getDataSchema(), rightOperator, node);
+          }
+        case LOOKUP:
+          return new LookupJoinOperator(context, leftOperator, rightOperator, node);
+        case ASOF:
+          return new AsofJoinOperator(context, leftOperator, left.getDataSchema(), rightOperator, node);
+        default:
+          throw new IllegalStateException("Unsupported JoinStrategy: " + joinStrategy);
       }
     }
 

--- a/pinot-query-runtime/src/test/resources/queries/AsOfJoin.json
+++ b/pinot-query-runtime/src/test/resources/queries/AsOfJoin.json
@@ -410,7 +410,7 @@
       },
       {
         "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.key_col) ON {t1}.key_col = {t2}.key_col",
-        "expectedException": ".*ASOF_JOIN operator only supports match conditions with a comparison between two columns of the same type.*",
+        "expectedException": ".*ASOF_JOIN only supports match conditions with a comparison between two columns of the same type.*",
         "comment": "We currently don't support MATCH_CONDITION comparing columns of different types"
       }
     ]

--- a/pinot-query-runtime/src/test/resources/queries/AsOfJoin.json
+++ b/pinot-query-runtime/src/test/resources/queries/AsOfJoin.json
@@ -1,0 +1,418 @@
+{
+  "as_of_join_queries": {
+    "tables": {
+      "t1": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      "t2": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["b", 2],
+          ["a", 1],
+          ["c", 3],
+          ["a", 2],
+          ["c", 1],
+          ["b", 3],
+          ["d", 5]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["c", 3, "c", 1]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col >= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col < {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["b", 2, "b", 3],
+          ["d", 4, "d", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col <= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3],
+          ["d", 4, "d", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, null, null],
+          ["b", 2, null, null],
+          ["c", 3, "c", 1],
+          ["d", 4, null, null],
+          ["e", 5, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col >= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3],
+          ["d", 4, null, null],
+          ["e", 5, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col < {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["b", 2, "b", 3],
+          ["c", 3, null, null],
+          ["d", 4, "d", 5],
+          ["e", 5, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col <= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3],
+          ["d", 4, "d", 5],
+          ["e", 5, null, null]
+        ]
+      }
+    ]
+  },
+  "as_of_join_queries_without_hash_key_join": {
+    "tables": {
+      "t1": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      "t2": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["b", 2],
+          ["a", 1],
+          ["c", 3],
+          ["a", 4],
+          ["c", 7],
+          ["b", 6],
+          ["d", 5]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON true",
+        "outputs": [
+          ["b", 2, "a", 1],
+          ["c", 3, "b", 2],
+          ["d", 4, "c", 3],
+          ["e", 5, "a", 4]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON true",
+        "outputs": [
+          ["a", 1, null, null],
+          ["b", 2, "a", 1],
+          ["c", 3, "b", 2],
+          ["d", 4, "c", 3],
+          ["e", 5, "a", 4]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col >= {t2}.asof_col) ON true",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3],
+          ["d", 4, "a", 4],
+          ["e", 5, "d", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col < {t2}.asof_col) ON true",
+        "outputs": [
+          ["a", 1, "b", 2],
+          ["b", 2, "c", 3],
+          ["c", 3, "a", 4],
+          ["d", 4, "d", 5],
+          ["e", 5, "b", 6]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col <= {t2}.asof_col) ON true",
+        "outputs": [
+          ["a", 1, "a", 1],
+          ["b", 2, "b", 2],
+          ["c", 3, "c", 3],
+          ["d", 4, "a", 4],
+          ["e", 5, "d", 5]
+        ]
+      }
+    ]
+  },
+  "as_of_join_queries_with_nulls": {
+    "tables": {
+      "t1": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["a", 5],
+          ["b", 3],
+          ["c", null],
+          ["d", 4],
+          ["e", 7],
+          ["f", 10],
+          ["g", 12]
+        ]
+      },
+      "t2": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 0],
+          ["a", 2],
+          ["a", null],
+          ["b", 2],
+          ["b", null],
+          ["c", 5],
+          ["d", 4],
+          ["d", 6],
+          ["f", null],
+          ["f", 11],
+          ["g", null],
+          ["h", 9]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 0],
+          ["a", 5, "a", 2],
+          ["b", 3, "b", 2]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col >= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 0],
+          ["a", 5, "a", 2],
+          ["b", 3, "b", 2],
+          ["d", 4, "d", 4]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col < {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["d", 4, "d", 6],
+          ["f", 10, "f", 11]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col <= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["d", 4, "d", 4],
+          ["f", 10, "f", 11]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 0],
+          ["a", 5, "a", 2],
+          ["b", 3, "b", 2],
+          ["c", null, null, null],
+          ["d", 4, null, null],
+          ["e", 7, null, null],
+          ["f", 10, null, null],
+          ["g", 12, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col >= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 0],
+          ["a", 5, "a", 2],
+          ["b", 3, "b", 2],
+          ["c", null, null, null],
+          ["d", 4, "d", 4],
+          ["e", 7, null, null],
+          ["f", 10, null, null],
+          ["g", 12, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col < {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["a", 5, null, null],
+          ["b", 3, null, null],
+          ["c", null, null, null],
+          ["d", 4, "d", 6],
+          ["e", 7, null, null],
+          ["f", 10, "f", 11],
+          ["g", 12, null, null]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col <= {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "outputs": [
+          ["a", 1, "a", 2],
+          ["a", 5, null, null],
+          ["b", 3, null, null],
+          ["c", null, null, null],
+          ["d", 4, "d", 4],
+          ["e", 7, null, null],
+          ["f", 10, "f", 11],
+          ["g", 12, null, null]
+        ]
+      }
+    ]
+  },
+  "as_of_join_unsupported_scenarios": {
+    "tables": {
+      "t1": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      "t2": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "asof_col", "type": "INT"}
+        ],
+        "inputs": [
+          ["b", 2],
+          ["a", 1],
+          ["c", 3],
+          ["a", 2],
+          ["c", 1],
+          ["b", 3],
+          ["d", 5]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col)",
+        "expectedException": ".*exception while parsing query.*",
+        "comment": "Calcite currently doesn't support ASOF JOINs without an ON clause. This isn't just a parser limitation, since the assumption is also built into the validator."
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col)",
+        "expectedException": ".*exception while parsing query.*",
+        "comment": "Calcite currently doesn't support ASOF JOINs without an ON clause. This isn't just a parser limitation, since the assumption is also built into the validator."
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col AND {t1}.asof_col > 0",
+        "expectedException": ".*ASOF JOIN condition must be a conjunction of equality comparisons.*"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col != {t2}.key_col",
+        "expectedException": ".*ASOF JOIN condition must be a conjunction of equality comparisons.*"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col) ON {t1}.key_col = {t2}.key_col OR {t1}.asof_col = {t2}.asof_col",
+        "expectedException": ".*ASOF JOIN condition must be a conjunction of equality comparisons.*"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*exception while parsing query.*",
+        "comment": "MATCH_CONDITION is required for ASOF JOINs"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} LEFT ASOF JOIN {t2} ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*exception while parsing query.*",
+        "comment": "MATCH_CONDITION is required for ASOF JOINs"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col != {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col = {t2}.asof_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col OR {t1}.key_col > {t1}.key_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.asof_col AND {t1}.key_col > {t1}.key_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > 0) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t1}.key_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF JOIN MATCH_CONDITION must be a comparison between columns from the two inputs.*",
+        "comment": "MATCH_CONDITION only supports a single predicate comparing two columns that is one out of: (>, >=, <, <=)"
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.asof_col, {t2}.key_col, {t2}.asof_col FROM {t1} ASOF JOIN {t2} MATCH_CONDITION({t1}.asof_col > {t2}.key_col) ON {t1}.key_col = {t2}.key_col",
+        "expectedException": ".*ASOF_JOIN operator only supports match conditions with a comparison between two columns of the same type.*",
+        "comment": "We currently don't support MATCH_CONDITION comparing columns of different types"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Adds support for `ASOF JOIN` (and `LEFT ASOF JOIN`) in the multi-stage engine with syntax and semantics similar to Snowflake's - https://docs.snowflake.com/en/sql-reference/constructs/asof-join.
- Calcite recently added support for this join type (in the parser, validator, and rel logic) in `1.38.0` - https://github.com/apache/calcite/pull/3883 (we recently upgraded from `1.37.0` to `1.39.0` - https://github.com/apache/pinot/pull/15263).
- Note that Calcite currently doesn't support `ASOF JOIN`s without an `ON` clause even though Snowflake does - https://docs.snowflake.com/en/sql-reference/constructs/asof-join#parameters. Currently, the workaround would be to use a clause like `ON TRUE` - https://github.com/apache/calcite/pull/3883#discussion_r2057922563. Note that Calcite enforces the `ON` clause in these joins to be a conjunction of equalities (apart from literal conditions).
- The `MATCH_CONDITION` clause is mandatory (in both Calcite and Snowflake).
- We don't use the `MATCH_CONDITION` to determine the exchange / distribution logic here in Pinot, we only use the actual join keys (from the `ON` clause) to implement the usual hash exchange. The reason is that `MATCH_CONDITION` can only be one out of `>`, `>=`, `<`, `<=` and the semantics of the join (finding the closest match) make it such that we can't use buckets to distribute the data accurately either. The hash exchange will be based on the join keys from the `ON` clause. If the clause is `ON TRUE`, we'll use a random + broadcast distribution strategy, similar to regular joins without equality based join conditions.
- This patch also refactors the physical `BaseJoinOperator` and existing implementations to increase reused logic and adds a new `AsofJoinOperator` implementation that uses a tree map for efficient (binary search based) computation of the closest match as per the `MATCH_CONDITION`.
- Since H2 doesn't support `ASOF JOIN` queries, the test cases added here only have manually validated logical correctness.