### PR TITLE
[Logical Table] Support logical tables in MSE.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -907,6 +907,17 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Given a logical table name in any case, returns the logical table name as defined in Helix/Segment/Schema
+   * @param logicalTableName logical tableName in any case.
+   * @return logicalTableName actually defined in Pinot (matches case) and exists ,else, return the input value
+   */
+  public String getActualLogicalTableName(String logicalTableName, @Nullable String databaseName) {
+    logicalTableName = DatabaseUtils.translateTableName(logicalTableName, databaseName, _tableCache.isIgnoreCase());
+    String actualTableName = _tableCache.getActualLogicalTableName(logicalTableName);
+    return actualTableName != null ? actualTableName : logicalTableName;
+  }
+
+  /**
    * Table related APIs
    */
   // TODO: move table related APIs here

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -206,5 +206,5 @@ public interface InstanceDataManager {
    * Returns the logical table config and schema for the given logical table name.
    */
   @Nullable
-  LogicalTableManager getLogicalTableManager(String logicalTableName);
+  LogicalTableContext getLogicalTableContext(String logicalTableName);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -201,4 +201,10 @@ public interface InstanceDataManager {
    * Returns the instance data directory
    */
   String getInstanceDataDir();
+
+  /**
+   * Returns the logical table config and schema for the given logical table name.
+   */
+  @Nullable
+  LogicalTableManager getLogicalTableManager(String logicalTableName);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableContext.java
@@ -23,13 +23,13 @@ import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
-public class LogicalTableManager {
+public class LogicalTableContext {
   private final LogicalTableConfig _logicalTableConfig;
   private final Schema _logicalTableSchema;
   private final TableConfig _refOfflineTableConfig;
   private final TableConfig _refRealtimeTableConfig;
 
-  public LogicalTableManager(LogicalTableConfig logicalTableConfig, Schema logicalTableSchema,
+  public LogicalTableContext(LogicalTableConfig logicalTableConfig, Schema logicalTableSchema,
       TableConfig refOfflineTableConfig, TableConfig refRealtimeTableConfig) {
     _logicalTableConfig = logicalTableConfig;
     _logicalTableSchema = logicalTableSchema;
@@ -40,12 +40,15 @@ public class LogicalTableManager {
   public LogicalTableConfig getLogicalTableConfig() {
     return _logicalTableConfig;
   }
+
   public Schema getLogicalTableSchema() {
     return _logicalTableSchema;
   }
+
   public TableConfig getRefOfflineTableConfig() {
     return _refOfflineTableConfig;
   }
+
   public TableConfig getRefRealtimeTableConfig() {
     return _refRealtimeTableConfig;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableManager.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager;
+
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class LogicalTableManager {
+  private final LogicalTableConfig _logicalTableConfig;
+  private final Schema _logicalTableSchema;
+  private final TableConfig _offlineTableConfig;
+  private final TableConfig _realtimeTableConfig;
+
+  public LogicalTableManager(LogicalTableConfig logicalTableConfig, Schema logicalTableSchema,
+      TableConfig offlineTableConfig, TableConfig realtimeTableConfig) {
+    _logicalTableConfig = logicalTableConfig;
+    _logicalTableSchema = logicalTableSchema;
+    _offlineTableConfig = offlineTableConfig;
+    _realtimeTableConfig = realtimeTableConfig;
+  }
+
+  public LogicalTableConfig getLogicalTableConfig() {
+    return _logicalTableConfig;
+  }
+  public Schema getLogicalTableSchema() {
+    return _logicalTableSchema;
+  }
+  public TableConfig getOfflineTableConfig() {
+    return _offlineTableConfig;
+  }
+  public TableConfig getRealtimeTableConfig() {
+    return _realtimeTableConfig;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/LogicalTableManager.java
@@ -26,15 +26,15 @@ import org.apache.pinot.spi.data.Schema;
 public class LogicalTableManager {
   private final LogicalTableConfig _logicalTableConfig;
   private final Schema _logicalTableSchema;
-  private final TableConfig _offlineTableConfig;
-  private final TableConfig _realtimeTableConfig;
+  private final TableConfig _refOfflineTableConfig;
+  private final TableConfig _refRealtimeTableConfig;
 
   public LogicalTableManager(LogicalTableConfig logicalTableConfig, Schema logicalTableSchema,
-      TableConfig offlineTableConfig, TableConfig realtimeTableConfig) {
+      TableConfig refOfflineTableConfig, TableConfig refRealtimeTableConfig) {
     _logicalTableConfig = logicalTableConfig;
     _logicalTableSchema = logicalTableSchema;
-    _offlineTableConfig = offlineTableConfig;
-    _realtimeTableConfig = realtimeTableConfig;
+    _refOfflineTableConfig = refOfflineTableConfig;
+    _refRealtimeTableConfig = refRealtimeTableConfig;
   }
 
   public LogicalTableConfig getLogicalTableConfig() {
@@ -43,10 +43,10 @@ public class LogicalTableManager {
   public Schema getLogicalTableSchema() {
     return _logicalTableSchema;
   }
-  public TableConfig getOfflineTableConfig() {
-    return _offlineTableConfig;
+  public TableConfig getRefOfflineTableConfig() {
+    return _refOfflineTableConfig;
   }
-  public TableConfig getRealtimeTableConfig() {
-    return _realtimeTableConfig;
+  public TableConfig getRefRealtimeTableConfig() {
+    return _refRealtimeTableConfig;
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.utils.builder.LogicalTableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -621,5 +622,15 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     assertEquals(queryResponse.get("numDocsScanned").asInt(), 0);
     assertEquals(queryResponse.get("numServersQueried").asInt(), 1);
     assertTrue(queryResponse.get("exceptions").isEmpty());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  void testControllerQuerySubmit(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    @Language("sql")
+    String query = "SELECT count(*) FROM " + getLogicalTableName();
+    JsonNode response = postQueryToController(query);
+    assertTrue(response.get("exceptions").isEmpty());
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -250,6 +250,13 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     return DEFAULT_TENANT;
   }
 
+  // Setup H2 table with the same name as the logical table.
+  protected void setUpH2Connection(List<File> avroFiles)
+      throws Exception {
+    setUpH2Connection();
+    ClusterIntegrationTestUtils.setUpH2TableWithAvro(avroFiles, getLogicalTableName(), _h2Connection);
+  }
+
   /**
    * Creates a new OFFLINE table config.
    */
@@ -414,22 +421,29 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     assertEquals(new HashSet<>(getPhysicalTableNames()), logicalTableConfig.getPhysicalTableConfigMap().keySet());
   }
 
-  @Test
-  public void testHardcodedQueries()
+  @Override
+  protected Map<String, String> getExtraQueryProperties() {
+    return Map.of(); //"timeoutMs", "300000");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testHardcodedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     super.testHardcodedQueries();
   }
 
-  @Test
   public void testQueriesFromQueryFile()
       throws Exception {
+    setUseMultiStageQueryEngine(false);
     super.testQueriesFromQueryFile();
   }
 
-  @Test
-  public void testGeneratedQueries()
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testGeneratedQueries(boolean useMultiStageQueryEngine)
       throws Exception {
-    super.testGeneratedQueries(true, false);
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    super.testGeneratedQueries(true, useMultiStageQueryEngine);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -616,6 +616,6 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     @Language("sql")
     String query = "SELECT count(*) FROM " + getLogicalTableName();
     JsonNode response = postQueryToController(query);
-    assertTrue(response.get("exceptions").isEmpty());
+    assertNoError(response)
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -421,11 +421,6 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     assertEquals(new HashSet<>(getPhysicalTableNames()), logicalTableConfig.getPhysicalTableConfigMap().keySet());
   }
 
-  @Override
-  protected Map<String, String> getExtraQueryProperties() {
-    return Map.of(); //"timeoutMs", "300000");
-  }
-
   @Test(dataProvider = "useBothQueryEngines")
   public void testHardcodedQueries(boolean useMultiStageQueryEngine)
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -344,8 +344,9 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     Map<String, PhysicalTableConfig> physicalTableConfigMap = new HashMap<>();
     TableConfig offlineTableConfig = createOfflineTableConfig(EMPTY_OFFLINE_TABLE_NAME);
     addTableConfig(offlineTableConfig);
-    physicalTableConfigMap.put(TableNameBuilder.OFFLINE.tableNameWithType(EMPTY_OFFLINE_TABLE_NAME), new PhysicalTableConfig());
-    String  refOfflineTableName = TableNameBuilder.OFFLINE.tableNameWithType(EMPTY_OFFLINE_TABLE_NAME);
+    physicalTableConfigMap.put(TableNameBuilder.OFFLINE.tableNameWithType(EMPTY_OFFLINE_TABLE_NAME),
+        new PhysicalTableConfig());
+    String refOfflineTableName = TableNameBuilder.OFFLINE.tableNameWithType(EMPTY_OFFLINE_TABLE_NAME);
 
     String logicalTableName = EMPTY_OFFLINE_TABLE_NAME + "_logical";
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -90,20 +90,10 @@ public class PinotCatalog implements Schema {
    */
   @Override
   public Set<String> getTableNames() {
-    Set<String> result = new HashSet<>();
-    for (String tableName: _tableCache.getTableNameMap().keySet()) {
-      if (DatabaseUtils.isPartOfDatabase(tableName, _databaseName)) {
-        result.add(tableName);
-      }
-    }
-
-    for (String logicalTableName: _tableCache.getLogicalTableNameMap().keySet()) {
-      if (DatabaseUtils.isPartOfDatabase(logicalTableName, _databaseName)) {
-        result.add(logicalTableName);
-      }
-    }
-
-    return result;
+    return Stream.concat(_tableCache.getTableNameMap().keySet().stream(),
+            _tableCache.getLogicalTableNameMap().keySet().stream())
+        .filter(n -> DatabaseUtils.isPartOfDatabase(n, _databaseName))
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.query.catalog;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.rel.type.RelProtoDataType;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -103,6 +103,8 @@ public class DispatchablePlanContext {
           dispatchablePlanMetadata.getWorkerIdToServerInstanceMap();
       Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap =
           dispatchablePlanMetadata.getWorkerIdToSegmentsMap();
+      Map<Integer, DispatchablePlanMetadata.TableTypeTableNameToSegmentsMap> workerIdToTableNameSegmentsMap =
+          dispatchablePlanMetadata.getWorkerIdToTableSegmentsMap();
       Map<Integer, Map<Integer, MailboxInfos>> workerIdToMailboxesMap =
           dispatchablePlanMetadata.getWorkerIdToMailboxesMap();
       Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdsMap = new HashMap<>();
@@ -114,6 +116,9 @@ public class DispatchablePlanContext {
         WorkerMetadata workerMetadata = new WorkerMetadata(workerId, workerIdToMailboxesMap.get(workerId));
         if (workerIdToSegmentsMap != null) {
           workerMetadata.setTableSegmentsMap(workerIdToSegmentsMap.get(workerId));
+        }
+        if (workerIdToTableNameSegmentsMap != null) {
+          workerMetadata.setLogicalTableSegmentsMap(workerIdToTableNameSegmentsMap.get(workerId));
         }
         workerMetadataArray[workerId] = workerMetadata;
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -103,7 +103,7 @@ public class DispatchablePlanContext {
           dispatchablePlanMetadata.getWorkerIdToServerInstanceMap();
       Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap =
           dispatchablePlanMetadata.getWorkerIdToSegmentsMap();
-      Map<Integer, DispatchablePlanMetadata.TableTypeTableNameToSegmentsMap> workerIdToTableNameSegmentsMap =
+      Map<Integer, Map<String, List<String>>> workerIdToTableNameSegmentsMap =
           dispatchablePlanMetadata.getWorkerIdToTableSegmentsMap();
       Map<Integer, Map<Integer, MailboxInfos>> workerIdToMailboxesMap =
           dispatchablePlanMetadata.getWorkerIdToMailboxesMap();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -107,6 +107,8 @@ public class DispatchablePlanContext {
           dispatchablePlanMetadata.getWorkerIdToTableSegmentsMap();
       Map<Integer, Map<Integer, MailboxInfos>> workerIdToMailboxesMap =
           dispatchablePlanMetadata.getWorkerIdToMailboxesMap();
+      Preconditions.checkArgument(workerIdToSegmentsMap == null || workerIdToTableNameSegmentsMap == null,
+          "Both workerIdToSegmentsMap and workerIdToTableNameSegmentsMap cannot be set at the same time");
       Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdsMap = new HashMap<>();
       WorkerMetadata[] workerMetadataArray = new WorkerMetadata[workerIdToServerInstanceMap.size()];
       for (Map.Entry<Integer, QueryServerInstance> serverEntry : workerIdToServerInstanceMap.entrySet()) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
@@ -82,22 +82,10 @@ public class DispatchablePlanMetadata implements Serializable {
   private final Map<Integer, Map<Integer, MailboxInfos>> _workerIdToMailboxesMap = new HashMap<>();
 
   /**
-   * Map from workerId -> {tableType -> {tableName -> segments}} is required for logical tables.
-   * Raw definition of the map is:
-   * Map<String, Map<String, Map<String, List<String>>>>. Since this definition is hard to understand - specifically
-   * what do each of the string keys store, we define two classes:
-   * {@link TableTypeToSegmentsMap} and {@link TableTypeTableNameToSegmentsMap} to help read code more easily.
+   * Map from workerId -> {physicalTableName -> segments} is required for logical tables.
    */
-  public static class TableTypeToSegmentsMap {
-    public final Map<String, List<String>> _map = new HashMap<>();
-  }
-
-  public static class TableTypeTableNameToSegmentsMap {
-    public final Map<String, TableTypeToSegmentsMap> _map = new HashMap<>();
-  }
-
+  private Map<Integer, Map<String, List<String>>> _workerIdToTableSegmentsMap;
   private LogicalTableRouteInfo _logicalTableRouteInfo;
-  private Map<Integer, TableTypeTableNameToSegmentsMap> _workerIdToTableSegmentsMap;
 
   public List<String> getScannedTables() {
     return _scannedTables;
@@ -208,12 +196,12 @@ public class DispatchablePlanMetadata implements Serializable {
   }
 
   @Nullable
-  public Map<Integer, TableTypeTableNameToSegmentsMap> getWorkerIdToTableSegmentsMap() {
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToTableSegmentsMap() {
     return _workerIdToTableSegmentsMap;
   }
 
   public void setWorkerIdToTableSegmentsMap(
-      Map<Integer, TableTypeTableNameToSegmentsMap> workerIdToTableSegmentsMap) {
+      Map<Integer, Map<String, List<String>>> workerIdToTableSegmentsMap) {
     _workerIdToTableSegmentsMap = workerIdToTableSegmentsMap;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -141,20 +141,18 @@ public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, Dispatchab
   public Void visitTableScan(TableScanNode node, DispatchablePlanContext context) {
     DispatchablePlanMetadata dispatchablePlanMetadata = getOrCreateDispatchablePlanMetadata(node, context);
 
-    LogicalTableRouteInfo logicalTableRouteInfo = null;
-
     String tableNameInNode = node.getTableName();
     String tableName = _tableCache.getActualTableName(tableNameInNode);
     if (tableName == null) {
       tableName = _tableCache.getActualLogicalTableName(tableNameInNode);
       Preconditions.checkNotNull(tableName, "Logical table config not found in table cache: " + tableNameInNode);
       LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
-      logicalTableRouteInfo = new LogicalTableRouteInfo();
+      LogicalTableRouteInfo logicalTableRouteInfo = new LogicalTableRouteInfo();
       tableRouteProvider.fillTableConfigMetadata(logicalTableRouteInfo, tableName, _tableCache);
+      dispatchablePlanMetadata.setLogicalTableRouteInfo(logicalTableRouteInfo);
     }
 
     dispatchablePlanMetadata.addScannedTable(tableName);
-    dispatchablePlanMetadata.setLogicalTableRouteInfo(logicalTableRouteInfo);
     dispatchablePlanMetadata.setTableOptions(
         node.getNodeHint().getHintOptions().get(PinotHintOptions.TABLE_HINT_OPTIONS));
     return null;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -149,7 +149,8 @@ public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, Dispatchab
       tableName = _tableCache.getActualLogicalTableName(tableNameInNode);
       Preconditions.checkNotNull(tableName, "Logical table config not found in table cache: " + tableName);
       LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
-      logicalTableRouteInfo = tableRouteProvider.getTableRouteInfo(tableName, _tableCache);
+      logicalTableRouteInfo = new LogicalTableRouteInfo();
+      tableRouteProvider.fillTableConfigMetadata(logicalTableRouteInfo, tableName, _tableCache);
     }
 
     dispatchablePlanMetadata.addScannedTable(tableName);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.physical;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
@@ -38,6 +39,8 @@ import org.apache.pinot.query.planner.plannode.SortNode;
 import org.apache.pinot.query.planner.plannode.TableScanNode;
 import org.apache.pinot.query.planner.plannode.ValueNode;
 import org.apache.pinot.query.planner.plannode.WindowNode;
+import org.apache.pinot.query.routing.table.LogicalTableRouteInfo;
+import org.apache.pinot.query.routing.table.LogicalTableRouteProvider;
 
 
 public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, DispatchablePlanContext> {
@@ -137,7 +140,20 @@ public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, Dispatchab
   @Override
   public Void visitTableScan(TableScanNode node, DispatchablePlanContext context) {
     DispatchablePlanMetadata dispatchablePlanMetadata = getOrCreateDispatchablePlanMetadata(node, context);
-    dispatchablePlanMetadata.addScannedTable(_tableCache.getActualTableName(node.getTableName()));
+
+    LogicalTableRouteInfo logicalTableRouteInfo = null;
+
+    String tableNameInNode = node.getTableName();
+    String tableName = _tableCache.getActualTableName(tableNameInNode);
+    if (tableName == null) {
+      tableName = _tableCache.getActualLogicalTableName(tableNameInNode);
+      Preconditions.checkNotNull(tableName, "Logical table config not found in table cache: " + tableName);
+      LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
+      logicalTableRouteInfo = tableRouteProvider.getTableRouteInfo(tableName, _tableCache);
+    }
+
+    dispatchablePlanMetadata.addScannedTable(tableName);
+    dispatchablePlanMetadata.setLogicalTableRouteInfo(logicalTableRouteInfo);
     dispatchablePlanMetadata.setTableOptions(
         node.getNodeHint().getHintOptions().get(PinotHintOptions.TABLE_HINT_OPTIONS));
     return null;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -147,7 +147,7 @@ public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, Dispatchab
     String tableName = _tableCache.getActualTableName(tableNameInNode);
     if (tableName == null) {
       tableName = _tableCache.getActualLogicalTableName(tableNameInNode);
-      Preconditions.checkNotNull(tableName, "Logical table config not found in table cache: " + tableName);
+      Preconditions.checkNotNull(tableName, "Logical table config not found in table cache: " + tableNameInNode);
       LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
       logicalTableRouteInfo = new LogicalTableRouteInfo();
       tableRouteProvider.fillTableConfigMetadata(logicalTableRouteInfo, tableName, _tableCache);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -586,17 +586,21 @@ public class WorkerManager {
 
     if (logicalTableRouteInfo.getOfflineTables() != null) {
       for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getOfflineTables()) {
-        Preconditions.checkNotNull(physicalTableRoute.getOfflineRoutingTable());
-        transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getOfflineTableName(),
-            physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap);
+        // Routing table maybe null if no routing table is found OR there are no segments.
+        if (physicalTableRoute.getOfflineRoutingTable() != null) {
+          transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getOfflineTableName(),
+              physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap);
+        }
       }
     }
 
     if (logicalTableRouteInfo.getRealtimeTables() != null) {
       for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getRealtimeTables()) {
-        Preconditions.checkNotNull(physicalTableRoute.getRealtimeRoutingTable());
-        transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getRealtimeTableName(),
-            physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap);
+        // Routing table maybe null if no routing table is found OR there are no segments.
+        if (physicalTableRoute.getRealtimeRoutingTable() != null) {
+          transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getRealtimeTableName(),
+              physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap);
+        }
       }
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -556,7 +556,7 @@ public class WorkerManager {
     LogicalTableRouteInfo logicalTableRouteInfo = metadata.getLogicalTableRouteInfo();
     Preconditions.checkNotNull(logicalTableRouteInfo);
     LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
-    tableRouteProvider.calculateTimeBoundaryInfo(logicalTableRouteInfo, _routingManager);
+    tableRouteProvider.fillRouteMetadata(logicalTableRouteInfo, _routingManager);
     if (logicalTableRouteInfo.getTimeBoundaryInfo() != null) {
       metadata.setTimeBoundaryInfo(logicalTableRouteInfo.getTimeBoundaryInfo());
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -556,6 +556,10 @@ public class WorkerManager {
     LogicalTableRouteInfo logicalTableRouteInfo = metadata.getLogicalTableRouteInfo();
     Preconditions.checkNotNull(logicalTableRouteInfo);
     LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
+    tableRouteProvider.calculateTimeBoundaryInfo(logicalTableRouteInfo, _routingManager);
+    if (logicalTableRouteInfo.getTimeBoundaryInfo() != null) {
+      metadata.setTimeBoundaryInfo(logicalTableRouteInfo.getTimeBoundaryInfo());
+    }
     BrokerRequest offlineBrokerRequest = null;
     BrokerRequest realtimeBrokerRequest = null;
 
@@ -574,7 +578,9 @@ public class WorkerManager {
 
     assignTableSegmentsToWorkers(logicalTableRouteInfo, metadata);
 
-    // TODO: Set Time Boundary Info if applicable. https://github.com/apache/pinot/issues/15640
+    if (logicalTableRouteInfo.getTimeBoundaryInfo() != null) {
+      metadata.setTimeBoundaryInfo(logicalTableRouteInfo.getTimeBoundaryInfo());
+    }
   }
 
   private static void assignTableSegmentsToWorkers(LogicalTableRouteInfo logicalTableRouteInfo,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -577,10 +577,6 @@ public class WorkerManager {
         realtimeBrokerRequest, context.getRequestId());
 
     assignTableSegmentsToWorkers(logicalTableRouteInfo, metadata);
-
-    if (logicalTableRouteInfo.getTimeBoundaryInfo() != null) {
-      metadata.setTimeBoundaryInfo(logicalTableRouteInfo.getTimeBoundaryInfo());
-    }
   }
 
   private static void assignTableSegmentsToWorkers(LogicalTableRouteInfo logicalTableRouteInfo,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
@@ -76,13 +76,17 @@ public class WorkerMetadata {
 
   @Nullable
   public Map<String, List<String>> getTableSegmentsMap() {
-    String tableSegmentsMapStr = _customProperties.get(TABLE_SEGMENTS_MAP_KEY);
+    return deserializeStringSegmentListMap(TABLE_SEGMENTS_MAP_KEY);
+  }
+
+  private Map<String, List<String>> deserializeStringSegmentListMap(String propertyKey) {
+    String tableSegmentsMapStr = _customProperties.get(propertyKey);
     if (tableSegmentsMapStr != null) {
       try {
         return JsonUtils.stringToObject(tableSegmentsMapStr, new TypeReference<Map<String, List<String>>>() {
         });
       } catch (IOException e) {
-        throw new RuntimeException("Unable to deserialize table segments map: " + tableSegmentsMapStr, e);
+        throw new RuntimeException("Unable to deserialize " + propertyKey + " : " + tableSegmentsMapStr, e);
       }
     } else {
       return null;
@@ -106,18 +110,7 @@ public class WorkerMetadata {
 
   @Nullable
   public Map<String, List<String>> getLogicalTableSegmentsMap() {
-    String logicalTableSegmentsMapStr = _customProperties.get(LOGICAL_TABLE_SEGMENTS_MAP_KEY);
-    if (logicalTableSegmentsMapStr != null) {
-      try {
-        return JsonUtils.stringToObject(logicalTableSegmentsMapStr,
-            new TypeReference<Map<String, List<String>>>() {
-            });
-      } catch (IOException e) {
-        throw new RuntimeException("Unable to deserialize table segments map: " + logicalTableSegmentsMapStr, e);
-      }
-    } else {
-      return null;
-    }
+    return deserializeStringSegmentListMap(LOGICAL_TABLE_SEGMENTS_MAP_KEY);
   }
 
   public void setLogicalTableSegmentsMap(Map<String, List<String>> logicalTableSegmentsMap) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.query.planner.physical.DispatchablePlanMetadata;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -106,12 +105,13 @@ public class WorkerMetadata {
   }
 
   @Nullable
-  public DispatchablePlanMetadata.TableTypeTableNameToSegmentsMap getLogicalTableSegmentsMap() {
+  public Map<String, List<String>> getLogicalTableSegmentsMap() {
     String logicalTableSegmentsMapStr = _customProperties.get(LOGICAL_TABLE_SEGMENTS_MAP_KEY);
     if (logicalTableSegmentsMapStr != null) {
       try {
         return JsonUtils.stringToObject(logicalTableSegmentsMapStr,
-            DispatchablePlanMetadata.TableTypeTableNameToSegmentsMap.class);
+            new TypeReference<Map<String, List<String>>>() {
+            });
       } catch (IOException e) {
         throw new RuntimeException("Unable to deserialize table segments map: " + logicalTableSegmentsMapStr, e);
       }
@@ -120,8 +120,7 @@ public class WorkerMetadata {
     }
   }
 
-  public void setLogicalTableSegmentsMap(
-      DispatchablePlanMetadata.TableTypeTableNameToSegmentsMap logicalTableSegmentsMap) {
+  public void setLogicalTableSegmentsMap(Map<String, List<String>> logicalTableSegmentsMap) {
     String logicalTableSegmentsMapStr;
     try {
       logicalTableSegmentsMapStr = JsonUtils.objectToString(logicalTableSegmentsMap);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProvider.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProvider.java
@@ -99,6 +99,33 @@ public class ImplicitHybridTableRouteProvider implements TableRouteProvider {
     return tableRouteInfo;
   }
 
+  public ImplicitHybridTableRouteInfo getTableRouteInfo(String tableName, TableCache tableCache) {
+    ImplicitHybridTableRouteInfo tableRouteInfo = new ImplicitHybridTableRouteInfo();
+
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+
+    if (tableType == TableType.OFFLINE) {
+      tableRouteInfo.setOfflineTableName(tableName);
+    } else if (tableType == TableType.REALTIME) {
+      tableRouteInfo.setRealtimeTableName(tableName);
+    } else {
+      tableRouteInfo.setOfflineTableName(TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+      tableRouteInfo.setRealtimeTableName(TableNameBuilder.REALTIME.tableNameWithType(tableName));
+    }
+
+    String offlineTableName = tableRouteInfo.getOfflineTableName();
+    String realtimeTableName = tableRouteInfo.getRealtimeTableName();
+
+    if (offlineTableName != null) {
+      tableRouteInfo.setOfflineTableConfig(tableCache.getTableConfig(offlineTableName));
+    }
+
+    if (realtimeTableName != null) {
+      tableRouteInfo.setRealtimeTableConfig(tableCache.getTableConfig(realtimeTableName));
+    }
+    return tableRouteInfo;
+  }
+
   @Override
   public void calculateRoutes(TableRouteInfo tableRouteInfo, RoutingManager routingManager,
       BrokerRequest offlineBrokerRequest,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
@@ -45,7 +45,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 public class LogicalTableRouteInfo extends BaseTableRouteInfo {
-  private final LogicalTableConfig _logicalTable;
+  private final String _logicalTableName;
   private List<TableRouteInfo> _offlineTables;
   private List<TableRouteInfo> _realtimeTables;
   private TableConfig _offlineTableConfig;
@@ -58,12 +58,12 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
   private BrokerRequest _realtimeBrokerRequest;
   private TimeBoundaryInfo _timeBoundaryInfo;
 
-  LogicalTableRouteInfo() {
-    _logicalTable = null;
+  public LogicalTableRouteInfo() {
+    _logicalTableName = null;
   }
 
   public LogicalTableRouteInfo(LogicalTableConfig logicalTable) {
-    _logicalTable = logicalTable;
+    _logicalTableName = logicalTable.getTableName();
   }
 
   @Override
@@ -137,6 +137,11 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
     instanceRequest.setTableSegmentsInfoList(tableSegmentsInfoList);
     instanceRequest.setBrokerId(brokerId);
     return instanceRequest;
+  }
+
+  @Nullable
+  public String getLogicalTableName() {
+    return _logicalTableName;
   }
 
   @Nullable
@@ -234,15 +239,15 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
   @Nullable
   @Override
   public String getOfflineTableName() {
-    return hasOffline() && _logicalTable != null ? TableNameBuilder.OFFLINE.tableNameWithType(
-        _logicalTable.getTableName()) : null;
+    return hasOffline() && _logicalTableName != null ? TableNameBuilder.OFFLINE.tableNameWithType(_logicalTableName)
+        : null;
   }
 
   @Nullable
   @Override
   public String getRealtimeTableName() {
-    return hasRealtime() && _logicalTable != null ? TableNameBuilder.REALTIME.tableNameWithType(
-        _logicalTable.getTableName()) : null;
+    return hasRealtime() && _logicalTableName != null ? TableNameBuilder.REALTIME.tableNameWithType(_logicalTableName)
+        : null;
   }
 
   @Nullable

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.request.TableSegmentsInfo;
 import org.apache.pinot.core.routing.ServerRouteInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.BaseTableRouteInfo;
+import org.apache.pinot.core.transport.ImplicitHybridTableRouteInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.transport.TableRouteInfo;
@@ -39,16 +40,15 @@ import org.apache.pinot.query.timeboundary.TimeBoundaryStrategy;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 public class LogicalTableRouteInfo extends BaseTableRouteInfo {
-  private final String _logicalTableName;
-  private List<TableRouteInfo> _offlineTables;
-  private List<TableRouteInfo> _realtimeTables;
+  private String _logicalTableName;
+  private List<ImplicitHybridTableRouteInfo> _offlineTables;
+  private List<ImplicitHybridTableRouteInfo> _realtimeTables;
   private TableConfig _offlineTableConfig;
   private TableConfig _realtimeTableConfig;
   private QueryConfig _queryConfig;
@@ -60,14 +60,6 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
 
   private TimeBoundaryStrategy _timeBoundaryStrategy;
   private TimeBoundaryInfo _timeBoundaryInfo;
-
-  public LogicalTableRouteInfo() {
-    _logicalTableName = null;
-  }
-
-  public LogicalTableRouteInfo(LogicalTableConfig logicalTable) {
-    _logicalTableName = logicalTable.getTableName();
-  }
 
   @Override
   public Map<ServerRoutingInstance, InstanceRequest> getRequestMap(long requestId, String brokerId, boolean preferTls) {
@@ -140,6 +132,10 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
     instanceRequest.setTableSegmentsInfoList(tableSegmentsInfoList);
     instanceRequest.setBrokerId(brokerId);
     return instanceRequest;
+  }
+
+  public void setLogicalTableName(String logicalTableName) {
+    _logicalTableName = logicalTableName;
   }
 
   @Nullable
@@ -364,20 +360,20 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
   }
 
   @Nullable
-  public List<TableRouteInfo> getOfflineTables() {
+  public List<ImplicitHybridTableRouteInfo> getOfflineTables() {
     return _offlineTables;
   }
 
-  public void setOfflineTables(List<TableRouteInfo> offlineTables) {
+  public void setOfflineTables(List<ImplicitHybridTableRouteInfo> offlineTables) {
     _offlineTables = offlineTables;
   }
 
   @Nullable
-  public List<TableRouteInfo> getRealtimeTables() {
+  public List<ImplicitHybridTableRouteInfo> getRealtimeTables() {
     return _realtimeTables;
   }
 
-  public void setRealtimeTables(List<TableRouteInfo> realtimeTables) {
+  public void setRealtimeTables(List<ImplicitHybridTableRouteInfo> realtimeTables) {
     _realtimeTables = realtimeTables;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteInfo.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.transport.BaseTableRouteInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.transport.TableRouteInfo;
+import org.apache.pinot.query.timeboundary.TimeBoundaryStrategy;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -56,6 +57,8 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
 
   private BrokerRequest _offlineBrokerRequest;
   private BrokerRequest _realtimeBrokerRequest;
+
+  private TimeBoundaryStrategy _timeBoundaryStrategy;
   private TimeBoundaryInfo _timeBoundaryInfo;
 
   public LogicalTableRouteInfo() {
@@ -392,5 +395,14 @@ public class LogicalTableRouteInfo extends BaseTableRouteInfo {
 
   public void setRealtimeBrokerRequest(BrokerRequest realtimeBrokerRequest) {
     _realtimeBrokerRequest = realtimeBrokerRequest;
+  }
+
+  @Nullable
+  public TimeBoundaryStrategy getTimeBoundaryStrategy() {
+    return _timeBoundaryStrategy;
+  }
+
+  public void setTimeBoundaryStrategy(TimeBoundaryStrategy timeBoundaryStrategy) {
+    _timeBoundaryStrategy = timeBoundaryStrategy;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteProvider.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteProvider.java
@@ -41,8 +41,8 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
 
   @Override
   public TableRouteInfo getTableRouteInfo(String tableName, TableCache tableCache, RoutingManager routingManager) {
-    LogicalTableConfig logicalTable = tableCache.getLogicalTableConfig(tableName);
-    if (logicalTable == null) {
+    LogicalTableConfig logicalTableConfig = tableCache.getLogicalTableConfig(tableName);
+    if (logicalTableConfig == null) {
       return new LogicalTableRouteInfo();
     }
 
@@ -50,7 +50,7 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
 
     List<TableRouteInfo> offlineTables = new ArrayList<>();
     List<TableRouteInfo> realtimeTables = new ArrayList<>();
-    for (String physicalTableName : logicalTable.getPhysicalTableConfigMap().keySet()) {
+    for (String physicalTableName : logicalTableConfig.getPhysicalTableConfigMap().keySet()) {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(physicalTableName);
       Preconditions.checkNotNull(tableType);
       TableRouteInfo physicalTableInfo =
@@ -64,29 +64,29 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
       }
     }
 
-    LogicalTableRouteInfo routeInfo = new LogicalTableRouteInfo(logicalTable);
+    LogicalTableRouteInfo routeInfo = new LogicalTableRouteInfo(logicalTableConfig);
     if (!offlineTables.isEmpty()) {
-      TableConfig offlineTableConfig = tableCache.getTableConfig(logicalTable.getRefOfflineTableName());
+      TableConfig offlineTableConfig = tableCache.getTableConfig(logicalTableConfig.getRefOfflineTableName());
       Preconditions.checkNotNull(offlineTableConfig,
-          "Offline table config not found: " + logicalTable.getRefOfflineTableName());
+          "Offline table config not found: " + logicalTableConfig.getRefOfflineTableName());
       routeInfo.setOfflineTables(offlineTables);
       routeInfo.setOfflineTableConfig(offlineTableConfig);
     }
     if (!realtimeTables.isEmpty()) {
-      TableConfig realtimeTableConfig = tableCache.getTableConfig(logicalTable.getRefRealtimeTableName());
+      TableConfig realtimeTableConfig = tableCache.getTableConfig(logicalTableConfig.getRefRealtimeTableName());
       Preconditions.checkNotNull(realtimeTableConfig,
-          "Realtime table config not found: " + logicalTable.getRefRealtimeTableName());
+          "Realtime table config not found: " + logicalTableConfig.getRefRealtimeTableName());
       routeInfo.setRealtimeTables(realtimeTables);
       routeInfo.setRealtimeTableConfig(realtimeTableConfig);
     }
-    routeInfo.setQueryConfig(logicalTable.getQueryConfig());
+    routeInfo.setQueryConfig(logicalTableConfig.getQueryConfig());
 
     TimeBoundaryInfo timeBoundaryInfo;
     if (!offlineTables.isEmpty() && !realtimeTables.isEmpty()) {
-      String boundaryStrategy = logicalTable.getTimeBoundaryConfig().getBoundaryStrategy();
+      String boundaryStrategy = logicalTableConfig.getTimeBoundaryConfig().getBoundaryStrategy();
       TimeBoundaryStrategy timeBoundaryStrategy =
           TimeBoundaryStrategyService.getInstance().getTimeBoundaryStrategy(boundaryStrategy);
-      timeBoundaryStrategy.init(logicalTable, tableCache);
+      timeBoundaryStrategy.init(logicalTableConfig, tableCache);
       timeBoundaryInfo = timeBoundaryStrategy.computeTimeBoundary(routingManager);
       if (timeBoundaryInfo == null) {
         LOGGER.info("No time boundary info found for logical hybrid table: ");
@@ -99,8 +99,8 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
   }
 
   public LogicalTableRouteInfo getTableRouteInfo(String tableName, TableCache tableCache) {
-    LogicalTableConfig logicalTable = tableCache.getLogicalTableConfig(tableName);
-    if (logicalTable == null) {
+    LogicalTableConfig logicalTableConfig = tableCache.getLogicalTableConfig(tableName);
+    if (logicalTableConfig == null) {
       return new LogicalTableRouteInfo();
     }
 
@@ -108,7 +108,7 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
 
     List<TableRouteInfo> offlineTables = new ArrayList<>();
     List<TableRouteInfo> realtimeTables = new ArrayList<>();
-    for (String physicalTableName : logicalTable.getPhysicalTableConfigMap().keySet()) {
+    for (String physicalTableName : logicalTableConfig.getPhysicalTableConfigMap().keySet()) {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(physicalTableName);
       Preconditions.checkNotNull(tableType);
       TableRouteInfo physicalTableInfo = routeProvider.getTableRouteInfo(physicalTableName, tableCache);
@@ -122,32 +122,32 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
       }
     }
 
-    LogicalTableRouteInfo routeInfo = new LogicalTableRouteInfo(logicalTable);
+    LogicalTableRouteInfo routeInfo = new LogicalTableRouteInfo(logicalTableConfig);
     if (!offlineTables.isEmpty()) {
-      TableConfig offlineTableConfig = tableCache.getTableConfig(logicalTable.getRefOfflineTableName());
+      TableConfig offlineTableConfig = tableCache.getTableConfig(logicalTableConfig.getRefOfflineTableName());
       Preconditions.checkNotNull(offlineTableConfig,
-          "Offline table config not found: " + logicalTable.getRefOfflineTableName());
+          "Offline table config not found: " + logicalTableConfig.getRefOfflineTableName());
       routeInfo.setOfflineTables(offlineTables);
       routeInfo.setOfflineTableConfig(offlineTableConfig);
     }
 
     if (!realtimeTables.isEmpty()) {
-      TableConfig realtimeTableConfig = tableCache.getTableConfig(logicalTable.getRefRealtimeTableName());
+      TableConfig realtimeTableConfig = tableCache.getTableConfig(logicalTableConfig.getRefRealtimeTableName());
       Preconditions.checkNotNull(realtimeTableConfig,
-          "Realtime table config not found: " + logicalTable.getRefRealtimeTableName());
+          "Realtime table config not found: " + logicalTableConfig.getRefRealtimeTableName());
       routeInfo.setRealtimeTables(realtimeTables);
       routeInfo.setRealtimeTableConfig(realtimeTableConfig);
     }
 
     if (!offlineTables.isEmpty() && !realtimeTables.isEmpty()) {
-      String boundaryStrategy = logicalTable.getTimeBoundaryConfig().getBoundaryStrategy();
+      String boundaryStrategy = logicalTableConfig.getTimeBoundaryConfig().getBoundaryStrategy();
       TimeBoundaryStrategy timeBoundaryStrategy =
           TimeBoundaryStrategyService.getInstance().getTimeBoundaryStrategy(boundaryStrategy);
-      timeBoundaryStrategy.init(logicalTable, tableCache);
+      timeBoundaryStrategy.init(logicalTableConfig, tableCache);
       routeInfo.setTimeBoundaryStrategy(timeBoundaryStrategy);
     }
 
-    routeInfo.setQueryConfig(logicalTable.getQueryConfig());
+    routeInfo.setQueryConfig(logicalTableConfig.getQueryConfig());
     return routeInfo;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteProvider.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/LogicalTableRouteProvider.java
@@ -161,7 +161,6 @@ public class LogicalTableRouteProvider implements TableRouteProvider {
       } else {
         logicalTableRouteInfo.setTimeBoundaryInfo(timeBoundaryInfo);
       }
-
     }
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/PhysicalTableRouteProvider.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/table/PhysicalTableRouteProvider.java
@@ -45,7 +45,6 @@ public class PhysicalTableRouteProvider extends ImplicitHybridTableRouteProvider
   @Override
   public void calculateRoutes(TableRouteInfo tableRouteInfo, RoutingManager routingManager,
       BrokerRequest offlineBrokerRequest, BrokerRequest realtimeBrokerRequest, long requestId) {
-    assert (tableRouteInfo.isExists());
     String offlineTableName = tableRouteInfo.getOfflineTableName();
     String realtimeTableName = tableRouteInfo.getRealtimeTableName();
     Map<ServerInstance, ServerRouteInfo> offlineRoutingTable = null;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.timeboundary;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.config.provider.TableCache;
@@ -36,7 +37,28 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 @AutoService(TimeBoundaryStrategy.class)
 public class MinTimeBoundaryStrategy implements TimeBoundaryStrategy {
 
-  public static final String INCLUDED_TABLES = "includedTables";
+  private static final String INCLUDED_TABLES = "includedTables";
+  Map<String, DateTimeFormatSpec> _dateTimeFormatSpecMap;
+
+  @Override
+  public void init(LogicalTableConfig logicalTableConfig, TableCache tableCache) {
+    Map<String, Object> parameters = logicalTableConfig.getTimeBoundaryConfig().getParameters();
+    List<String> includedTables = getTimeBoundaryTableNames(logicalTableConfig);
+    _dateTimeFormatSpecMap = new HashMap<>(includedTables.size());
+    for (String physicalTableName : includedTables) {
+      String rawTableName = TableNameBuilder.extractRawTableName(physicalTableName);
+      Schema schema = tableCache.getSchema(rawTableName);
+      TableConfig tableConfig = tableCache.getTableConfig(physicalTableName);
+      Preconditions.checkArgument(tableConfig != null, "Table config not found for table: %s", physicalTableName);
+      Preconditions.checkArgument(schema != null, "Schema not found for table: %s", physicalTableName);
+      String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+      DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
+      Preconditions.checkArgument(dateTimeFieldSpec != null, "Time column not found in schema for table: %s",
+          physicalTableName);
+      DateTimeFormatSpec specFormatSpec = dateTimeFieldSpec.getFormatSpec();
+      _dateTimeFormatSpecMap.put(physicalTableName, specFormatSpec);
+    }
+  }
 
   @Override
   public String getName() {
@@ -44,29 +66,13 @@ public class MinTimeBoundaryStrategy implements TimeBoundaryStrategy {
   }
 
   @Override
-  public TimeBoundaryInfo computeTimeBoundary(LogicalTableConfig logicalTableConfig, TableCache tableCache,
-      RoutingManager routingManager) {
+  public TimeBoundaryInfo computeTimeBoundary(RoutingManager routingManager) {
     TimeBoundaryInfo minTimeBoundaryInfo = null;
     long minTimeBoundary = Long.MAX_VALUE;
-    Map<String, Object> parameters = logicalTableConfig.getTimeBoundaryConfig().getParameters();
-    List<String> includedTables =
-        parameters != null ? (List) parameters.getOrDefault("includedTables", List.of()) : List.of();
-    for (String physicalTableName : includedTables) {
-      TimeBoundaryInfo current = routingManager.getTimeBoundaryInfo(physicalTableName);
+    for (Map.Entry<String, DateTimeFormatSpec> entry : _dateTimeFormatSpecMap.entrySet()) {
+      TimeBoundaryInfo current = routingManager.getTimeBoundaryInfo(entry.getKey());
       if (current != null) {
-        String rawTableName = TableNameBuilder.extractRawTableName(physicalTableName);
-        Schema schema = tableCache.getSchema(rawTableName);
-        TableConfig tableConfig = tableCache.getTableConfig(physicalTableName);
-        Preconditions.checkArgument(tableConfig != null,
-            "Table config not found for table: %s", physicalTableName);
-        Preconditions.checkArgument(schema != null,
-            "Schema not found for table: %s", physicalTableName);
-        String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
-        DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
-        Preconditions.checkArgument(dateTimeFieldSpec != null,
-            "Time column not found in schema for table: %s", physicalTableName);
-        DateTimeFormatSpec specFormatSpec = dateTimeFieldSpec.getFormatSpec();
-        long currentTimeBoundaryMillis = specFormatSpec.fromFormatToMillis(current.getTimeValue());
+        long currentTimeBoundaryMillis = entry.getValue().fromFormatToMillis(current.getTimeValue());
         if (minTimeBoundaryInfo == null) {
           minTimeBoundaryInfo = current;
           minTimeBoundary = currentTimeBoundaryMillis;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategy.java
@@ -42,7 +42,6 @@ public class MinTimeBoundaryStrategy implements TimeBoundaryStrategy {
 
   @Override
   public void init(LogicalTableConfig logicalTableConfig, TableCache tableCache) {
-    Map<String, Object> parameters = logicalTableConfig.getTimeBoundaryConfig().getParameters();
     List<String> includedTables = getTimeBoundaryTableNames(logicalTableConfig);
     _dateTimeFormatSpecMap = new HashMap<>(includedTables.size());
     for (String physicalTableName : includedTables) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/timeboundary/TimeBoundaryStrategy.java
@@ -35,15 +35,19 @@ public interface TimeBoundaryStrategy {
   String getName();
 
   /**
+   * Initializes the time boundary strategy with the given logical table configuration and table cache.
+   * @param logicalTableConfig The logical table configuration to use for initialization.
+   * @param tableCache The table cache to use for initialization.
+   */
+  void init(LogicalTableConfig logicalTableConfig, TableCache tableCache);
+
+  /**
    * Computes the time boundary for the given physical table names.
    *
-   * @param logicalTableConfig The logical table configuration.
-   * @param tableCache The table cache to use for fetching table metadata.
    * @param routingManager The routing manager to use for computing the time boundary.
    * @return The computed time boundary information.
    */
-  TimeBoundaryInfo computeTimeBoundary(LogicalTableConfig logicalTableConfig, TableCache tableCache,
-      RoutingManager routingManager);
+  TimeBoundaryInfo computeTimeBoundary(RoutingManager routingManager);
 
 
   /**

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/BaseTableRouteTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/BaseTableRouteTest.java
@@ -170,7 +170,7 @@ public class BaseTableRouteTest {
     TimeBoundaryStrategyService mockService = mock(TimeBoundaryStrategyService.class);
     when(TimeBoundaryStrategyService.getInstance()).thenReturn(mockService);
     when(mockService.getTimeBoundaryStrategy(any())).thenReturn(_timeBoundaryStrategy);
-    when(_timeBoundaryStrategy.computeTimeBoundary(any(), any(), any())).thenReturn(mock(TimeBoundaryInfo.class));
+    when(_timeBoundaryStrategy.computeTimeBoundary(any())).thenReturn(mock(TimeBoundaryInfo.class));
   }
 
   @AfterClass

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProviderCalculateRouteTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProviderCalculateRouteTest.java
@@ -27,9 +27,9 @@ import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.ServerRouteInfo;
-import org.apache.pinot.core.transport.ImplicitHybridTableRouteInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.core.transport.TableRouteInfo;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -59,9 +59,8 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
     }
   }
 
-  private ImplicitHybridTableRouteInfo getImplicitHybridTableRouteInfo(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+  private TableRouteInfo getImplicitHybridTableRouteInfo(String tableName) {
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
     BrokerRequestPair brokerRequestPair =
         getBrokerRequestPair(tableName, routeInfo.hasOffline(), routeInfo.hasRealtime(),
             routeInfo.getOfflineTableName(), routeInfo.getRealtimeTableName());
@@ -73,7 +72,7 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
 
   private void assertTableRoute(String tableName, Map<String, Set<String>> expectedOfflineRoutingTable,
       Map<String, Set<String>> expectedRealtimeRoutingTable, boolean isOfflineExpected, boolean isRealtimeExpected) {
-    ImplicitHybridTableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
+    TableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
 
     // If a routing table for offline table is expected, then compare it with the expected routing table.
     if (isOfflineExpected) {
@@ -281,7 +280,7 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
   private void assertEqualsTableRouteInfoGetTableRouteResult(String tableName,
       Map<String, Set<String>> expectedOfflineRoutingTable,
       Map<String, Set<String>> expectedRealtimeRoutingTable, boolean isOfflineExpected, boolean isRealtimeExpected) {
-    ImplicitHybridTableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
+    TableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
     GetTableRouteResult expectedTableRoute = getTableRouting(tableName, _routingManager);
 
     if (isOfflineExpected) {
@@ -332,7 +331,7 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
 
   @Test(dataProvider = "routeNotExistsProvider")
   void testTableRoutingForRouteNotExists(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
+    TableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
     GetTableRouteResult expectedTableRoute = getTableRouting(tableName, _routingManager);
 
     assertNull(expectedTableRoute._offlineRoutingTable);
@@ -348,7 +347,7 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
   @Test(dataProvider = "partiallyDisabledTableAndRouteProvider")
   void testTableRoutingForPartiallyDisabledTable(String tableName, Map<String, Set<String>> expectedOfflineRoutingTable,
       Map<String, Set<String>> expectedRealtimeRoutingTable) {
-    ImplicitHybridTableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
+    TableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
     GetTableRouteResult expectedTableRoute = getTableRouting(tableName, _routingManager);
 
     if (expectedOfflineRoutingTable == null) {
@@ -376,7 +375,7 @@ public class ImplicitHybridTableRouteProviderCalculateRouteTest extends BaseTabl
 
   @Test(dataProvider = "disabledTableProvider")
   void testTableRoutingForDisabledTable(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
+    TableRouteInfo routeInfo = getImplicitHybridTableRouteInfo(tableName);
     GetTableRouteResult expectedTableRoute = getTableRouting(tableName, _routingManager);
 
     if (expectedTableRoute._offlineTableDisabled) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProviderGetTableRouteTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/table/ImplicitHybridTableRouteProviderGetTableRouteTest.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.routing.table;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
-import org.apache.pinot.core.transport.ImplicitHybridTableRouteInfo;
+import org.apache.pinot.core.transport.TableRouteInfo;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -41,26 +41,21 @@ import static org.testng.Assert.assertTrue;
 public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTableRouteTest {
   @Test(dataProvider = "offlineTableProvider")
   public void testOfflineTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isOffline(), "The table should be offline");
   }
 
   @Test(dataProvider = "realtimeTableProvider")
   public void testRealtimeTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isRealtime(), "The table should be realtime");
   }
 
   @Test(dataProvider = "hybridTableProvider")
   public void testHybridTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
 
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isHybrid(), "The table should be hybrid");
@@ -71,62 +66,48 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
    */
   @Test
   public void testWithNoTimeBoundary() {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo("b", _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo("b", _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isRealtime(), "The table should be realtime");
   }
 
   @Test(dataProvider = "nonExistentTableProvider")
   public void testNonExistentTableName(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertFalse(routeInfo.isExists(), "The table should not exist");
   }
 
   @Test(dataProvider = "routeExistsProvider")
   public void testRouteExists(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isRouteExists(), "The table should have route");
   }
 
   @Test(dataProvider = "routeNotExistsProvider")
   public void testRouteNotExists(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertFalse(routeInfo.isRouteExists(), "The table should not have route");
   }
 
   @Test(dataProvider = "notDisabledTableProvider")
   public void testNotDisabledTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertFalse(routeInfo.isDisabled(), "The table should not be disabled");
   }
 
   @Test(dataProvider = "partiallyDisabledTableProvider")
   public void testPartiallyDisabledTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertFalse(routeInfo.isDisabled(), "The table should be disabled");
   }
 
   @Test(dataProvider = "disabledTableProvider")
   public void testDisabledTable(String parameter) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
-
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(parameter, _tableCache, _routingManager);
     assertTrue(routeInfo.isExists(), "The table should exist");
     assertTrue(routeInfo.isDisabled(), "The table should not have route");
   }
@@ -158,10 +139,8 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
     /**
      * Similar if offlineTableName is not null and there is a route in the routing routeInfo. Same for
      * realtimeTableName.
-     * @param routeInfo
-     * @return
      */
-    boolean similar(ImplicitHybridTableRouteInfo routeInfo) {
+    boolean similar(TableRouteInfo routeInfo) {
       boolean isEquals = true;
 
       if (_offlineTableName != null) {
@@ -272,13 +251,11 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
   /**
    * This test checks tables that have a table config and an entry in routing manager.
    * It makes sure that getTableNameAndConfig() behaves the same way as ImplicitTableRouteComputer.
-   * @param tableName
    */
   @Test(dataProvider = "tableNameAndConfigSuccessProvider")
   public void testTableNameAndConfigSuccess(String tableName) {
     TableNameAndConfig tableNameAndConfig = getTableNameAndConfig(tableName);
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
     assertTrue(tableNameAndConfig.similar(routeInfo), "The table name and config should match the hybrid table");
   }
 
@@ -303,13 +280,11 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
 
   /**
    * This test checks tables that do not have a table config or an entry in routing manager.
-   * @param tableName
    */
   @Test(dataProvider = "tableNameAndConfigFailureProvider")
   public void testTableNameAndConfigFailure(String tableName) {
     TableNameAndConfig tableNameAndConfig = getTableNameAndConfig(tableName);
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
 
     // getTableNameAndConfig() returns an error as a BrokerResponse with the right error code.
     assertNotNull(tableNameAndConfig._brokerResponse);
@@ -373,12 +348,10 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
   /**
    * If a table is not disabled, then checkTableDisabled() should return null.
    * ImplicitTableRouteComputer should not be disabled.
-   * @param tableName
    */
   @Test(dataProvider = "notDisabledTableProvider")
   public void testNotDisabledWithCheckDisabled(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
 
     ExceptionOrResponse exceptionOrResponse =
         checkTableDisabled(routeInfo.hasOffline() && routeInfo.isOfflineTableDisabled(),
@@ -393,12 +366,10 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
   /**
    * In a hybrid table, if one of the tables is disabled, then checkTableDisabled() should return an exception.
    * ImplicitTableRouteComputer should not be disabled.
-   * @param tableName
    */
   @Test(dataProvider = "partiallyDisabledTableProvider")
   public void testPartiallyDisabledWithCheckDisabled(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
 
     ExceptionOrResponse exceptionOrResponse =
         checkTableDisabled(routeInfo.hasOffline() && routeInfo.isOfflineTableDisabled(),
@@ -416,12 +387,10 @@ public class ImplicitHybridTableRouteProviderGetTableRouteTest extends BaseTable
    * If a table is disabled, then checkTableDisabled() should return a broker response with error code
    * TABLE_IS_DISABLED.
    * ImplicitTableRouteComputer should be disabled.
-   * @param tableName
    */
   @Test(dataProvider = "disabledTableProvider")
   public void testDisabledWithCheckDisabled(String tableName) {
-    ImplicitHybridTableRouteInfo routeInfo =
-        _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
+    TableRouteInfo routeInfo = _hybridTableRouteProvider.getTableRouteInfo(tableName, _tableCache, _routingManager);
 
     ExceptionOrResponse exceptionOrResponse =
         checkTableDisabled(routeInfo.hasOffline() && routeInfo.isOfflineTableDisabled(),

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategyTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategyTest.java
@@ -84,7 +84,6 @@ public class MinTimeBoundaryStrategyTest {
 
     return new Object[][]{
         {timeBoundaryInfoMap, List.of("table3_OFFLINE"), "table3_OFFLINE"},
-        {timeBoundaryInfoMap, List.of("Invalid_OFFLINE"), "Invalid_OFFLINE"},
         {timeBoundaryInfoMap, List.of("table2_OFFLINE", "table3_OFFLINE"), "table2_OFFLINE"},
         {timeBoundaryInfoMap, List.of("table3_OFFLINE", "table2_OFFLINE", "table4_OFFLINE"), "table2_OFFLINE"},
         {timeBoundaryInfoMap, List.of(), "empty_includedTables_OFFLINE"}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategyTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/timeboundary/MinTimeBoundaryStrategyTest.java
@@ -102,8 +102,8 @@ public class MinTimeBoundaryStrategyTest {
   private void testComputeTimeBoundary(Map<String, TimeBoundaryInfo> timeBoundaryInfoMap, String expectedTableName,
       Map<String, Object> parameters) {
     setupMocks(timeBoundaryInfoMap);
-    TimeBoundaryInfo timeBoundaryInfo = _minTimeBoundaryStrategy.computeTimeBoundary(
-        createLogicalTableConfig(parameters), _mockTableCache, _mockRoutingManager);
+    _minTimeBoundaryStrategy.init(createLogicalTableConfig(parameters), _mockTableCache);
+    TimeBoundaryInfo timeBoundaryInfo = _minTimeBoundaryStrategy.computeTimeBoundary(_mockRoutingManager);
     assertSame(timeBoundaryInfo, timeBoundaryInfoMap.get(expectedTableName));
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -448,33 +448,33 @@ public class ServerPlanRequestUtils {
           offlineTableRouteInfoList.isEmpty() ? realtimeTableRouteInfoList : offlineTableRouteInfoList;
       String tableType = offlineTableRouteInfoList.isEmpty() ? TableType.REALTIME.name() : TableType.OFFLINE.name();
       if (tableType.equals(TableType.OFFLINE.name())) {
-        Preconditions.checkNotNull(logicalTableManager.getOfflineTableConfig());
+        Preconditions.checkNotNull(logicalTableManager.getRefOfflineTableConfig());
         String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(logicalTableName);
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.OFFLINE, offlineTableName,
-                logicalTableManager.getOfflineTableConfig(), logicalTableManager.getLogicalTableSchema(), null,
+                logicalTableManager.getRefOfflineTableConfig(), logicalTableManager.getLogicalTableSchema(), null,
                 routeInfoList));
       } else {
-        Preconditions.checkNotNull(logicalTableManager.getRealtimeTableConfig());
+        Preconditions.checkNotNull(logicalTableManager.getRefRealtimeTableConfig());
         String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(logicalTableName);
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.REALTIME,
-                realtimeTableName, logicalTableManager.getRealtimeTableConfig(),
+                realtimeTableName, logicalTableManager.getRefRealtimeTableConfig(),
                 logicalTableManager.getLogicalTableSchema(), null, routeInfoList));
       }
     } else {
-      Preconditions.checkNotNull(logicalTableManager.getOfflineTableConfig());
-      Preconditions.checkNotNull(logicalTableManager.getRealtimeTableConfig());
+      Preconditions.checkNotNull(logicalTableManager.getRefOfflineTableConfig());
+      Preconditions.checkNotNull(logicalTableManager.getRefRealtimeTableConfig());
       String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(logicalTableName);
       String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(logicalTableName);
       PinotQuery offlinePinotQuery = pinotQuery.deepCopy();
       PinotQuery realtimePinotQuery = pinotQuery.deepCopy();
       return List.of(
           compileInstanceRequest(executionContext, offlinePinotQuery, timeBoundaryInfo, TableType.OFFLINE,
-              offlineTableName, logicalTableManager.getOfflineTableConfig(),
+              offlineTableName, logicalTableManager.getRefOfflineTableConfig(),
               logicalTableManager.getLogicalTableSchema(), null, offlineTableRouteInfoList),
           compileInstanceRequest(executionContext, realtimePinotQuery, timeBoundaryInfo, TableType.REALTIME,
-              realtimeTableName, logicalTableManager.getRealtimeTableConfig(),
+              realtimeTableName, logicalTableManager.getRefRealtimeTableConfig(),
               logicalTableManager.getLogicalTableSchema(), null, realtimeTableRouteInfoList));
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -252,6 +252,12 @@ public class ServerPlanRequestUtils {
     instanceRequest.setCid(QueryThreadContext.getCid());
     instanceRequest.setBrokerId("unknown");
     instanceRequest.setEnableTrace(executionContext.isTraceEnabled());
+    /*
+      * If segmentList is not null, it means that the query is for a single table and we can directly set the segments.
+      * If segmentList is null, it means that the query is for a logical table and we need to set TableSegmentInfoList
+      *
+      * Either one of segmentList or tableRouteInfoList has to be set, but not both.
+     */
     if (segmentList != null) {
       instanceRequest.setSearchSegments(segmentList);
     } else {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -47,7 +47,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
-import org.apache.pinot.core.data.manager.LogicalTableManager;
+import org.apache.pinot.core.data.manager.LogicalTableContext;
 import org.apache.pinot.core.data.manager.provider.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploader;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
@@ -520,9 +520,10 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     }
   }
 
+  // TODO: LogicalTableContext has to be cached. https://github.com/apache/pinot/issues/15859
   @Nullable
   @Override
-  public LogicalTableManager getLogicalTableManager(String logicalTableName) {
+  public LogicalTableContext getLogicalTableContext(String logicalTableName) {
     Schema schema = ZKMetadataProvider.getSchema(getPropertyStore(), logicalTableName);
     if (schema == null) {
       LOGGER.warn("Failed to find schema for logical table: {}, skipping", logicalTableName);
@@ -554,6 +555,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
         return null;
       }
     }
-    return new LogicalTableManager(logicalTableConfig, schema, offlineTableConfig, realtimeTableConfig);
+    return new LogicalTableContext(logicalTableConfig, schema, offlineTableConfig, realtimeTableConfig);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -47,6 +47,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.LogicalTableManager;
 import org.apache.pinot.core.data.manager.provider.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploader;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
@@ -64,6 +65,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.plugin.PluginManager;
@@ -516,5 +518,42 @@ public class HelixInstanceDataManager implements InstanceDataManager {
         }
       });
     }
+  }
+
+  @Nullable
+  @Override
+  public LogicalTableManager getLogicalTableManager(String logicalTableName) {
+    Schema schema = ZKMetadataProvider.getSchema(getPropertyStore(), logicalTableName);
+    if (schema == null) {
+      LOGGER.warn("Failed to find schema for logical table: {}, skipping", logicalTableName);
+      return null;
+    }
+    LogicalTableConfig logicalTableConfig = ZKMetadataProvider.getLogicalTableConfig(getPropertyStore(),
+        logicalTableName);
+    if (logicalTableConfig == null) {
+      LOGGER.warn("Failed to find logical table config for logical table: {}, skipping", logicalTableName);
+      return null;
+    }
+
+    TableConfig offlineTableConfig = null;
+    if (logicalTableConfig.getRefOfflineTableName() != null) {
+      offlineTableConfig = ZKMetadataProvider.getOfflineTableConfig(getPropertyStore(),
+          logicalTableConfig.getRefOfflineTableName());
+      if (offlineTableConfig == null) {
+        LOGGER.warn("Failed to find offline table config for logical table: {}, skipping", logicalTableName);
+        return null;
+      }
+    }
+
+    TableConfig realtimeTableConfig = null;
+    if (logicalTableConfig.getRefRealtimeTableName() != null) {
+      realtimeTableConfig = ZKMetadataProvider.getRealtimeTableConfig(getPropertyStore(),
+          logicalTableConfig.getRefRealtimeTableName());
+      if (realtimeTableConfig == null) {
+        LOGGER.warn("Failed to find realtime table config for logical table: {}, skipping", logicalTableName);
+        return null;
+      }
+    }
+    return new LogicalTableManager(logicalTableConfig, schema, offlineTableConfig, realtimeTableConfig);
   }
 }


### PR DESCRIPTION
This PR adds support to execute queries on logical tables in MSE. It uses classes introduced in #15634.

The high-level workflow is:
* `PinotCatalog` also exposes logical tables as tables.
* `DispatchPlanVisitor` checks if the `TableScanNode` points to a logical table. If yes, adds `LogicalTableRouteInfo` to `DispatchablePlanMetadata`.
* `WorkerManager` creates a `workerId -> {tableType -> {tableName -> segments}}`. This is different from physical tables which require  `workerId -> {tableType -> segments}`
* `ServerPlanRequestUtils` uses this map to create `InstanceRequest` with the field for `TableSegmentsInfo`. 

The last step triggers SSE engine to process segments of all physical tables in the logical table. 

Closes #15749 