### PR TITLE
Add a unit test to verify the intended behavior of OrDocIdSet

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/docidsets/OrDocIdSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/docidsets/OrDocIdSetTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.docidsets;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.core.common.BlockDocIdSet;
+import org.apache.pinot.core.operator.dociditerators.BitmapDocIdIterator;
+import org.apache.pinot.core.operator.dociditerators.OrDocIdIterator;
+import org.apache.pinot.core.operator.dociditerators.SortedDocIdIterator;
+import org.apache.pinot.spi.utils.Pairs;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class OrDocIdSetTest {
+  @Test
+  public void iteratorReturnsBitmapDocIdIteratorWhenOnlyIndexBasedIteratorsExist() {
+    // All the idsets are index-base BlockDocIdIterator (SortedDocIdIterator or BitmapBasedDocIdIterator)
+    SortedDocIdSet sortedDocIdSet = mock(SortedDocIdSet.class);
+    SortedDocIdIterator sortedIterator = mock(SortedDocIdIterator.class);
+    BitmapDocIdSet bitmapDocIdSet = mock(BitmapDocIdSet.class);
+    BitmapDocIdIterator bitmapIterator = mock(BitmapDocIdIterator.class);
+
+    when(sortedDocIdSet.iterator()).thenReturn(sortedIterator);
+    when(bitmapDocIdSet.iterator()).thenReturn(bitmapIterator);
+    when(sortedIterator.getDocIdRanges()).thenReturn(Collections.singletonList(new Pairs.IntPair(1, 10)));
+    when(bitmapIterator.getDocIds()).thenReturn(new MutableRoaringBitmap());
+
+    List<BlockDocIdSet> docIdSets = Arrays.asList(sortedDocIdSet, bitmapDocIdSet);
+    OrDocIdSet orDocIdSet = new OrDocIdSet(docIdSets, 100);
+    BlockDocIdIterator iterator = orDocIdSet.iterator();
+    // Make sure the returned iterator is a BitmapDocIdIterator instead of an OrDocIdIterator.
+    assertFalse(iterator instanceof BitmapDocIdIterator);
+    assertTrue(iterator instanceof OrDocIdIterator);
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Test verifies that OrDocIdSet\.iterator returns OrDocIdIterator when only index\-based iterators are present\.

```mermaid
flowchart TD
  N0["Enter test method #40;F1#41;"]:::stAdded
  N1["Create mocks for docid sets and iterators #40;F1#41;"]:::stAdded
  N2["Configure when#45;thenReturn for mocks #40;F1#41;"]:::stAdded
  N3["Build list and instantiate OrDocIdSet #40;F1#41;"]:::stAdded
  N4["Call orDocIdSet#46;iterator#40;#41; #40;F1#41;"]:::stAdded
  N5["Assert iterator is OrDocIdIterator not BitmapDocIdIterator #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"passes mocks"| N2
  N2 -->|"provides configured mocks"| N3
  N3 -->|"invokes iterator#40;#41;"| N4
  N4 -->|"feeds iterator to assertions"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/test/java/org/apache/pinot/core/operator/docidsets/OrDocIdSetTest\.java — [after](https://github.com/apache/pinot/blob/39dcd4f3269591b09bf85e4e279f419002d6c5ea/pinot-core/src/test/java/org/apache/pinot/core/operator/docidsets/OrDocIdSetTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjBkNjZjMjVmNjI1NTUzNjM1NzM4NDdiZGM0YWEzNjllZTRkYjZjZTUiLCJjb250ZXh0X2hhc2giOiJlODBhNzE5MjlkMWQxMDQ0NDI1MzhhODg0MDc5ODcxNTVjNWY3OTViNTY0YjcyODBiNmUyMzdlZTdiN2QxZjFhIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTc1MTkyLCJoZWFkX3NoYSI6IjM5ZGNkNGYzMjY5NTkxYjA5YmY4NWU0ZTI3OWY0MTkwMDJkNmM1ZWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIwZDY2YzI1ZjYyNTU1MzYzNTczODQ3YmRjNGFhMzY5ZWU0ZGI2Y2U1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 9e19ab1dbcf48165c197cba2c46b05f38f737a1d5a964b99bf1e53b79f41f7e5 -->
<!-- pinot-pr-flow:end -->


Add a unit test to verify the critical behavior of OrDocIdSet as stated in its javadoc comment:

```
When there are more than one index-base BlockDocIdIterator (SortedDocIdIterator or BitmapBasedDocIdIterator),
 *     merge them and construct a BitmapDocIdIterator from the merged document ids. If there is no remaining
 *     BlockDocIdIterator, directly return the merged BitmapDocIdIterator; 
```

Today the actual implementation in fact violates the above behavior as shown.