### PR TITLE
 Add Table config decorator support

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -49,6 +49,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
+import org.apache.pinot.spi.utils.TableConfigDecoratorRegistry;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -602,7 +603,9 @@ public class ZKMetadataProvider {
     }
     try {
       TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
-      return replaceVariables ? ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(tableConfig) : tableConfig;
+      TableConfig processedTableConfig = replaceVariables
+        ? ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(tableConfig) : tableConfig;
+      return TableConfigDecoratorRegistry.applyDecorator(processedTableConfig);
     } catch (Exception e) {
       LOGGER.error("Caught exception while creating table config from ZNRecord: {}", znRecord.getId(), e);
       return null;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigDecorator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigDecorator.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+/**
+ * Interface for decorating TableConfig objects.
+ * Implementations of this interface can wrap a TableConfig
+ * to add or modify behavior.
+ */
+public interface TableConfigDecorator {
+
+    /**
+     * Decorates the given TableConfig.
+     * Implementations should modify the provided TableConfig object or return a new one
+     * with the desired changes.
+     *
+     * @param tableConfig The original TableConfig loaded from the metadata store.
+     * @return The decorated (potentially modified) TableConfig.
+     */
+    TableConfig decorate(TableConfig tableConfig);
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TableConfigDecoratorRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TableConfigDecoratorRegistry.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigDecorator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registry for TableConfigDecorator implementations.
+ * Enables external plugins to register decorators that enhance TableConfig objects.
+ * By default, no decorator is registered.
+ */
+public class TableConfigDecoratorRegistry {
+    private TableConfigDecoratorRegistry() {
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableConfigDecoratorRegistry.class);
+
+    // Default no-op decorator
+    private static final TableConfigDecorator NOOP = tableConfig -> tableConfig;
+
+    // Initialize with the no-op decorator
+    private static final AtomicReference<TableConfigDecorator> DECORATOR_INSTANCE = new AtomicReference<>(NOOP);
+
+    /**
+     * Registers a decorator during startup.
+     *
+     * @param decorator The decorator to register
+     * @return true if registration was successful, false if already registered
+     */
+    public static boolean register(TableConfigDecorator decorator) {
+       return DECORATOR_INSTANCE.compareAndSet(NOOP, decorator);
+    }
+
+    /**
+     * Applies the registered decorator to a TableConfig.
+     *
+     * @param tableConfig The config to decorate
+     * @return The decorated config or original if decoration fails
+     */
+    public static TableConfig applyDecorator(TableConfig tableConfig) {
+        if (tableConfig == null) {
+            return null;
+        }
+
+        TableConfigDecorator decorator = DECORATOR_INSTANCE.get();
+        if (decorator == null) {
+            LOGGER.debug("No decorator registered, returning original TableConfig");
+            return tableConfig;
+        }
+
+        try {
+            return decorator.decorate(tableConfig);
+        } catch (Exception e) {
+            LOGGER.error("Failed to apply decorator to table config for table: {}",
+                tableConfig.getTableName(), e);
+            return tableConfig;
+        }
+    }
+}


### PR DESCRIPTION
## Introduce TableConfig Decorator

This PR introduces a decorator pattern for `TableConfig` objects, providing a pluggable way to alter or augment table configurations.

**Changes:**

* **Added `TableConfigDecorator` Interface (`pinot-spi`)**:
    * Introduced a new interface `org.apache.pinot.spi.config.table.TableConfigDecorator`.
    * This interface defines a single method, `decorate(TableConfig tableConfig)`, which takes the original `TableConfig` and returns a potentially modified `TableConfig`

* **Added `TableConfigDecoratorRegistry` (`pinot-spi`)**:
    * Created a new registry class `org.apache.pinot.spi.utils.TableConfigDecoratorRegistry` to manage decorator instances.
    * It holds a static, atomically updated reference to a single `TableConfigDecorator` instance, initialized with a default no-op decorator.
    * Provides a `register(TableConfigDecorator decorator)` method to allow setting a decorator implementation, intended for use during startup.
    * Provides an `applyDecorator(TableConfig tableConfig)` method that applies the registered decorator to a given `TableConfig`, returning the original config if no decorator is registered or if an error occurs during decoration.

* **Integrated Decorator into `ZKMetadataProvider` (`pinot-common`)**:
    * Modified `ZKMetadataProvider.getTableConfig()`. After fetching the `TableConfig` from Zookeeper the resulting `TableConfig` is now passed through `TableConfigDecoratorRegistry.applyDecorator()` before being returned. This ensures any registered decorator is applied automatically during the config loading process.

**Impact:**

This enhancement allows external code (like plugins) to implement and register a custom TableConfigDecorator during system initialization. Once registered, this decorator will be automatically applied by ZKMetadataProvider to every table configuration it loads