### PR TITLE
Add skipSegmentPreprocess flag to TableConfigBuilder

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2347,6 +2347,14 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  public void testValidateSkipSegmentPreprocessFlag() {
+    TableConfig tableconfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(
+        "timeColumn").setSkipSegmentPreprocess(true).build();
+    Assert.assertTrue(tableconfig.getIndexingConfig().isSkipSegmentPreprocess(),
+        "skipSegmentPreprocess will be true");
+  }
+
+  @Test
   public void testValidateHybridTableConfig() {
     TableConfig realtimeTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
     TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2347,14 +2347,6 @@ public class TableConfigUtilsTest {
   }
 
   @Test
-  public void testValidateSkipSegmentPreprocessFlag() {
-    TableConfig tableconfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(
-        "timeColumn").setSkipSegmentPreprocess(true).build();
-    Assert.assertTrue(tableconfig.getIndexingConfig().isSkipSegmentPreprocess(),
-        "skipSegmentPreprocess will be true");
-  }
-
-  @Test
   public void testValidateHybridTableConfig() {
     TableConfig realtimeTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
     TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -342,11 +342,6 @@ public class TableConfigBuilder {
     return this;
   }
 
-  public TableConfigBuilder setSkipSegmentPreprocess(boolean skipSegmentPreprocess) {
-    _skipSegmentPreprocess = skipSegmentPreprocess;
-    return this;
-  }
-
   public TableConfigBuilder setAggregateMetrics(boolean aggregateMetrics) {
     _aggregateMetrics = aggregateMetrics;
     return this;
@@ -370,6 +365,11 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setColumnMajorSegmentBuilderEnabled(boolean columnMajorSegmentBuilderEnabled) {
     _columnMajorSegmentBuilderEnabled = columnMajorSegmentBuilderEnabled;
+    return this;
+  }
+
+  public TableConfigBuilder setSkipSegmentPreprocess(boolean skipSegmentPreprocess) {
+    _skipSegmentPreprocess = skipSegmentPreprocess;
     return this;
   }
 
@@ -502,6 +502,7 @@ public class TableConfigBuilder {
     indexingConfig.setSegmentPartitionConfig(_segmentPartitionConfig);
     indexingConfig.setNullHandlingEnabled(_nullHandlingEnabled);
     indexingConfig.setColumnMajorSegmentBuilderEnabled(_columnMajorSegmentBuilderEnabled);
+    indexingConfig.setSkipSegmentPreprocess(_skipSegmentPreprocess);
     indexingConfig.setVarLengthDictionaryColumns(_varLengthDictionaryColumns);
     indexingConfig.setStarTreeIndexConfigs(_starTreeIndexConfigs);
     indexingConfig.setJsonIndexColumns(_jsonIndexColumns);
@@ -513,7 +514,6 @@ public class TableConfigBuilder {
     indexingConfig.setNoDictionaryCardinalityRatioThreshold(_noDictionaryCardinalityRatioThreshold);
     indexingConfig.setTierOverwrites(_tierOverwrites);
     indexingConfig.setJsonIndexConfigs(_jsonIndexConfigs);
-    indexingConfig.setSkipSegmentPreprocess(_skipSegmentPreprocess);
 
     if (_customConfig == null) {
       _customConfig = new TableCustomConfig(null);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -105,6 +105,7 @@ public class TableConfigBuilder {
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _nullHandlingEnabled;
   private boolean _columnMajorSegmentBuilderEnabled = true;
+  private boolean _skipSegmentPreprocess;
   private List<String> _varLengthDictionaryColumns;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private List<String> _jsonIndexColumns;
@@ -341,6 +342,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setSkipSegmentPreprocess(boolean skipSegmentPreprocess) {
+    _skipSegmentPreprocess = skipSegmentPreprocess;
+    return this;
+  }
+
   public TableConfigBuilder setAggregateMetrics(boolean aggregateMetrics) {
     _aggregateMetrics = aggregateMetrics;
     return this;
@@ -507,6 +513,7 @@ public class TableConfigBuilder {
     indexingConfig.setNoDictionaryCardinalityRatioThreshold(_noDictionaryCardinalityRatioThreshold);
     indexingConfig.setTierOverwrites(_tierOverwrites);
     indexingConfig.setJsonIndexConfigs(_jsonIndexConfigs);
+    indexingConfig.setSkipSegmentPreprocess(_skipSegmentPreprocess);
 
     if (_customConfig == null) {
       _customConfig = new TableCustomConfig(null);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.utils.builder;
+
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for the validations in {@link TableConfigBuilder}
+ */
+public class TableConfigBuilderTest {
+
+  private static final String TABLE_NAME = "testTable";
+  private static final String TIME_COLUMN = "timeColumn";
+
+  @Test
+  public void testValidateSkipSegmentPreprocessFlag() {
+
+    TableConfig tableconfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+        .setSkipSegmentPreprocess(true).build();
+    Assert.assertTrue(tableconfig.getIndexingConfig().isSkipSegmentPreprocess(),
+        "skipSegmentPreprocess will be true");
+  }
+}


### PR DESCRIPTION
This PR adds the skipSegmentPreprocess flag to the TableConfigBuilder, which will allow users to configure it using the set method in tableconfig, instead of manually changing the Indexingconfig after building the Tableconfig.

It is related to the following PR: https://github.com/apache/pinot/pull/14982 
