### PR TITLE
[pinot-avro plugin] by default enable logical types support

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -39,7 +39,7 @@ import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
 public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
   private Set<String> _fields;
   private boolean _extractAll = false;
-  private boolean _applyLogicalTypes;
+  private boolean _applyLogicalTypes = true;
 
   @Override
   public void init(@Nullable Set<String> fields, @Nullable RecordExtractorConfig recordExtractorConfig) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorConfig.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
  * Config for {@link AvroRecordExtractor}
  */
 public class AvroRecordExtractorConfig implements RecordExtractorConfig {
-  private boolean _enableLogicalTypes = false;
+  private boolean _enableLogicalTypes = true;
 
   @Override
   public void init(Map<String, String> props) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordReaderConfig.java
@@ -24,7 +24,7 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
  * Config for {@link AvroRecordReader}
  */
 public class AvroRecordReaderConfig implements RecordReaderConfig {
-  private boolean _enableLogicalTypes;
+  private boolean _enableLogicalTypes = true;
 
   public boolean isEnableLogicalTypes() {
     return _enableLogicalTypes;

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordToPinotRowGeneratorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordToPinotRowGeneratorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -66,8 +67,8 @@ public class AvroRecordToPinotRowGeneratorTest {
     GenericRow genericRow = new GenericRow();
 
     // List
-    genericRecord.put("intMV", List.of(1, 2, 3));
-    genericRecord.put("stringMV", List.of("value1", "value2", "value3"));
+    genericRecord.put("intMV", new ArrayList(List.of(1, 2, 3)));
+    genericRecord.put("stringMV", new ArrayList(List.of("value1", "value2", "value3")));
     avroRecordExtractor.extract(genericRecord, genericRow);
     assertEqualsDeep(genericRow.getFieldToValueMap(),
         Map.of("intMV", new Object[]{1, 2, 3}, "stringMV", new Object[]{"value1", "value2", "value3"}));
@@ -98,8 +99,8 @@ public class AvroRecordToPinotRowGeneratorTest {
 
     // Empty List
     genericRow.clear();
-    genericRecord.put("intMV", List.of());
-    genericRecord.put("stringMV", List.of());
+    genericRecord.put("intMV", new ArrayList<>());
+    genericRecord.put("stringMV", new ArrayList<>());
     avroRecordExtractor.extract(genericRecord, genericRow);
     assertEqualsDeep(genericRow.getFieldToValueMap(), Map.of("intMV", new Object[0], "stringMV", new Object[0]));
 
@@ -131,9 +132,9 @@ public class AvroRecordToPinotRowGeneratorTest {
     avroRecordExtractor.init(null, null);
     GenericRow genericRow = new GenericRow();
 
-    Map<String, Integer> intMap = Map.of("v1", 1, "v2", 2, "v3", 3);
+    Map<String, Integer> intMap = new HashMap(Map.of("v1", 1, "v2", 2, "v3", 3));
     genericRecord.put("intMap", intMap);
-    Map<String, String> stringMap = Map.of("v1", "value1", "v2", "value2", "v3", "value3");
+    Map<String, String> stringMap = new HashMap(Map.of("v1", "value1", "v2", "value2", "v3", "value3"));
     genericRecord.put("stringMap", stringMap);
     avroRecordExtractor.extract(genericRecord, genericRow);
     assertEqualsDeep(genericRow.getFieldToValueMap(), Map.of("intMap", intMap, "stringMap", stringMap));


### PR DESCRIPTION
This pull request introduces changes to improve logical type handling and enhance schema processing in the Avro input format plugin. It also updates test cases to ensure compatibility with the modified logic. The most important changes include enabling logical types by default, refactoring schema processing methods, and adapting test cases for better compatibility with the new implementation.


# Release Note
[Backward incompatible][Avro plugin] Enable Avro logical types support by default.
