### PR TITLE
Reduce warning logs when consumer thread is interrupted

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -277,7 +277,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private boolean _segmentBuildFailedWithDeterministicError = false;
   private final StreamConsumerFactory _streamConsumerFactory;
   private final StreamPartitionMsgOffsetFactory _streamPartitionMsgOffsetFactory;
-  private final AtomicBoolean _shutdownRequested = new AtomicBoolean(false);
 
   // Segment end criteria
   private volatile long _consumeEndTime = 0;


### PR DESCRIPTION
This pull request introduces a small but meaningful change to the error handling logic in the `handleTransientStreamErrors` method of `RealtimeSegmentDataManager`. The change ensures that interruptions caused by `InterruptedException` are logged at the debug level when `_shouldStop` is true, improving clarity during debugging.