### PR TITLE
Set conservative default for gRPC query sever worker thread count

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -64,8 +64,6 @@ import org.apache.pinot.spi.query.QueryThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.lang.Math.min;
-
 
 // TODO: Plug in QueryScheduler
 public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBase {
@@ -75,7 +73,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> SERVER_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
 
-  private static final int DEFAULT_GRPC_QUERY_WORKER_THREAD = min(8, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
+  private static final int DEFAULT_GRPC_QUERY_WORKER_THREAD =
+      Math.max(2, Math.min(8, ResourceManager.DEFAULT_QUERY_WORKER_THREADS));
 
   private final QueryExecutor _queryExecutor;
   private final ServerMetrics _serverMetrics;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -64,6 +64,7 @@ import org.apache.pinot.spi.query.QueryThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.lang.Math.min;
 
 
 // TODO: Plug in QueryScheduler
@@ -73,6 +74,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
   // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> SERVER_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
+
+  private static final int DEFAULT_GRPC_QUERY_WORKER_THREAD = min(8, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
 
   private final QueryExecutor _queryExecutor;
   private final ServerMetrics _serverMetrics;
@@ -107,7 +110,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
     _executorService = QueryThreadContext.contextAwareExecutorService(
         Executors.newFixedThreadPool(config.isQueryWorkerThreadsSet()
             ? config.getQueryWorkerThreads()
-            : ResourceManager.DEFAULT_QUERY_WORKER_THREADS)
+            : DEFAULT_GRPC_QUERY_WORKER_THREAD)
     );
     _queryExecutor = queryExecutor;
     _serverMetrics = serverMetrics;


### PR DESCRIPTION
Previously, the gRPC query server defaulted to using `2 * num_cores` threads for query workers. This PR adjusts the default to a lower cap (min(8, 2 * num_cores)) to reduce memory usage during request spikes, especially on machines with a high number of cores.