### PR TITLE
Add metrics for monitoring server's message queue size

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -117,7 +117,10 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   MAILBOX_SERVER_CACHE_SIZE_SMALL("bytes", true),
   MAILBOX_SERVER_CACHE_SIZE_NORMAL("bytes", true),
   MAILBOX_SERVER_THREADLOCALCACHE("bytes", true),
-  MAILBOX_SERVER_CHUNK_SIZE("bytes", true);
+  MAILBOX_SERVER_CHUNK_SIZE("bytes", true),
+
+  // how many message are there in the server's message queue in helix
+  HELIX_MESSAGE_COUNT("count", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -120,7 +120,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   MAILBOX_SERVER_CHUNK_SIZE("bytes", true),
 
   // how many message are there in the server's message queue in helix
-  HELIX_MESSAGE_COUNT("count", true);
+  HELIX_MESSAGES_COUNT("count", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -711,7 +711,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
         Server.DEFAULT_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS);
     _helixMessageCountScheduler = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("message-count-scheduler-%d").setDaemon(true).build());
-    _helixMessageCountScheduler.scheduleAtFixedRate(this::refreshMessageCount, 0, refreshIntervalSeconds, TimeUnit.SECONDS);
+    _helixMessageCountScheduler.scheduleAtFixedRate(this::refreshMessageCount, 0, refreshIntervalSeconds,
+        TimeUnit.SECONDS);
 
     LOGGER.info("Initializing and registering the DefaultClusterConfigChangeHandler");
     try {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
@@ -147,7 +146,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseServerStarter.class);
 
   private static final long CONSUMER_DIRECTORY_EXCEPTION_VALUE = -1L;
-
   protected String _helixClusterName;
   protected String _zkAddress;
   protected PinotConfiguration _serverConf;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -169,7 +169,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected DefaultClusterConfigChangeHandler _clusterConfigChangeHandler;
   protected volatile boolean _isServerReadyToServeQueries = false;
   private ScheduledExecutorService _helixMessageCountScheduler;
-  private final AtomicInteger _cachedMessageCount = new AtomicInteger(0);
 
   @Override
   public void init(PinotConfiguration serverConf)
@@ -1081,12 +1080,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
       List<String> children = dataAccessor.getBaseDataAccessor()
           .getChildNames(String.format("/%s/INSTANCES/%s/MESSAGES", _helixClusterName, _instanceId), 0);
       int messageCount = children == null ? 0 : children.size();
-      _cachedMessageCount.set(messageCount);
       ServerMetrics serverMetrics = _serverInstance.getServerMetrics();
       serverMetrics.setValueOfGlobalGauge(ServerGauge.HELIX_MESSAGES_COUNT, messageCount);
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Updated Helix message count to: {}", messageCount);
-      }
     } catch (Exception e) {
       LOGGER.warn("Failed to refresh Helix message count", e);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1041,6 +1041,9 @@ public class CommonConstants {
     public static final String LUCENE_MIN_REFRESH_INTERVAL_MS = "pinot.server.lucene.min.refresh.interval.ms";
     public static final int DEFAULT_LUCENE_MIN_REFRESH_INTERVAL_MS = 10;
 
+    public static final String CONFIG_OF_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = "server.messageCount.refreshIntervalSeconds";
+    public static final int DEFAULT_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = 30;
+
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1042,7 +1042,7 @@ public class CommonConstants {
     public static final int DEFAULT_LUCENE_MIN_REFRESH_INTERVAL_MS = 10;
 
     public static final String CONFIG_OF_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS =
-        "server.messagesCount.refreshIntervalSeconds";
+        "pinot.server.messagesCount.refreshIntervalSeconds";
     public static final int DEFAULT_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = 30;
 
     public static class SegmentCompletionProtocol {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1041,7 +1041,8 @@ public class CommonConstants {
     public static final String LUCENE_MIN_REFRESH_INTERVAL_MS = "pinot.server.lucene.min.refresh.interval.ms";
     public static final int DEFAULT_LUCENE_MIN_REFRESH_INTERVAL_MS = 10;
 
-    public static final String CONFIG_OF_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = "server.messageCount.refreshIntervalSeconds";
+    public static final String CONFIG_OF_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS =
+        "server.messagesCount.refreshIntervalSeconds";
     public static final int DEFAULT_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = 30;
 
     public static class SegmentCompletionProtocol {


### PR DESCRIPTION
During large table rebalances, a massive number of state transitions may be triggered. If a server cannot keep up, the size of its Helix message queue can grow significantly. This PR adds visibility into the server-side Helix message queue size.

Some rationale:
- This PR delegates responsibility to each server instance to monitor and log its own message queue size metrics, instead of relying on the controller.
- It decouples the getHelixServerMessageCount() method from the metrics scraping thread. This ensures that:  
  - The frequency of metrics scraping does not introduce additional I/O pressure on ZooKeeper.
  - ZooKeeper I/O latency do not interfere with the metrics scraping process.

 ## Test

In quickstart trigger segment reload, meanwhile intentionally block segment reload handler in server, then observing the queue size bump from 0 -> 1, after let segment reload go through, saw metric go back to 0

![Screenshot 2025-05-06 at 4 20 47 PM](https://github.com/user-attachments/assets/29a0cd39-b88f-454d-95d8-b35186b5c869)