### PR TITLE
Add configs to logical tables

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LogicalTableUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LogicalTableUtils.java
@@ -21,11 +21,14 @@ package org.apache.pinot.common.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.spi.config.table.QueryConfig;
+import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -44,6 +47,21 @@ public class LogicalTableUtils {
     LogicalTableConfigBuilder builder = new LogicalTableConfigBuilder()
         .setTableName(record.getSimpleField(LogicalTableConfig.LOGICAL_TABLE_NAME_KEY))
         .setBrokerTenant(record.getSimpleField(LogicalTableConfig.BROKER_TENANT_KEY));
+
+    if (record.getSimpleField(LogicalTableConfig.QUERY_CONFIG_KEY) != null) {
+      builder.setQueryConfig(JsonUtils.stringToObject(record.getSimpleField(LogicalTableConfig.QUERY_CONFIG_KEY),
+          QueryConfig.class));
+    }
+    if (record.getSimpleField(LogicalTableConfig.QUOTA_CONFIG_KEY) != null) {
+      builder.setQuotaConfig(JsonUtils.stringToObject(record.getSimpleField(LogicalTableConfig.QUOTA_CONFIG_KEY),
+          QuotaConfig.class));
+    }
+    if (record.getSimpleField(LogicalTableConfig.REF_OFFLINE_TABLE_NAME_KEY) != null) {
+      builder.setRefOfflineTableName(record.getSimpleField(LogicalTableConfig.REF_OFFLINE_TABLE_NAME_KEY));
+    }
+    if (record.getSimpleField(LogicalTableConfig.REF_REALTIME_TABLE_NAME_KEY) != null) {
+      builder.setRefRealtimeTableName(record.getSimpleField(LogicalTableConfig.REF_REALTIME_TABLE_NAME_KEY));
+    }
 
     Map<String, PhysicalTableConfig> physicalTableConfigMap = new HashMap<>();
     for (Map.Entry<String, String> entry : record.getMapField(LogicalTableConfig.PHYSICAL_TABLE_CONFIG_KEY)
@@ -70,10 +88,25 @@ public class LogicalTableUtils {
     record.setSimpleField(LogicalTableConfig.LOGICAL_TABLE_NAME_KEY, logicalTableConfig.getTableName());
     record.setSimpleField(LogicalTableConfig.BROKER_TENANT_KEY, logicalTableConfig.getBrokerTenant());
     record.setMapField(LogicalTableConfig.PHYSICAL_TABLE_CONFIG_KEY, physicalTableConfigMap);
+
+    if (logicalTableConfig.getQueryConfig() != null) {
+      record.setSimpleField(LogicalTableConfig.QUERY_CONFIG_KEY, logicalTableConfig.getQueryConfig().toJsonString());
+    }
+    if (logicalTableConfig.getQuotaConfig() != null) {
+      record.setSimpleField(LogicalTableConfig.QUOTA_CONFIG_KEY, logicalTableConfig.getQuotaConfig().toJsonString());
+    }
+    if (logicalTableConfig.getRefOfflineTableName() != null) {
+      record.setSimpleField(LogicalTableConfig.REF_OFFLINE_TABLE_NAME_KEY,
+          logicalTableConfig.getRefOfflineTableName());
+    }
+    if (logicalTableConfig.getRefRealtimeTableName() != null) {
+      record.setSimpleField(LogicalTableConfig.REF_REALTIME_TABLE_NAME_KEY,
+          logicalTableConfig.getRefRealtimeTableName());
+    }
     return record;
   }
 
-  public static void validateLogicalTableName(LogicalTableConfig logicalTableConfig, List<String> allPhysicalTables,
+  public static void validateLogicalTableConfig(LogicalTableConfig logicalTableConfig, List<String> allPhysicalTables,
       Set<String> allBrokerTenantNames) {
     String tableName = logicalTableConfig.getTableName();
     if (StringUtils.isEmpty(tableName)) {
@@ -91,6 +124,9 @@ public class LogicalTableUtils {
           "Invalid logical table. Reason: 'physicalTableConfigMap' should not be null or empty");
     }
 
+    Set<String> offlineTableNames = new HashSet<>();
+    Set<String> realtimeTableNames = new HashSet<>();
+
     for (Map.Entry<String, PhysicalTableConfig> entry : logicalTableConfig.getPhysicalTableConfigMap().entrySet()) {
       String physicalTableName = entry.getKey();
       PhysicalTableConfig physicalTableConfig = entry.getValue();
@@ -106,6 +142,44 @@ public class LogicalTableUtils {
             "Invalid logical table. Reason: 'physicalTableConfig' should not be null for physical table: "
                 + physicalTableName);
       }
+
+      if (TableNameBuilder.isOfflineTableResource(physicalTableName)) {
+        offlineTableNames.add(physicalTableName);
+      } else if (TableNameBuilder.isRealtimeTableResource(physicalTableName)) {
+        realtimeTableNames.add(physicalTableName);
+      }
+    }
+
+    // validate ref offline table name is not null or empty when offline tables exists
+    if (!offlineTableNames.isEmpty() && StringUtils.isEmpty(logicalTableConfig.getRefOfflineTableName())) {
+      throw new IllegalArgumentException(
+          "Invalid logical table. Reason: 'refOfflineTableName' should not be null or empty when offline table exists");
+    }
+
+    // validate ref realtime table name is not null or empty when realtime tables exists
+    if (!realtimeTableNames.isEmpty() && StringUtils.isEmpty(logicalTableConfig.getRefRealtimeTableName())) {
+      throw new IllegalArgumentException(
+          "Invalid logical table. Reason: 'refRealtimeTableName' should not be null or empty when realtime table "
+              + "exists");
+    }
+
+    // validate ref offline table name is present in the offline tables
+    if (!offlineTableNames.isEmpty() && !offlineTableNames.contains(logicalTableConfig.getRefOfflineTableName())) {
+      throw new IllegalArgumentException(
+          "Invalid logical table. Reason: 'refOfflineTableName' should be one of the provided offline tables");
+    }
+
+    // validate ref realtime table name is present in the realtime tables
+    if (!realtimeTableNames.isEmpty() && !realtimeTableNames.contains(logicalTableConfig.getRefRealtimeTableName())) {
+      throw new IllegalArgumentException(
+          "Invalid logical table. Reason: 'refRealtimeTableName' should be one of the provided realtime tables");
+    }
+
+    // validate quota.storage is not set
+    QuotaConfig quotaConfig = logicalTableConfig.getQuotaConfig();
+    if (quotaConfig != null && !StringUtils.isEmpty(quotaConfig.getStorage())) {
+      throw new IllegalArgumentException(
+          "Invalid logical table. Reason: 'quota.storage' should not be set for logical table");
     }
 
     // validate broker tenant

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLogicalTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLogicalTableResource.java
@@ -218,7 +218,7 @@ public class PinotLogicalTableResource {
         logicalTableConfig.setBrokerTenant(DEFAULT_BROKER_TENANT);
       }
 
-      LogicalTableUtils.validateLogicalTableName(
+      LogicalTableUtils.validateLogicalTableConfig(
           logicalTableConfig,
           _pinotHelixResourceManager.getAllTables(),
           _pinotHelixResourceManager.getAllBrokerTenantNames()
@@ -242,7 +242,7 @@ public class PinotLogicalTableResource {
         logicalTableConfig.setBrokerTenant(DEFAULT_BROKER_TENANT);
       }
 
-      LogicalTableUtils.validateLogicalTableName(
+      LogicalTableUtils.validateLogicalTableConfig(
           logicalTableConfig,
           _pinotHelixResourceManager.getAllTables(),
           _pinotHelixResourceManager.getAllBrokerTenantNames()

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -70,6 +70,7 @@ import org.apache.pinot.controller.api.resources.PauseStatusDetails;
 import org.apache.pinot.controller.api.resources.TableViews;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
+import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -395,9 +396,16 @@ public class ControllerTest {
     for (String physicalTableName : physicalTableNames) {
       physicalTableConfigMap.put(physicalTableName, new PhysicalTableConfig());
     }
+    String offlineTableName =
+        physicalTableNames.stream().filter(TableNameBuilder::isOfflineTableResource).findFirst().orElse(null);
+    String realtimeTableName =
+        physicalTableNames.stream().filter(TableNameBuilder::isRealtimeTableResource).findFirst().orElse(null);
     LogicalTableConfigBuilder builder = new LogicalTableConfigBuilder()
         .setTableName(tableName)
         .setBrokerTenant(brokerTenant)
+        .setRefOfflineTableName(offlineTableName)
+        .setRefRealtimeTableName(realtimeTableName)
+        .setQuotaConfig(new QuotaConfig(null, "999"))
         .setPhysicalTableConfigMap(physicalTableConfigMap);
     return builder.build();
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/LogicalTableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/LogicalTableConfig.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pinot.spi.data;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.table.QueryConfig;
+import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class LogicalTableConfig extends BaseJsonConfig {
 
   private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
@@ -37,10 +38,20 @@ public class LogicalTableConfig extends BaseJsonConfig {
   public static final String LOGICAL_TABLE_NAME_KEY = "tableName";
   public static final String PHYSICAL_TABLE_CONFIG_KEY = "physicalTableConfigMap";
   public static final String BROKER_TENANT_KEY = "brokerTenant";
+  public static final String QUERY_CONFIG_KEY = "query";
+  public static final String QUOTA_CONFIG_KEY = "quota";
+  public static final String REF_OFFLINE_TABLE_NAME_KEY = "refOfflineTableName";
+  public static final String REF_REALTIME_TABLE_NAME_KEY = "refRealtimeTableName";
 
   private String _tableName;
   private String _brokerTenant;
   private Map<String, PhysicalTableConfig> _physicalTableConfigMap;
+  @JsonProperty(QUERY_CONFIG_KEY)
+  private QueryConfig _queryConfig;
+  @JsonProperty(QUOTA_CONFIG_KEY)
+  private QuotaConfig _quotaConfig;
+  private String _refOfflineTableName;
+  private String _refRealtimeTableName;
 
   public static LogicalTableConfig fromString(String logicalTableString)
       throws IOException {
@@ -72,6 +83,42 @@ public class LogicalTableConfig extends BaseJsonConfig {
     _brokerTenant = brokerTenant;
   }
 
+  @JsonProperty(QUERY_CONFIG_KEY)
+  @Nullable
+  public QueryConfig getQueryConfig() {
+    return _queryConfig;
+  }
+
+  public void setQueryConfig(QueryConfig queryConfig) {
+    _queryConfig = queryConfig;
+  }
+
+  @JsonProperty(QUOTA_CONFIG_KEY)
+  @Nullable
+  public QuotaConfig getQuotaConfig() {
+    return _quotaConfig;
+  }
+
+  public void setQuotaConfig(QuotaConfig quotaConfig) {
+    _quotaConfig = quotaConfig;
+  }
+
+  public String getRefOfflineTableName() {
+    return _refOfflineTableName;
+  }
+
+  public void setRefOfflineTableName(String refOfflineTableName) {
+    _refOfflineTableName = refOfflineTableName;
+  }
+
+  public String getRefRealtimeTableName() {
+    return _refRealtimeTableName;
+  }
+
+  public void setRefRealtimeTableName(String refRealtimeTableName) {
+    _refRealtimeTableName = refRealtimeTableName;
+  }
+
   private JsonNode toJsonObject() {
     return DEFAULT_MAPPER.valueToTree(this);
   }
@@ -92,23 +139,6 @@ public class LogicalTableConfig extends BaseJsonConfig {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (this == object) {
-      return true;
-    }
-    if (object == null || getClass() != object.getClass()) {
-      return false;
-    }
-    LogicalTableConfig that = (LogicalTableConfig) object;
-    return Objects.equals(getTableName(), that.getTableName());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(getTableName());
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/LogicalTableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/LogicalTableConfigBuilder.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.spi.utils.builder;
 
 import java.util.Map;
+import org.apache.pinot.spi.config.table.QueryConfig;
+import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.PhysicalTableConfig;
 
@@ -27,6 +29,11 @@ public class LogicalTableConfigBuilder {
   private String _tableName;
   private Map<String, PhysicalTableConfig> _physicalTableConfigMap;
   private String _brokerTenant;
+  private QueryConfig _queryConfig;
+  private QuotaConfig _quotaConfig;
+  private String _refOfflineTableName;
+  private String _refRealtimeTableName;
+
 
   public LogicalTableConfigBuilder setTableName(String tableName) {
     _tableName = tableName;
@@ -43,11 +50,35 @@ public class LogicalTableConfigBuilder {
     return this;
   }
 
+  public LogicalTableConfigBuilder setQueryConfig(QueryConfig queryConfig) {
+    _queryConfig = queryConfig;
+    return this;
+  }
+
+  public LogicalTableConfigBuilder setQuotaConfig(QuotaConfig quotaConfig) {
+    _quotaConfig = quotaConfig;
+    return this;
+  }
+
+  public LogicalTableConfigBuilder setRefOfflineTableName(String refOfflineTableName) {
+    _refOfflineTableName = refOfflineTableName;
+    return this;
+  }
+
+  public LogicalTableConfigBuilder setRefRealtimeTableName(String refRealtimeTableName) {
+    _refRealtimeTableName = refRealtimeTableName;
+    return this;
+  }
+
   public LogicalTableConfig build() {
     LogicalTableConfig logicalTableConfig = new LogicalTableConfig();
     logicalTableConfig.setTableName(_tableName);
     logicalTableConfig.setPhysicalTableConfigMap(_physicalTableConfigMap);
     logicalTableConfig.setBrokerTenant(_brokerTenant);
+    logicalTableConfig.setQueryConfig(_queryConfig);
+    logicalTableConfig.setQuotaConfig(_quotaConfig);
+    logicalTableConfig.setRefOfflineTableName(_refOfflineTableName);
+    logicalTableConfig.setRefRealtimeTableName(_refRealtimeTableName);
     return logicalTableConfig;
   }
 }


### PR DESCRIPTION
The PR adds more configs for logical tables like query config, quota config, reference offline and realtime tables.
Adds validation for the new configs.
Updates the table cache for logical tables to process the expression overrides and store it.

Testing:
- unit tests for the validations and expression preprocessing


closes: #15607 #15709 #15710 