### PR TITLE
Fix up rebalance batching partitionId calculation to account for COMPLETED segment partitioning differently as done in RealtimeSegmentAssignment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1813,13 +1813,13 @@ public class TableRebalancer {
             // rebalance without batching
             partitionId = 0;
           } else {
-            // This how partitionId is calculated for OFFLINE tables
+            // This is how partitionId is calculated for OFFLINE tables
             partitionId = SegmentAssignmentUtils.getOfflineSegmentPartitionId(segmentName, _tableNameWithType,
                 _helixManager, _partitionColumn);
           }
         } else {
           if (isConsuming || !_instancePartitionsMap.containsKey(InstancePartitionsType.COMPLETED)) {
-            // This how partitionId is calculated for CONSUMING segments and ONLINE segments without COMPLETED
+            // This is how partitionId is calculated for CONSUMING segments and ONLINE segments without COMPLETED
             // instance partitions in RealtimeSegmentAssignment
             partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
                 _helixManager, _partitionColumn);
@@ -1833,7 +1833,7 @@ public class TableRebalancer {
               // rebalance without batching
               partitionId = 0;
             } else {
-              // This how partitionId is calculated for REALTIME tables if a partition column exists and if the
+              // This is how partitionId is calculated for REALTIME tables if a partition column exists and if the
               // COMPLETED instance partitions has more than 1 partition
               partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
                   _helixManager, _partitionColumn);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1756,9 +1756,12 @@ public class TableRebalancer {
     for (Map.Entry<String, Map<String, String>> assignment : currentAssignment.entrySet()) {
       String segmentName = assignment.getKey();
       Map<String, String> instanceStateMap = assignment.getValue();
+      Collection<String> segmentStates = instanceStateMap.values();
 
+      boolean isConsuming = segmentStates.stream().noneMatch(state -> state.equals(SegmentStateModel.ONLINE))
+          && segmentStates.stream().anyMatch(state -> state.equals(SegmentStateModel.CONSUMING));
       int partitionId =
-          segmentPartitionIdMap.computeIfAbsent(segmentName, v -> partitionIdFetcher.fetch(segmentName));
+          segmentPartitionIdMap.computeIfAbsent(segmentName, v -> partitionIdFetcher.fetch(segmentName, isConsuming));
       Set<String> assignedInstances = instanceStateMap.keySet();
       partitionIdToAssignedInstancesToCurrentAssignmentMap.computeIfAbsent(partitionId, k -> new HashMap<>())
           .computeIfAbsent(assignedInstances, k -> new TreeMap<>()).put(segmentName, instanceStateMap);
@@ -1770,7 +1773,7 @@ public class TableRebalancer {
   @VisibleForTesting
   @FunctionalInterface
   interface PartitionIdFetcher {
-    int fetch(String segmentName);
+    int fetch(String segmentName, boolean isConsuming);
   }
 
   private static class PartitionIdFetcherImpl implements PartitionIdFetcher {
@@ -1791,7 +1794,7 @@ public class TableRebalancer {
     }
 
     @Override
-    public int fetch(String segmentName) {
+    public int fetch(String segmentName, boolean isConsuming) {
       Integer partitionId;
       if (_isStrictRealtimeSegmentAssignment) {
         // This is how partitionId is calculated for StrictRealtimeSegmentAssignment. Here partitionId is mandatory
@@ -1801,8 +1804,8 @@ public class TableRebalancer {
         Preconditions.checkState(partitionId != null, "Failed to find partition id for segment: %s of table: %s",
             segmentName, _tableNameWithType);
       } else {
-        boolean isOfflineTable = TableNameBuilder.getTableTypeFromTableName(_tableNameWithType) == TableType.OFFLINE;
-        if (isOfflineTable) {
+        TableType tableType = TableNameBuilder.getTableTypeFromTableName(_tableNameWithType);
+        if (tableType == TableType.OFFLINE) {
           InstancePartitions instancePartitions = _instancePartitionsMap.get(InstancePartitionsType.OFFLINE);
           assert instancePartitions != null;
           if (_partitionColumn == null || instancePartitions.getNumPartitions() == 1) {
@@ -1815,13 +1818,27 @@ public class TableRebalancer {
                 _helixManager, _partitionColumn);
           }
         } else {
-          // This how partitionId is calculated for CONSUMING segments in RealtimeSegmentAssignment
-          // TODO: Add handling for COMPLETED segments if in the future this is allowed for StrictReplicaGroup and
-          //       the partitionId calculation differs from the CONSUMING segments. For StrictRealtimeSegmentAssignment
-          //       the partitionId is mandated today. If this mandate is maintained then there may be no need to add
-          //       special handling for COMPLETED segments after all
-          partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
-              _helixManager, _partitionColumn);
+          if (isConsuming || !_instancePartitionsMap.containsKey(InstancePartitionsType.COMPLETED)) {
+            // This how partitionId is calculated for CONSUMING segments and ONLINE segments without COMPLETED
+            // instance partitions in RealtimeSegmentAssignment
+            partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
+                _helixManager, _partitionColumn);
+          } else {
+            // This is how partitionId is calculated for ONLINE segments when COMPLETED instance partitions exist
+            // in RealtimeSegmentAssignment
+            InstancePartitions instancePartitions = _instancePartitionsMap.get(InstancePartitionsType.COMPLETED);
+            assert instancePartitions != null;
+            if (_partitionColumn == null || instancePartitions.getNumPartitions() == 1) {
+              // Fallback to partitionId 0, in this case batching will not be possible so we will fall back to a full
+              // rebalance without batching
+              partitionId = 0;
+            } else {
+              // This how partitionId is calculated for REALTIME tables if a partition column exists and if the
+              // COMPLETED instance partitions has more than 1 partition
+              partitionId = SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType,
+                  _helixManager, _partitionColumn);
+            }
+          }
         }
       }
       return partitionId;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -44,8 +44,8 @@ import static org.testng.Assert.fail;
 
 public class TableRebalancerTest {
 
-  private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = segmentName -> 0;
-  private static final TableRebalancer.PartitionIdFetcher SIMPLE_PARTITION_FETCHER = segmentName -> {
+  private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = (segmentName, isConsuming) -> 0;
+  private static final TableRebalancer.PartitionIdFetcher SIMPLE_PARTITION_FETCHER = (segmentName, isConsuming) -> {
     LLCSegmentName name = LLCSegmentName.of(segmentName);
     return name == null ? -1 : name.getPartitionGroupId();
   };


### PR DESCRIPTION
The rebalance batching needs to fetch the partitionId of the segments for `strictReplicaGroup` instance selector enabled tables. The logic added today blindly uses the CONSUMING segment logic for REALTIME tables that are using the `RealtimeSegmentAssignment` class for segment assignment. For scenarios when a partitionId is not found from segmentName or segment ZK metadata, this allocates a default partitionId as `segmentName.hashCode() % 10000`.

For COMPLETED segments, the `RealtimeSegmentAssignment` actually used a different mechanism to assign a default partitionId if `partitionColumn == null` or `numPartitions = 1` for the COMPLETED instance partitions, which is to always allocate partitionId = 0. It falls back to the CONSUMING segment mechanism for other cases.

This PR exposes to the partition ID fetcher details about whether the segment is CONSUMING or not, and utilized the instance partitions map to identify if a COMPLETED instance partitions exists for this table or not and makes decisions on partitionId calculations based on that.

Testing done (using HybridQuickStart and with strictReplicaGroup instance selector enabled for all tests):

- REALTIME tables which don't use `StrictRealtimeSegmentAssignment` (which is most affected by changes in this PR)
    - Validated that if it doesn't use COMPLETED instance partitions, the correct code path is called for fetching the partitionId for both ONLINE and CONSUMING segments (i.e. based on segment name)
     - Validated that if it uses COMPLETED instance partitions such that numPartitions = 1, it lands up marking all the ONLINE segments as partitionId = 0 (as expected) and moves them as a whole. The CONSUMING segments continue to be processed with the correct partitionId (i.e. based on segment name)
     -  Validated that if it uses COMPLETED instance partitions such that numPartitions = 3, but partitionColumn = null, it lands up marking all the ONLINE segments as partitionId = 0 (as expected) and moves them as a whole. The CONSUMING segments continue to be processed with the correct partitionId (i.e. based on segment name)
    - Validated that if it uses COMPLETED instance partitions such that numPartitions = 3, but partitionColumn is set (i.e. non-null), it lands up calculating the partitionId similarly as CONSUMING segments for all the ONLINE segments based on the segment name (as expected). The same logic is still true of the CONSUMING segments (and both get the same partitionId).