### PR TITLE
make dedup table use strict replica group assignment too

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
@@ -42,8 +42,8 @@ public class SegmentAssignmentFactory {
     } else {
       UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
       DedupConfig dedupConfig = tableConfig.getDedupConfig();
-      if ((upsertConfig != null && upsertConfig.getMode() != UpsertConfig.Mode.NONE) ||
-          (dedupConfig != null && dedupConfig.isDedupEnabled())) {
+      if ((upsertConfig != null && upsertConfig.getMode() != UpsertConfig.Mode.NONE) || (dedupConfig != null
+          && dedupConfig.isDedupEnabled())) {
         segmentAssignment = new StrictRealtimeSegmentAssignment();
       } else {
         segmentAssignment = new RealtimeSegmentAssignment();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -40,7 +41,9 @@ public class SegmentAssignmentFactory {
       segmentAssignment = new OfflineSegmentAssignment();
     } else {
       UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
-      if (upsertConfig != null && upsertConfig.getMode() != UpsertConfig.Mode.NONE) {
+      DedupConfig dedupConfig = tableConfig.getDedupConfig();
+      if ((upsertConfig != null && upsertConfig.getMode() != UpsertConfig.Mode.NONE) ||
+          (dedupConfig != null && dedupConfig.isDedupEnabled())) {
         segmentAssignment = new StrictRealtimeSegmentAssignment();
       } else {
         segmentAssignment = new RealtimeSegmentAssignment();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
+import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -39,6 +40,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateM
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -67,7 +69,6 @@ public class StrictRealtimeSegmentAssignmentTest {
       InstancePartitionsType.CONSUMING.getInstancePartitionsName(RAW_TABLE_NAME);
 
   private List<String> _segments;
-  private SegmentAssignment _segmentAssignment;
   private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMap;
   private InstancePartitions _newConsumingInstancePartitions;
 
@@ -78,16 +79,6 @@ public class StrictRealtimeSegmentAssignmentTest {
       _segments.add(new LLCSegmentName(RAW_TABLE_NAME, segmentId % NUM_PARTITIONS, segmentId / NUM_PARTITIONS,
           System.currentTimeMillis()).getSegmentName());
     }
-
-    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
-    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
-            .setStreamConfigs(streamConfigs).setUpsertConfig(upsertConfig)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
-            .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
-
     _instancePartitionsMap = new TreeMap<>();
     // CONSUMING instances:
     // {
@@ -126,25 +117,40 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
   }
 
-  @Test
-  public void testFactory() {
-    assertTrue(_segmentAssignment instanceof StrictRealtimeSegmentAssignment);
+  @DataProvider(name = "tableTypes")
+  public Object[] getTableTypes() {
+    return new Object[]{"upsert", "dedup"};
   }
 
-  @Test
-  public void testAssignSegment() {
-    assertTrue(_segmentAssignment instanceof StrictRealtimeSegmentAssignment);
+  private static SegmentAssignment createSegmentAssignment(String tableType) {
+    TableConfigBuilder builder = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+        .setNumReplicas(NUM_REPLICAS)
+        .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
+        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1));
+    TableConfig tableConfig;
+    if ("upsert".equalsIgnoreCase(tableType)) {
+      tableConfig = builder.setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).build();
+    } else {
+      tableConfig = builder.setDedupConfig(new DedupConfig()).build();
+    }
+    return SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
+  }
+
+  @Test(dataProvider = "tableTypes")
+  public void testAssignSegment(String tableType) {
+    SegmentAssignment segmentAssignment = createSegmentAssignment(tableType);
+    assertTrue(segmentAssignment instanceof StrictRealtimeSegmentAssignment);
     Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
         ImmutableMap.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
     int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     // Add segments for partition 0/1/2, but add no segment for partition 3.
     List<String> instancesAssigned;
-    boolean consistent;
     for (int segmentId = 0; segmentId < 3; segmentId++) {
       String segmentName = _segments.get(segmentId);
       instancesAssigned =
-          _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
       // Segment 0 (partition 0) should be assigned to instance 0, 3, 6
       // Segment 1 (partition 1) should be assigned to instance 1, 4, 7
@@ -171,7 +177,7 @@ public class StrictRealtimeSegmentAssignmentTest {
     int segmentId = 3;
     String segmentName = _segments.get(segmentId);
     instancesAssigned =
-        _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
+        segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
     assertEquals(instancesAssigned,
         Arrays.asList("new_consumingInstance_0", "new_consumingInstance_3", "new_consumingInstance_6"));
     addToAssignment(currentAssignment, segmentId, instancesAssigned);
@@ -180,7 +186,7 @@ public class StrictRealtimeSegmentAssignmentTest {
     for (segmentId = 4; segmentId < 7; segmentId++) {
       segmentName = _segments.get(segmentId);
       instancesAssigned =
-          _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
+          segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Those segments are assigned according to the assignment from idealState, instead of using new_xxx instances
@@ -197,20 +203,20 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
   }
 
-  @Test
-  public void testAssignSegmentWithOfflineSegment() {
-    assertTrue(_segmentAssignment instanceof StrictRealtimeSegmentAssignment);
+  @Test(dataProvider = "tableTypes")
+  public void testAssignSegmentWithOfflineSegment(String tableType) {
+    SegmentAssignment segmentAssignment = createSegmentAssignment(tableType);
+    assertTrue(segmentAssignment instanceof StrictRealtimeSegmentAssignment);
     Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
         ImmutableMap.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
     int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     // Add segments for partition 0/1/2, but add no segment for partition 3.
     List<String> instancesAssigned;
-    boolean consistent;
     for (int segmentId = 0; segmentId < 3; segmentId++) {
       String segmentName = _segments.get(segmentId);
       instancesAssigned =
-          _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
       // Segment 0 (partition 0) should be assigned to instance 0, 3, 6
       // Segment 1 (partition 1) should be assigned to instance 1, 4, 7
@@ -238,7 +244,7 @@ public class StrictRealtimeSegmentAssignmentTest {
     for (int segmentId = 3; segmentId < 7; segmentId++) {
       String segmentName = _segments.get(segmentId);
       instancesAssigned =
-          _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
+          segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Those segments are assigned according to the assignment from idealState, instead of using new_xxx instances
@@ -255,9 +261,10 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
   }
 
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void testAssignSegmentToCompletedServers() {
-    _segmentAssignment.assignSegment("seg01", new TreeMap<>(), new TreeMap<>());
+  @Test(expectedExceptions = IllegalStateException.class, dataProvider = "tableTypes")
+  public void testAssignSegmentToCompletedServers(String tableType) {
+    SegmentAssignment segmentAssignment = createSegmentAssignment(tableType);
+    segmentAssignment.assignSegment("seg01", new TreeMap<>(), new TreeMap<>());
   }
 
   private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,
@@ -276,7 +283,7 @@ public class StrictRealtimeSegmentAssignmentTest {
         SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
   }
 
-  private HelixManager createHelixManager() {
+  private static HelixManager createHelixManager() {
     HelixManager helixManager = mock(HelixManager.class);
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);


### PR DESCRIPTION
This PR ensures dedup table to use strict replica group assignment too. Like upsert table, for dedup table, the segments from same partition must be hosted on same server as well.