### PR TITLE
Rename LeafStageTransferableBlockOperator to LeafStageOperator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -61,7 +61,7 @@ import org.apache.pinot.query.routing.StagePlan;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
 import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
-import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
+import org.apache.pinot.query.runtime.operator.LeafStageOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
@@ -471,10 +471,8 @@ public class QueryRunner {
 
     Map<PlanNode, ExplainedNode> leafNodes = new HashMap<>();
     BiConsumer<PlanNode, MultiStageOperator> leafNodesConsumer = (node, operator) -> {
-      if (operator instanceof LeafStageTransferableBlockOperator) {
-        LeafStageTransferableBlockOperator leafOperator = (LeafStageTransferableBlockOperator) operator;
-        ExplainedNode explainedNode = leafOperator.explain();
-        leafNodes.put(node, explainedNode);
+      if (operator instanceof LeafStageOperator) {
+        leafNodes.put(node, ((LeafStageOperator) operator).explain());
       }
     };
     // compile OpChain

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/RowHeapDataBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/RowHeapDataBlock.java
@@ -42,7 +42,7 @@ public class RowHeapDataBlock implements MseBlock.Data {
   private final List<Object[]> _rows;
   /// This is a hack we created to support different hash exchange distributions.
   /// We should find a new way to keep this information that is more solid than the current one.
-  /// This information is only set in [org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator] and
+  /// This information is only set in [org.apache.pinot.query.runtime.operator.LeafStageOperator] and
   /// [org.apache.pinot.query.runtime.operator.AggregateOperator] and consumed in
   /// [org.apache.pinot.query.runtime.operator.exchange.HashExchange] when we need to shuffle data.
   /// This means that the value of this attribute is the same for all blocks in the stage, so we should be able to

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageOperator.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.proto.Plan;
@@ -71,23 +70,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Leaf-stage transfer block operator is used to wrap around the leaf stage process results. They are passed to the
- * Pinot server to execute query thus only one {@link DataTable} were returned. However, to conform with the
- * intermediate stage operators. An additional {@link MetadataBlock} needs to be transferred after the data block.
- *
- * <p>In order to achieve this:
- * <ul>
- *   <li>The leaf-stage result is split into data payload block and metadata payload block.</li>
- *   <li>In case the leaf-stage result contains error or only metadata, we skip the data payload block.</li>
- *   <li>Leaf-stage result blocks are in the {@link ColumnDataType#getStoredColumnDataTypes()} format
- *       thus requires canonicalization.</li>
- * </ul>
- */
-public class LeafStageTransferableBlockOperator extends MultiStageOperator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(LeafStageTransferableBlockOperator.class);
-  private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
+/// Leaf-stage operator processes the leaf stage of a multi-stage query with single-stage engine on the server.
+/// The data schema of the result expected from leaf stage might be different from the one returned from single-stage
+/// engine, thus the leaf stage operator needs to convert the data types of the result to conform with the expected
+/// data schema.
+public class LeafStageOperator extends MultiStageOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LeafStageOperator.class);
+  private static final String EXPLAIN_NAME = "LEAF_STAGE";
 
   // Use a special results block to indicate that this is the last results block
   private static final MetadataResultsBlock LAST_RESULTS_BLOCK = new MetadataResultsBlock();
@@ -105,8 +94,8 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private volatile Map<Integer, String> _exceptions;
   private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
 
-  public LeafStageTransferableBlockOperator(OpChainExecutionContext context, List<ServerQueryRequest> requests,
-      DataSchema dataSchema, QueryExecutor queryExecutor, ExecutorService executorService) {
+  public LeafStageOperator(OpChainExecutionContext context, List<ServerQueryRequest> requests, DataSchema dataSchema,
+      QueryExecutor queryExecutor, ExecutorService executorService) {
     super(context);
     int numRequests = requests.size();
     Preconditions.checkArgument(numRequests == 1 || numRequests == 2, "Expected 1 or 2 requests, got: %s", numRequests);
@@ -312,8 +301,8 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   }
 
   public ExplainedNode explain() {
-    Preconditions.checkState(_requests.stream()
-        .allMatch(request -> request.getQueryContext().getExplain() == ExplainMode.NODE),
+    Preconditions.checkState(
+        _requests.stream().allMatch(request -> request.getQueryContext().getExplain() == ExplainMode.NODE),
         "All requests must have explain mode set to ExplainMode.NODE");
 
     if (_executionFuture == null) {
@@ -354,12 +343,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     if (tableName == null) { // this should never happen, but let's be paranoid to never fail
       attributes = Collections.emptyMap();
     } else {
-      attributes = Collections.singletonMap("table", Plan.ExplainNode.AttributeValue.newBuilder()
-          .setString(tableName)
-          .build());
+      attributes =
+          Collections.singletonMap("table", Plan.ExplainNode.AttributeValue.newBuilder().setString(tableName).build());
     }
-    return new ExplainedNode(_context.getStageId(), _dataSchema, null, childNodes,
-        "LeafStageCombineOperator", attributes);
+    return new ExplainedNode(_context.getStageId(), _dataSchema, null, childNodes, "LeafStageCombineOperator",
+        attributes);
   }
 
   private ExplainedNode asNode(ExplainInfo info) {
@@ -369,8 +357,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
       inputs.add(asNode(info.getInputs().get(i)));
     }
 
-    return new ExplainedNode(_context.getStageId(), _dataSchema, null, inputs, info.getTitle(),
-        info.getAttributes());
+    return new ExplainedNode(_context.getStageId(), _dataSchema, null, inputs, info.getTitle(), info.getAttributes());
   }
 
   private Future<Void> startExecution() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LookupJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LookupJoinOperator.java
@@ -58,7 +58,7 @@ public class LookupJoinOperator extends MultiStageOperator {
       Set.of(JoinRelType.INNER, JoinRelType.LEFT, JoinRelType.SEMI, JoinRelType.ANTI);
 
   private final MultiStageOperator _leftInput;
-  private final LeafStageTransferableBlockOperator _rightInput;
+  private final LeafStageOperator _rightInput;
   private final JoinRelType _joinType;
   private final int[] _leftKeyIds;
   private final DimensionTableDataManager _rightTable;
@@ -72,9 +72,8 @@ public class LookupJoinOperator extends MultiStageOperator {
       MultiStageOperator rightInput, JoinNode node) {
     super(context);
     _leftInput = leftInput;
-    Preconditions.checkState(rightInput instanceof LeafStageTransferableBlockOperator,
-        "Right input must be leaf stage operator");
-    _rightInput = (LeafStageTransferableBlockOperator) rightInput;
+    Preconditions.checkState(rightInput instanceof LeafStageOperator, "Right input must be leaf stage operator");
+    _rightInput = (LeafStageOperator) rightInput;
     _joinType = node.getJoinType();
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(_joinType), "Join type: % is not supported for lookup join",
         _joinType);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -261,16 +261,15 @@ public abstract class MultiStageOperator
         response.mergeMaxRowsInOperator(stats.getLong(SetOperator.StatKey.EMITTED_ROWS));
       }
     },
-    LEAF(LeafStageTransferableBlockOperator.StatKey.class) {
+    LEAF(LeafStageOperator.StatKey.class) {
       @Override
       public void mergeInto(BrokerResponseNativeV2 response, StatMap<?> map) {
         @SuppressWarnings("unchecked")
-        StatMap<LeafStageTransferableBlockOperator.StatKey> stats =
-            (StatMap<LeafStageTransferableBlockOperator.StatKey>) map;
-        response.mergeMaxRowsInOperator(stats.getLong(LeafStageTransferableBlockOperator.StatKey.EMITTED_ROWS));
+        StatMap<LeafStageOperator.StatKey> stats = (StatMap<LeafStageOperator.StatKey>) map;
+        response.mergeMaxRowsInOperator(stats.getLong(LeafStageOperator.StatKey.EMITTED_ROWS));
 
         StatMap<BrokerResponseNativeV2.StatKey> brokerStats = new StatMap<>(BrokerResponseNativeV2.StatKey.class);
-        for (LeafStageTransferableBlockOperator.StatKey statKey : stats.keySet()) {
+        for (LeafStageOperator.StatKey statKey : stats.keySet()) {
           statKey.updateBrokerMetadata(brokerStats, stats);
         }
         response.addBrokerStats(brokerStats);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -41,7 +41,7 @@ import org.apache.pinot.query.runtime.operator.FilterOperator;
 import org.apache.pinot.query.runtime.operator.HashJoinOperator;
 import org.apache.pinot.query.runtime.operator.IntersectAllOperator;
 import org.apache.pinot.query.runtime.operator.IntersectOperator;
-import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
+import org.apache.pinot.query.runtime.operator.LeafStageOperator;
 import org.apache.pinot.query.runtime.operator.LiteralValueOperator;
 import org.apache.pinot.query.runtime.operator.LookupJoinOperator;
 import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
@@ -105,7 +105,7 @@ public class PlanNodeToOpChain {
       MultiStageOperator result;
       if (context.getLeafStageContext() != null && context.getLeafStageContext().getLeafStageBoundaryNode() == node) {
         ServerPlanRequestContext leafStageContext = context.getLeafStageContext();
-        result = new LeafStageTransferableBlockOperator(context, leafStageContext.getServerQueryRequests(),
+        result = new LeafStageOperator(context, leafStageContext.getServerQueryRequests(),
             leafStageContext.getLeafStageBoundaryNode().getDataSchema(), leafStageContext.getLeafQueryExecutor(),
             leafStageContext.getExecutorService());
       } else {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageOperatorTest.java
@@ -53,9 +53,9 @@ import static org.mockito.Mockito.when;
 
 
 // TODO: add tests for Agg / GroupBy / Distinct result blocks
-public class LeafStageTransferableBlockOperatorTest {
+public class LeafStageOperatorTest {
   private final ExecutorService _executorService = Executors.newCachedThreadPool();
-  private final AtomicReference<LeafStageTransferableBlockOperator> _operatorRef = new AtomicReference<>();
+  private final AtomicReference<LeafStageOperator> _operatorRef = new AtomicReference<>();
 
   private AutoCloseable _mocks;
 
@@ -82,7 +82,7 @@ public class LeafStageTransferableBlockOperatorTest {
   private QueryExecutor mockQueryExecutor(List<BaseResultsBlock> dataBlocks, InstanceResponseBlock metadataBlock) {
     QueryExecutor queryExecutor = mock(QueryExecutor.class);
     when(queryExecutor.execute(any(), any(), any())).thenAnswer(invocation -> {
-      LeafStageTransferableBlockOperator operator = _operatorRef.get();
+      LeafStageOperator operator = _operatorRef.get();
       for (BaseResultsBlock dataBlock : dataBlocks) {
         operator.addResultsBlock(dataBlock);
       }
@@ -111,9 +111,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-            queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // When:
@@ -143,9 +143,9 @@ public class LeafStageTransferableBlockOperatorTest {
         Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1),
-            desiredSchema, queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), desiredSchema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // When:
@@ -171,9 +171,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-            queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // When:
@@ -204,9 +204,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(2), schema,
-            queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(2), schema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // Then: the 5th block should be EOS
@@ -230,9 +230,9 @@ public class LeafStageTransferableBlockOperatorTest {
     InstanceResponseBlock errorBlock = new InstanceResponseBlock();
     errorBlock.addException(QueryErrorCode.QUERY_EXECUTION, "foobar");
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, errorBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-            queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // When:
@@ -258,9 +258,9 @@ public class LeafStageTransferableBlockOperatorTest {
     InstanceResponseBlock emptySelectionResponseBlock =
         new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList(), queryContext));
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, emptySelectionResponseBlock);
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1),
-            desiredSchema, queryExecutor, _executorService);
+    LeafStageOperator operator =
+        new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), desiredSchema, queryExecutor,
+            _executorService);
     _operatorRef.set(operator);
 
     // When:
@@ -282,11 +282,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        spy(
-            new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-                queryExecutor, _executorService)
-        );
+    LeafStageOperator operator =
+        spy(new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService));
 
     _operatorRef.set(operator);
 
@@ -307,11 +305,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        spy(
-            new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-                queryExecutor, _executorService)
-        );
+    LeafStageOperator operator =
+        spy(new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService));
 
     _operatorRef.set(operator);
 
@@ -332,11 +328,9 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
     InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
     QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
-    LeafStageTransferableBlockOperator operator =
-        spy(
-            new LeafStageTransferableBlockOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema,
-                queryExecutor, _executorService)
-        );
+    LeafStageOperator operator =
+        spy(new LeafStageOperator(OperatorTestUtil.getTracingContext(), mockQueryRequests(1), schema, queryExecutor,
+            _executorService));
 
     _operatorRef.set(operator);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -54,7 +54,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class MailboxReceiveOperatorTest {
@@ -77,9 +79,9 @@ public class MailboxReceiveOperatorTest {
   @BeforeClass
   public void setUp() {
     MailboxInfos mailboxInfosBoth = new SharedMailboxInfos(new MailboxInfo("localhost", 1234, List.of(0, 1)));
-    _stageMetadataBoth = new StageMetadata(0,
-        Stream.of(0, 1).map(workerId -> new WorkerMetadata(workerId, Map.of(1, mailboxInfosBoth), Map.of()))
-            .collect(Collectors.toList()), Map.of());
+    _stageMetadataBoth = new StageMetadata(0, Stream.of(0, 1)
+        .map(workerId -> new WorkerMetadata(workerId, Map.of(1, mailboxInfosBoth), Map.of()))
+        .collect(Collectors.toList()), Map.of());
     MailboxInfos mailboxInfos1 = new SharedMailboxInfos(new MailboxInfo("localhost", 1234, List.of(0)));
     _stageMetadata1 =
         new StageMetadata(0, List.of(new WorkerMetadata(0, Map.of(1, mailboxInfos1), Map.of())), Map.of());
@@ -145,8 +147,7 @@ public class MailboxReceiveOperatorTest {
   public void shouldReceiveSingletonErrorMailbox() {
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
     String errorMessage = "TEST ERROR";
-    when(_mailbox1.poll()).thenReturn(
-        OperatorTestUtil.errorWithStats(new RuntimeException(errorMessage), List.of()));
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.errorWithStats(new RuntimeException(errorMessage), List.of()));
     try (MailboxReceiveOperator operator = getOperator(_stageMetadata1, RelDistribution.Type.SINGLETON)) {
       MseBlock block = operator.nextBlock();
       assertTrue(block.isError());
@@ -176,13 +177,10 @@ public class MailboxReceiveOperatorTest {
     Object[] row2 = new Object[]{2, 2};
     Object[] row3 = new Object[]{3, 3};
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
-    when(_mailbox1.poll()).thenReturn(
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row1),
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row3),
-        OperatorTestUtil.eosWithEmptyStats());
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row1),
+        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row3), OperatorTestUtil.eosWithEmptyStats());
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
-    when(_mailbox2.poll()).thenReturn(
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row2),
+    when(_mailbox2.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row2),
         OperatorTestUtil.eosWithEmptyStats());
     try (MailboxReceiveOperator operator = getOperator(_stageMetadataBoth, RelDistribution.Type.HASH_DISTRIBUTED)) {
       // Receive first block from server1
@@ -199,12 +197,10 @@ public class MailboxReceiveOperatorTest {
   public void shouldGetReceptionReceiveErrorMailbox() {
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
     String errorMessage = "TEST ERROR";
-    when(_mailbox1.poll()).thenReturn(
-        OperatorTestUtil.errorWithEmptyStats(new RuntimeException(errorMessage)));
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.errorWithEmptyStats(new RuntimeException(errorMessage)));
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
     Object[] row = new Object[]{3, 3};
-    when(_mailbox2.poll()).thenReturn(
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row),
+    when(_mailbox2.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row),
         OperatorTestUtil.eosWithEmptyStats());
     try (MailboxReceiveOperator operator = getOperator(_stageMetadataBoth, RelDistribution.Type.HASH_DISTRIBUTED)) {
       MseBlock block = operator.nextBlock();
@@ -219,13 +215,10 @@ public class MailboxReceiveOperatorTest {
     Object[] row2 = new Object[]{2, 2};
     Object[] row3 = new Object[]{3, 3};
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
-    when(_mailbox1.poll()).thenReturn(
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row1),
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row3),
-        OperatorTestUtil.eosWithEmptyStats());
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row1),
+        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row3), OperatorTestUtil.eosWithEmptyStats());
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
-    when(_mailbox2.poll()).thenReturn(
-        OperatorTestUtil.blockWithStats(DATA_SCHEMA, row2),
+    when(_mailbox2.poll()).thenReturn(OperatorTestUtil.blockWithStats(DATA_SCHEMA, row2),
         OperatorTestUtil.eosWithEmptyStats());
     try (MailboxReceiveOperator operator = getOperator(_stageMetadataBoth, RelDistribution.Type.HASH_DISTRIBUTED)) {
       // Receive first block from server1
@@ -244,25 +237,19 @@ public class MailboxReceiveOperatorTest {
   public void differentUpstreamStatsProduceEmptyStats()
       throws IOException {
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
-    List<DataBuffer> stats1 = new MultiStageQueryStats.Builder(1)
-        .addLast(open ->
-            open.addLastOperator(Type.MAILBOX_SEND, new StatMap<>(MailboxSendOperator.StatKey.class))
-                .addLastOperator(Type.LEAF, new StatMap<>(LeafStageTransferableBlockOperator.StatKey.class))
-                .close())
-        .build()
-        .serialize();
+    List<DataBuffer> stats1 = new MultiStageQueryStats.Builder(1).addLast(
+        open -> open.addLastOperator(Type.MAILBOX_SEND, new StatMap<>(MailboxSendOperator.StatKey.class))
+            .addLastOperator(Type.LEAF, new StatMap<>(LeafStageOperator.StatKey.class))
+            .close()).build().serialize();
     ReceivingMailbox.MseBlockWithStats block1 = OperatorTestUtil.eosWithStats(stats1);
     when(_mailbox1.poll()).thenReturn(block1);
 
     when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
-    List<DataBuffer> stats2 = new MultiStageQueryStats.Builder(1)
-        .addLast(open ->
-            open.addLastOperator(Type.MAILBOX_SEND, new StatMap<>(MailboxSendOperator.StatKey.class))
-                .addLastOperator(Type.FILTER, new StatMap<>(FilterOperator.StatKey.class))
-                .addLastOperator(Type.LEAF, new StatMap<>(LeafStageTransferableBlockOperator.StatKey.class))
-                .close())
-        .build()
-        .serialize();
+    List<DataBuffer> stats2 = new MultiStageQueryStats.Builder(1).addLast(
+        open -> open.addLastOperator(Type.MAILBOX_SEND, new StatMap<>(MailboxSendOperator.StatKey.class))
+            .addLastOperator(Type.FILTER, new StatMap<>(FilterOperator.StatKey.class))
+            .addLastOperator(Type.LEAF, new StatMap<>(LeafStageOperator.StatKey.class))
+            .close()).build().serialize();
     ReceivingMailbox.MseBlockWithStats block2 = OperatorTestUtil.eosWithStats(stats2);
     when(_mailbox2.poll()).thenReturn(block2);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -62,7 +62,7 @@ public class OperatorTestUtil {
   public static MultiStageQueryStats getDummyStats(int stageId) {
     MultiStageQueryStats stats = MultiStageQueryStats.emptyStats(stageId);
     stats.getCurrentStats()
-        .addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafStageTransferableBlockOperator.StatKey.class));
+        .addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafStageOperator.StatKey.class));
     return stats;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStatsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/MultiStageQueryStatsTest.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.query.runtime.operator.BaseMailboxReceiveOperator;
-import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
+import org.apache.pinot.query.runtime.operator.LeafStageOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.SortOperator;
@@ -80,15 +80,15 @@ public class MultiStageQueryStatsTest {
         )
         .addLast(stageStats ->
             stageStats.addLastOperator(MultiStageOperator.Type.LEAF,
-                    new StatMap<>(LeafStageTransferableBlockOperator.StatKey.class)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.NUM_SEGMENTS_QUERIED, 1)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.NUM_SEGMENTS_PROCESSED, 1)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.NUM_SEGMENTS_MATCHED, 1)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.NUM_DOCS_SCANNED, 10)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.NUM_ENTRIES_SCANNED_POST_FILTER, 5)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.TOTAL_DOCS, 5)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.EXECUTION_TIME_MS, 95)
-                        .merge(LeafStageTransferableBlockOperator.StatKey.TABLE, "a"))
+                    new StatMap<>(LeafStageOperator.StatKey.class)
+                        .merge(LeafStageOperator.StatKey.NUM_SEGMENTS_QUERIED, 1)
+                        .merge(LeafStageOperator.StatKey.NUM_SEGMENTS_PROCESSED, 1)
+                        .merge(LeafStageOperator.StatKey.NUM_SEGMENTS_MATCHED, 1)
+                        .merge(LeafStageOperator.StatKey.NUM_DOCS_SCANNED, 10)
+                        .merge(LeafStageOperator.StatKey.NUM_ENTRIES_SCANNED_POST_FILTER, 5)
+                        .merge(LeafStageOperator.StatKey.TOTAL_DOCS, 5)
+                        .merge(LeafStageOperator.StatKey.EXECUTION_TIME_MS, 95)
+                        .merge(LeafStageOperator.StatKey.TABLE, "a"))
                 .addLastOperator(MultiStageOperator.Type.MAILBOX_SEND,
                     new StatMap<>(MailboxSendOperator.StatKey.class)
                         .merge(MailboxSendOperator.StatKey.STAGE, 2)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -46,7 +46,7 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.runtime.MultiStageStatsTreeBuilder;
-import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
+import org.apache.pinot.query.runtime.operator.LeafStageOperator;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
@@ -337,7 +337,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
         }
 
         Assert.assertNotNull(_tableToSegmentMap.get(tableName));
-        String statName = LeafStageTransferableBlockOperator.StatKey.NUM_SEGMENTS_QUERIED.getStatName();
+        String statName = LeafStageOperator.StatKey.NUM_SEGMENTS_QUERIED.getStatName();
         int numSegmentsQueried = entry.getValue().get(statName).asInt();
         Assert.assertEquals(numSegmentsQueried, _tableToSegmentMap.get(tableName).size());
       }


### PR DESCRIPTION
Given there is no more `TransferableBlock` after #15245, rename this class to be more concise.