### PR TITLE
Add button to Pause/Resume consumption in Table UI

### DIFF
--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -152,6 +152,22 @@ declare module 'Models' {
     serversUnparsableRespond: number;
     _segmentToConsumingInfoMap: Record<string, ConsumingInfo[]>;
   }
+  
+  /**
+   * Pause status information for a realtime table
+   */
+  export interface PauseStatusDetails {
+    /** Whether the table is currently paused */
+    pauseFlag: boolean;
+    /** List of segments still in consuming state when paused */
+    consumingSegments: string[];
+    /** Reason code for pause state */
+    reasonCode: string;
+    /** Optional comment provided when pausing/resuming */
+    comment: string;
+    /** Timestamp of the pause/resume action */
+    timestamp: string;
+  }
 
   export type TableSchema = {
     dimensionFieldSpecs: Array<schema>;

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -50,7 +50,8 @@ import {
   SchemaInfo,
   SegmentStatusInfo,
   ServerToSegmentsCount,
-  ConsumingSegmentsInfo
+  ConsumingSegmentsInfo,
+  PauseStatusDetails
 } from 'Models';
 
 const headers = {
@@ -116,6 +117,20 @@ export const getSegmentsStatus = (name: string): Promise<AxiosResponse<SegmentSt
 // API: GET /tables/{tableName}/consumingSegmentsInfo
 export const getConsumingSegmentsInfo = (name: string): Promise<AxiosResponse<ConsumingSegmentsInfo>> =>
   baseApi.get(`/tables/${name}/consumingSegmentsInfo`);
+
+// Pause or resume consumption of a realtime table
+// API: POST /tables/{tableName}/pauseConsumption
+export const pauseConsumption = (name: string, comment?: string): Promise<AxiosResponse<PauseStatusDetails>> =>
+  baseApi.post(`/tables/${name}/pauseConsumption`, null, { params: { comment } });
+
+// API: POST /tables/{tableName}/resumeConsumption
+export const resumeConsumption = (name: string, comment?: string, consumeFrom?: string): Promise<AxiosResponse<PauseStatusDetails>> =>
+  baseApi.post(`/tables/${name}/resumeConsumption`, null, { params: { comment, consumeFrom } });
+
+// Fetch pause status for a realtime table
+// API: GET /tables/{tableName}/pauseStatus
+export const getPauseStatus = (name: string): Promise<AxiosResponse<PauseStatusDetails>> =>
+  baseApi.get(`/tables/${name}/pauseStatus`);
 
 export const getInstances = (): Promise<AxiosResponse<Instances>> =>
   baseApi.get('/instances');

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -109,7 +109,10 @@ import {
   getSchemaInfo,
   getSegmentsStatus,
   getConsumingSegmentsInfo,
-  getServerToSegmentsCount
+  getServerToSegmentsCount,
+  pauseConsumption,
+  resumeConsumption,
+  getPauseStatus
 } from '../requests';
 import { baseApi } from './axios-config';
 import Utils from './Utils';
@@ -821,6 +824,19 @@ const toggleTableState = (tableName, state, tableType) => {
     return response.data;
   });
 };
+// Pause or resume consumption of a realtime table
+// Returns PauseStatusDetails
+const pauseConsumptionOp = (tableName, comment) => {
+  return pauseConsumption(tableName, comment).then((response) => response.data);
+};
+
+const resumeConsumptionOp = (tableName, comment, consumeFrom) => {
+  return resumeConsumption(tableName, comment, consumeFrom).then((response) => response.data);
+};
+
+const getPauseStatusData = (tableName) => {
+  return getPauseStatus(tableName).then((response) => response.data);
+};
 
 const deleteInstance = (instanceName) => {
   return dropInstance(instanceName).then((response)=>{
@@ -1397,6 +1413,10 @@ export default {
   updateUser,
   getAuthUserNameFromAccessToken,
   getAuthUserEmailFromAccessToken,
+  // Pause/resume consumption of realtime tables
+  pauseConsumptionOp,
+  resumeConsumptionOp,
+  getPauseStatusData,
   fetchServerToSegmentsCountData,
   getConsumingSegmentsInfoData
 };


### PR DESCRIPTION
This pull request introduces a new feature to manage the pause and resume functionality for real-time table consumption in the Pinot Controller UI. It includes updates to the UI components, API integrations, and utility methods to support this functionality. Key changes include adding new states and effects for handling pause/resume actions, integrating new API endpoints, and updating the UI to display the pause status.

### UI Enhancements:
* Added a toggle switch in `TenantDetails.tsx` to allow users to pause or resume real-time table consumption. The switch is conditionally enabled based on the current table type and pause status.
* Introduced status chips (`ACTIVE`, `PAUSED`, `PAUSING`, `RESUMING...`) to visually indicate the consumption status of real-time tables. Styles for these chips were added to `useStyles`. 

![Screen Recording 2025-04-28 at 11 27 18 AM (1)](https://github.com/user-attachments/assets/5080b0b1-e290-435f-84f6-1270e6a9db51)

### State Management:
* Added new state variables in `TenantDetails.tsx` to manage pause/resume action progress, polling for status updates, and the pause status data fetched from the backend.
* Implemented a cleanup mechanism using `useEffect` to ensure polling intervals are cleared on component unmount.

### API Integrations:
* Added new API methods (`pauseConsumption`, `resumeConsumption`, `getPauseStatus`) in `index.ts` to interact with the backend endpoints for pausing/resuming consumption and fetching pause status.
* Updated `PinotMethodUtils.ts` to include utility methods (`pauseConsumptionOp`, `resumeConsumptionOp`, `getPauseStatusData`) for consuming the new API endpoints. 

### Dropdown Menu for Rebalance Operations:
* Replaced the "Rebalance Servers" button with a dropdown menu for rebalance operations, providing a cleaner and more organized UI.

![Screenshot 2025-04-28 at 11 29 38 AM](https://github.com/user-attachments/assets/96f938dd-ea3b-49bd-9c45-48f9547f8655)
