### PR TITLE
Create proper response when all segments are pruned on broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
@@ -40,8 +40,9 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
-/// Similar to {@link org.apache.pinot.core.operator.blocks.results.ResultsBlockUtils} which handles empty results on
-/// the server side, this class handles empty results on the broker side.
+/// Similar to [org.apache.pinot.core.operator.blocks.results.ResultsBlockUtils] which handles empty results on the
+/// server side, this class handles empty results on the broker side.
+// TODO: Consider extracting common code for these 2 classes.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class EmptyResponseUtils {
   private EmptyResponseUtils() {
@@ -114,19 +115,17 @@ public class EmptyResponseUtils {
     return new ResultTable(new DataSchema(columnNames, columnDataTypes), List.of());
   }
 
-  /**
-   * Tries to fill an {@link DataSchema} when no row has been returned.
-   *
-   * Response data schema can be inaccurate (all columns set to STRING) when all segments are pruned on broker or
-   * server.
-   *
-   * Priority is:
-   * - Types from multi-stage engine validation for the given query (if allowed).
-   * - Types from schema for the given table (only applicable to identifiers).
-   * - Types from single-stage engine response (no action).
-   *
-   * Multi-stage engine schema will be available only if query compiles.
-   */
+  /// Tries to fill an [DataSchema] when no row has been returned.
+  ///
+  /// Response data schema can be inaccurate (all columns set to STRING) when all segments are pruned on broker or
+  /// server.
+  ///
+  /// Priority is:
+  /// - Types from multi-stage engine validation for the given query (if allowed).
+  /// - Types from schema for the given table (only applicable to identifiers).
+  /// - Types from single-stage engine response (no action).
+  ///
+  /// Multi-stage engine schema will be available only if query compiles.
   public static void fillEmptyResponseSchema(boolean useMSE, BrokerResponse response, TableCache tableCache,
       Schema schema, String database, String query) {
     Preconditions.checkState(response.getNumRowsResultSet() == 0, "Cannot fill schema for non-empty response");

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+/// Similar to {@link org.apache.pinot.core.operator.blocks.results.ResultsBlockUtils} which handles empty results on
+/// the server side, this class handles empty results on the broker side.
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class EmptyResponseUtils {
+  private EmptyResponseUtils() {
+  }
+
+  // TODO: Use schema to fill the correct data types for empty results.
+  public static ResultTable buildEmptyResultTable(QueryContext queryContext) {
+    if (queryContext.getAggregationFunctions() == null) {
+      return buildEmptySelectionResultTable(queryContext);
+    }
+    if (queryContext.getGroupByExpressions() == null) {
+      return buildEmptyAggregationResultTable(queryContext);
+    }
+    return buildEmptyGroupByResultTable(queryContext);
+  }
+
+  private static ResultTable buildEmptySelectionResultTable(QueryContext queryContext) {
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    int numSelectExpressions = selectExpressions.size();
+    String[] columnNames = new String[numSelectExpressions];
+    for (int i = 0; i < numSelectExpressions; i++) {
+      columnNames[i] = selectExpressions.get(i).toString();
+    }
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numSelectExpressions];
+    // NOTE: Use STRING column data type as default for selection query
+    Arrays.fill(columnDataTypes, ColumnDataType.STRING);
+    return new ResultTable(new DataSchema(columnNames, columnDataTypes), List.of());
+  }
+
+  private static ResultTable buildEmptyAggregationResultTable(QueryContext queryContext) {
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    assert filteredAggregationFunctions != null;
+    int numAggregations = filteredAggregationFunctions.size();
+    String[] columnNames = new String[numAggregations];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numAggregations];
+    Object[] row = new Object[numAggregations];
+    for (int i = 0; i < numAggregations; i++) {
+      Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[i] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
+      columnDataTypes[i] = aggregationFunction.getFinalResultColumnType();
+      row[i] = aggregationFunction.extractFinalResult(
+          aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder()));
+    }
+    return new ResultTable(new DataSchema(columnNames, columnDataTypes), List.<Object[]>of(row));
+  }
+
+  private static ResultTable buildEmptyGroupByResultTable(QueryContext queryContext) {
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
+    assert filteredAggregationFunctions != null && groupByExpressions != null;
+    int numColumns = groupByExpressions.size() + filteredAggregationFunctions.size();
+    String[] columnNames = new String[numColumns];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+    int index = 0;
+    for (ExpressionContext groupByExpression : groupByExpressions) {
+      columnNames[index] = groupByExpression.toString();
+      // Use STRING column data type as default for group-by expressions
+      columnDataTypes[index] = ColumnDataType.STRING;
+      index++;
+    }
+    for (Pair<AggregationFunction, FilterContext> pair : filteredAggregationFunctions) {
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[index] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
+      columnDataTypes[index] = aggregationFunction.getFinalResultColumnType();
+      index++;
+    }
+    return new ResultTable(new DataSchema(columnNames, columnDataTypes), List.of());
+  }
+
+  /**
+   * Tries to fill an {@link DataSchema} when no row has been returned.
+   *
+   * Response data schema can be inaccurate (all columns set to STRING) when all segments are pruned on broker or
+   * server.
+   *
+   * Priority is:
+   * - Types from multi-stage engine validation for the given query (if allowed).
+   * - Types from schema for the given table (only applicable to identifiers).
+   * - Types from single-stage engine response (no action).
+   *
+   * Multi-stage engine schema will be available only if query compiles.
+   */
+  public static void fillEmptyResponseSchema(boolean useMSE, BrokerResponse response, TableCache tableCache,
+      Schema schema, String database, String query) {
+    Preconditions.checkState(response.getNumRowsResultSet() == 0, "Cannot fill schema for non-empty response");
+
+    DataSchema dataSchema = response.getResultTable() != null ? response.getResultTable().getDataSchema() : null;
+
+    List<RelDataTypeField> dataTypeFields = null;
+    // Turn on (with pinot.broker.use.mse.to.fill.empty.response.schema=true or query option
+    // useMSEToFillEmptyResponseSchema=true) only for clusters where no queries with huge IN clauses are expected
+    // (see https://github.com/apache/pinot/issues/15064)
+    if (useMSE) {
+      QueryEnvironment queryEnvironment = new QueryEnvironment(database, tableCache, null);
+      RelRoot root;
+      try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+        root = compiledQuery.getRelRoot();
+      } catch (Exception ignored) {
+        root = null;
+      }
+      if (root != null && root.validatedRowType != null) {
+        dataTypeFields = root.validatedRowType.getFieldList();
+      }
+    }
+
+    if (dataSchema == null && dataTypeFields == null) {
+      // No schema available, nothing we can do
+      return;
+    }
+
+    if (dataSchema == null || (dataTypeFields != null && dataSchema.size() != dataTypeFields.size())) {
+      // If data schema is not available or has different number of columns than the validated row type, we use the
+      // validated row type to populate the schema.
+      int numColumns = dataTypeFields.size();
+      String[] columnNames = new String[numColumns];
+      ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+      for (int i = 0; i < numColumns; i++) {
+        RelDataTypeField dataTypeField = dataTypeFields.get(i);
+        columnNames[i] = dataTypeField.getName();
+        ColumnDataType columnDataType;
+        try {
+          columnDataType = RelToPlanNodeConverter.convertToColumnDataType(dataTypeField.getType());
+        } catch (Exception ignored) {
+          columnDataType = ColumnDataType.UNKNOWN;
+        }
+        columnDataTypes[i] = columnDataType;
+      }
+      response.setResultTable(new ResultTable(new DataSchema(columnNames, columnDataTypes), List.of()));
+      return;
+    }
+
+    // When data schema is available, try to fix the data types within it.
+    ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+    int numColumns = columnDataTypes.length;
+    if (dataTypeFields != null) {
+      // Fill data type with the validated row type when it is available.
+      for (int i = 0; i < numColumns; i++) {
+        try {
+          columnDataTypes[i] = RelToPlanNodeConverter.convertToColumnDataType(dataTypeFields.get(i).getType());
+        } catch (Exception ignored) {
+          // Ignore exception and keep the type from response
+        }
+      }
+    } else {
+      // Fill data type with the schema when validated row type is not available.
+      String[] columnNames = dataSchema.getColumnNames();
+      for (int i = 0; i < numColumns; i++) {
+        FieldSpec fieldSpec = schema.getFieldSpecFor(columnNames[i]);
+        if (fieldSpec != null) {
+          try {
+            columnDataTypes[i] = ColumnDataType.fromDataType(fieldSpec.getDataType(), fieldSpec.isSingleValueField());
+          } catch (Exception ignored) {
+            // Ignore exception and keep the type from response
+          }
+        }
+      }
+    }
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import java.util.List;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class EmptyResponseUtilsTest {
+
+  @Test
+  public void testBuildEmptyResultTable() {
+    // Selection
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT a, b FROM testTable WHERE foo = 'bar'");
+    ResultTable resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    DataSchema dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnNames(), new String[]{"a", "b"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    assertTrue(resultTable.getRows().isEmpty());
+
+    // Distinct
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT a, b FROM testTable WHERE foo = 'bar'");
+    resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnNames(), new String[]{"a", "b"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    assertTrue(resultTable.getRows().isEmpty());
+
+    // Aggregation
+    queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar'");
+    resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnNames(), new String[]{"count(*)", "sum(a)", "max(b)"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 1);
+    Object[] row = rows.get(0);
+    assertEquals(row[0], 0L);
+    assertEquals(row[1], 0.0);
+    assertEquals(row[2], Double.NEGATIVE_INFINITY);
+
+    // Group-by
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT c, d, COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar' GROUP BY c, d");
+    resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnNames(), new String[]{"c", "d", "count(*)", "sum(a)", "max(b)"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
+    assertTrue(resultTable.getRows().isEmpty());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/cursors/AbstractResponseStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/cursors/AbstractResponseStore.java
@@ -185,7 +185,7 @@ public abstract class AbstractResponseStore implements ResponseStore {
     int totalTableRows = response.getNumRowsResultSet();
 
     if (totalTableRows == 0 && offset == 0) {
-      // If sum records is 0, then result set is empty.
+      // TODO: Set a result table with schema and no rows
       response.setResultTable(null);
       response.setOffset(0);
       response.setNumRows(0);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
@@ -40,6 +40,7 @@ public class ResultsBlockUtils {
   private ResultsBlockUtils() {
   }
 
+  // TODO: Use schema to fill the correct data types for empty results.
   public static BaseResultsBlock buildEmptyQueryResults(QueryContext queryContext) {
     if (QueryContextUtils.isSelectionQuery(queryContext)) {
       return buildEmptySelectionQueryResults(queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -41,7 +41,7 @@ import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 /**
  * Helper class to reduce and set gap fill results into the BrokerResponseNative
  */
-abstract class BaseGapfillProcessor {
+public abstract class BaseGapfillProcessor {
   protected final QueryContext _queryContext;
 
   protected final int _limitForAggregatedResult;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -82,12 +82,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   @Override
-  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
-    super.overrideBrokerConf(brokerConf);
-    brokerConf.setProperty(CommonConstants.Broker.USE_MSE_TO_FILL_EMPTY_RESPONSE_SCHEMA, true);
-  }
-
-  @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
     try {
       LOGGER.info("Set segment.store.uri: {} for server with scheme: {}", _controllerConfig.getDataDir(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CursorIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CursorIntegrationTest.java
@@ -60,7 +60,7 @@ public class CursorIntegrationTest extends BaseClusterIntegrationTestSet {
       "SELECT ArrDelay, CarrierDelay, (ArrDelay - CarrierDelay) AS diff FROM mytable WHERE ArrDelay > CarrierDelay "
           + "ORDER BY diff, ArrDelay, CarrierDelay LIMIT 100000";
   private static final String EMPTY_RESULT_QUERY =
-      "SELECT SUM(CAST(CAST(ArrTime AS varchar) AS LONG)) FROM mytable WHERE DaysSinceEpoch <> 16312 AND 1 != 1";
+      "SELECT CAST(CAST(ArrTime AS varchar) AS LONG) FROM mytable WHERE DaysSinceEpoch <> 16312 AND 1 != 1";
 
   private static int _resultSize;
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -29,9 +29,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.task.AdhocTaskConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -47,12 +45,6 @@ import static org.testng.Assert.assertEquals;
 
 public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIntegrationTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGenerationMinionClusterIntegrationTest.class);
-
-  @Override
-  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
-    super.overrideBrokerConf(brokerConf);
-    brokerConf.setProperty(CommonConstants.Broker.USE_MSE_TO_FILL_EMPTY_RESPONSE_SCHEMA, true);
-  }
 
   @BeforeClass
   public void setUp()

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/utils/ParserUtils.java
@@ -18,19 +18,8 @@
  */
 package org.apache.pinot.query.parser.utils;
 
-import com.google.common.base.Preconditions;
-import java.util.List;
-import org.apache.calcite.rel.RelRoot;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.pinot.common.config.provider.TableCache;
-import org.apache.pinot.common.response.BrokerResponse;
-import org.apache.pinot.common.response.broker.ResultTable;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.QueryEnvironment;
-import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,96 +41,5 @@ public class ParserUtils {
     boolean canCompile = queryEnvironment.canCompileQuery(query);
     LOGGER.debug("Multi-stage query compilation time = {}ms", System.currentTimeMillis() - compileStartTime);
     return canCompile;
-  }
-
-  /**
-   * Tries to fill an empty or not properly filled {@link DataSchema} when no row has been returned.
-   *
-   * Response data schema can be inaccurate or incomplete in several forms:
-   * 1. No result table at all (when all segments have been pruned on broker).
-   * 2. Data schema has all columns set to default type (STRING) (when all segments pruned on server).
-   *
-   * Priority is:
-   * - Types from multi-stage engine validation for the given query (if allowed).
-   * - Types from schema for the given table (only applicable to selection fields).
-   * - Types from single-stage engine response (no action).
-   *
-   * Multi-stage engine schema will be available only if query compiles.
-   */
-  public static void fillEmptyResponseSchema(boolean useMSE, BrokerResponse response, TableCache tableCache,
-      Schema schema, String database, String query) {
-    Preconditions.checkState(response.getNumRowsResultSet() == 0, "Cannot fill schema for non-empty response");
-
-    DataSchema dataSchema = response.getResultTable() != null ? response.getResultTable().getDataSchema() : null;
-
-    List<RelDataTypeField> dataTypeFields = null;
-    // Turn on (with pinot.broker.use.mse.to.fill.empty.response.schema=true or query option
-    // useMSEToFillEmptyResponseSchema=true) only for clusters where no queries with huge IN clauses are expected
-    // (see https://github.com/apache/pinot/issues/15064)
-    if (useMSE) {
-      QueryEnvironment queryEnvironment = new QueryEnvironment(database, tableCache, null);
-      RelRoot root;
-      try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
-        root = compiledQuery.getRelRoot();
-      } catch (Exception ignored) {
-        root = null;
-      }
-      if (root != null && root.validatedRowType != null) {
-        dataTypeFields = root.validatedRowType.getFieldList();
-      }
-    }
-
-    if (dataSchema == null && dataTypeFields == null) {
-      // No schema available, nothing we can do
-      return;
-    }
-
-    if (dataSchema == null || (dataTypeFields != null && dataSchema.size() != dataTypeFields.size())) {
-      // If data schema is not available or has different number of columns than the validated row type, we use the
-      // validated row type to populate the schema.
-      int numColumns = dataTypeFields.size();
-      String[] columnNames = new String[numColumns];
-      ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
-      for (int i = 0; i < numColumns; i++) {
-        RelDataTypeField dataTypeField = dataTypeFields.get(i);
-        columnNames[i] = dataTypeField.getName();
-        ColumnDataType columnDataType;
-        try {
-          columnDataType = RelToPlanNodeConverter.convertToColumnDataType(dataTypeField.getType());
-        } catch (Exception ignored) {
-          columnDataType = ColumnDataType.UNKNOWN;
-        }
-        columnDataTypes[i] = columnDataType;
-      }
-      response.setResultTable(new ResultTable(new DataSchema(columnNames, columnDataTypes), List.of()));
-      return;
-    }
-
-    // When data schema is available, try to fix the data types within it.
-    ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
-    int numColumns = columnDataTypes.length;
-    if (dataTypeFields != null) {
-      // Fill data type with the validated row type when it is available.
-      for (int i = 0; i < numColumns; i++) {
-        try {
-          columnDataTypes[i] = RelToPlanNodeConverter.convertToColumnDataType(dataTypeFields.get(i).getType());
-        } catch (Exception ignored) {
-          // Ignore exception and keep the type from response
-        }
-      }
-    } else {
-      // Fill data type with the schema when validated row type is not available.
-      String[] columnNames = dataSchema.getColumnNames();
-      for (int i = 0; i < numColumns; i++) {
-        FieldSpec fieldSpec = schema.getFieldSpecFor(columnNames[i]);
-        if (fieldSpec != null) {
-          try {
-            columnDataTypes[i] = ColumnDataType.fromDataType(fieldSpec.getDataType(), fieldSpec.isSingleValueField());
-          } catch (Exception ignored) {
-            // Ignore exception and keep the type from response
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Another attempt over #15502 

Add broker side empty response handling similar to server side (`ResultsBlockUtils`) so that when all segments are pruned on the broker side, we can still get a proper response.