### PR TITLE
Follow-up to [#15706] - Fixing Swagger UI redirection from controller UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -32,7 +32,7 @@ let navigationItems = [
   { id: 1, name: 'Cluster Manager', link: '/', icon: <ClusterManagerIcon /> },
   { id: 2, name: 'Query Console', link: '/query', icon: <QueryConsoleIcon /> },
   { id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> },
-  { id: 4, name: 'Swagger REST API', link: './help', target: '_blank', icon: <SwaggerIcon /> }
+  { id: 4, name: 'Swagger REST API', link: 'help', target: '_blank', icon: <SwaggerIcon /> }
 ];
 
 const Layout = (props) => {


### PR DESCRIPTION
### **Issue:**

Follow-up to [[#15706](https://github.com/apache/pinot/pull/15706)](https://github.com/apache/pinot/pull/15706) — fixes regression in Swagger UI link behavior introduced while adding reverse proxy (e.g., Apache Knox) compatibility.

### **Description:**

This PR resolves a bug where the "Swagger REST API" link in the Pinot Controller UI redirects to the landing page (`/`) instead of loading the Swagger UI (`/help` or `/api`) when running a local setup (e.g., `localhost:9000`).

The issue was caused by using a relative path (`./help`) in the navigation link, which breaks local routing in some setups. While this worked for Knox proxies, it broke the local development experience.

### **Changes Made:**

* Updated the Swagger link in `Layout.tsx` to use an absolute path (`help`) instead of a relative one (`./help`).
* Ensured the link works consistently from controller UI.


### **Impact:**

* Restores expected Swagger UI functionality in local environments.
* Improves robustness of Controller UI navigation.

### **Testing:**

* Verified Swagger UI loads correctly via `http://localhost:9000/help`.
* Checked that all other navigation items in the Controller UI work as expected.
