### PR TITLE
Memory based request throttling for grpc query server

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/GrpcConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/GrpcConfig.java
@@ -49,6 +49,11 @@ public class GrpcConfig {
 
   public static final String CONFIG_QUERY_WORKER_THREADS = "queryWorkerThreads";
 
+  // memory usage threshold that triggers request throttling
+  public static final String REQUEST_THROTTLING_MEMORY_THRESHOLD_BYTES = "requestThrottlingMemoryThresholdBytes";
+  // Default threshold in bytes (16GB)
+  public static final long DEFAULT_REQUEST_THROTTLING_MEMORY_THRESHOLD_BYTES = 16 * 1024 * 1024 * 1024L;
+
   private final TlsConfig _tlsConfig;
   private final PinotConfiguration _pinotConfig;
 
@@ -110,6 +115,14 @@ public class GrpcConfig {
 
   public int getQueryWorkerThreads() {
     return _pinotConfig.getProperty(CONFIG_QUERY_WORKER_THREADS, Integer.class);
+  }
+
+  public long getRequestThrottlingMemoryThresholdBytes() {
+    return _pinotConfig.getProperty(REQUEST_THROTTLING_MEMORY_THRESHOLD_BYTES, Long.class);
+  }
+
+  public boolean isRequestThrottlingMemroyThresholdSet() {
+    return _pinotConfig.containsKey(REQUEST_THROTTLING_MEMORY_THRESHOLD_BYTES);
   }
 
   public boolean isQueryWorkerThreadsSet() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -133,6 +133,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
   LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
 
+  GRPC_MEMORY_REJECTIONS("rejections", true, "Number of grpc requests rejected due to memory pressure"),
+
   DIRECT_MEMORY_OOM("directMemoryOOMCount", true),
 
   // Multi-stage

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -80,6 +80,9 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   private final ExecutorService _executorService;
   private final AccessControl _accessControl;
   private final ServerQueryLogger _queryLogger = ServerQueryLogger.getInstance();
+  // Memory allocator and throttling configuration
+  private final PooledByteBufAllocator _bufAllocator;
+  private final long _memoryThresholdBytes;
 
   // Filter to keep track of gRPC connections.
   private class GrpcQueryTransportFilter extends ServerTransportFilter {
@@ -112,6 +115,14 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
     _queryExecutor = queryExecutor;
     _serverMetrics = serverMetrics;
 
+    _bufAllocator = new PooledByteBufAllocator(true);
+
+    if (config.isRequestThrottlingMemroyThresholdSet()) {
+      _memoryThresholdBytes = config.getRequestThrottlingMemoryThresholdBytes();
+    } else {
+      _memoryThresholdBytes = GrpcConfig.DEFAULT_REQUEST_THROTTLING_MEMORY_THRESHOLD_BYTES;
+    }
+
     try {
       NettyServerBuilder builder = NettyServerBuilder.forPort(port);
       if (tlsConfig != null) {
@@ -119,8 +130,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       }
 
       // Add metrics for Netty buffer allocator
-      PooledByteBufAllocator bufAllocator = new PooledByteBufAllocator(true);
-      PooledByteBufAllocatorMetric metric = bufAllocator.metric();
+      PooledByteBufAllocatorMetric metric = _bufAllocator.metric();
       ServerMetrics metrics = ServerMetrics.get();
       metrics.setOrUpdateGlobalGauge(ServerGauge.GRPC_NETTY_POOLED_USED_DIRECT_MEMORY, metric::usedDirectMemory);
       metrics.setOrUpdateGlobalGauge(ServerGauge.GRPC_NETTY_POOLED_USED_HEAP_MEMORY, metric::usedHeapMemory);
@@ -135,8 +145,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
           .maxInboundMessageSize(config.getMaxInboundMessageSizeBytes())
           .addService(this)
           .addTransportFilter(new GrpcQueryTransportFilter())
-          .withOption(ChannelOption.ALLOCATOR, bufAllocator)
-          .withChildOption(ChannelOption.ALLOCATOR, bufAllocator)
+          .withOption(ChannelOption.ALLOCATOR, _bufAllocator)
+          .withChildOption(ChannelOption.ALLOCATOR, _bufAllocator)
           .build();
     } catch (Exception e) {
       throw new RuntimeException("Failed to start secure grpcQueryServer", e);
@@ -194,6 +204,19 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
     long startTime = System.nanoTime();
     _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_QUERIES, 1);
     _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_BYTES_RECEIVED, request.getSerializedSize());
+
+    // Check memory usage before processing the request
+    long usedDirectMemory = _bufAllocator.metric().usedDirectMemory();
+    if (usedDirectMemory > _memoryThresholdBytes) {
+      LOGGER.warn("Request rejected due to memory pressure. Used direct memory: {} bytes, threshold: {} bytes",
+          usedDirectMemory, _memoryThresholdBytes);
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_MEMORY_REJECTIONS, 1);
+      responseObserver.onError(Status.RESOURCE_EXHAUSTED
+          .withDescription(String.format("Server under memory pressure (used: %d bytes, threshold: %d bytes)",
+              usedDirectMemory, _memoryThresholdBytes))
+          .asException());
+      return;
+    }
 
     try (QueryThreadContext.CloseableContext closeme = QueryThreadContext.open()) {
       QueryThreadContext.setQueryEngine("sse-grpc");


### PR DESCRIPTION
This PR introduce a memory based throttling mechanism for requests towards grpc query server: when grpc query server's direct memory usage is high and exceed certain threshold, it will start rejecting further requests with RESOURCE_EXHAUSTED grpc status code until memory usage back down below that threshold.

## Testing:

We simulated sustained synthetic query traffic targeting a server with limited network bandwidth and CPU(# of grpc thread).

**Without memory throttling**: direct memory usage can reach up to 1GB in the test setup.

<img width="836" alt="Screenshot 2025-05-01 at 1 08 20 AM" src="https://github.com/user-attachments/assets/b683bf8a-89cf-45f6-a7f2-262cc999c3e2" />

**With throttling enabled (threshold = 400MB)** under the same setup: Memory usage is capped more effectively.

<img width="812" alt="Screenshot 2025-05-01 at 12 57 45 AM" src="https://github.com/user-attachments/assets/37b42760-b602-43f8-87d0-85a0f411aa88" />

meanwhile we also observe rejected requests due to throttling:

<img width="774" alt="Screenshot 2025-05-01 at 1 40 31 AM" src="https://github.com/user-attachments/assets/07babc59-545d-4325-94fa-73ac810a4d65" />

On the client side, the following exception is seen:
```
Error in task: java.lang.RuntimeException: io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: Server under memory pressure (used: 427819008 bytes, threshold: 419430400 bytes)
```

Note:
This mechanism provides best-effort control over memory usage. It does not guarantee memory will remain strictly below the threshold at all times. For instance:
- Large query responses may cause a brief memory overshoot.
- Concurrent request bursts can overshoot the threshold if they arrive in parallel before throttling is triggered. (However, such concurrency is naturally bounded by the gRPC thread pool size)