### PR TITLE
SegmentRelocator should skip rebalancing tables that haven't completed rebalance since the last relocator run

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -80,6 +80,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
   private final Set<String> _waitingTables;
   private final BlockingQueue<String> _waitingQueue;
+  private final Set<String> _tablesUndergoingRebalance;
 
   public SegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics,
@@ -120,17 +121,23 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
           LOGGER.warn("Got interrupted while rebalancing tables sequentially", e);
         }
       });
+      _tablesUndergoingRebalance = null;
     } else {
       _waitingTables = null;
       _waitingQueue = null;
+      _tablesUndergoingRebalance = ConcurrentHashMap.newKeySet();
     }
   }
 
   @Override
   protected void processTable(String tableNameWithType) {
     if (_waitingTables == null) {
-      LOGGER.debug("Rebalance table: {} immediately", tableNameWithType);
-      _executorService.submit(() -> rebalanceTable(tableNameWithType));
+      if (_tablesUndergoingRebalance == null || !_tablesUndergoingRebalance.contains(tableNameWithType)) {
+        LOGGER.debug("Rebalance table: {} immediately", tableNameWithType);
+        _executorService.submit(() -> rebalanceTable(tableNameWithType));
+      } else {
+        LOGGER.info("The previous rebalance has not yet completed, skip rebalancing table {}", tableNameWithType);
+      }
       return;
     }
     putTableToWait(tableNameWithType);
@@ -196,6 +203,10 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     rebalanceConfig.setMinimizeDataMovement(_minimizeDataMovement);
 
     try {
+      if (_tablesUndergoingRebalance != null) {
+        LOGGER.debug("Start rebalancing table: {}, adding to tablesUndergoingRebalance", tableNameWithType);
+        _tablesUndergoingRebalance.add(tableNameWithType);
+      }
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.
       // Table rebalance moves segments to the new ideal servers, which can change for a segment when its target
       // tier is updated. New servers can put segments onto the right tier when loading the segments. After that,
@@ -219,6 +230,11 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       }
     } catch (Throwable t) {
       LOGGER.error("Caught exception/error while rebalancing table: {}", tableNameWithType, t);
+    } finally {
+      if (_tablesUndergoingRebalance != null) {
+        LOGGER.debug("Done rebalancing table: {}, removing from tablesUndergoingRebalance", tableNameWithType);
+        _tablesUndergoingRebalance.remove(tableNameWithType);
+      }
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -133,6 +133,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
   @Override
   protected void processTable(String tableNameWithType) {
     if (_waitingTables == null) {
+      assert _tablesUndergoingRebalance != null;
       if (!_tablesUndergoingRebalance.contains(tableNameWithType)) {
         LOGGER.debug("Rebalance table: {} immediately", tableNameWithType);
         _executorService.submit(() -> rebalanceTable(tableNameWithType));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.Criteria;
@@ -80,7 +81,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
   private final Set<String> _waitingTables;
   private final BlockingQueue<String> _waitingQueue;
-  private final Set<String> _tablesUndergoingRebalance;
+  @Nullable private final Set<String> _tablesUndergoingRebalance;
 
   public SegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -203,15 +203,15 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     rebalanceConfig.setIncludeConsuming(_includeConsuming);
     rebalanceConfig.setMinimizeDataMovement(_minimizeDataMovement);
 
-    try {
-      if (_tablesUndergoingRebalance != null) {
-        LOGGER.debug("Start rebalancing table: {}, adding to tablesUndergoingRebalance", tableNameWithType);
-        if (!_tablesUndergoingRebalance.add(tableNameWithType)) {
-          LOGGER.warn("Skip rebalancing table: {}, table already exists in tablesUndergoingRebalance, a rebalance "
-              + "must have already been started", tableNameWithType);
-          return;
-        }
+    if (_tablesUndergoingRebalance != null) {
+      LOGGER.debug("Start rebalancing table: {}, adding to tablesUndergoingRebalance", tableNameWithType);
+      if (!_tablesUndergoingRebalance.add(tableNameWithType)) {
+        LOGGER.warn("Skip rebalancing table: {}, table already exists in tablesUndergoingRebalance, a rebalance "
+            + "must have already been started", tableNameWithType);
+        return;
       }
+    }
+    try {
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.
       // Table rebalance moves segments to the new ideal servers, which can change for a segment when its target
       // tier is updated. New servers can put segments onto the right tier when loading the segments. After that,


### PR DESCRIPTION
Today when `SegmentRelocator` runs, it issues a table rebalance request for each table without checking whether the last rebalance it had issued completed or not. For small rebalances that move a few segments, this is usually okay, since we expect that the previous rebalance triggered by `SegmentRelocator` completes quickly. Sometimes it can happen that a large rebalance is issued, or rebalance takes a long time to complete for other reasons. In such cases, the `SegmentRelocator` should avoid issuing a new a table rebalance request for the given table.

We saw an issue where there was a long table rebalance started by `SegmentRelocator` that took multiple hours to finish. In spite of that, every hour a new table rebalance job was created, and that rebalance job would land up running in parallel for the same table. This adds CPU load to the controllers as each table rebalance loops and runs an EV-IS convergence check.

**Note:** this PR does not address scenarios where a long running table rebalance is triggered outside of `SegmentRelocator` and `SegmentRelocator` creates a new table rebalance request for that table. This only addresses the rebalances triggered by `SegmentRelocator`. If we want to address this across all rebalances, we need to come up with a design to address this since today we allow multiple rebalances to run in parallel for a given table and we expect idempotent results. 

One low-hanging fruit might be to have the `SegmentRelocator` check if there are any user issued rebalance jobs by checking ZK to see if any IN_PROGRESS rebalance jobs exist. If this is a good idea, I can open a new PR to address this separately.

**Why we didn't go with sequential table mode:** `SegmentRelocator` provides a sequential table mode today that issues rebalance jobs for each table in a sequential manner. The main concern with using this mode is that if a table lands up taking a long time to rebalance, none of the other tables can be scheduled by `SegmentRelocator` until this long running rebalance completes. This means it could be hours or even days before certain tables get a chance to run depending on how long the rebalances take.

**Testing:**
- Manually tested with a short run frequency of `SegmentRelocator` to ensure that if it triggers a rebalance, and that rebalance takes longer to complete, it does not create a new rebalance job for that table. On the other hand, if the rebalance job completes, the next `SegmentRelocator` run does create a new rebalance job.
- Also manually tested single table mode to ensure nothing breaks there
- Manually tested that if there is an ongoing rebalance triggered by user, `SegmentRelocator` will still schedule a rebalance in that case (as expected) since it does not look at ongoing rebalances to decide that were triggered outside of `SegmentRelocator`