### PR TITLE
Adding null check for fromZNRecord while creating a new InstancePartitions from ZNRecord

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -119,6 +120,7 @@ public class InstancePartitions {
   }
 
   public static InstancePartitions fromZNRecord(ZNRecord znRecord) {
+    Preconditions.checkArgument(znRecord != null, "ZNRecord cannot be null");
     return new InstancePartitions(znRecord.getId(), znRecord.getListFields());
   }
 


### PR DESCRIPTION
We see a null pointer exception while deleting the tables in our integration environment. The null pointer exception is due to ZNRecord being null when calling fromZNRecord  to create a new InstancePartitions.
This code path is under deleteTable flow which is replaced by deleteRealtimeTable and deleteOfflineTable in the newer version. At uber, we are still using the deleteTable and we see NullPointerException in the logs.
Adding a null check precondition to avoid such unhandled NullPointerException.