### PR TITLE
Don't use static variables for per-table metadata in ReplicaGroupSegmentAssignmentStrategy

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
 class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupSegmentAssignmentStrategy.class);
 
-  private static HelixManager _helixManager;
-  private static String _tableName;
-  private static String _partitionColumn;
+  private HelixManager _helixManager;
+  private String _tableName;
+  private String _partitionColumn;
   private int _replication;
   private TableConfig _tableConfig;
 


### PR DESCRIPTION
- It's unclear why these were static variables in the first place, and it seems like this has gone unnoticed for so long only because all usages seem to be creating a new instance of the `SegmentAssignmentStrategy` right before calling `assignSegment` or `reassignSegments`.
- That isn't bulletproof though and we could run into all kinds of weird issues if multiple tables using replica groups require segments to be assigned or rebalanced concurrently.