### PR TITLE
Cleanup the segment metadata reading logic in SegmentPreProcessor

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
@@ -63,6 +63,7 @@ public class SegmentMetadataUtils {
       propertiesConfiguration.setProperty(entry.getKey(), entry.getValue());
     }
     savePropertiesConfiguration(propertiesConfiguration, segmentMetadata.getIndexDir());
+    // TODO: Revisit if we can save the overhead of reloading the metadata when invoked from ForwardIndexHandler
     segmentDirectory.reloadMetadata();
     return segmentDirectory.getSegmentMetadata();
   }


### PR DESCRIPTION
- Always use the one from `SegmentDirectory` to avoid bugs introduced by inconsistent segment metadata
- Reduce some unnecessary metadata load