### PR TITLE
Fix needReload to fetch status from servers in ExternalView

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -80,8 +80,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
 
     Map<String, RebalancePreCheckerResult> preCheckResult = new HashMap<>();
     // Check for reload status
-    preCheckResult.put(NEEDS_RELOAD_STATUS,
-        checkReloadNeededOnServers(tableNameWithType, preCheckContext.getCurrentAssignment(), tableRebalanceLogger));
+    preCheckResult.put(NEEDS_RELOAD_STATUS, checkReloadNeededOnServers(tableNameWithType, tableRebalanceLogger));
     // Check whether minimizeDataMovement is set in TableConfig
     preCheckResult.put(IS_MINIMIZE_DATA_MOVEMENT,
         checkIsMinimizeDataMovement(tableConfig, rebalanceConfig, tableRebalanceLogger));
@@ -109,8 +108,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
    * TODO: Add an API to check for whether segments in deep store are up to date with the table configs and schema
    *       and add a pre-check here to call that API.
    */
-  private RebalancePreCheckerResult checkReloadNeededOnServers(String tableNameWithType,
-      Map<String, Map<String, String>> currentAssignment, Logger tableRebalanceLogger) {
+  private RebalancePreCheckerResult checkReloadNeededOnServers(String tableNameWithType, Logger tableRebalanceLogger) {
     tableRebalanceLogger.info("Fetching whether reload is needed");
     Boolean needsReload = null;
     if (_executorService == null) {
@@ -120,18 +118,12 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     try (PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager()) {
       TableMetadataReader metadataReader = new TableMetadataReader(_executorService, connectionManager,
           _pinotHelixResourceManager);
-      // Only send needReload request to servers that are part of the current assignment. The tagged server list may
-      // include new servers which are part of target assignment but not current assignment. needReload throws an
-      // exception for servers that don't contain segments for the given table
-      Set<String> currentlyAssignedServers = getCurrentlyAssignedServers(currentAssignment);
       TableMetadataReader.TableReloadJsonResponse needsReloadMetadataPair =
-          metadataReader.getServerSetCheckSegmentsReloadMetadata(tableNameWithType, 30_000, currentlyAssignedServers);
+          metadataReader.getServerCheckSegmentsReloadMetadata(tableNameWithType, 30_000);
       Map<String, JsonNode> needsReloadMetadata = needsReloadMetadataPair.getServerReloadJsonResponses();
       int failedResponses = needsReloadMetadataPair.getNumFailedResponses();
-      tableRebalanceLogger.info(
-          "Received {} needs reload responses and {} failed responses from servers with "
-              + "number of servers queried: {}", needsReloadMetadata.size(), failedResponses,
-          currentlyAssignedServers.size());
+      tableRebalanceLogger.info("Received {} needs reload responses and {} failed responses from servers assigned "
+              + "to table", needsReloadMetadata.size(), failedResponses);
       needsReload = needsReloadMetadata.values().stream().anyMatch(value -> value.get("needReload").booleanValue());
       if (!needsReload && failedResponses > 0) {
         tableRebalanceLogger.warn(
@@ -262,14 +254,6 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
           "Error while trying to fetch instance assignment config, assuming minimizeDataMovement is false", e);
     }
     return RebalancePreCheckerResult.error("Got exception when fetching instance assignment, check manually");
-  }
-
-  private Set<String> getCurrentlyAssignedServers(Map<String, Map<String, String>> currentAssignment) {
-    Set<String> servers = new HashSet<>();
-    for (Map<String, String> serverStateMap : currentAssignment.values()) {
-      servers.addAll(serverStateMap.keySet());
-    }
-    return servers;
   }
 
   private RebalancePreCheckerResult checkDiskUtilization(Map<String, Map<String, String>> currentAssignment,


### PR DESCRIPTION
Fix needReload to fetch status from servers in ExternalView

Today the `needReload` API fetches the status from the servers with the instance tag corresponding to the Tenant. This is not a true reflection of which servers actually host the segments (e.g. rebalance the instance tags may have changed, tiered storage uses tier tags for other tiers, we could have tagOverride setup for REALTIME tables). A better reflection is to use the ExternalView as source of truth as it has the currently assigned servers.

This also changes the Rebalance pre-check for needReload to utilize the same ExternalView API

Tested this locally in QuickStart with a few different scenarios:
- Tenant migration should show needReload API and rebalance pre-check based on EV
- Added delays to all the state transition callbacks to emulate slow updates to EV and checked the API still works
- Additional testing to verify that we skip sending requests to servers that have all segments in ERROR / OFFLINE state for the table

Note: Earlier we did make a fix for Rebalance pre-check to use `currentAssignment` (from IdealState) and in that we had discussed that for non-rebalance case it might be okay to look at tagged servers itself. This is an update because we found non-rebalance scenarios where tagged server list is not enough as well, so we decided to unify the logic in both cases. `ExternalView` is more of a source of truth than `IdealState` so we changed to using this.