### PR TITLE
Allow segment pre-processing failure during segment loading phase

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
@@ -152,7 +152,19 @@ public class SegmentPreProcessor implements AutoCloseable {
         if (type != StandardIndexes.forward()) {
           IndexHandler handler = createHandler(type);
           indexHandlers.add(handler);
-          handler.updateIndices(segmentWriter);
+          try {
+            handler.updateIndices(segmentWriter);
+          } catch (IllegalStateException | UnsupportedOperationException e) {
+            // Index creation can fail when an index is unsupported for the current column or segment representation.
+            // For example, a range index is unsupported for a raw TIMESTAMP column but supported after the column is
+            // changed to dictionary encoding. Log these expected failures and continue with the next index handler.
+            LOGGER.error("Failed to create index: {} for segment: {}", type, segmentName, e);
+            indexHandlers.remove(handler);
+          } catch (Exception e) {
+            // Handle unexpected exceptions separately to avoid masking critical issues.
+            LOGGER.error("Unexpected error while creating index: {} for segment: {}", type, segmentName, e);
+            throw e;
+          }
         }
       }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -371,15 +371,16 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
     _fieldConfigMap.put(EXISTING_STRING_COL_RAW,
         new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST,
             null, null, null, fstIndexes, null, null));
-    if (segmentVersion == SegmentVersion.v1) {
-      assertThrows(UnsupportedOperationException.class, this::runPreProcessor);
-      return;
-    }
     runPreProcessor();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(INDEX_DIR);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertTrue(columnMetadata.hasDictionary());
-    assertTrue(columnMetadata.getIndexSizeFor(StandardIndexes.fst()) > 0);
+    if (segmentVersion == SegmentVersion.v1) {
+      assertFalse(columnMetadata.hasDictionary());
+      assertEquals(columnMetadata.getIndexSizeFor(StandardIndexes.fst()), ColumnMetadata.UNAVAILABLE);
+    } else {
+      assertTrue(columnMetadata.hasDictionary());
+      assertTrue(columnMetadata.getIndexSizeFor(StandardIndexes.fst()) > 0);
+    }
   }
 
   @Test(dataProvider = "bothV1AndV3")


### PR DESCRIPTION
Currently, if the preprocessing failed to create index for a segment, it will put the segment into ERROR state.
This behavior seems to be good, but in reality, it will fail a server restart due to the segment ERROR and the only way to fix this is to revert the index configs or skipPreprocess for the table.

All in all it's a lot of operational burden and nervous.

This change makes the preprocess index handler just log error and move forward, so the users could come back and decide if they want to fix this and how to fix it.
