### PR TITLE
Fails Online Transition for Segment Build Failures

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1462,8 +1462,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               } else if (_currentOffset.compareTo(endOffset) == 0) {
                 _segmentLogger
                     .info("Current offset {} matches offset in zk {}. Replacing segment", _currentOffset, endOffset);
-                boolean result = buildSegmentAndReplace();
-                if (!result) {
+                boolean replaced = buildSegmentAndReplace();
+                if (!replaced) {
                   throw new RuntimeException("Failed to build the segment: " + _segmentNameStr);
                 }
               } else {
@@ -1482,8 +1482,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
                 if (success) {
                   _segmentLogger.info("Caught up to offset {}", _currentOffset);
-                  boolean result = buildSegmentAndReplace();
-                  if (!result) {
+                  boolean replaced = buildSegmentAndReplace();
+                  if (!replaced) {
                     throw new RuntimeException("Failed to build the segment: " + _segmentNameStr);
                   }
                 } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -970,8 +970,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       // We could not build the segment. Go into error state.
       _state = State.ERROR;
       _segmentLogger.error("Could not build segment for {}", _segmentNameStr);
-      if (_segmentBuildFailedWithDeterministicError && _tableConfig.getIngestionConfig()
-          .isRetryOnSegmentBuildPrecheckFailure()) {
+      if (_segmentBuildFailedWithDeterministicError && (_tableConfig.getIngestionConfig() != null)
+          && _tableConfig.getIngestionConfig().isRetryOnSegmentBuildPrecheckFailure()) {
         _segmentLogger.error(
             "Found non-recoverable segment build error for {}, from offset {} to {}, sending notifyCannotBuild event.",
             _segmentNameStr, _startOffset, _currentOffset);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildFailureException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildFailureException.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.data.manager.realtime;
 
 public class SegmentBuildFailureException extends Exception {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildFailureException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildFailureException.java
@@ -1,0 +1,11 @@
+package org.apache.pinot.core.data.manager.realtime;
+
+public class SegmentBuildFailureException extends Exception {
+  public SegmentBuildFailureException(String errorMessage, Throwable cause) {
+    super(errorMessage, cause);
+  }
+
+  public SegmentBuildFailureException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -949,7 +949,8 @@ public class RealtimeSegmentDataManagerTest {
       return new PartitionConsumer();
     }
 
-    public SegmentBuildDescriptor invokeBuildForCommit(long leaseTime) {
+    public SegmentBuildDescriptor invokeBuildForCommit(long leaseTime)
+        throws SegmentBuildFailureException {
       super.buildSegmentForCommit(leaseTime);
       return getSegmentBuildDescriptor();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -582,6 +582,15 @@ public class RealtimeSegmentDataManagerTest {
       Assert.assertTrue(segmentDataManager._downloadAndReplaceCalled);
       Assert.assertFalse(segmentDataManager._buildAndReplaceCalled);
     }
+
+    // Test Runtime Exception is thrown when build segment fails.
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      segmentDataManager._failSegmentBuildAndReplace = true;
+      segmentDataManager._stopWaitTimeMs = 0;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.HOLDING);
+      segmentDataManager.setCurrentOffset(finalOffsetValue);
+      Assert.expectThrows(RuntimeException.class, () -> segmentDataManager.goOnlineFromConsuming(metadata));
+    }
   }
 
   @Test
@@ -874,6 +883,7 @@ public class RealtimeSegmentDataManagerTest {
     public Field _shouldStop;
     public Field _stopReason;
     public Field _segmentBuildFailedWithDeterministicError;
+    public boolean _failSegmentBuildAndReplace = false;
     private Field _streamMsgOffsetFactory;
     public LinkedList<LongMsgOffset> _consumeOffsets = new LinkedList<>();
     public LinkedList<SegmentCompletionProtocol.Response> _responses = new LinkedList<>();
@@ -1023,7 +1033,7 @@ public class RealtimeSegmentDataManagerTest {
     @Override
     protected boolean buildSegmentAndReplace() {
       _buildAndReplaceCalled = true;
-      return true;
+      return !_failSegmentBuildAndReplace;
     }
 
     @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.data.manager.realtime.ConsumerCoordinator;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.core.data.manager.realtime.SegmentBuildFailureException;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -56,7 +57,8 @@ public class FailureInjectingRealtimeSegmentDataManager extends RealtimeSegmentD
     _failCommit = failCommit;
   }
 
-  protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
+  protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit)
+      throws SegmentBuildFailureException {
      if (_failCommit) {
        throw new RuntimeException("Forced failure in buildSegmentInternal");
      }


### PR DESCRIPTION
**Bug**:
Before this PR, `CONSUMING -> ONLINE` transition can be successful even if server fails to load the segment when it tries to build the local mutable segment (During catch up or already caught up scenarios). 
After the failure, The current state of the segment will be `ONLINE` but it should be `ERROR`.

**PR**:
This PR aims to fix above bug by throwing exception so that current state of the segment in the server can be marked as ERROR.