### PR TITLE
Add netty memory related metrics for GrpcMailboxServer

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -77,7 +77,17 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   /**
    * The estimated number of query server threads for all currently running multi-stage queries.
    */
-  ESTIMATED_MSE_SERVER_THREADS("number", true);
+  ESTIMATED_MSE_SERVER_THREADS("number", true),
+
+  // GrpcMailboxServer memory metrics
+  MAILBOX_SERVER_USED_DIRECT_MEMORY("bytes", true),
+  MAILBOX_SERVER_USED_HEAP_MEMORY("bytes", true),
+  MAILBOX_SERVER_ARENAS_DIRECT("arenas", true),
+  MAILBOX_SERVER_ARENAS_HEAP("arenas", true),
+  MAILBOX_SERVER_CACHE_SIZE_SMALL("bytes", true),
+  MAILBOX_SERVER_CACHE_SIZE_NORMAL("bytes", true),
+  MAILBOX_SERVER_THREADLOCALCACHE("bytes", true),
+  MAILBOX_SERVER_CHUNK_SIZE("bytes", true);
 
   private final String _brokerGaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -97,7 +97,17 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_CONSUMER_DIR_USAGE("bytes", true),
   SEGMENT_DOWNLOAD_SPEED("bytes", true),
   PREDOWNLOAD_SPEED("bytes", true),
-  ZK_JUTE_MAX_BUFFER("zkJuteMaxBuffer", true);
+  ZK_JUTE_MAX_BUFFER("zkJuteMaxBuffer", true),
+
+  // GrpcMailboxServer memory metrics
+  MAILBOX_SERVER_USED_DIRECT_MEMORY("bytes", true),
+  MAILBOX_SERVER_USED_HEAP_MEMORY("bytes", true),
+  MAILBOX_SERVER_ARENAS_DIRECT("arenas", true),
+  MAILBOX_SERVER_ARENAS_HEAP("arenas", true),
+  MAILBOX_SERVER_CACHE_SIZE_SMALL("bytes", true),
+  MAILBOX_SERVER_CACHE_SIZE_NORMAL("bytes", true),
+  MAILBOX_SERVER_THREADLOCALCACHE("bytes", true),
+  MAILBOX_SERVER_CHUNK_SIZE("bytes", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
@@ -55,9 +55,7 @@ public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter
    * should always call after registration
    */
   public static ServerMetrics get() {
-    ServerMetrics ret = SERVER_METRICS_INSTANCE.get();
-    assert ret != null;
-    return ret;
+    return SERVER_METRICS_INSTANCE.get();
   }
 
   public ServerMetrics(PinotMetricsRegistry metricsRegistry) {


### PR DESCRIPTION
Similar to what we did for grpc query/broker server in https://github.com/apache/pinot/pull/15625, we add the the set of memory metrics for GrpcMailboxServer as well. Notice that GrpcMailboxServer can be either run from server or broker, so we choose where to log the metric depends on where it runs
