### PR TITLE
Fix up elapsed time calculation for rebalance progress stats when carry over are present

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
@@ -242,7 +242,10 @@ public class TableRebalanceProgressStats {
       int remainingSegmentsToChange) {
     double elapsedTimeInSeconds = (double) (System.currentTimeMillis() - startTime) / 1000.0;
     int segmentsAlreadyChanged = totalSegmentsToChange - remainingSegmentsToChange;
-    return segmentsAlreadyChanged == 0 ? totalSegmentsToChange == 0 ? 0.0 : -1.0
+    // If carry over + remaining segments to change are > total segments to change then number of segments already
+    // changed may be -ve, in which case we should just set the default value as we cannot measure elapsed time
+    //return segmentsAlreadyChanged <= 0 ? totalSegmentsToChange == 0 ? 0.0 : -1.0
+    return segmentsAlreadyChanged <= 0 ? totalSegmentsToChange == 0 ? 0.0 : -1.0
         : (double) remainingSegmentsToChange / (double) segmentsAlreadyChanged * elapsedTimeInSeconds;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
@@ -244,7 +244,6 @@ public class TableRebalanceProgressStats {
     int segmentsAlreadyChanged = totalSegmentsToChange - remainingSegmentsToChange;
     // If carry over + remaining segments to change are > total segments to change then number of segments already
     // changed may be -ve, in which case we should just set the default value as we cannot measure elapsed time
-    //return segmentsAlreadyChanged <= 0 ? totalSegmentsToChange == 0 ? 0.0 : -1.0
     return segmentsAlreadyChanged <= 0 ? totalSegmentsToChange == 0 ? 0.0 : -1.0
         : (double) remainingSegmentsToChange / (double) segmentsAlreadyChanged * elapsedTimeInSeconds;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -581,10 +581,10 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
         startTimeMs = existingProgressStats._startTimeMs;
         progressStats._estimatedTimeToCompleteAddsInSeconds =
             TableRebalanceProgressStats.calculateEstimatedTimeToCompleteChange(startTimeMs,
-                progressStats._totalSegmentsToBeAdded, progressStats._totalRemainingSegmentsToBeAdded);
+                progressStats._totalSegmentsToBeAdded, totalSegmentsToBeAdded);
         progressStats._estimatedTimeToCompleteDeletesInSeconds =
             TableRebalanceProgressStats.calculateEstimatedTimeToCompleteChange(startTimeMs,
-                progressStats._totalSegmentsToBeDeleted, progressStats._totalRemainingSegmentsToBeDeleted);
+                progressStats._totalSegmentsToBeDeleted, totalSegmentsToBeDeleted);
         progressStats._averageSegmentSizeInBytes = existingProgressStats._averageSegmentSizeInBytes;
         progressStats._totalEstimatedDataToBeMovedInBytes =
             TableRebalanceProgressStats.calculateNewEstimatedDataToBeMovedInBytes(


### PR DESCRIPTION
Found an issue where the rebalance progress stats can show a -ve value for estimated time remaining when there are lingering carry over segments that cause remaining segments to be added + carry over to be > total segments to be added.

This can occur in scenarios where some pending EV-IS convergence is happening before the IS is updated for table rebalance for the first time, or under scenarios where multiple rebalance jobs can be running (especially those triggered by SegmentRelocator that uses bestEfforts=true which doesn't wait for convergence).

Just reset the estimated time remaining to be -1.0 instead in such scenarios to avoid confusion. It is hard to calculate an estimate for such cases as we don't know the total segments from the carry over and how many of those were processed.

@raghavyadav01 @klsince @J-HowHuang 