### PR TITLE
Fix Swagger UI redirect issue by preserving Knox gateway path in base…

### DIFF
--- a/pinot-common/src/main/resources/swagger-ui/index.html
+++ b/pinot-common/src/main/resources/swagger-ui/index.html
@@ -62,7 +62,7 @@
     if (url && url.length > 1) {
       url = decodeURIComponent(url[1]);
     } else {
-      url = "/swagger.json";
+      url = "./swagger.json";
     }
 
     // Build a system

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -32,7 +32,7 @@ let navigationItems = [
   { id: 1, name: 'Cluster Manager', link: '/', icon: <ClusterManagerIcon /> },
   { id: 2, name: 'Query Console', link: '/query', icon: <QueryConsoleIcon /> },
   { id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> },
-  { id: 4, name: 'Swagger REST API', link: 'help', target: '_blank', icon: <SwaggerIcon /> }
+  { id: 4, name: 'Swagger REST API', link: './help', target: '_blank', icon: <SwaggerIcon /> }
 ];
 
 const Layout = (props) => {

--- a/pinot-controller/src/main/resources/swagger/api/index.html
+++ b/pinot-controller/src/main/resources/swagger/api/index.html
@@ -62,7 +62,7 @@
     if (url && url.length > 1) {
       url = decodeURIComponent(url[1]);
     } else {
-      url = "/swagger.json";
+      url = "./swagger.json";
     }
 
     // Build a system

--- a/pinot-integration-tests/src/test/resources/index.html
+++ b/pinot-integration-tests/src/test/resources/index.html
@@ -61,7 +61,7 @@
     if (url && url.length > 1) {
       url = decodeURIComponent(url[1]);
     } else {
-      url = "/swagger.json";
+      url = "./swagger.json";
     }
 
     // Build a system

--- a/pinot-server/src/main/resources/api/index.html
+++ b/pinot-server/src/main/resources/api/index.html
@@ -62,7 +62,7 @@
     if (url && url.length > 1) {
       url = decodeURIComponent(url[1]);
     } else {
-      url = "/swagger.json";
+      url = "./swagger.json";
     }
 
     // Build a system


### PR DESCRIPTION
Issue #15706 

**Description:**  
This PR addresses issues with the Swagger UI when served behind reverse proxies such as Apache Knox. Previously, the Swagger UI hardcoded the base path to `/swagger.json` and relative links like `'help'`, causing redirection to incorrect paths and breaking functionality in proxied environments.

**Changes Made:**
- Replaced absolute paths (`/swagger.json`) with relative paths (`./swagger.json`) in all `index.html` files across modules:
  - `pinot-common`
  - `pinot-controller`
  - `pinot-server`
  - `pinot-integration-tests`
- Updated the Swagger link in the Pinot Controller UI's navigation (`Layout.tsx`) to use a relative path (`./help`) to ensure compatibility with Knox path rewriting.

**Impact:**  
This change ensures that Swagger UI functions correctly when accessed through reverse proxies that alter the base URL (e.g., `/gateway/pinot/`), resolving redirect and resource loading issues.

**Testing:**  
Verified that Swagger UI loads and works as expected when accessed via Knox gateway with the appropriate service/rewrite configuration.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/35a2279c-8366-4626-8bb1-7be76be546be" />
