### PR TITLE
[bugfix][ui] Fix: Prevent Runtime Errors by Validating Add Schema JSON Fields

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddSchemaOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddSchemaOp.tsx
@@ -156,7 +156,7 @@ export default function AddSchemaOp({
         const types = ["dimensionFieldSpecs","metricFieldSpecs","dateTimeFieldSpecs"];
         let notEmpty = true;
         types.map((t)=>{
-          if(schemaConfig[t].length)
+          if(schemaConfig[t] && schemaConfig[t].length > 0)
           {
             notEmpty = false
           }


### PR DESCRIPTION
### Prevent Runtime Errors by Validating Schema Fields

This pull request addresses a potential runtime error in the isObjEmpty function by adding a validation check to ensure that each field in the schemaConfig object exists before accessing its length property.

**Changes Made**

<img width="450" alt="Screenshot 2025-04-30 at 20 40 22" src="https://github.com/user-attachments/assets/d90a39ba-9874-4034-bdb6-ee16222acc8d" />


**Reason for Change**

Previously, if any of the specified fields (dimensionFieldSpecs, metricFieldSpecs, or dateTimeFieldSpecs) were undefined or null, accessing their length property would result in a runtime error. This change ensures that the field exists and is an array before attempting to access its length, thereby enhancing the robustness of the function.

**Impact**

This is a non-breaking change that improves error handling in the isObjEmpty function. It does not introduce any new features or alter existing functionality beyond the added validation.