### PR TITLE
Allow raw JSON as input for Add table button in Pinot UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { createStyles, DialogContent, Grid, makeStyles, Theme} from '@material-ui/core';
+import { createStyles, DialogContent, Grid, makeStyles, Theme, Button, ButtonGroup } from '@material-ui/core';
 import Dialog from '../../CustomDialog';
 import SimpleAccordion from '../../SimpleAccordion';
 import AddTableComponent from './AddTableComponent';
@@ -46,7 +46,11 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   })
 );
-
+// View modes for simple form or raw JSON editing
+enum EditView {
+  SIMPLE = "SIMPLE",
+  JSON = "JSON"
+}
 type Props = {
   hideModal: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   fetchData: Function,
@@ -130,7 +134,9 @@ export default function AddOfflineTableOp({
   tableType
 }: Props) {
   const classes = useStyles();
+  const [editView, setEditView] = useState<EditView>(EditView.SIMPLE);
   const [tableObj, setTableObj] = useState(JSON.parse(JSON.stringify(defaultTableObj)));
+  const [jsonTableObj, setJsonTableObj] = useState(JSON.parse(JSON.stringify(defaultTableObj)));
   const [schemaObj, setSchemaObj] = useState(JSON.parse(JSON.stringify(defaultSchemaObj)));
   const [tableName, setTableName] = useState('');
   const [columnName, setColumnName] = useState([]);
@@ -150,6 +156,14 @@ export default function AddOfflineTableOp({
   useEffect(()=>{
     setTableObj({...tableObj,"tableType":tableType})
   },[])
+  // Sync state when toggling between simple and JSON view
+  useEffect(() => {
+    if (editView === EditView.JSON) {
+      setJsonTableObj(JSON.parse(JSON.stringify(tableObj)));
+    } else {
+      setTableObj(JSON.parse(JSON.stringify(jsonTableObj)));
+    }
+  }, [editView]);
 
   const updateSchemaObj = async (tableName) => {
     //table name is same as schema name
@@ -226,15 +240,33 @@ const checkFields = (tableObj,fields) => {
   };
 
   const handleSave = async () => {
-    if(await validateTableConfig()){
-      const tableCreationResp = await PinotMethodUtils.saveTableAction(tableObj);
-      dispatch({
-        type: (tableCreationResp.error || typeof tableCreationResp === 'string') ? 'error' : 'success',
-        message: tableCreationResp.error || tableCreationResp.status || tableCreationResp,
-        show: true
-      });
-      tableCreationResp.status && fetchData();
-      tableCreationResp.status && hideModal(null);
+    // Determine which config to save based on view
+    const configToSave = editView === EditView.SIMPLE ? tableObj : jsonTableObj;
+    // Validate based on view
+    if (editView === EditView.SIMPLE) {
+      if (!await validateTableConfig()) {
+        return;
+      }
+    } else {
+      const validTable = await PinotMethodUtils.validateTableAction(configToSave);
+      if (validTable.error || typeof validTable === 'string') {
+        dispatch({
+          type: 'error',
+          message: validTable.error || validTable,
+          show: true
+        });
+        return;
+      }
+    }
+    const tableCreationResp = await PinotMethodUtils.saveTableAction(configToSave);
+    dispatch({
+      type: (tableCreationResp.error || typeof tableCreationResp === 'string') ? 'error' : 'success',
+      message: tableCreationResp.error || tableCreationResp.status || tableCreationResp,
+      show: true
+    });
+    if (tableCreationResp.status) {
+      fetchData();
+      hideModal(null);
     }
   };
 
@@ -255,13 +287,32 @@ const checkFields = (tableObj,fields) => {
       open={true}
       handleClose={hideModal}
       handleSave={handleSave}
-      title={`Add ${tableType} Table`}
+      title={
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span>Add {tableType} Table</span>
+          <ButtonGroup size="small" color="primary">
+            <Button
+              variant={editView === EditView.SIMPLE ? 'contained' : 'outlined'}
+              onClick={() => setEditView(EditView.SIMPLE)}
+            >
+              Simple
+            </Button>
+            <Button
+              variant={editView === EditView.JSON ? 'contained' : 'outlined'}
+              onClick={() => setEditView(EditView.JSON)}
+            >
+              Json
+            </Button>
+          </ButtonGroup>
+        </div>
+      }
       size="xl"
       disableBackdropClick={true}
       disableEscapeKeyDown={true}
     >
       <DialogContent>
-        <Grid container spacing={2}>
+        {editView === EditView.SIMPLE && (
+          <Grid container spacing={2}>
           <Grid item xs={12}>
             <SimpleAccordion
               headerTitle="Add Table"
@@ -383,6 +434,19 @@ const checkFields = (tableObj,fields) => {
             </div>
           </Grid>
         </Grid>
+        )}
+        {editView === EditView.JSON && (
+          <CustomCodemirror
+            data={jsonTableObj}
+            isEditable={true}
+            returnCodemirrorValue={(newValue) => {
+              try {
+                const jsonObj = JSON.parse(newValue);
+                setJsonTableObj(jsonObj);
+              } catch (e) {}
+            }}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
This pull request introduces a toggleable view mode (Simple and JSON) for adding offline and realtime tables in the Pinot Controller UI. It enhances the user experience by allowing users to switch between a form-based interface and a raw JSON editor. The most important changes include adding the toggle functionality, syncing state between the two views, and validating configurations based on the selected view.

### New Features for View Modes:

* Added an `EditView` enum to define the two view modes: `SIMPLE` and `JSON` 

### State Management Enhancements:

* Added `editView`, `tableObj`, and `jsonTableObj` states to manage data for both views 

### Validation and Save Logic:

* Updated the `handleSave` method to validate and save configurations based on the active view mode 

### UI Updates for JSON View:

* Integrated `CustomCodemirror` for JSON editing, with error handling for invalid JSON inputs 


![Screenshot 2025-04-25 at 8 18 05 PM](https://github.com/user-attachments/assets/0266f4b5-0e02-4648-9b8b-b194b03303e1)

