### PR TITLE
Enables auto reset of error segments by default

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -1084,7 +1084,7 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public boolean isAutoResetErrorSegmentsOnValidationEnabled() {
-    return getProperty(ControllerPeriodicTasksConf.AUTO_RESET_ERROR_SEGMENTS_VALIDATION, false);
+    return getProperty(ControllerPeriodicTasksConf.AUTO_RESET_ERROR_SEGMENTS_VALIDATION, true);
   }
 
   public long getStatusCheckerInitialDelayInSeconds() {


### PR DESCRIPTION
Small change to always reset error segments in Realtime Segment Validation Manager.

I have asked the reason of keeping this feature behind the flag here [https://github.com/apache/pinot/pull/14217#issuecomment-2839693930](https://github.com/apache/pinot/pull/14217#issuecomment-2839693930) which I feel should always be enabled without any config.