### PR TITLE
Retry postStopConsumedMsg for segment init errors

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1729,7 +1729,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       setConsumeEndTime(segmentZKMetadata, now());
       _segmentCommitterFactory =
           new SegmentCommitterFactory(_segmentLogger, _protocolHandler, tableConfig, indexLoadingConfig, serverMetrics);
-      throw new RuntimeException();
     } catch (Throwable t) {
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),
           "Failed to initialize segment data manager", t));


### PR DESCRIPTION
This PR adds infinite retry until `postStopConsumedMsg` returns success. 

1 bug which can happen before this PR:
- Incase of segment initialisation error like OOM error because of an index, The server tries to send `postStopConsumedMsg` message to the controller so that controller can change ideal state of the segment to offline. This is required so that Realtime segment validation manager (RVM) job can restart consumption of partitions of the failed segments.
However if server fails to send `postStopConsumedMsg` message to controller successfully, the ideal state of segment remains consuming and segment is never fixed by RVM job. There will be no consumer thread on server despite segment's ideal state in consuming state.

