### PR TITLE
Dont apply Decorator to the table configs in Rest API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -485,7 +485,7 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
-    return getTableConfig(propertyStore, tableNameWithType, true);
+    return getTableConfig(propertyStore, tableNameWithType, true, true);
   }
 
   /**
@@ -497,9 +497,9 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
-      boolean replaceVariables) {
+      boolean replaceVariables, boolean applyDecorator) {
     return toTableConfig(propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), null,
-        AccessOption.PERSISTENT), replaceVariables);
+        AccessOption.PERSISTENT), replaceVariables, applyDecorator);
   }
 
   @Nullable
@@ -537,7 +537,7 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getOfflineTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
-    return getOfflineTableConfig(propertyStore, tableName, true);
+    return getOfflineTableConfig(propertyStore, tableName, true, true);
   }
 
   /**
@@ -549,8 +549,9 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getOfflineTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName,
-      boolean replaceVariables) {
-    return getTableConfig(propertyStore, TableNameBuilder.OFFLINE.tableNameWithType(tableName), replaceVariables);
+      boolean replaceVariables, boolean applyDecorator) {
+    return getTableConfig(propertyStore, TableNameBuilder.OFFLINE.tableNameWithType(tableName), replaceVariables,
+        applyDecorator);
   }
 
   /**
@@ -562,7 +563,7 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getRealtimeTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
-    return getRealtimeTableConfig(propertyStore, tableName, true);
+    return getRealtimeTableConfig(propertyStore, tableName, true, true);
   }
 
   /**
@@ -574,8 +575,9 @@ public class ZKMetadataProvider {
    */
   @Nullable
   public static TableConfig getRealtimeTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName,
-      boolean replaceVariables) {
-    return getTableConfig(propertyStore, TableNameBuilder.REALTIME.tableNameWithType(tableName), replaceVariables);
+      boolean replaceVariables, boolean applyDecorator) {
+    return getTableConfig(propertyStore, TableNameBuilder.REALTIME.tableNameWithType(tableName), replaceVariables,
+        applyDecorator);
   }
 
   public static List<TableConfig> getAllTableConfigs(ZkHelixPropertyStore<ZNRecord> propertyStore) {
@@ -603,11 +605,12 @@ public class ZKMetadataProvider {
 
   @Nullable
   private static TableConfig toTableConfig(@Nullable ZNRecord znRecord) {
-    return toTableConfig(znRecord, true);
+    return toTableConfig(znRecord, true, true);
   }
 
   @Nullable
-  private static TableConfig toTableConfig(@Nullable ZNRecord znRecord, boolean replaceVariables) {
+  private static TableConfig toTableConfig(@Nullable ZNRecord znRecord, boolean replaceVariables,
+      boolean applyDecorator) {
     if (znRecord == null) {
       return null;
     }
@@ -615,7 +618,7 @@ public class ZKMetadataProvider {
       TableConfig tableConfig = TableConfigUtils.fromZNRecord(znRecord);
       TableConfig processedTableConfig = replaceVariables
           ? ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(tableConfig) : tableConfig;
-      return TableConfigDecoratorRegistry.applyDecorator(processedTableConfig);
+      return applyDecorator ? TableConfigDecoratorRegistry.applyDecorator(processedTableConfig) : tableConfig;
     } catch (Exception e) {
       LOGGER.error("Caught exception while creating table config from ZNRecord: {}", znRecord.getId(), e);
       return null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -387,14 +387,14 @@ public class PinotTableRestletResource {
 
       if ((tableTypeStr == null || TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false);
+        TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false, false);
         Preconditions.checkNotNull(tableConfig);
         ret.set(TableType.OFFLINE.name(), tableConfig.toJsonNode());
       }
 
       if ((tableTypeStr == null || TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false);
+        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false, false);
         Preconditions.checkNotNull(tableConfig);
         ret.set(TableType.REALTIME.name(), tableConfig.toJsonNode());
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -166,8 +166,8 @@ public class TableConfigsRestletResource {
         throw new NotFoundException(
             String.format("Schema does not exist for table %s Use POST to create it first.", tableName));
       }
-      TableConfig offlineTableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false);
-      TableConfig realtimeTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false);
+      TableConfig offlineTableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false, false);
+      TableConfig realtimeTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false, false);
       TableConfigs config = new TableConfigs(tableName, schema, offlineTableConfig, realtimeTableConfig);
       return config.toJsonString();
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1865,7 +1865,7 @@ public class PinotHelixResourceManager {
     PinotHelixPropertyStoreZnRecordProvider pinotHelixPropertyStoreZnRecordProvider =
         PinotHelixPropertyStoreZnRecordProvider.forTable(_propertyStore);
     if (pinotHelixPropertyStoreZnRecordProvider.exist(TableNameBuilder.OFFLINE.tableNameWithType(tableName))
-    || pinotHelixPropertyStoreZnRecordProvider.exist(TableNameBuilder.REALTIME.tableNameWithType(tableName))) {
+        || pinotHelixPropertyStoreZnRecordProvider.exist(TableNameBuilder.REALTIME.tableNameWithType(tableName))) {
       throw new TableAlreadyExistsException("Table name: " + tableName + " already exists");
     }
 
@@ -3516,7 +3516,7 @@ public class PinotHelixResourceManager {
    */
   @Nullable
   public TableConfig getOfflineTableConfig(String tableName) {
-    return getOfflineTableConfig(tableName, true);
+    return getOfflineTableConfig(tableName, true, true);
   }
 
   /**
@@ -3524,11 +3524,12 @@ public class PinotHelixResourceManager {
    *
    * @param tableName Table name with or without type suffix
    * @param replaceVariables Whether to replace environment variables and system properties with their actual values
+   * @param applyDecorator Whether to apply decorator to the table config
    * @return Table config
    */
   @Nullable
-  public TableConfig getOfflineTableConfig(String tableName, boolean replaceVariables) {
-    return ZKMetadataProvider.getOfflineTableConfig(_propertyStore, tableName, replaceVariables);
+  public TableConfig getOfflineTableConfig(String tableName, boolean replaceVariables, boolean applyDecorator) {
+    return ZKMetadataProvider.getOfflineTableConfig(_propertyStore, tableName, replaceVariables, applyDecorator);
   }
 
   /**
@@ -3540,7 +3541,7 @@ public class PinotHelixResourceManager {
    */
   @Nullable
   public TableConfig getRealtimeTableConfig(String tableName) {
-    return getRealtimeTableConfig(tableName, true);
+    return getRealtimeTableConfig(tableName, true, true);
   }
 
   /**
@@ -3548,11 +3549,12 @@ public class PinotHelixResourceManager {
    *
    * @param tableName Table name with or without type suffix
    * @param replaceVariables Whether to replace environment variables and system properties with their actual values
+   * @param applyDecorator Whether to apply decorator to the table config
    * @return Table config
    */
   @Nullable
-  public TableConfig getRealtimeTableConfig(String tableName, boolean replaceVariables) {
-    return ZKMetadataProvider.getRealtimeTableConfig(_propertyStore, tableName, replaceVariables);
+  public TableConfig getRealtimeTableConfig(String tableName, boolean replaceVariables, boolean applyDecorator) {
+    return ZKMetadataProvider.getRealtimeTableConfig(_propertyStore, tableName, replaceVariables, applyDecorator);
   }
 
   /**


### PR DESCRIPTION
This PR introduces a flag to control the application of the TableConfig decorator

Currently, when retrieving `TableConfig` objects, the `TableConfigDecoratorRegistry.applyDecorator` method is always invoked by default. While applying decorators is often desired for runtime usage of the table config, there are scenarios, particularly in API endpoints that expose the raw stored configuration, where applying the decorator is unnecessary. 

This change introduces an optional boolean flag, `applyDecorator`, to relevant methods for fetching `TableConfig`. This allows callers to explicitly control whether or not the table config decorator should be applied.

**Changes**

1.  **`ZKMetadataProvider`:**
    * Overloaded existing `getTableConfig`, `getOfflineTableConfig`, and `getRealtimeTableConfig` methods to accept an additional `boolean applyDecorator` parameter.
    * Modified the internal `toTableConfig` helper method to use the value of the `applyDecorator` flag to conditionally call `TableConfigDecoratorRegistry.applyDecorator`.
    * Updated the original overloaded methods (without the `applyDecorator` parameter) to call the new overloaded versions with `applyDecorator` set to `true` for backward compatibility and to maintain the default behavior where decorators are applied.

2.  **`PinotHelixResourceManager`:**
    * Overloaded existing `getOfflineTableConfig` and `getRealtimeTableConfig` methods to accept an additional `boolean applyDecorator` parameter.
    * Updated these overloaded methods to pass the `applyDecorator` flag down to the corresponding `ZKMetadataProvider` calls.
    * Updated the original overloaded methods (without the `applyDecorator` parameter) to call the new overloaded versions with `applyDecorator` set to `true`.

3.  **REST API Endpoints:**
    * In `PinotTableRestletResource` and `TableConfigsRestletResource`, updated the API endpoints that fetch and return `TableConfig` objects to call the `PinotHelixResourceManager` methods with `applyDecorator` set to `false`. This ensures that these APIs return the raw, un-decorated table configuration as stored in ZK.

This change provides more fine-grained control over TableConfig retrieval and ensures that APIs exposing the raw configuration return the exact stored data.