### PR TITLE
Precondition for overflow in VarLengthValueWriter

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
@@ -94,8 +94,6 @@ public class VarLengthValueWriter implements Closeable {
   private final ByteBuffer _offsetBuffer;
   private final ByteBuffer _valueBuffer;
 
-  private long _totalLength;
-
   public VarLengthValueWriter(File outputFile, int numValues)
       throws IOException {
     _fileChannel = new RandomAccessFile(outputFile, "rw").getChannel();
@@ -109,7 +107,6 @@ public class VarLengthValueWriter implements Closeable {
 
     _valueBuffer = _offsetBuffer.duplicate();
     _valueBuffer.position(HEADER_LENGTH + (numValues + 1) * Integer.BYTES);
-    _totalLength += HEADER_LENGTH;
   }
 
   public void add(byte[] value)
@@ -119,8 +116,7 @@ public class VarLengthValueWriter implements Closeable {
 
   public void add(byte[] value, int length)
       throws IOException {
-    _totalLength += length;
-    Preconditions.checkArgument(_totalLength < Integer.MAX_VALUE,
+    Preconditions.checkArgument((long) _valueBuffer.position() + length < Integer.MAX_VALUE,
         "2GB data limit exceeded. Try reducing segment size.");
     _offsetBuffer.putInt(_valueBuffer.position());
     _valueBuffer.put(value, 0, length);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.io.util;
 
+import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +94,8 @@ public class VarLengthValueWriter implements Closeable {
   private final ByteBuffer _offsetBuffer;
   private final ByteBuffer _valueBuffer;
 
+  private long _totalLength;
+
   public VarLengthValueWriter(File outputFile, int numValues)
       throws IOException {
     _fileChannel = new RandomAccessFile(outputFile, "rw").getChannel();
@@ -115,6 +118,9 @@ public class VarLengthValueWriter implements Closeable {
 
   public void add(byte[] value, int length)
       throws IOException {
+    _totalLength += length;
+    Preconditions.checkArgument(_totalLength < Integer.MAX_VALUE,
+        "2GB data limit exceeded. Try reducing segment size.");
     _offsetBuffer.putInt(_valueBuffer.position());
     _valueBuffer.put(value, 0, length);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueWriter.java
@@ -109,6 +109,7 @@ public class VarLengthValueWriter implements Closeable {
 
     _valueBuffer = _offsetBuffer.duplicate();
     _valueBuffer.position(HEADER_LENGTH + (numValues + 1) * Integer.BYTES);
+    _totalLength += HEADER_LENGTH;
   }
 
   public void add(byte[] value)


### PR DESCRIPTION
Use a precondition for overflow in VarLengthValueWriter to allow retry during the feature introduced in https://github.com/apache/pinot/pull/15234. Also provides a hint for users to fix this manually. 