### PR TITLE
[multistage] Multistage Engine Lite Mode (prototype)

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
@@ -57,6 +57,7 @@ public class PhysicalPlannerContext {
    */
   private final String _instanceId;
   private final Map<String, String> _queryOptions;
+  private final boolean _useLiteMode;
 
   /**
    * Used by controller when it needs to extract table names from the query.
@@ -69,6 +70,7 @@ public class PhysicalPlannerContext {
     _requestId = 0;
     _instanceId = "";
     _queryOptions = Map.of();
+    _useLiteMode = false;
   }
 
   public PhysicalPlannerContext(RoutingManager routingManager, String hostName, int port, long requestId,
@@ -79,6 +81,7 @@ public class PhysicalPlannerContext {
     _requestId = requestId;
     _instanceId = instanceId;
     _queryOptions = queryOptions == null ? Map.of() : queryOptions;
+    _useLiteMode = PhysicalPlannerContext.useLiteMode(queryOptions);
   }
 
   public Supplier<Integer> getNodeIdGenerator() {
@@ -114,10 +117,21 @@ public class PhysicalPlannerContext {
     return _queryOptions;
   }
 
+  public boolean isUseLiteMode() {
+    return _useLiteMode;
+  }
+
   public static boolean isUsePhysicalOptimizer(@Nullable Map<String, String> queryOptions) {
     if (queryOptions == null) {
       return false;
     }
     return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.USE_PHYSICAL_OPTIMIZER, "false"));
+  }
+
+  private static boolean useLiteMode(@Nullable Map<String, String> queryOptions) {
+    if (queryOptions == null) {
+      return false;
+    }
+    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.USE_LITE_MODE, "false"));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAggregate.java
@@ -129,4 +129,10 @@ public class PhysicalAggregate extends Aggregate implements PRelNode {
   public int getLimit() {
     return _limit;
   }
+
+  public PhysicalAggregate withLimit(int newLimit) {
+    return new PhysicalAggregate(getCluster(), getTraitSet(), getHints(), groupSet, groupSets, aggCalls, _nodeId,
+        _pRelInputs.get(0), _pinotDataDistribution, _leafStage, _aggType, _leafReturnFinalResult, _collations,
+        newLimit);
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalSort.java
@@ -96,4 +96,9 @@ public class PhysicalSort extends Sort implements PRelNode {
     return new PhysicalSort(getCluster(), getTraitSet(), getHints(), getCollation(), offset, fetch, _pRelInputs.get(0),
         _nodeId, _pinotDataDistribution, true);
   }
+
+  public PhysicalSort withFetch(RexNode newFetch) {
+    return new PhysicalSort(getCluster(), getTraitSet(), getHints(), getCollation(), offset, newFetch,
+        _pRelInputs.get(0), _nodeId, _pinotDataDistribution, _leafStage);
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PRelOptRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PRelOptRule.java
@@ -49,4 +49,9 @@ public abstract class PRelOptRule {
   public PRelNode getParentNode(PRelOptRuleCall call) {
     return call._parents.isEmpty() ? null : call._parents.getLast();
   }
+
+  public boolean isLeafBoundary(PRelOptRuleCall call) {
+    PRelNode parentNode = getParentNode(call);
+    return call._currentNode.isLeafStage() && (parentNode == null || !parentNode.isLeafStage());
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeSortInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeSortInsertRule.java
@@ -85,6 +85,7 @@ public class LiteModeSortInsertRule extends PRelOptRule {
       PhysicalAggregate aggregate = (PhysicalAggregate) call._currentNode;
       Preconditions.checkState(aggregate.getLimit() <= DEFAULT_SERVER_STAGE_LIMIT,
           "Group trim limit={} exceeds server stage limit={}", aggregate.getLimit(), DEFAULT_SERVER_STAGE_LIMIT);
+      // TODO(mse-physical): This resets the limit to server stage limit. Should we stick with group-trim limit?
       return aggregate.withLimit(DEFAULT_SERVER_STAGE_LIMIT);
     }
     PRelNode input = call._currentNode;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeSortInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeSortInsertRule.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalSort;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRule;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelOptRuleCall;
+import org.apache.pinot.query.type.TypeFactory;
+
+
+/**
+ * Lite mode sets a hard limit on the number of rows that the leaf stage is allowed to return. This rule ensures the
+ * same. This is done by adding a Sort in the leaf stage if one doesn't exist already.
+ * <p>
+ *  When the leaf stage has an aggregation and no Sort, then we can add the limit to the aggregate itself to enable
+ *  server-level group trimming, which achieves the same purpose as adding a Sort. If the aggregation limit is higher
+ *  than the hard-limit, then this Rule will throw an error.
+ * </p>
+ * <p>
+ *   When the leaf stage has a Sort already, we verify that the limit doesn't exceed the configured hard limit.
+ * </p>
+ */
+public class LiteModeSortInsertRule extends PRelOptRule {
+  private static final TypeFactory TYPE_FACTORY = new TypeFactory();
+  private static final RexBuilder REX_BUILDER = new RexBuilder(TYPE_FACTORY);
+  // TODO: This should be configurable at broker and via SET statements.
+  private static final int DEFAULT_SERVER_STAGE_LIMIT = 100_000;
+  private final PhysicalPlannerContext _context;
+
+  public LiteModeSortInsertRule(PhysicalPlannerContext context) {
+    _context = context;
+  }
+
+  @Override
+  public boolean matches(PRelOptRuleCall call) {
+    return isLeafBoundary(call);
+  }
+
+  @Override
+  public PRelNode onMatch(PRelOptRuleCall call) {
+    RexNode newFetch = REX_BUILDER.makeLiteral(DEFAULT_SERVER_STAGE_LIMIT, TYPE_FACTORY.createSqlType(
+        SqlTypeName.INTEGER));
+    if (call._currentNode instanceof PhysicalSort) {
+      // When current node is a Sort, if it has a fetch already, verify it is less than the hard limit. Otherwise,
+      // set the configured hard limit within the same Sort.
+      PhysicalSort sort = (PhysicalSort) call._currentNode;
+      if (sort.fetch != null) {
+        int currentFetch = RexExpressionUtils.getValueAsInt(sort.fetch);
+        Preconditions.checkState(currentFetch <= DEFAULT_SERVER_STAGE_LIMIT,
+            "Attempted to stream %s records from server which exceed limit %s", currentFetch,
+            DEFAULT_SERVER_STAGE_LIMIT);
+        return sort;
+      }
+      return sort.withFetch(newFetch);
+    }
+    if (call._currentNode instanceof PhysicalAggregate) {
+      // When current node is aggregate, add the limit to the Aggregate itself and skip adding the Sort.
+      PhysicalAggregate aggregate = (PhysicalAggregate) call._currentNode;
+      Preconditions.checkState(aggregate.getLimit() <= DEFAULT_SERVER_STAGE_LIMIT,
+          "Group trim limit={} exceeds server stage limit={}", aggregate.getLimit(), DEFAULT_SERVER_STAGE_LIMIT);
+      return aggregate.withLimit(DEFAULT_SERVER_STAGE_LIMIT);
+    }
+    PRelNode input = call._currentNode;
+    return new PhysicalSort(input.unwrap().getCluster(), RelTraitSet.createEmpty(), List.of(),
+        RelCollations.EMPTY, null /* offset */, newFetch, input, nodeId(), input.getPinotDataDistributionOrThrow(),
+        true);
+  }
+
+  private int nodeId() {
+    return _context.getNodeIdGenerator().get();
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRule.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTrait;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.physical.v2.ExchangeStrategy;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelNodeTransformer;
+
+
+/**
+ * Lite mode uses a single worker for all stages except the leaf stage. Since leaf stage assignment is done before this
+ * rule is called, we simply need to sample a random worker from the leaf stage, and assign it to all the non-leaf
+ * plan nodes.
+ */
+public class LiteModeWorkerAssignmentRule implements PRelNodeTransformer {
+  private static final Random RANDOM = new Random();
+  private final PhysicalPlannerContext _context;
+
+  public LiteModeWorkerAssignmentRule(PhysicalPlannerContext context) {
+    _context = context;
+  }
+
+  @Override
+  public PRelNode execute(PRelNode currentNode) {
+    Set<String> workerSet = new HashSet<>();
+    accumulateWorkers(currentNode, workerSet);
+    List<String> workers = List.of(sampleWorker(workerSet));
+    PinotDataDistribution pdd = new PinotDataDistribution(RelDistribution.Type.SINGLETON, workers, workers.hashCode(),
+        null, null);
+    return addExchangeAndWorkers(currentNode, null, pdd);
+  }
+
+  public PRelNode addExchangeAndWorkers(PRelNode currentNode, @Nullable PRelNode parent, PinotDataDistribution pdd) {
+    if (currentNode.isLeafStage()) {
+      if (parent == null) {
+        return currentNode;
+      }
+      return new PhysicalExchange(nodeId(), currentNode, pdd, Collections.emptyList(),
+          ExchangeStrategy.SINGLETON_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy());
+    }
+    List<PRelNode> newInputs = new ArrayList<>();
+    for (PRelNode input : currentNode.getPRelInputs()) {
+      newInputs.add(addExchangeAndWorkers(input, currentNode, pdd));
+    }
+    return currentNode.with(newInputs, pdd);
+  }
+
+  /**
+   * Stores workers assigned to the leaf stage nodes into the provided Set. Note that each worker has an integer prefix
+   * which denotes the "workerId". We remove that prefix before storing them in the set.
+   */
+  @VisibleForTesting
+  static void accumulateWorkers(PRelNode currentNode, Set<String> workerSink) {
+    if (currentNode.isLeafStage()) {
+      workerSink.addAll(currentNode.getPinotDataDistributionOrThrow().getWorkers().stream()
+          .map(LiteModeWorkerAssignmentRule::stripIdPrefixFromWorker).collect(Collectors.toSet()));
+      return;
+    }
+    for (PRelNode input : currentNode.getPRelInputs()) {
+      accumulateWorkers(input, workerSink);
+    }
+  }
+
+  /**
+   * Samples a worker from the given set.
+   */
+  @VisibleForTesting
+  static String sampleWorker(Set<String> workers) {
+    final int chosenIndex = RANDOM.nextInt(workers.size());
+    int index = 0;
+    for (String worker : workers) {
+      if (index == chosenIndex) {
+        return String.format("0@%s", worker);
+      }
+      index++;
+    }
+    throw new IllegalStateException(String.format("Could not sample worker. Set: %s. idx: %d", workers, chosenIndex));
+  }
+
+  @VisibleForTesting
+  static String stripIdPrefixFromWorker(String worker) {
+    return worker.split("@")[1];
+  }
+
+  private int nodeId() {
+    return _context.getNodeIdGenerator().get();
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRuleTest.java
@@ -43,7 +43,7 @@ public class LiteModeWorkerAssignmentRuleTest {
 
   @Test
   public void testSampleWorker() {
-    Set<String> workers = Set.of("worker-0", "worker-1", "worker-2");
+    List<String> workers = List.of("worker-0", "worker-1", "worker-2");
     Set<String> selectionCandidates = Set.of("0@worker-0", "0@worker-1", "0@worker-2");
     Set<String> selectedWorkers = new HashSet<>();
     for (int iteration = 0; iteration < 1000; iteration++) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LiteModeWorkerAssignmentRuleTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.doReturn;
+import static org.testng.Assert.*;
+
+
+public class LiteModeWorkerAssignmentRuleTest {
+  @Test
+  public void testAccumulateWorkers() {
+    PRelNode leafOne = create(List.of(), true, List.of("0@server-1", "1@server-2"));
+    PRelNode leafTwo = create(List.of(), true, List.of("0@server-2", "1@server-1"));
+    PRelNode intermediateNode = create(List.of(leafOne, leafTwo), false, List.of("0@server-3", "1@server-4"));
+    Set<String> workers = new HashSet<>();
+    LiteModeWorkerAssignmentRule.accumulateWorkers(intermediateNode, workers);
+    assertEquals(workers, Set.of("server-1", "server-2"));
+  }
+
+  @Test
+  public void testSampleWorker() {
+    Set<String> workers = Set.of("worker-0", "worker-1", "worker-2");
+    Set<String> selectionCandidates = Set.of("0@worker-0", "0@worker-1", "0@worker-2");
+    Set<String> selectedWorkers = new HashSet<>();
+    for (int iteration = 0; iteration < 1000; iteration++) {
+      selectedWorkers.add(LiteModeWorkerAssignmentRule.sampleWorker(workers));
+    }
+    assertEquals(selectedWorkers, selectionCandidates);
+  }
+
+  private PRelNode create(List<PRelNode> inputs, boolean isLeafStage, List<String> workers) {
+    // Setup mock pinot data distribution.
+    PinotDataDistribution mockPDD = Mockito.mock(PinotDataDistribution.class);
+    doReturn(workers).when(mockPDD).getWorkers();
+    // Setup mock PRelNode.
+    PRelNode current = Mockito.mock(PRelNode.class);
+    doReturn(isLeafStage).when(current).isLeafStage();
+    doReturn(mockPDD).when(current).getPinotDataDistributionOrThrow();
+    doReturn(inputs).when(current).getPRelInputs();
+    return current;
+  }
+}

--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -421,5 +421,104 @@
         ]
       }
     ]
+  },
+  "physical_opt_lite_mode_single_rel_queries": {
+    "queries": [
+      {
+        "description": "Simple SELECT with WHERE query.",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR SELECT col2, col3 FROM a WHERE col1 = 'foo'",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalSort(fetch=[100000])",
+          "\n  PhysicalProject(col2=[$1], col3=[$2])",
+          "\n    PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n      PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Auto elimination of partial aggregate when group-by on partitioning column. There's no sort because the limit is added to Agg.",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR SELECT col2, COUNT(*) FROM a WHERE col1 = 'foo' GROUP BY col2",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalAggregate(group=[{1}], agg#0=[COUNT()])",
+          "\n  PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n    PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Sub-queries with chained transformations",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR WITH tmp AS (SELECT col1, col2, col3, COUNT(*) FROM a WHERE col1 = 'foo' GROUP BY col1, col2, col3) SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY col2 ORDER BY col3) as rnk, col1 FROM tmp) WHERE rnk = 1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalProject(rnk=[$3], col1=[$0])",
+          "\n  PhysicalFilter(condition=[=($3, 1)])",
+          "\n    PhysicalWindow(window#0=[window(partition {1} order by [2] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
+          "\n      PhysicalAggregate(group=[{0, 1, 2}])",
+          "\n        PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n          PhysicalAggregate(group=[{0, 1, 2}])",
+          "\n            PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n              PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Pagination on group-by results",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR WITH tmp AS (SELECT col1, col2, col3, COUNT(*) FROM a WHERE col1 = 'foo' GROUP BY col1, col2, col3 ORDER BY col2) SELECT * FROM tmp LIMIT 100,400",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalSort(offset=[100], fetch=[400])",
+          "\n  PhysicalAggregate(group=[{0, 1, 2}], agg#0=[COUNT($3)])",
+          "\n    PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n      PhysicalAggregate(group=[{0, 1, 2}], agg#0=[COUNT()])",
+          "\n        PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n          PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      }
+    ]
+  },
+  "physical_opt_lite_mode_bi_rel_queries": {
+    "queries": [
+      {
+        "description": "Query with single semi join",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR SELECT col2, col3 FROM a WHERE col1 = 'foo' AND col2 IN (SELECT col1 FROM b)",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n  PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n    PhysicalSort(fetch=[100000])",
+          "\n      PhysicalProject(col2=[$1], col3=[$2])",
+          "\n        PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n          PhysicalTableScan(table=[[default, a]])",
+          "\n  PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n    PhysicalSort(fetch=[100000])",
+          "\n      PhysicalProject(col1=[$0])",
+          "\n        PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Query with single semi join and aggregation",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR SELECT COUNT(*), col2 FROM a WHERE col1 = 'foo' AND col2 IN (SELECT col1 FROM b) GROUP BY col2",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalProject(EXPR$0=[$1], col2=[$0])",
+          "\n  PhysicalAggregate(group=[{0}], agg#0=[COUNT()])",
+          "\n    PhysicalJoin(condition=[=($0, $1)], joinType=[semi])",
+          "\n      PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n        PhysicalSort(fetch=[100000])",
+          "\n          PhysicalProject(col2=[$1])",
+          "\n            PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n              PhysicalTableScan(table=[[default, a]])",
+          "\n      PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], distKeys=[[]], execStrategy=[STREAMING], collation=[[]])",
+          "\n        PhysicalSort(fetch=[100000])",
+          "\n          PhysicalProject(col1=[$0])",
+          "\n            PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      }
+    ]
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -620,6 +620,7 @@ public class CommonConstants {
         // usually low, and this query option allows the MSE Optimizer to infer the partition of a segment based on its
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
+        public static final String USE_LITE_MODE = "useLiteMode";
       }
 
       public static class QueryOptionValue {


### PR DESCRIPTION
# Summary

**Goal:** Prototype the MSE Lite Mode to enable testing in our clusters so we can make informed decisions about its semantics and overall guarantees. (e.g. what is the most intuitive way to add limit to the leaf stage that is least confusing and maximally transparent to users)

Prototypes the Multistage Engine Lite Mode as described in #14640. The feature is hidden behind a flag and can only be enabled if one has also set the `usePhysicalOptimizer=true` query option.

This builds on top of the existing Optimizer changes and leverages many of the optimizations that are provided by that optimizer.

# Specifics

## Worker Assignment

Worker and Exchange are assigned using a new rule. This is because the generic Worker/Exchange assignment rule handles the general case, and for the Lite Mode we have some custom logic like picking a random server instance out of the ones assigned to the leaf stage.

The assignment is quite simple: the leaf stage assignment is done by the existing `LeafStageWorkerAssignmentRule`, and the new Lite Mode assignment rule simply samples a server instance from the leaf stage workers, and uses it for the all plan nodes except the leaf stage.

## Integration with Sort/Aggregate Pushdown

Both of these rules are still run since there are scenarios where we would like to push down the Sort or Aggregate to the leaf. e.g. if I have a query like `SELECT col1, COUNT(*) FROM tbl GROUP BY col1`, then the aggregate should be pushed down to the leaf stage in most cases for obvious reasons.

## Sort Insert Rule

If there doesn't exist a limit already in the leaf stage, we add it. Currently I am using a hardcoded value but in the future we'll make it configurable per se.

# Semantics

None of the semantics in this PR are final and are subject to broader community review. Based on testing from this PR, I'll file a PEP to describe the semantics in detail.

# Test Plan

Added Unit Tests. We are also testing this out in our clusters.
