### PR TITLE
[multistage] Add Pushdown and Worker Rules

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -1,0 +1,379 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
+import org.apache.pinot.query.planner.logical.TransformationTracker;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.ExchangeNode;
+import org.apache.pinot.query.planner.plannode.FilterNode;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.PlanNode.NodeHint;
+import org.apache.pinot.query.planner.plannode.ProjectNode;
+import org.apache.pinot.query.planner.plannode.SetOpNode;
+import org.apache.pinot.query.planner.plannode.SortNode;
+import org.apache.pinot.query.planner.plannode.TableScanNode;
+import org.apache.pinot.query.planner.plannode.ValueNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PRelToPlanNodeConverter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PRelToPlanNodeConverter.class);
+  private static final int DEFAULT_STAGE_ID = -1;
+
+  private final BrokerMetrics _brokerMetrics = BrokerMetrics.get();
+  private boolean _joinFound;
+  private boolean _windowFunctionFound;
+  @Nullable
+  private final TransformationTracker.Builder<PlanNode, RelNode> _tracker;
+
+  public PRelToPlanNodeConverter(@Nullable TransformationTracker.Builder<PlanNode, RelNode> tracker) {
+    _tracker = tracker;
+  }
+
+  /**
+   * Converts a {@link RelNode} into its serializable counterpart.
+   * NOTE: Stage ID is not determined yet.
+   */
+  public static PlanNode toPlanNode(PRelNode pRelNode, int stageId) {
+    RelNode node = pRelNode.unwrap();
+    PlanNode result;
+    if (node instanceof TableScan) {
+      result = convertTableScan((TableScan) node);
+    } else if (node instanceof Project) {
+      result = convertProject((Project) node);
+    } else if (node instanceof Filter) {
+      result = convertFilter((Filter) node);
+    } else if (node instanceof PhysicalAggregate) {
+      result = convertAggregate((PhysicalAggregate) node);
+    } else if (node instanceof Sort) {
+      result = convertSort((Sort) node);
+    } else if (node instanceof Exchange) {
+      result = convertPhysicalExchange((PhysicalExchange) node);
+    } else if (node instanceof PhysicalJoin) {
+      /* _brokerMetrics.addMeteredGlobalValue(BrokerMeter.JOIN_COUNT, 1);
+      if (!_joinFound) {
+        _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERIES_WITH_JOINS, 1);
+        _joinFound = true;
+      } */
+      result = convertJoin((PhysicalJoin) node);
+    } else if (node instanceof Window) {
+      /* _brokerMetrics.addMeteredGlobalValue(BrokerMeter.WINDOW_COUNT, 1);
+      if (!_windowFunctionFound) {
+        _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERIES_WITH_WINDOW, 1);
+        _windowFunctionFound = true;
+      } */
+      result = convertWindow((Window) node);
+    } else if (node instanceof Values) {
+      result = convertValues((Values) node);
+    } else if (node instanceof SetOp) {
+      result = convertSetOp((SetOp) node);
+    } else {
+      throw new IllegalStateException("Unsupported RelNode: " + node);
+    }
+    result.setStageId(stageId);
+    /* if (_tracker != null) {
+      _tracker.trackCreation(node, result);
+    } */
+    return result;
+  }
+
+  public static ExchangeNode convertPhysicalExchange(PhysicalExchange node) {
+    // TODO(mse-physical): Why are table names passed to ExchangeNode?
+    return new ExchangeNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()),
+        new ArrayList<>(), node.getRelExchangeType(), RelDistribution.Type.ANY, node.getDistributionKeys(),
+        false, node.getRelCollation().getFieldCollations(), false,
+        !node.getRelCollation().getKeys().isEmpty(), Set.of() /* table names */, node.getExchangeStrategy());
+  }
+
+  public static SetOpNode convertSetOp(SetOp node) {
+    return new SetOpNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), SetOpNode.SetOpType.fromObject(node), node.all);
+  }
+
+  public static ValueNode convertValues(Values node) {
+    List<List<RexExpression.Literal>> literalRows = new ArrayList<>(node.tuples.size());
+    for (List<RexLiteral> tuple : node.tuples) {
+      List<RexExpression.Literal> literalRow = new ArrayList<>(tuple.size());
+      for (RexLiteral rexLiteral : tuple) {
+        literalRow.add(RexExpressionUtils.fromRexLiteral(rexLiteral));
+      }
+      literalRows.add(literalRow);
+    }
+    return new ValueNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), literalRows);
+  }
+
+  public static WindowNode convertWindow(Window node) {
+    // Only a single Window Group should exist per WindowNode.
+    Preconditions.checkState(node.groups.size() == 1, "Only a single window group is allowed, got: %s",
+        node.groups.size());
+    Window.Group windowGroup = node.groups.get(0);
+
+    int numAggregates = windowGroup.aggCalls.size();
+    List<RexExpression.FunctionCall> aggCalls = new ArrayList<>(numAggregates);
+    for (int i = 0; i < numAggregates; i++) {
+      aggCalls.add(RexExpressionUtils.fromWindowAggregateCall(windowGroup.aggCalls.get(i)));
+    }
+    WindowNode.WindowFrameType windowFrameType =
+        windowGroup.isRows ? WindowNode.WindowFrameType.ROWS : WindowNode.WindowFrameType.RANGE;
+
+    int lowerBound;
+    if (windowGroup.lowerBound.isUnbounded()) {
+      // Lower bound can't be unbounded following
+      lowerBound = Integer.MIN_VALUE;
+    } else if (windowGroup.lowerBound.isCurrentRow()) {
+      lowerBound = 0;
+    } else {
+      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
+      RexLiteral offset = (RexLiteral) windowGroup.lowerBound.getOffset();
+      lowerBound = offset == null ? Integer.MIN_VALUE
+          : (windowGroup.lowerBound.isPreceding() ? -1 * RexExpressionUtils.getValueAsInt(offset)
+              : RexExpressionUtils.getValueAsInt(offset));
+    }
+    int upperBound;
+    if (windowGroup.upperBound.isUnbounded()) {
+      // Upper bound can't be unbounded preceding
+      upperBound = Integer.MAX_VALUE;
+    } else if (windowGroup.upperBound.isCurrentRow()) {
+      upperBound = 0;
+    } else {
+      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
+      RexLiteral offset = (RexLiteral) windowGroup.upperBound.getOffset();
+      upperBound = offset == null ? Integer.MAX_VALUE
+          : (windowGroup.upperBound.isFollowing() ? RexExpressionUtils.getValueAsInt(offset)
+              : -1 * RexExpressionUtils.getValueAsInt(offset));
+    }
+
+    // TODO: The constants are already extracted in the PinotWindowExchangeNodeInsertRule, we can remove them from
+    // the WindowNode and plan serde.
+    List<RexExpression.Literal> constants = new ArrayList<>(node.constants.size());
+    for (RexLiteral constant : node.constants) {
+      constants.add(RexExpressionUtils.fromRexLiteral(constant));
+    }
+    return new WindowNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), windowGroup.keys.asList(), windowGroup.orderKeys.getFieldCollations(),
+        aggCalls, windowFrameType, lowerBound, upperBound, constants);
+  }
+
+  public static SortNode convertSort(Sort node) {
+    int fetch = RexExpressionUtils.getValueAsInt(node.fetch);
+    int offset = RexExpressionUtils.getValueAsInt(node.offset);
+    return new SortNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), node.getCollation().getFieldCollations(), fetch, offset);
+  }
+
+  public static AggregateNode convertAggregate(PhysicalAggregate node) {
+    List<AggregateCall> aggregateCalls = node.getAggCallList();
+    int numAggregates = aggregateCalls.size();
+    List<RexExpression.FunctionCall> functionCalls = new ArrayList<>(numAggregates);
+    List<Integer> filterArgs = new ArrayList<>(numAggregates);
+    for (AggregateCall aggregateCall : aggregateCalls) {
+      functionCalls.add(RexExpressionUtils.fromAggregateCall(aggregateCall));
+      filterArgs.add(aggregateCall.filterArg);
+    }
+    return new AggregateNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), functionCalls, filterArgs, node.getGroupSet().asList(), node.getAggType(),
+        node.isLeafReturnFinalResult(), node.getCollations(), node.getLimit());
+  }
+
+  public static ProjectNode convertProject(Project node) {
+    return new ProjectNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), RexExpressionUtils.fromRexNodes(node.getProjects()));
+  }
+
+  public static FilterNode convertFilter(Filter node) {
+    return new FilterNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        new ArrayList<>(), RexExpressionUtils.fromRexNode(node.getCondition()));
+  }
+
+  public static TableScanNode convertTableScan(TableScan node) {
+    String tableName = getTableNameFromTableScan(node);
+    List<RelDataTypeField> fields = node.getRowType().getFieldList();
+    List<String> columns = new ArrayList<>(fields.size());
+    for (RelDataTypeField field : fields) {
+      columns.add(field.getName());
+    }
+    return new TableScanNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
+        List.of(), tableName, columns);
+  }
+
+  public static JoinNode convertJoin(PhysicalJoin join) {
+    JoinInfo joinInfo = join.analyzeCondition();
+    DataSchema dataSchema = toDataSchema(join.getRowType());
+    List<PlanNode> inputs = new ArrayList<>();
+    JoinRelType joinType = join.getJoinType();
+    JoinNode.JoinStrategy joinStrategy;
+    if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
+      joinStrategy = JoinNode.JoinStrategy.LOOKUP;
+    } else {
+      joinStrategy = JoinNode.JoinStrategy.HASH;
+    }
+    return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(join.getHints()), inputs, joinType,
+        joinInfo.leftKeys, joinInfo.rightKeys, RexExpressionUtils.fromRexNodes(joinInfo.nonEquiConditions),
+        joinStrategy);
+  }
+
+  public static DataSchema toDataSchema(RelDataType rowType) {
+    if (rowType instanceof RelRecordType) {
+      RelRecordType recordType = (RelRecordType) rowType;
+      String[] columnNames = recordType.getFieldNames().toArray(new String[]{});
+      ColumnDataType[] columnDataTypes = new ColumnDataType[columnNames.length];
+      for (int i = 0; i < columnNames.length; i++) {
+        columnDataTypes[i] = convertToColumnDataType(recordType.getFieldList().get(i).getType());
+      }
+      return new DataSchema(columnNames, columnDataTypes);
+    } else {
+      throw new IllegalArgumentException("Unsupported RelDataType: " + rowType);
+    }
+  }
+
+  public static ColumnDataType convertToColumnDataType(RelDataType relDataType) {
+    SqlTypeName sqlTypeName = relDataType.getSqlTypeName();
+    if (sqlTypeName == SqlTypeName.NULL) {
+      return ColumnDataType.UNKNOWN;
+    }
+    boolean isArray = (sqlTypeName == SqlTypeName.ARRAY);
+    if (isArray) {
+      assert relDataType.getComponentType() != null;
+      sqlTypeName = relDataType.getComponentType().getSqlTypeName();
+    }
+    switch (sqlTypeName) {
+      case BOOLEAN:
+        return isArray ? ColumnDataType.BOOLEAN_ARRAY : ColumnDataType.BOOLEAN;
+      case TINYINT:
+      case SMALLINT:
+      case INTEGER:
+        return isArray ? ColumnDataType.INT_ARRAY : ColumnDataType.INT;
+      case BIGINT:
+        return isArray ? ColumnDataType.LONG_ARRAY : ColumnDataType.LONG;
+      case DECIMAL:
+        return resolveDecimal(relDataType, isArray);
+      case FLOAT:
+      case REAL:
+        return isArray ? ColumnDataType.FLOAT_ARRAY : ColumnDataType.FLOAT;
+      case DOUBLE:
+        return isArray ? ColumnDataType.DOUBLE_ARRAY : ColumnDataType.DOUBLE;
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+        return isArray ? ColumnDataType.TIMESTAMP_ARRAY : ColumnDataType.TIMESTAMP;
+      case CHAR:
+      case VARCHAR:
+        return isArray ? ColumnDataType.STRING_ARRAY : ColumnDataType.STRING;
+      case BINARY:
+      case VARBINARY:
+        return isArray ? ColumnDataType.BYTES_ARRAY : ColumnDataType.BYTES;
+      case MAP:
+        return ColumnDataType.MAP;
+      case OTHER:
+      case ANY:
+        return ColumnDataType.OBJECT;
+      default:
+        if (relDataType.getComponentType() != null) {
+          throw new IllegalArgumentException("Unsupported collection type: " + relDataType);
+        }
+        LOGGER.warn("Unexpected SQL type: {}, use OBJECT instead", sqlTypeName);
+        return ColumnDataType.OBJECT;
+    }
+  }
+
+  /**
+   * Calcite uses DEMICAL type to infer data type hoisting and infer arithmetic result types. down casting this back to
+   * the proper primitive type for Pinot.
+   * TODO: Revisit this method:
+   *  - Currently we are converting exact value to approximate value
+   *  - Integer can only cover all values with precision 9; Long can only cover all values with precision 18
+   *
+   * {@link RequestUtils#getLiteralExpression(SqlLiteral)}
+   * @param relDataType the DECIMAL rel data type.
+   * @param isArray
+   * @return proper {@link ColumnDataType}.
+   * @see {@link org.apache.calcite.rel.type.RelDataTypeFactoryImpl#decimalOf}.
+   */
+  private static ColumnDataType resolveDecimal(RelDataType relDataType, boolean isArray) {
+    int precision = relDataType.getPrecision();
+    int scale = relDataType.getScale();
+    if (scale == 0) {
+      if (precision <= 10) {
+        return isArray ? ColumnDataType.INT_ARRAY : ColumnDataType.INT;
+      } else if (precision <= 38) {
+        return isArray ? ColumnDataType.LONG_ARRAY : ColumnDataType.LONG;
+      } else {
+        return isArray ? ColumnDataType.DOUBLE_ARRAY : ColumnDataType.BIG_DECIMAL;
+      }
+    } else {
+      // NOTE: Do not use FLOAT to represent DECIMAL to be consistent with single-stage engine behavior.
+      //       See {@link RequestUtils#getLiteralExpression(SqlLiteral)}.
+      if (precision <= 30) {
+        return isArray ? ColumnDataType.DOUBLE_ARRAY : ColumnDataType.DOUBLE;
+      } else {
+        return isArray ? ColumnDataType.DOUBLE_ARRAY : ColumnDataType.BIG_DECIMAL;
+      }
+    }
+  }
+
+  public static String getTableNameFromTableScan(TableScan tableScan) {
+    return getTableNameFromRelTable(tableScan.getTable());
+  }
+
+  public static String getTableNameFromRelTable(RelOptTable table) {
+    List<String> qualifiedName = table.getQualifiedName();
+    return qualifiedName.size() == 1 ? qualifiedName.get(0)
+        : DatabaseUtils.constructFullyQualifiedTableName(qualifiedName.get(0), qualifiedName.get(1));
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PinotDataDistribution.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PinotDataDistribution.java
@@ -119,13 +119,12 @@ public class PinotDataDistribution {
     RelDistribution.Type constraintType = distributionConstraint.getType();
     switch (constraintType) {
       case ANY:
+      case RANDOM_DISTRIBUTED:
         return true;
       case BROADCAST_DISTRIBUTED:
         return _type == RelDistribution.Type.BROADCAST_DISTRIBUTED;
       case SINGLETON:
         return _type == RelDistribution.Type.SINGLETON;
-      case RANDOM_DISTRIBUTED:
-        return _type == RelDistribution.Type.RANDOM_DISTRIBUTED;
       case HASH_DISTRIBUTED:
         if (_type != RelDistribution.Type.HASH_DISTRIBUTED) {
           return false;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalExchange.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalExchange.java
@@ -93,7 +93,7 @@ public class PhysicalExchange extends Exchange implements PRelNode {
   @Override
   public Exchange copy(RelTraitSet traitSet, RelNode newInput, RelDistribution newDistribution) {
     Preconditions.checkState(newInput instanceof PRelNode, "Expected input of PhysicalExchange to be a PRelNode");
-    Preconditions.checkState(traitSet.isEmpty(), "Expected empty trait set for PhysicalExchange");
+    // TODO(mse-physical): this always uses streaming exec strategy at the moment.
     return new PhysicalExchange(_nodeId, (PRelNode) newInput, _pinotDataDistribution, _distributionKeys,
         _exchangeStrategy, _relCollation, PinotExecStrategyTrait.getDefaultExecStrategy());
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PhysicalOptRuleSet.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PhysicalOptRuleSet.java
@@ -22,9 +22,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.physical.v2.opt.rules.AggregatePushdownRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LeafStageAggregateRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LeafStageBoundaryRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LeafStageWorkerAssignmentRule;
+import org.apache.pinot.query.planner.physical.v2.opt.rules.SortPushdownRule;
+import org.apache.pinot.query.planner.physical.v2.opt.rules.WorkerExchangeAssignmentRule;
 
 
 public class PhysicalOptRuleSet {
@@ -37,9 +40,9 @@ public class PhysicalOptRuleSet {
     transformers.add(create(new LeafStageWorkerAssignmentRule(context, tableCache), RuleExecutors.Type.POST_ORDER,
         context));
     transformers.add(create(new LeafStageAggregateRule(context), RuleExecutors.Type.POST_ORDER, context));
-    // transformers.add(new WorkerExchangeAssignmentRule(context));
-    // transformers.add(create(new AggregatePushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
-    // transformers.add(create(new SortPushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
+    transformers.add(new WorkerExchangeAssignmentRule(context));
+    transformers.add(create(new AggregatePushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
+    transformers.add(create(new SortPushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
     return transformers;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/AggregatePushdownRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/AggregatePushdownRule.java
@@ -1,0 +1,290 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.calcite.rel.rules.PinotRuleUtils;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTrait;
+import org.apache.pinot.common.function.sql.PinotSqlAggFunction;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.apache.pinot.query.planner.physical.v2.mapping.DistMappingGenerator;
+import org.apache.pinot.query.planner.physical.v2.mapping.PinotDistMapping;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRule;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRuleCall;
+import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+/**
+ * Does the following:
+ * 1. Converts agg calls to their proper forms.
+ * 2. Adds aggregate under Exchange, if exchange is an input.
+ * 3. Handles leafReturnFinalResult thing.
+ */
+public class AggregatePushdownRule extends PRelOptRule {
+  private final PhysicalPlannerContext _context;
+
+  public AggregatePushdownRule(PhysicalPlannerContext context) {
+    _context = context;
+  }
+
+  @Override
+  public boolean matches(PRelOptRuleCall call) {
+    return call._currentNode instanceof Aggregate;
+  }
+
+  @Override
+  public PRelNode onMatch(PRelOptRuleCall call) {
+    Aggregate aggRel = (Aggregate) call._currentNode;
+    Preconditions.checkState(aggRel instanceof PhysicalAggregate, "Expected PhysicalAggregate, got %s", aggRel);
+    boolean hasGroupBy = !aggRel.getGroupSet().isEmpty();
+    RelCollation withinGroupCollation = extractWithinGroupCollation(aggRel);
+    Map<String, String> hintOptions =
+        PinotHintStrategyTable.getHintOptions(aggRel.getHints(), PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+    if (hintOptions == null) {
+      hintOptions = Map.of();
+    }
+    boolean isInputExchange = call._currentNode.unwrap().getInput(0) instanceof Exchange;
+    if (!isInputExchange || withinGroupCollation != null || (hasGroupBy && Boolean.parseBoolean(
+        hintOptions.get(PinotHintOptions.AggregateOptions.IS_SKIP_LEAF_STAGE_GROUP_BY)))) {
+      return skipPartialAggregate(call._currentNode);
+    }
+    return addPartialAggregate((PhysicalAggregate) call._currentNode, hintOptions, _context.getNodeIdGenerator());
+  }
+
+  private static PRelNode skipPartialAggregate(PRelNode aggPRelNode) {
+    PhysicalAggregate aggRel = (PhysicalAggregate) aggPRelNode.unwrap();
+    List<AggregateCall> newAggCalls = buildAggCalls(aggRel, AggType.DIRECT, false);
+    return new PhysicalAggregate(aggRel.getCluster(), aggRel.getTraitSet(), aggRel.getHints(), aggRel.getGroupSet(),
+        aggRel.groupSets, newAggCalls, aggRel.getNodeId(), aggRel.getPRelInput(0),
+        aggRel.getPinotDataDistributionOrThrow(), aggRel.isLeafStage(), AggType.DIRECT,
+        false /* leaf return final agg */, aggRel.getCollations(), aggRel.getLimit());
+  }
+
+  private static PRelNode addPartialAggregate(PhysicalAggregate aggPRelNode, Map<String, String> hintOptions,
+      Supplier<Integer> idGenerator) {
+    // Old: Aggregate (o0) > Exchange (o1) > Input (o2)
+    // New: Aggregate (n0) > Exchange (n1) > Aggregate (n2) > Input (o2)
+    boolean leafReturnFinalResult =
+        Boolean.parseBoolean(hintOptions.get(PinotHintOptions.AggregateOptions.IS_LEAF_RETURN_FINAL_RESULT));
+    // init old PRelNodes
+    PhysicalAggregate o0 = aggPRelNode;
+    PhysicalExchange o1 = (PhysicalExchange) o0.getPRelInput(0);
+    PRelNode o2 = o1.getPRelInput(0);
+    // Create n2
+    PhysicalAggregate n2 = new PhysicalAggregate(o0.getCluster(), RelTraitSet.createEmpty(), List.of() /* hints */,
+        o0.getGroupSet(), o0.groupSets, buildAggCalls(o0, AggType.LEAF, leafReturnFinalResult), idGenerator.get(),
+        o2, null /* data dist */, o2.isLeafStage(), AggType.LEAF, leafReturnFinalResult, aggPRelNode.getCollations(),
+        aggPRelNode.getLimit());
+    PinotDistMapping mapFromInputToPartialAgg = DistMappingGenerator.compute(o2.unwrap(), n2, null);
+    PinotDataDistribution leafAggDataDistribution = o2.getPinotDataDistributionOrThrow().apply(
+        mapFromInputToPartialAgg);
+    n2 = (PhysicalAggregate) n2.with(n2.getPRelInputs(), leafAggDataDistribution);
+    // Create n1.
+    List<Integer> newDistKeys = mapFromInputToPartialAgg.getMappedKeys(o1.getDistributionKeys()).get(0);
+    RelCollation newCollation = o1.getRelCollation() == null ? null
+        : PinotDistMapping.apply(o1.getRelCollation(), mapFromInputToPartialAgg);
+    PhysicalExchange n1 = new PhysicalExchange(o1.getNodeId(), n2,
+        o1.getPinotDataDistributionOrThrow().apply(mapFromInputToPartialAgg), newDistKeys, o1.getExchangeStrategy(),
+        newCollation, PinotExecStrategyTrait.getDefaultExecStrategy());
+    return convertAggFromIntermediateInput(aggPRelNode, n1, AggType.FINAL, leafReturnFinalResult,
+        PinotDistMapping.apply(RelCollations.of(o0.getCollations()), mapFromInputToPartialAgg).getFieldCollations(),
+        aggPRelNode.getLimit(), idGenerator);
+  }
+
+  // TODO: Currently it only handles one WITHIN GROUP collation across all AggregateCalls.
+  @Nullable
+  private static RelCollation extractWithinGroupCollation(Aggregate aggRel) {
+    for (AggregateCall aggCall : aggRel.getAggCallList()) {
+      RelCollation collation = aggCall.getCollation();
+      if (!collation.getFieldCollations().isEmpty()) {
+        return collation;
+      }
+    }
+    return null;
+  }
+
+  private static PhysicalAggregate convertAggFromIntermediateInput(PhysicalAggregate physicalAggregate,
+      PhysicalExchange exchange, AggType aggType, boolean leafReturnFinalResult,
+      @Nullable List<RelFieldCollation> collations, int limit, Supplier<Integer> nodeId) {
+    Aggregate aggRel = (Aggregate) physicalAggregate.unwrap();
+    RelNode input = aggRel.getInput();
+    List<RexNode> projects = findImmediateProjects(input);
+    // Create new AggregateCalls from exchange input. Exchange produces results with group keys followed by intermediate
+    // aggregate results.
+    int groupCount = aggRel.getGroupCount();
+    List<AggregateCall> orgAggCalls = aggRel.getAggCallList();
+    int numAggCalls = orgAggCalls.size();
+    List<AggregateCall> aggCalls = new ArrayList<>(numAggCalls);
+    for (int i = 0; i < numAggCalls; i++) {
+      AggregateCall orgAggCall = orgAggCalls.get(i);
+      List<Integer> argList = orgAggCall.getArgList();
+      int index = groupCount + i;
+      RexInputRef inputRef = RexInputRef.of(index, aggRel.getRowType());
+      // Generate rexList from argList and replace literal reference with literal. Keep the first argument as is.
+      int numArguments = argList.size();
+      List<RexNode> rexList;
+      if (numArguments <= 1) {
+        rexList = ImmutableList.of(inputRef);
+      } else {
+        rexList = new ArrayList<>(numArguments);
+        rexList.add(inputRef);
+        for (int j = 1; j < numArguments; j++) {
+          int argument = argList.get(j);
+          if (projects != null && projects.get(argument) instanceof RexLiteral) {
+            rexList.add(projects.get(argument));
+          } else {
+            // Replace all the input reference in the rexList to the new input reference.
+            rexList.add(inputRef);
+          }
+        }
+      }
+      aggCalls.add(buildAggCall(exchange, orgAggCall, rexList, groupCount, aggType, leafReturnFinalResult));
+    }
+    ImmutableBitSet.Builder groupSetBuilder = ImmutableBitSet.builder();
+    for (int i = 0; i < groupCount; i++) {
+      groupSetBuilder.set(i);
+    }
+    ImmutableBitSet groupSet = groupSetBuilder.build();
+    List<ImmutableBitSet> groupSets = null;
+    if (!groupSet.isEmpty()) {
+      groupSets = List.of(groupSet);
+    }
+    return new PhysicalAggregate(aggRel.getCluster(), aggRel.getTraitSet(), aggRel.getHints(), groupSet,
+        groupSets, aggCalls, nodeId.get(), exchange, physicalAggregate.getPinotDataDistributionOrThrow(),
+        false, aggType, leafReturnFinalResult, collations, limit);
+  }
+
+  public static List<AggregateCall> buildAggCalls(Aggregate aggRel, AggType aggType, boolean leafReturnFinalResult) {
+    RelNode input = aggRel.getInput();
+    List<RexNode> projects = findImmediateProjects(input);
+    List<AggregateCall> orgAggCalls = aggRel.getAggCallList();
+    List<AggregateCall> aggCalls = new ArrayList<>(orgAggCalls.size());
+    for (AggregateCall orgAggCall : orgAggCalls) {
+      // Generate rexList from argList and replace literal reference with literal. Keep the first argument as is.
+      List<Integer> argList = orgAggCall.getArgList();
+      int numArguments = argList.size();
+      List<RexNode> rexList;
+      if (numArguments == 0) {
+        rexList = ImmutableList.of();
+      } else if (numArguments == 1) {
+        rexList = ImmutableList.of(RexInputRef.of(argList.get(0), input.getRowType()));
+      } else {
+        rexList = new ArrayList<>(numArguments);
+        rexList.add(RexInputRef.of(argList.get(0), input.getRowType()));
+        for (int i = 1; i < numArguments; i++) {
+          int argument = argList.get(i);
+          if (projects != null && projects.get(argument) instanceof RexLiteral) {
+            rexList.add(projects.get(argument));
+          } else {
+            rexList.add(RexInputRef.of(argument, input.getRowType()));
+          }
+        }
+      }
+      aggCalls.add(buildAggCall(input, orgAggCall, rexList, aggRel.getGroupCount(), aggType, leafReturnFinalResult));
+    }
+    return aggCalls;
+  }
+
+  // TODO: Revisit the following logic:
+  //   - DISTINCT is resolved here
+  //   - argList is replaced with rexList
+  private static AggregateCall buildAggCall(RelNode input, AggregateCall orgAggCall, List<RexNode> rexList,
+      int numGroups, AggType aggType, boolean leafReturnFinalResult) {
+    SqlAggFunction orgAggFunction = orgAggCall.getAggregation();
+    String functionName = orgAggFunction.getName();
+    SqlKind kind = orgAggFunction.getKind();
+    SqlFunctionCategory functionCategory = orgAggFunction.getFunctionType();
+    if (orgAggCall.isDistinct()) {
+      if (kind == SqlKind.COUNT) {
+        functionName = "DISTINCTCOUNT";
+        kind = SqlKind.OTHER_FUNCTION;
+        functionCategory = SqlFunctionCategory.USER_DEFINED_FUNCTION;
+      } else if (kind == SqlKind.LISTAGG) {
+        rexList.add(input.getCluster().getRexBuilder().makeLiteral(true));
+      }
+    }
+    SqlReturnTypeInference returnTypeInference = null;
+    RelDataType returnType = null;
+    // Override the intermediate result type inference if it is provided
+    if (aggType.isOutputIntermediateFormat()) {
+      AggregationFunctionType functionType = AggregationFunctionType.getAggregationFunctionType(functionName);
+      returnTypeInference = leafReturnFinalResult ? functionType.getFinalReturnTypeInference()
+          : functionType.getIntermediateReturnTypeInference();
+    }
+    // When the output is not intermediate format, or intermediate result type inference is not provided (intermediate
+    // result type the same as final result type), use the explicit return type
+    if (returnTypeInference == null) {
+      returnType = orgAggCall.getType();
+      returnTypeInference = ReturnTypes.explicit(returnType);
+    }
+    SqlOperandTypeChecker operandTypeChecker =
+        aggType.isInputIntermediateFormat() ? OperandTypes.ANY : orgAggFunction.getOperandTypeChecker();
+    SqlAggFunction sqlAggFunction =
+        new PinotSqlAggFunction(functionName, kind, returnTypeInference, operandTypeChecker, functionCategory);
+    return AggregateCall.create(sqlAggFunction, false, orgAggCall.isApproximate(), orgAggCall.ignoreNulls(), rexList,
+        ImmutableList.of(), aggType.isInputIntermediateFormat() ? -1 : orgAggCall.filterArg, orgAggCall.distinctKeys,
+        orgAggCall.collation, numGroups, input, returnType, null);
+  }
+
+  @Nullable
+  private static List<RexNode> findImmediateProjects(RelNode relNode) {
+    relNode = PinotRuleUtils.unboxRel(relNode);
+    if (relNode instanceof Project) {
+      return ((Project) relNode).getProjects();
+    } else if (relNode instanceof Union) {
+      return findImmediateProjects(relNode.getInput(0));
+    }
+    return null;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/SortPushdownRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/SortPushdownRule.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalSort;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRule;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRuleCall;
+import org.apache.pinot.query.type.TypeFactory;
+
+
+/**
+ * <h1>Overview</h1>
+ * When a Sort node is on top of an Exchange, it may make sense to add a copy of the Sort under the Exchange too for
+ * performance reasons. E.g. if the Sort has a fetch of 50 rows, then it makes sense to trim the amount of rows
+ * sent across the Exchange too.
+ */
+public class SortPushdownRule extends PRelOptRule {
+  private static final TypeFactory TYPE_FACTORY = new TypeFactory();
+  private static final RexBuilder REX_BUILDER = new RexBuilder(TYPE_FACTORY);
+  private final PhysicalPlannerContext _context;
+
+  public SortPushdownRule(PhysicalPlannerContext context) {
+    _context = context;
+  }
+
+  @Override
+  public boolean matches(PRelOptRuleCall call) {
+    return call._currentNode.unwrap() instanceof Sort
+        && call._currentNode.unwrap().getInput(0) instanceof Exchange;
+  }
+
+  @Override
+  public PRelNode onMatch(PRelOptRuleCall call) {
+    // Push down sort when there's a fetch. Don't push down offset, since we can't compute it without total order.
+    PhysicalSort sort = (PhysicalSort) call._currentNode.unwrap();
+    RexNode newSortFetch = computeEffectiveFetch(sort.fetch, sort.offset);
+    if (newSortFetch == null) {
+      return call._currentNode;
+    }
+    // Old: Sort (o0) > Exchange (o1) > Input (o2)
+    // New: Sort (n0) > Exchange (n1) > Sort (n2) > Input (o2)
+    PRelNode o0 = call._currentNode;
+    PhysicalExchange o1 = (PhysicalExchange) o0.getPRelInput(0);
+    PRelNode o2 = o1.getPRelInput(0);
+    if (o2 instanceof Sort) {
+      return call._currentNode;
+    }
+    // TODO(mse-physical): Preserve collation in PinotDataDistribution.
+    PhysicalSort n2 = new PhysicalSort(sort.getCluster(), RelTraitSet.createEmpty(), List.of(), sort.collation,
+        null /* offset */, newSortFetch, o2, nodeId(), o2.getPinotDataDistributionOrThrow(), o2.isLeafStage());
+    PhysicalExchange n1 = new PhysicalExchange(nodeId(), n2, o1.getPinotDataDistributionOrThrow(),
+        o1.getDistributionKeys(), o1.getExchangeStrategy(), o1.getRelCollation(), o1.getExecStrategy());
+    return new PhysicalSort(sort.getCluster(), sort.getTraitSet(), sort.getHints(), sort.getCollation(),
+        sort.offset, sort.fetch, n1, sort.getNodeId(), sort.getPinotDataDistributionOrThrow(), false);
+  }
+
+  @Nullable
+  @VisibleForTesting
+  static RexNode computeEffectiveFetch(@Nullable RexNode fetch, @Nullable RexNode offset) {
+    RexNode result;
+    if (fetch == null) {
+      result = null;
+    } else if (offset == null) {
+      result = fetch;
+    } else {
+      int total = RexExpressionUtils.getValueAsInt(fetch) + RexExpressionUtils.getValueAsInt(offset);
+      result = REX_BUILDER.makeLiteral(total, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
+    }
+    return result;
+  }
+
+  @VisibleForTesting
+  static RexNode createLiteral(int value) {
+    return REX_BUILDER.makeLiteral(value, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
+  }
+
+  private int nodeId() {
+    return _context.getNodeIdGenerator().get();
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/WorkerExchangeAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/WorkerExchangeAssignmentRule.java
@@ -1,0 +1,433 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTrait;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.planner.physical.v2.ExchangeStrategy;
+import org.apache.pinot.query.planner.physical.v2.HashDistributionDesc;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.apache.pinot.query.planner.physical.v2.mapping.DistMappingGenerator;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelNodeTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * <h1>Overview</h1>
+ * Assigns workers to the plan tree. Leaf stage should already have workers assigned before this Rule is run.
+ * This rule also adds Exchanges when either of the following conditions are met:
+ * <ul>
+ *   <li>When the data distribution does not match the trait constraints.</li>
+ *   <li>When the data is not sorted by the required RelCollation.</li>
+ *   <li>When the workers don't match. E.g. if the workers are same but in different orders, then we'll need to
+ *   add an exchange</li>
+ * </ul>
+ * <h1>Features</h1>
+ * <ul>
+ *   <li>If data is partitioned in the same way across the same number of workers, then Identity Exchange would be
+ *   used.</li>
+ *   <li>Can simplify Exchanges for arbitrarily long plans. E.g. you can have any number of joins on the partitioning
+ *   key, and this Rule would still be able to use Identity Exchange for the entire plan.</li>
+ * </ul>
+ */
+public class WorkerExchangeAssignmentRule implements PRelNodeTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerExchangeAssignmentRule.class);
+  private final PhysicalPlannerContext _physicalPlannerContext;
+  private static final String DEFAULT_HASH_FUNCTION = KeySelector.DEFAULT_HASH_ALGORITHM;
+
+  public WorkerExchangeAssignmentRule(PhysicalPlannerContext context) {
+    _physicalPlannerContext = context;
+  }
+
+  @Override
+  public PRelNode execute(PRelNode currentNode) {
+    return executeInternal(currentNode, null);
+  }
+
+  public PRelNode executeInternal(PRelNode currentNode, @Nullable PRelNode parent) {
+    if (currentNode.isLeafStage() && !isLeafStageBoundary(currentNode, parent)) {
+      return currentNode;
+    }
+    if (currentNode.getPRelInputs().isEmpty()) {
+      return processCurrentNode(currentNode, parent);
+    }
+    if (currentNode.getPRelInputs().size() == 1) {
+      List<PRelNode> newInputs = List.of(executeInternal(currentNode.getPRelInput(0), currentNode));
+      currentNode = currentNode.with(newInputs);
+      return processCurrentNode(currentNode, parent);
+    }
+    // Process first input.
+    List<PRelNode> newInputs = new ArrayList<>();
+    newInputs.add(executeInternal(currentNode.getPRelInput(0), currentNode));
+    newInputs.addAll(currentNode.getPRelInputs().subList(1, currentNode.getPRelInputs().size()));
+    currentNode = currentNode.with(newInputs);
+    // Process current node.
+    currentNode = processCurrentNode(currentNode, parent);
+    // Process remaining inputs.
+    if (currentNode instanceof PhysicalExchange) {
+      PhysicalExchange exchange = (PhysicalExchange) currentNode;
+      currentNode = exchange.getPRelInput(0);
+      for (int index = 1; index < currentNode.getPRelInputs().size(); index++) {
+        newInputs.set(index, executeInternal(currentNode.getPRelInput(index), currentNode));
+      }
+      currentNode = currentNode.with(newInputs);
+      currentNode = inheritDistDescFromInputs(currentNode);
+      return exchange.with(List.of(currentNode));
+    }
+    for (int index = 1; index < currentNode.getPRelInputs().size(); index++) {
+      newInputs.set(index, executeInternal(currentNode.getPRelInput(index), currentNode));
+    }
+    currentNode = currentNode.with(newInputs);
+    currentNode = inheritDistDescFromInputs(currentNode);
+    return currentNode;
+  }
+
+  PRelNode processCurrentNode(PRelNode currentNode, @Nullable PRelNode parentNode) {
+    // Step-1: Initialize variables.
+    boolean isLeafStageBoundary = isLeafStageBoundary(currentNode, parentNode);
+    // Step-2: Get current node's distribution. If the current node already has a distribution attached, use that.
+    //         Otherwise, compute it using DistMappingGenerator.
+    PinotDataDistribution currentNodeDistribution = computeCurrentNodeDistribution(currentNode, parentNode);
+    currentNode = currentNode.with(currentNode.getPRelInputs(), currentNodeDistribution);
+    // Step-3: Add an optional exchange to meet unmet distribution trait constraint, if it exists. This also takes care
+    //         of different workers when the parent already has workers assigned to it (when parent is not a SingleRel).
+    PRelNode currentNodeExchange = meetDistributionConstraint(currentNode, currentNodeDistribution, parentNode);
+    // Step-4: Meet ordering requirement on output streams.
+    currentNodeExchange = meetCollationConstraint(currentNode, currentNodeExchange, currentNodeDistribution);
+    if (currentNodeExchange != null) {
+      // Update current node with its distribution, and update currentNodeExchange to point to the new current node.
+      currentNode = currentNode.with(currentNode.getPRelInputs(), currentNodeDistribution);
+      currentNodeExchange = currentNodeExchange.with(ImmutableList.of(currentNode),
+          currentNodeExchange.getPinotDataDistributionOrThrow());
+      return currentNodeExchange;
+    }
+    if (isLeafStageBoundary && parentNode != null) {
+      currentNode = currentNode.with(currentNode.getPRelInputs(), currentNodeDistribution);
+      // Update current node with its distribution, and since this is a leaf stage boundary, add an identity exchange.
+      return new PhysicalExchange(nodeId(), currentNode,
+          currentNode.getPinotDataDistribution(), Collections.emptyList(), ExchangeStrategy.IDENTITY_EXCHANGE,
+          null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    // When no exchange, simply update current node with the distribution.
+    return currentNode.with(currentNode.getPRelInputs(), currentNodeDistribution);
+  }
+
+  PRelNode inheritDistDescFromInputs(PRelNode currentNode) {
+    // Inherit distribution trait from inputs (except left-most input, which is already inherited).
+    if (currentNode.getPRelInputs().size() <= 1
+        || currentNode.getPinotDataDistributionOrThrow().getType() != RelDistribution.Type.HASH_DISTRIBUTED) {
+      return currentNode;
+    }
+    PinotDataDistribution currentDistribution = currentNode.getPinotDataDistributionOrThrow();
+    Set<HashDistributionDesc> newDistributionSet =
+        new HashSet<>(currentNode.getPinotDataDistributionOrThrow().getHashDistributionDesc());
+    List<RelNode> leadingSiblings = new ArrayList<>();
+    for (int inputIndex = 1; inputIndex < currentNode.getPRelInputs().size(); inputIndex++) {
+      leadingSiblings.add(currentNode.unwrap().getInput(inputIndex - 1));
+      PinotDataDistribution inputDistribution = currentNode.getPRelInput(inputIndex).getPinotDataDistributionOrThrow();
+      if (inputDistribution.getType() == RelDistribution.Type.HASH_DISTRIBUTED) {
+        PinotDataDistribution inheritedDist = inputDistribution.apply(DistMappingGenerator.compute(
+            currentNode.unwrap().getInput(inputIndex), currentNode.unwrap(), leadingSiblings));
+        if (inheritedDist.getType() == RelDistribution.Type.HASH_DISTRIBUTED) {
+          newDistributionSet.addAll(inheritedDist.getHashDistributionDesc());
+        }
+      }
+    }
+    PinotDataDistribution finalDist = new PinotDataDistribution(RelDistribution.Type.HASH_DISTRIBUTED,
+        currentDistribution.getWorkers(), currentDistribution.getWorkerHash(), newDistributionSet,
+        currentDistribution.getCollation());
+    return currentNode.with(currentNode.getPRelInputs(), finalDist);
+  }
+
+  @Nullable
+  @VisibleForTesting
+  PRelNode meetDistributionConstraint(PRelNode currentNode, PinotDataDistribution derivedDistribution,
+      @Nullable PRelNode parent) {
+    RelDistribution relDistribution = coalesceDistribution(currentNode.unwrap().getTraitSet().getDistribution());
+    PinotDataDistribution parentDistribution = parent == null ? null : parent.getPinotDataDistribution();
+    boolean isDistributionSatisfied = derivedDistribution.satisfies(relDistribution);
+    boolean forcePartitioned = forcePartitioned(parent);
+    PRelNode currentNodeExchange = null;
+    if (forcePartitioned) {
+      if (!isDistributionSatisfied) {
+        LOGGER.warn("Forced partitioning info, even though inferred distribution does not satisfy traits");
+      }
+      if (parentDistribution != null && parentDistribution.getWorkerHash() != derivedDistribution.getWorkerHash()) {
+        throw new IllegalStateException("Attempted to forcefully skip exchange even though workers different in "
+            + "parent");
+      }
+    } else if (isDistributionSatisfied) {
+      if (parentDistribution != null) {
+        // currentNode is right sibling of another node, and since workers for the top-level node are already fixed,
+        // we need to make sure that the current node's data-distribution aligns with that.
+        // e.g. if parent is an inner-join with servers (S0, S1) with 16 partitions of data, then the right join must
+        // also have the same servers and number of partitions, merely being hash-distributed is not enough.
+        currentNodeExchange = meetParentEnforcedDistributionConstraint(currentNode, relDistribution, parent,
+            derivedDistribution);
+      }
+    } else {
+      if (parentDistribution == null) {
+        currentNodeExchange = meetDistributionConstraintNoParent(currentNode, derivedDistribution,
+            relDistribution);
+      } else {
+        currentNodeExchange = meetParentEnforcedDistributionConstraint(currentNode, relDistribution, parent,
+            derivedDistribution);
+      }
+    }
+    return currentNodeExchange;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  PRelNode meetCollationConstraint(PRelNode currentNode, @Nullable PRelNode currentNodeExchange,
+      PinotDataDistribution derivedDistribution) {
+    RelCollation relCollation = coalesceCollation(currentNode.unwrap().getTraitSet().getCollation());
+    if (currentNodeExchange == null) {
+      if (!derivedDistribution.satisfies(relCollation)) {
+        // TODO(mse-physical): We can simply use the Sort operator here. That would avoid creation of another plan
+        //   fragment too.
+        // Add new identity exchange for sort.
+        PinotDataDistribution newDataDistribution = derivedDistribution.withCollation(relCollation);
+        currentNodeExchange = new PhysicalExchange(nodeId(), currentNode,
+            newDataDistribution, Collections.emptyList(), ExchangeStrategy.IDENTITY_EXCHANGE, relCollation,
+            PinotExecStrategyTrait.getDefaultExecStrategy());
+      }
+    } else {
+      if (!relCollation.getKeys().isEmpty()) {
+        // Update existing exchange and add sort.
+        PhysicalExchange oldExchange = (PhysicalExchange) currentNodeExchange.unwrap();
+        PinotDataDistribution newDataDistribution = currentNodeExchange.getPinotDataDistributionOrThrow();
+        currentNodeExchange = new PhysicalExchange(_physicalPlannerContext.getNodeIdGenerator().get(),
+            oldExchange.getPRelInput(0), newDataDistribution.withCollation(relCollation),
+            oldExchange.getDistributionKeys(), oldExchange.getExchangeStrategy(), relCollation,
+            PinotExecStrategyTrait.getDefaultExecStrategy());
+      }
+    }
+    return currentNodeExchange;
+  }
+
+  /**
+   * There's no parent distribution and given distribution is not satisfied with default assignment.
+   * <b>Assumption:</b> Since no parent distribution, implies current node is single child and hence workers will
+   *   be same.
+   */
+  private PRelNode meetDistributionConstraintNoParent(PRelNode currentNode,
+      PinotDataDistribution currentNodeDistribution, RelDistribution distributionConstraint) {
+    Preconditions.checkState(!currentNodeDistribution.satisfies(distributionConstraint),
+        "Method should only be called when constraint is not met");
+    if (distributionConstraint.getType() == RelDistribution.Type.BROADCAST_DISTRIBUTED) {
+      PinotDataDistribution pinotDataDistribution = new PinotDataDistribution(
+          RelDistribution.Type.BROADCAST_DISTRIBUTED, currentNodeDistribution.getWorkers(),
+          currentNodeDistribution.getWorkerHash(), null, null);
+      return new PhysicalExchange(nodeId(), currentNode, pinotDataDistribution, List.of(),
+          ExchangeStrategy.BROADCAST_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    if (distributionConstraint.getType() == RelDistribution.Type.SINGLETON) {
+      List<String> newWorkers = currentNodeDistribution.getWorkers().subList(0, 1);
+      PinotDataDistribution pinotDataDistribution = new PinotDataDistribution(RelDistribution.Type.SINGLETON,
+          newWorkers, newWorkers.hashCode(), null, null);
+      return new PhysicalExchange(nodeId(), currentNode, pinotDataDistribution, List.of(),
+          ExchangeStrategy.SINGLETON_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    if (distributionConstraint.getType() == RelDistribution.Type.HASH_DISTRIBUTED) {
+      HashDistributionDesc desc = new HashDistributionDesc(
+          distributionConstraint.getKeys(), DEFAULT_HASH_FUNCTION, currentNodeDistribution.getWorkers().size());
+      PinotDataDistribution pinotDataDistribution = new PinotDataDistribution(
+          RelDistribution.Type.HASH_DISTRIBUTED, currentNodeDistribution.getWorkers(),
+          currentNodeDistribution.getWorkerHash(), ImmutableSet.of(desc), null);
+      return new PhysicalExchange(nodeId(), currentNode, pinotDataDistribution, distributionConstraint.getKeys(),
+          ExchangeStrategy.PARTITIONING_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    throw new IllegalStateException("Distribution constraint not met: " + distributionConstraint.getType());
+  }
+
+  @Nullable
+  private PRelNode meetParentEnforcedDistributionConstraint(PRelNode currentNode, RelDistribution relDistribution,
+      PRelNode parent, PinotDataDistribution assumedDistribution) {
+    PinotDataDistribution parentDistribution = parent.getPinotDataDistributionOrThrow();
+    boolean parentHasSameWorkers = parentDistribution.getWorkerHash() == assumedDistribution.getWorkerHash();
+    if (parentDistribution.getWorkers().size() == 1) {
+      relDistribution = RelDistributions.SINGLETON;
+    }
+    if (relDistribution.getType() == RelDistribution.Type.RANDOM_DISTRIBUTED
+        || relDistribution.getType() == RelDistribution.Type.ANY) {
+      // Since distribution trait constraints are no-op, we just need to check workers.
+      // TODO: Think if we need to treat random distribution as a constraint.
+      if (parentHasSameWorkers) {
+        return null;
+      }
+      // If parent has different workers, do a random exchange.
+      // TODO: Can optimize this to reduce fan out?
+      PinotDataDistribution newDistribution = new PinotDataDistribution(RelDistribution.Type.RANDOM_DISTRIBUTED,
+          parentDistribution.getWorkers(), parentDistribution.getWorkerHash(), null, null);
+      return new PhysicalExchange(nodeId(), currentNode, newDistribution, List.of(), ExchangeStrategy.RANDOM_EXCHANGE,
+          null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    } else if (relDistribution.getType() == RelDistribution.Type.BROADCAST_DISTRIBUTED) {
+      if (assumedDistribution.getType() == RelDistribution.Type.BROADCAST_DISTRIBUTED) {
+        if (parentHasSameWorkers) {
+          return null;
+        }
+        // TODO: Add broadcast to broadcast exchange.
+        throw new IllegalStateException("Can't do broadcast to broadcast exchange yet");
+      }
+      PinotDataDistribution newDistribution = new PinotDataDistribution(RelDistribution.Type.BROADCAST_DISTRIBUTED,
+          parentDistribution.getWorkers(), parentDistribution.getWorkerHash(), null, null);
+      return new PhysicalExchange(nodeId(), currentNode, newDistribution, List.of(),
+          ExchangeStrategy.BROADCAST_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    } else if (relDistribution.getType() == RelDistribution.Type.SINGLETON) {
+      if (parentHasSameWorkers) {
+        return null;
+      }
+      Preconditions.checkState(parentDistribution.getWorkers().size() == 1,
+          "Singleton constraint but parent has %s workers", parentDistribution.getWorkers().size());
+      PinotDataDistribution newDistribution = new PinotDataDistribution(RelDistribution.Type.SINGLETON,
+          parentDistribution.getWorkers(), parentDistribution.getWorkerHash(), null, null);
+      return new PhysicalExchange(nodeId(), currentNode, newDistribution, List.of(),
+          ExchangeStrategy.SINGLETON_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    Preconditions.checkState(relDistribution.getType() == RelDistribution.Type.HASH_DISTRIBUTED,
+        "Unexpected distribution constraint: %s", relDistribution.getType());
+    Preconditions.checkState(parent instanceof PhysicalJoin, "Expected parent to be join. Found: %s", parent);
+    PhysicalJoin parentJoin = (PhysicalJoin) parent;
+    // TODO(mse-physical): add support for sub-partitioning and coalescing exchange.
+    HashDistributionDesc hashDistToMatch = getLeftInputHashDistributionDesc(parentJoin).orElseThrow();
+    if (assumedDistribution.satisfies(relDistribution)) {
+      if (parentDistribution.getWorkers().size() == assumedDistribution.getWorkers().size()) {
+        List<Integer> distKeys = relDistribution.getKeys();
+        HashDistributionDesc currentNodeDesc = assumedDistribution.getHashDistributionDesc().stream().filter(
+            desc -> desc.getKeys().equals(distKeys)).findFirst().orElseThrow();
+        if (currentNodeDesc.getHashFunction().equals(hashDistToMatch.getHashFunction())) {
+          boolean canSkipExchange = false;
+          if (currentNodeDesc.getNumPartitions() == hashDistToMatch.getNumPartitions()) {
+            canSkipExchange = true;
+          } else if (complicatedButColocated(currentNodeDesc.getNumPartitions(), hashDistToMatch.getNumPartitions(),
+              parentDistribution.getWorkers().size())) {
+            canSkipExchange = true;
+          }
+          if (canSkipExchange && parentHasSameWorkers) {
+            return null;
+          } else if (canSkipExchange) {
+            PinotDataDistribution newDistribution = new PinotDataDistribution(assumedDistribution.getType(),
+                parentDistribution.getWorkers(), parentDistribution.getWorkerHash(),
+                assumedDistribution.getHashDistributionDesc(), assumedDistribution.getCollation());
+            return new PhysicalExchange(nodeId(), currentNode, newDistribution, List.of(),
+                ExchangeStrategy.IDENTITY_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+          }
+        }
+      }
+      // TODO: Add support for sub-partitioning or coalescing exchange here.
+    }
+    // Re-partition.
+    int numberOfPartitions = hashDistToMatch.getNumPartitions();
+    String hashFunction = hashDistToMatch.getHashFunction();
+    HashDistributionDesc newDesc = new HashDistributionDesc(relDistribution.getKeys(), hashFunction,
+        numberOfPartitions);
+    PinotDataDistribution newDistribution = new PinotDataDistribution(RelDistribution.Type.HASH_DISTRIBUTED,
+        parentDistribution.getWorkers(), parentDistribution.getWorkerHash(), ImmutableSet.of(newDesc),
+        null);
+    return new PhysicalExchange(nodeId(), currentNode, newDistribution, relDistribution.getKeys(),
+        ExchangeStrategy.PARTITIONING_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+  }
+
+  private boolean complicatedButColocated(int partitionOne, int partitionTwo, int numStreams) {
+    int minP = Math.min(partitionOne, partitionTwo);
+    int maxP = Math.max(partitionOne, partitionTwo);
+    return minP > 0 && maxP % minP == 0 && minP % numStreams == 0;
+  }
+
+  private int nodeId() {
+    return _physicalPlannerContext.getNodeIdGenerator().get();
+  }
+
+  private Optional<HashDistributionDesc> getLeftInputHashDistributionDesc(PhysicalJoin join) {
+    List<Integer> leftKeys = join.analyzeCondition().leftKeys;
+    return join.getPRelInput(0).getPinotDataDistributionOrThrow().getHashDistributionDesc().stream()
+        .filter(desc -> desc.getKeys().equals(leftKeys))
+        .findFirst();
+  }
+
+  /**
+   * Computes the PinotDataDistribution of the given node from the input node. This assumes that all traits of the
+   * input node are already satisfied.
+   */
+  private static PinotDataDistribution computeCurrentNodeDistribution(PRelNode currentNode, @Nullable PRelNode parent) {
+    if (currentNode.getPinotDataDistribution() != null) {
+      Preconditions.checkState(isLeafStageBoundary(currentNode, parent),
+          "current node should not have assigned data distribution unless it's a boundary");
+      return currentNode.getPinotDataDistributionOrThrow();
+    }
+    PinotDataDistribution inputDistribution = currentNode.getPRelInput(0).getPinotDataDistributionOrThrow();
+    return inputDistribution.apply(DistMappingGenerator.compute(
+        currentNode.unwrap().getInput(0), currentNode.unwrap(), null));
+  }
+
+  private static boolean isLeafStageBoundary(PRelNode currentNode, @Nullable PRelNode parentNode) {
+    if (currentNode.isLeafStage()) {
+      return parentNode == null || !parentNode.isLeafStage();
+    }
+    return false;
+  }
+
+  private static boolean forcePartitioned(@Nullable PRelNode parent) {
+    // TODO: Setup explicit metadata to force assume distribution constraint met.
+    if (parent instanceof Aggregate) {
+      Aggregate aggRel = (Aggregate) parent.unwrap();
+      Map<String, String> hintOptions =
+          PinotHintStrategyTable.getHintOptions(aggRel.getHints(), PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+      hintOptions = hintOptions == null ? Map.of() : hintOptions;
+      boolean hasGroupBy = !aggRel.getGroupSet().isEmpty();
+      return hasGroupBy && Boolean.parseBoolean(
+          hintOptions.get(PinotHintOptions.AggregateOptions.IS_PARTITIONED_BY_GROUP_BY_KEYS));
+    }
+    return false;
+  }
+
+  private static RelDistribution coalesceDistribution(@Nullable RelDistribution distribution) {
+    return distribution == null ? RelDistributions.ANY : distribution;
+  }
+
+  private static RelCollation coalesceCollation(@Nullable RelCollation collation) {
+    return collation == null ? RelCollations.EMPTY : collation;
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/SortPushdownRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/SortPushdownRuleTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class SortPushdownRuleTest {
+  @Test
+  public void testComputeEffectiveFetchWhenFetchIsNull() {
+    assertNull(SortPushdownRule.computeEffectiveFetch(null, null));
+    assertNull(SortPushdownRule.computeEffectiveFetch(null, SortPushdownRule.createLiteral(100)));
+  }
+
+  @Test
+  public void testComputeEffectiveFetchWhenOnlyFetch() {
+    RexNode fetch = SortPushdownRule.createLiteral(100);
+    assertEquals(RexExpressionUtils.getValueAsInt(SortPushdownRule.computeEffectiveFetch(fetch, null)), 100);
+  }
+
+  @Test
+  public void testComputeEffectiveFetchWhenFetchAndOffset() {
+    RexNode fetch = SortPushdownRule.createLiteral(100);
+    RexNode offset = SortPushdownRule.createLiteral(11);
+    assertEquals(RexExpressionUtils.getValueAsInt(SortPushdownRule.computeEffectiveFetch(fetch, offset)), 111);
+  }
+}


### PR DESCRIPTION
**Note:** Does NOT touch any existing multistage code path and only contains changes to the new optimizer.

# Summary

Adds Sort / Aggregate Pushdown and Worker Assignment rules. Also adds the `PRelToPlanNodeConverter` which is taken as is from the `RelToPlanNodeConverter`. I have commented out the Spooling and metrics related code for now and will be fixing them in a future PR as part of productionization of the Physical Optimizer.

## Sort Pushdown

Sort pushdown pushes a Sort past an Exchange when there's a non-null "fetch" set in the Sort. The value of the fetch is computed using "fetch + offset" value of the top-level sort.

**Note:** There are possibilities to do more kinds of pushdown here. For instance, if there's a fetch only Sort right above a Join, then we could annotate the Join with the fetch limit and remove the Sort.

## Aggregate Pushdown

This is similar to the existing `PinotAggregateNodeExchangeInsertRule`.

## Worker Assignment

Worker assignment is where Exchanges are simplified, allowing for full plan colocation. I have added some details in the Javadoc of the corresponding class.

# Test Plan

We have the full Physical Optimizer changes running in a test cluster, and the next PR will also add Integration Tests. You can see a preview of them here: https://github.com/ankitsultana/pinot/pull/46/files#diff-25751d60157478f9d864a75c86bf6902f7870c879640887741e59d17e0162643