### PR TITLE
Added timeouts to the resource deletion calls from SegmentDeletionManager

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -324,13 +324,17 @@ public class SegmentDeletionManagerTest {
     PinotFS pinotFS = PinotFSFactory.create("fake");
 
     URI tableUri1 = new URI("fake://bucket/sc/managed/pinot/Deleted_Segments/table_1/");
-    URI segment1ForTable1 = new URI(tableUri1.getPath() + "segment1" + RETENTION_UNTIL_SEPARATOR + "201901010000");
-    URI segment2ForTable1 = new URI(tableUri1.getPath() + "segment2" + RETENTION_UNTIL_SEPARATOR + "210001010000");
     pinotFS.mkdir(tableUri1);
-    pinotFS.mkdir(segment1ForTable1);
-    pinotFS.mkdir(segment2ForTable1);
-    // Create dummy files
+    for (int i = 0; i < 101; i++) {
+      URI segmentURIForTable =
+          new URI(tableUri1.getPath() + "segment" + i + RETENTION_UNTIL_SEPARATOR + "201901010000");
+      pinotFS.mkdir(segmentURIForTable);
+    }
+    // Add a segment that will not be deleted as it won't meet the retention age criteria.
+    URI segmentURIForTable = new URI(tableUri1.getPath() + "segment2" + RETENTION_UNTIL_SEPARATOR + "210001010000");
+    pinotFS.mkdir(segmentURIForTable);
 
+    // Create dummy files
     URI tableUri2 = new URI("fake://bucket/sc/managed/pinot/Deleted_Segments/table_2/");
     URI segment1ForTable2 = new URI(tableUri2.getPath() + "segment1" + RETENTION_UNTIL_SEPARATOR + "201901010000");
     URI segment2ForTable2 = new URI(tableUri2.getPath() + "segment1" + RETENTION_UNTIL_SEPARATOR + "201801010000");
@@ -341,8 +345,9 @@ public class SegmentDeletionManagerTest {
     deletionManager1.removeAgedDeletedSegments(leadControllerManager);
     // all files should get deleted
     Assert.assertFalse(pinotFS.exists(tableUri2));
-    // only one file that is beyond retention should exist
-    Assert.assertEquals(pinotFS.listFiles(tableUri1, false).length, 1);
+
+    // One file that doesn't meet retention criteria, and another file due to the per attempt batch limit remains.
+    Assert.assertEquals(pinotFS.listFiles(tableUri1, false).length, 2);
   }
 
   @Test


### PR DESCRIPTION
## Description
Added a timeout wrapper to object deletion calls issued from the SegmentDeletionManager. Occasionally, we are running into stuck deletion calls while deleting objects from GCS. This timeout wrapper should help. This is causing the RetentionManager to be stuck forever.

**Error Details**
```
        at sun.nio.ch.NioSocketImpl.implRead(java.base@21.0.6/NioSocketImpl.java:304)
        at sun.nio.ch.NioSocketImpl.read(java.base@21.0.6/NioSocketImpl.java:346)
        at sun.nio.ch.NioSocketImpl$1.read(java.base@21.0.6/NioSocketImpl.java:796)
        at java.net.Socket$SocketInputStream.read(java.base@21.0.6/Socket.java:1099)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@21.0.6/SSLSocketInputRecord.java:489)
        at sun.security.ssl.SSLSocketInputRecord.readHeader(java.base@21.0.6/SSLSocketInputRecord.java:483)
        at sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(java.base@21.0.6/SSLSocketInputRecord.java:70)
        at sun.security.ssl.SSLSocketImpl.readApplicationRecord(java.base@21.0.6/SSLSocketImpl.java:1461)
        at sun.security.ssl.SSLSocketImpl$AppInputStream.read(java.base@21.0.6/SSLSocketImpl.java:1066)
        at java.io.BufferedInputStream.fill(java.base@21.0.6/BufferedInputStream.java:291)
        at java.io.BufferedInputStream.read1(java.base@21.0.6/BufferedInputStream.java:347)
        at java.io.BufferedInputStream.implRead(java.base@21.0.6/BufferedInputStream.java:420)
        at java.io.BufferedInputStream.read(java.base@21.0.6/BufferedInputStream.java:399)
        at sun.net.www.http.HttpClient.parseHTTPHeader(java.base@21.0.6/HttpClient.java:827)
        at sun.net.www.http.HttpClient.parseHTTP(java.base@21.0.6/HttpClient.java:759)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(java.base@21.0.6/HttpURLConnection.java:1705)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(java.base@21.0.6/HttpURLConnection.java:1614)
        at java.net.HttpURLConnection.getResponseCode(java.base@21.0.6/HttpURLConnection.java:531)
        at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(java.base@21.0.6/HttpsURLConnectionImpl.java:307)
        at com.google.api.client.http.javanet.NetHttpResponse.<init>(NetHttpResponse.java:36)
        at com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:152)
        at com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:84)
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1012)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:565)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:506)
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:616)
        at com.google.cloud.storage.spi.v1.HttpStorageRpc.delete(HttpStorageRpc.java:740)
        at com.google.cloud.storage.StorageImpl.lambda$delete$21(StorageImpl.java:627)
        at com.google.cloud.storage.StorageImpl$$Lambda/0x00007eeb32dbc880.call(Unknown Source)
        at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:102)
        at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
        at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
        at com.google.cloud.storage.Retrying.run(Retrying.java:65)
        at com.google.cloud.storage.StorageImpl.run(StorageImpl.java:1611)
        at com.google.cloud.storage.StorageImpl.delete(StorageImpl.java:627)
        at com.google.cloud.storage.Blob.delete(Blob.java:881)
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.delete(GcsPinotFS.java:414)
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.delete(GcsPinotFS.java:134)
        at org.apache.pinot.spi.filesystem.NoClosePinotFS.delete(NoClosePinotFS.java:50)
        at org.apache.pinot.controller.helix.core.SegmentDeletionManager.removeAgedDeletedSegments(SegmentDeletionManager.java:375)
        at org.apache.pinot.controller.helix.core.retention.RetentionManager.postprocess(RetentionManager.java:92)
```