### PR TITLE
Add memory allocation stats per query on server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -293,6 +293,22 @@ public class QueryLogger {
             .append(params._response.getRealtimeResponseSerializationCpuTimeNs());
       }
     },
+    OFFLINE_THREAD_MEM_ALLOCATED_BYTES("offlineThreadMemAllocatedBytes(total/thread/resSer)", ':') {
+      @Override
+      void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
+        builder.append(params._response.getOfflineTotalMemAllocatedBytes()).append('/')
+            .append(params._response.getOfflineThreadMemAllocatedBytes()).append('/')
+            .append(params._response.getOfflineResponseSerMemAllocatedBytes()).append('/');
+      }
+    },
+    REALTIME_THREAD_MEM_ALLOCATED_BYTES("realtimeThreadMemAllocatedBytes(total/thread/resSer)", ':') {
+      @Override
+      void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
+        builder.append(params._response.getRealtimeTotalMemAllocatedBytes()).append('/')
+            .append(params._response.getRealtimeThreadMemAllocatedBytes()).append('/')
+            .append(params._response.getRealtimeResponseSerMemAllocatedBytes()).append('/');
+      }
+    },
     CLIENT_IP("clientIp") {
       @Override
       void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -321,6 +321,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     statistics.setReduceTimeMillis(response.getBrokerReduceTimeMs());
     statistics.setOfflineThreadCpuTimeNs(response.getOfflineThreadCpuTimeNs());
     statistics.setRealtimeThreadCpuTimeNs(response.getRealtimeThreadCpuTimeNs());
+    statistics.setOfflineThreadMemAllocatedBytes(response.getOfflineThreadMemAllocatedBytes());
+    statistics.setRealtimeThreadMemAllocatedBytes(response.getRealtimeThreadMemAllocatedBytes());
+    statistics.setOfflineResponseSerMemAllocatedBytes(response.getOfflineResponseSerMemAllocatedBytes());
+    statistics.setRealtimeResponseSerMemAllocatedBytes(response.getRealtimeResponseSerMemAllocatedBytes());
+    statistics.setOfflineTotalMemAllocatedBytes(response.getOfflineTotalMemAllocatedBytes());
+    statistics.setRealtimeTotalMemAllocatedBytes(response.getRealtimeTotalMemAllocatedBytes());
     statistics.setOfflineSystemActivitiesCpuTimeNs(response.getOfflineSystemActivitiesCpuTimeNs());
     statistics.setRealtimeSystemActivitiesCpuTimeNs(response.getRealtimeSystemActivitiesCpuTimeNs());
     statistics.setOfflineResponseSerializationCpuTimeNs(response.getOfflineResponseSerializationCpuTimeNs());

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -142,11 +142,13 @@ public interface DataTable {
     OPERATOR_EXEC_START_TIME_MS(32, "operatorExecStartTimeMs", MetadataValueType.LONG),
     OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG),
     MAX_ROWS_IN_JOIN_REACHED(34, "maxRowsInJoinReached", MetadataValueType.STRING),
-    NUM_GROUPS_WARNING_LIMIT_REACHED(35, "numGroupsWarningLimitReached", MetadataValueType.STRING);
+    NUM_GROUPS_WARNING_LIMIT_REACHED(35, "numGroupsWarningLimitReached", MetadataValueType.STRING),
+    THREAD_MEM_ALLOCATED_BYTES(36, "threadMemAllocatedBytes", MetadataValueType.LONG),
+    RESPONSE_SER_MEM_ALLOCATED_BYTES(37, "responseSerMemAllocatedBytes", MetadataValueType.LONG);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!
-    private static final int MAX_ID = 35;
+    private static final int MAX_ID = 37;
 
     private static final MetadataKey[] ID_TO_ENUM_KEY_MAP = new MetadataKey[MAX_ID + 1];
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -421,10 +421,17 @@ public class DataTableImplV4 implements DataTable {
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
     writeLeadingSections(dataOutputStream);
 
-    // Add table serialization time metadata if thread timer is enabled.
+    // Add table serialization time and memory metadata if thread timer is enabled.
+    // TODO: The check on cpu time and memory measurement is not needed. We can remove it. But keeping it around for
+    // backward compatibility.
     if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
       long responseSerializationCpuTimeNs = threadTimer.getThreadTimeNs();
       getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(), String.valueOf(responseSerializationCpuTimeNs));
+    }
+    if (ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      long responseSerializationAllocatedBytes = threadTimer.getThreadAllocatedBytes();
+      getMetadata().put(MetadataKey.RESPONSE_SER_MEM_ALLOCATED_BYTES.getName(),
+          String.valueOf(responseSerializationAllocatedBytes));
     }
 
     // Write metadata: length followed by actual metadata bytes.

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -131,6 +131,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_PRUNED_BY_VALUE("numSegmentsPrunedByValue", false),
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
+  THREAD_MEM_ALLOCATED_BYTES("bytes", false),
+  RESPONSE_SER_MEM_ALLOCATED_BYTES("bytes", false),
+  TOTAL_MEM_ALLOCATED_BYTES("bytes", false),
   LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
 
   GRPC_MEMORY_REJECTIONS("rejections", true, "Number of grpc requests rejected due to memory pressure"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -334,6 +334,41 @@ public interface BrokerResponse {
   }
 
   /**
+   * Returns the thread memory bytes allocated for query execution against offline table.
+   */
+  long getOfflineThreadMemAllocatedBytes();
+
+  /**
+   * Returns the thread memory bytes allocated for query execution against realtime table.
+   */
+  long getRealtimeThreadMemAllocatedBytes();
+
+  /**
+   * Returns the memory bytes allocated  for response serialization against offline table.
+   */
+  long getOfflineResponseSerMemAllocatedBytes();
+
+  /**
+   * Returns the memory bytes allocated  for response serialization against realtime table.
+   */
+  long getRealtimeResponseSerMemAllocatedBytes();
+
+  /**
+   * Returns the total memory bytes allocated for query execution and response serialization against offline table.
+   */
+  default long getOfflineTotalMemAllocatedBytes() {
+    return getOfflineThreadMemAllocatedBytes() + getOfflineResponseSerMemAllocatedBytes();
+  }
+
+  /**
+   * Returns the total memory bytes allocated for query execution and response serialization against offline table.
+   */
+  default long getRealtimeTotalMemAllocatedBytes() {
+    return getRealtimeThreadMemAllocatedBytes() + getRealtimeResponseSerMemAllocatedBytes();
+  }
+
+
+  /**
    * Returns the total number of segments with an EmptyFilterOperator when Explain Plan is called.
    */
   long getExplainPlanNumEmptyFilterSegments();

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -53,7 +53,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "numSegmentsPrunedByValue", "brokerReduceTimeMs", "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs",
     "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
     "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs",
-    "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried"
+    "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried",
+    "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
+    "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes"
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BrokerResponseNative implements BrokerResponse {
@@ -100,6 +102,12 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _realtimeSystemActivitiesCpuTimeNs = 0L;
   private long _offlineResponseSerializationCpuTimeNs = 0L;
   private long _realtimeResponseSerializationCpuTimeNs = 0L;
+  private long _offlineThreadMemAllocatedBytes = 0L;
+  private long _realtimeThreadMemAllocatedBytes = 0L;
+  private long _offlineResponseSerMemAllocatedBytes = 0L;
+  private long _realtimeResponseSerMemAllocatedBytes = 0L;
+  private long _offlineTotalMemAllocatedBytes = 0L;
+  private long _realtimeTotalMemAllocatedBytes = 0L;
   private long _explainPlanNumEmptyFilterSegments = 0L;
   private long _explainPlanNumMatchAllFilterSegments = 0L;
   private Map<String, String> _traceInfo = new HashMap<>();
@@ -523,5 +531,38 @@ public class BrokerResponseNative implements BrokerResponse {
   @NotNull
   public Set<String> getTablesQueried() {
     return _tablesQueried;
+  }
+
+  @Override
+  public long getOfflineThreadMemAllocatedBytes() {
+    return _offlineThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public long getRealtimeThreadMemAllocatedBytes() {
+    return _realtimeThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public long getOfflineResponseSerMemAllocatedBytes() {
+    return _offlineResponseSerMemAllocatedBytes;
+  }
+
+  @Override
+  public long getRealtimeResponseSerMemAllocatedBytes() {
+    return _realtimeResponseSerMemAllocatedBytes;
+  }
+
+  public void setOfflineThreadMemAllocatedBytes(long offlineThreadMemAllocatedBytes) {
+    _offlineThreadMemAllocatedBytes = offlineThreadMemAllocatedBytes;
+  }
+  public void setRealtimeThreadMemAllocatedBytes(long realtimeThreadMemAllocatedBytes) {
+    _realtimeThreadMemAllocatedBytes = realtimeThreadMemAllocatedBytes;
+  }
+  public void setOfflineResponseSerMemAllocatedBytes(long offlineResponseSerMemAllocatedBytes) {
+    _offlineResponseSerMemAllocatedBytes = offlineResponseSerMemAllocatedBytes;
+  }
+  public void setRealtimeResponseSerMemAllocatedBytes(long realtimeResponseSerMemAllocatedBytes) {
+    _realtimeResponseSerMemAllocatedBytes = realtimeResponseSerMemAllocatedBytes;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -48,7 +48,9 @@ import org.apache.pinot.common.response.ProcessingException;
     "numSegmentsPrunedByValue", "brokerReduceTimeMs", "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs",
     "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
     "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs",
-    "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried"
+    "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried",
+    "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
+    "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes"
 })
 public class BrokerResponseNativeV2 implements BrokerResponse {
   private final StatMap<StatKey> _brokerStats = new StatMap<>(StatKey.class);
@@ -331,6 +333,26 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
 
   @Override
   public long getRealtimeThreadCpuTimeNs() {
+    return 0;
+  }
+
+  @Override
+  public long getOfflineThreadMemAllocatedBytes() {
+    return 0;
+  }
+
+  @Override
+  public long getRealtimeThreadMemAllocatedBytes() {
+    return 0;
+  }
+
+  @Override
+  public long getOfflineResponseSerMemAllocatedBytes() {
+    return 0;
+  }
+
+  @Override
+  public long getRealtimeResponseSerMemAllocatedBytes() {
     return 0;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -47,6 +47,7 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
   protected final QueryContext _queryContext;
 
   protected long _threadCpuTimeNs;
+  protected long _threadMemAllocatedBytes;
   protected long _systemActivitiesCpuTimeNs;
 
   public InstanceResponseOperator(BaseCombineOperator<?> combineOperator, List<SegmentContext> segmentContexts,
@@ -92,36 +93,40 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
   protected InstanceResponseBlock buildInstanceResponseBlock(BaseResultsBlock baseResultsBlock) {
     InstanceResponseBlock instanceResponseBlock = new InstanceResponseBlock(baseResultsBlock);
     instanceResponseBlock.addMetadata(MetadataKey.THREAD_CPU_TIME_NS.getName(), String.valueOf(_threadCpuTimeNs));
+    instanceResponseBlock.addMetadata(MetadataKey.THREAD_MEM_ALLOCATED_BYTES.getName(),
+        String.valueOf(_threadMemAllocatedBytes));
     instanceResponseBlock.addMetadata(MetadataKey.SYSTEM_ACTIVITIES_CPU_TIME_NS.getName(),
         String.valueOf(_systemActivitiesCpuTimeNs));
     return instanceResponseBlock;
   }
 
   protected BaseResultsBlock getBaseBlock() {
-    if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
-      long startWallClockTimeNs = System.nanoTime();
+    long startWallClockTimeNs = System.nanoTime();
+    ThreadResourceUsageProvider mainThreadResourceUsageProvider = new ThreadResourceUsageProvider();
 
-      ThreadResourceUsageProvider mainThreadResourceUsageProvider = new ThreadResourceUsageProvider();
-      BaseResultsBlock resultsBlock = getCombinedResults();
-      long mainThreadCpuTimeNs = mainThreadResourceUsageProvider.getThreadTimeNs();
+    BaseResultsBlock resultsBlock = getCombinedResults();
 
-      long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;
-      /*
-       * If/when the threadCpuTime based instrumentation is done for other parts of execution (planning, pruning etc),
-       * we will have to change the wallClockTime computation accordingly. Right now everything under
-       * InstanceResponseOperator is the one that is instrumented with threadCpuTime.
-       */
-      long multipleThreadCpuTimeNs = resultsBlock.getExecutionThreadCpuTimeNs();
-      int numServerThreads = resultsBlock.getNumServerThreads();
-      _systemActivitiesCpuTimeNs = calSystemActivitiesCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs,
-          mainThreadCpuTimeNs, numServerThreads);
-      _threadCpuTimeNs = mainThreadCpuTimeNs + multipleThreadCpuTimeNs;
+    // No-ops if CPU time measurement and/or memory allocation measurements are not enabled.
+    long mainThreadCpuTimeNs = mainThreadResourceUsageProvider.getThreadTimeNs();
+    long mainThreadMemAllocatedBytes = mainThreadResourceUsageProvider.getThreadAllocatedBytes();
 
-      return resultsBlock;
-    } else {
-      return getCombinedResults();
-    }
+    long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;
+
+    calculateResourceUsage(resultsBlock.getNumServerThreads(), resultsBlock.getExecutionThreadCpuTimeNs(),
+        mainThreadCpuTimeNs, resultsBlock.getExecutionThreadMemAllocatedBytes(), mainThreadMemAllocatedBytes, totalWallClockTimeNs);
+
+    return resultsBlock;
   }
+
+  private void calculateResourceUsage(int numServerThreads, long multipleThreadCpuTimeNs , long mainThreadCpuTimeNs,
+      long multipleThreadMemAllocatedBytes, long mainThreadMemAllocatedBytes, long totalWallClockTimeNs) {
+    _threadCpuTimeNs = mainThreadCpuTimeNs + multipleThreadCpuTimeNs;
+    _threadMemAllocatedBytes = mainThreadMemAllocatedBytes + multipleThreadMemAllocatedBytes;
+    _systemActivitiesCpuTimeNs = mainThreadCpuTimeNs == 0 ? 0
+        : calSystemActivitiesCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs, mainThreadCpuTimeNs,
+            numServerThreads);
+  }
+
 
   protected BaseResultsBlock getCombinedResults() {
     try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
@@ -47,6 +47,7 @@ public abstract class BaseResultsBlock implements Block {
   private int _numConsumingSegmentsProcessed;
   private int _numConsumingSegmentsMatched;
   private long _executionThreadCpuTimeNs;
+  private long _executionThreadMemAllocatedBytes;
   private int _numServerThreads;
 
   @Nullable
@@ -141,8 +142,17 @@ public abstract class BaseResultsBlock implements Block {
     return _executionThreadCpuTimeNs;
   }
 
+
   public void setExecutionThreadCpuTimeNs(long executionThreadCpuTimeNs) {
     _executionThreadCpuTimeNs = executionThreadCpuTimeNs;
+  }
+
+  public long getExecutionThreadMemAllocatedBytes() {
+    return _executionThreadMemAllocatedBytes;
+  }
+
+  public void setExecutionThreadMemAllocatedBytes(long executionThreadMemAllocatedBytes) {
+    _executionThreadMemAllocatedBytes = executionThreadMemAllocatedBytes;
   }
 
   public int getNumServerThreads() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -69,6 +69,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
   protected final AtomicReference<Throwable> _processingException = new AtomicReference<>();
 
   protected final AtomicLong _totalWorkerThreadCpuTimeNs = new AtomicLong(0);
+  protected final AtomicLong _totalWorkerThreadMemAllocatedBytes = new AtomicLong(0);
 
   protected BaseCombineOperator(ResultsBlockMerger<T> resultsBlockMerger, List<Operator> operators,
       QueryContext queryContext, ExecutorService executorService) {
@@ -136,6 +137,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
           }
 
           _totalWorkerThreadCpuTimeNs.getAndAdd(threadResourceUsageProvider.getThreadTimeNs());
+          _totalWorkerThreadMemAllocatedBytes.getAndAdd(threadResourceUsageProvider.getThreadAllocatedBytes());
         }
       });
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -80,7 +80,7 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
      */
     int numServerThreads = Math.min(_numTasks, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
     CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators, _totalWorkerThreadCpuTimeNs.get(),
-        numServerThreads);
+        numServerThreads, _totalWorkerThreadMemAllocatedBytes.get());
     return mergedBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -34,7 +34,7 @@ public class CombineOperatorUtils {
    * Sets the execution statistics into the results block.
    */
   public static void setExecutionStatistics(BaseResultsBlock resultsBlock, List<Operator> operators,
-      long threadCpuTimeNs, int numServerThreads) {
+      long threadCpuTimeNs, int numServerThreads, long threadMemAllocatedBytes) {
     int numSegmentsProcessed = operators.size();
     int numSegmentsMatched = 0;
     int numConsumingSegmentsProcessed = 0;
@@ -71,6 +71,7 @@ public class CombineOperatorUtils {
     resultsBlock.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
     resultsBlock.setNumTotalDocs(numTotalDocs);
     resultsBlock.setExecutionThreadCpuTimeNs(threadCpuTimeNs);
+    resultsBlock.setExecutionThreadMemAllocatedBytes(threadMemAllocatedBytes);
     resultsBlock.setNumServerThreads(numServerThreads);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
@@ -54,7 +54,7 @@ public class SelectionOnlyCombineOperator extends BaseSingleBlockCombineOperator
     // For LIMIT 0 query, only process one segment to get the data schema
     if (_numRowsToKeep == 0) {
       BaseResultsBlock resultsBlock = (BaseResultsBlock) _operators.get(0).nextBlock();
-      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators, 0, 1);
+      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators, 0, 1, 0);
       return resultsBlock;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -113,7 +113,7 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
     BaseResultsBlock finalBlock = new MetadataResultsBlock();
     int numServerThreads = Math.min(_numTasks, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
     CombineOperatorUtils.setExecutionStatistics(finalBlock, _operators, _totalWorkerThreadCpuTimeNs.get(),
-        numServerThreads);
+        numServerThreads, _totalWorkerThreadMemAllocatedBytes.get());
     return finalBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
+import org.apache.pinot.common.proto.Broker;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
@@ -58,6 +59,12 @@ public class ExecutionStatsAggregator {
   private long _realtimeResponseSerializationCpuTimeNs = 0L;
   private long _offlineTotalCpuTimeNs = 0L;
   private long _realtimeTotalCpuTimeNs = 0L;
+  private long _offlineThreadMemAllocatedBytes = 0L;
+  private long _realtimeThreadMemAllocatedBytes = 0L;
+  private long _offlineResponseSerMemAllocatedBytes = 0L;
+  private long _realtimeResponseSerMemAllocatedBytes = 0L;
+  private long _offlineTotalMemAllocatedBytes = 0L;
+  private long _realtimeTotalMemAllocatedBytes = 0L;
   private long _numSegmentsPrunedByServer = 0L;
   private long _numSegmentsPrunedInvalid = 0L;
   private long _numSegmentsPrunedByLimit = 0L;
@@ -173,6 +180,28 @@ public class ExecutionStatsAggregator {
     _realtimeTotalCpuTimeNs =
         _realtimeThreadCpuTimeNs + _realtimeSystemActivitiesCpuTimeNs + _realtimeResponseSerializationCpuTimeNs;
 
+    // Stats for memory allocated.
+    String threadMemAllocatedBytesStr = metadata.get(DataTable.MetadataKey.THREAD_MEM_ALLOCATED_BYTES.getName());
+    if (tableType != null && threadMemAllocatedBytesStr != null) {
+      if (tableType == TableType.OFFLINE) {
+        _offlineThreadMemAllocatedBytes += Long.parseLong(threadMemAllocatedBytesStr);
+      } else {
+        _realtimeThreadMemAllocatedBytes += Long.parseLong(threadMemAllocatedBytesStr);
+      }
+    }
+    String responseSerMemAlocatedBytesStr = metadata.get(DataTable.MetadataKey.RESPONSE_SER_MEM_ALLOCATED_BYTES.getName());
+    if (tableType != null && responseSerMemAlocatedBytesStr != null) {
+      if (tableType == TableType.OFFLINE) {
+        _offlineResponseSerMemAllocatedBytes += Long.parseLong(responseSerMemAlocatedBytesStr);
+      } else {
+         _realtimeResponseSerMemAllocatedBytes += Long.parseLong(responseSerMemAlocatedBytesStr);
+      }
+    }
+    _offlineTotalMemAllocatedBytes =
+        _offlineThreadMemAllocatedBytes + _offlineResponseSerMemAllocatedBytes;
+    _realtimeTotalMemAllocatedBytes =
+        _realtimeThreadMemAllocatedBytes + _realtimeResponseSerMemAllocatedBytes;
+
     withNotNullLongMetadata(metadata, DataTable.MetadataKey.NUM_SEGMENTS_PRUNED_BY_SERVER,
         l -> _numSegmentsPrunedByServer += l);
     withNotNullLongMetadata(metadata, DataTable.MetadataKey.NUM_SEGMENTS_PRUNED_INVALID,
@@ -231,6 +260,10 @@ public class ExecutionStatsAggregator {
     brokerResponseNative.setRealtimeSystemActivitiesCpuTimeNs(_realtimeSystemActivitiesCpuTimeNs);
     brokerResponseNative.setOfflineResponseSerializationCpuTimeNs(_offlineResponseSerializationCpuTimeNs);
     brokerResponseNative.setRealtimeResponseSerializationCpuTimeNs(_realtimeResponseSerializationCpuTimeNs);
+    brokerResponseNative.setOfflineThreadMemAllocatedBytes(_offlineThreadMemAllocatedBytes);
+    brokerResponseNative.setRealtimeThreadMemAllocatedBytes(_realtimeThreadMemAllocatedBytes);
+    brokerResponseNative.setOfflineResponseSerMemAllocatedBytes(_offlineResponseSerMemAllocatedBytes);
+    brokerResponseNative.setRealtimeResponseSerMemAllocatedBytes(_realtimeResponseSerMemAllocatedBytes);
     brokerResponseNative.setNumSegmentsPrunedByServer(_numSegmentsPrunedByServer);
     brokerResponseNative.setNumSegmentsPrunedInvalid(_numSegmentsPrunedInvalid);
     brokerResponseNative.setNumSegmentsPrunedByLimit(_numSegmentsPrunedByLimit);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -613,4 +613,24 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(brokerResponse.getOfflineThreadCpuTimeNs(), 0);
     assertEquals(brokerResponse.getRealtimeThreadCpuTimeNs(), 0);
   }
+
+  @Test
+  public void testThreadMemAllocatedBytes() {
+    String query = "SELECT * FROM testTable";
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    // NOTE: Need to check whether thread mem measurement is enabled because some environments might not support
+    //       ThreadMXBean.getThreadAllocatedBytes()
+    if (ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      assertTrue(brokerResponse.getOfflineThreadMemAllocatedBytes() > 0);
+      assertTrue(brokerResponse.getRealtimeThreadMemAllocatedBytes() > 0);
+    }
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(false);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getOfflineThreadMemAllocatedBytes(), 0);
+    assertEquals(brokerResponse.getRealtimeThreadMemAllocatedBytes(), 0);
+  }
+
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
@@ -224,6 +224,21 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testMemoryAllocationStats(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    notSupportedInV2();
+    JsonNode queryResponse = postQuery(COUNT_STAR_QUERY);
+    long offlineThreadMemAllocatedBytes = queryResponse.get("offlineThreadMemAllocatedBytes").asLong();
+    long offlineResponseSerMemAllocatedBytes = queryResponse.get("offlineResponseSerMemAllocatedBytes").asLong();
+    long offlineTotalMemAllocatedBytes = queryResponse.get("offlineTotalMemAllocatedBytes").asLong();
+
+    Assert.assertTrue(offlineThreadMemAllocatedBytes > 0);
+    Assert.assertTrue(offlineResponseSerMemAllocatedBytes > 0);
+    Assert.assertEquals(offlineTotalMemAllocatedBytes, offlineThreadMemAllocatedBytes + offlineResponseSerMemAllocatedBytes);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testSelectionOnlyOOM(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
@@ -54,6 +54,12 @@ public class DefaultRequestContext implements RequestScope {
   private long _realtimeResponseSerializationCpuTimeNs;
   private long _offlineTotalCpuTimeNs;
   private long _realtimeTotalCpuTimeNs;
+  private long _offlineThreadMemAllocatedBytes;
+  private long _realtimeThreadMemAllocatedBytes;
+  private long _offlineResponseSerMemAllocatedBytes;
+  private long _realtimeResponseSerMemAllocatedBytes;
+  private long _offlineTotalMemAllocatedBytes;
+  private long _realtimeTotalMemAllocatedBytes;
   private int _numServersQueried;
   private int _numServersResponded;
   private boolean _isNumGroupsLimitReached;
@@ -402,6 +408,66 @@ public class DefaultRequestContext implements RequestScope {
   @Override
   public void setRealtimeThreadCpuTimeNs(long realtimeThreadCpuTimeNs) {
     _realtimeThreadCpuTimeNs = realtimeThreadCpuTimeNs;
+  }
+
+  @Override
+  public long getOfflineThreadMemAllocatedBytes() {
+    return _offlineThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public void setOfflineThreadMemAllocatedBytes(long offlineThreadMemAllocatedBytes) {
+    _offlineThreadMemAllocatedBytes = offlineThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public long getRealtimeThreadMemAllocatedBytes() {
+    return _realtimeThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public void setRealtimeThreadMemAllocatedBytes(long realtimeThreadMemAllocatedBytes) {
+    _realtimeThreadMemAllocatedBytes = realtimeThreadMemAllocatedBytes;
+  }
+
+  @Override
+  public long getOfflineResponseSerMemAllocatedBytes() {
+    return _offlineResponseSerMemAllocatedBytes;
+  }
+
+  @Override
+  public void setOfflineResponseSerMemAllocatedBytes(long offlineResponseSerMemAllocatedBytes) {
+    _offlineResponseSerMemAllocatedBytes = offlineResponseSerMemAllocatedBytes;
+  }
+
+  @Override
+  public long getRealtimeResponseSerMemAllocatedBytes() {
+    return _realtimeResponseSerMemAllocatedBytes;
+  }
+
+  @Override
+  public void setRealtimeResponseSerMemAllocatedBytes(long realtimeResponseSerMemAllocatedBytes) {
+    _realtimeResponseSerMemAllocatedBytes = realtimeResponseSerMemAllocatedBytes;
+  }
+
+  @Override
+  public long getOfflineTotalMemAllocatedBytes() {
+    return _offlineTotalMemAllocatedBytes;
+  }
+
+  @Override
+  public void setOfflineTotalMemAllocatedBytes(long offlineTotalMemAllocatedBytes) {
+    _offlineTotalMemAllocatedBytes = offlineTotalMemAllocatedBytes;
+  }
+
+  @Override
+  public long getRealtimeTotalMemAllocatedBytes() {
+    return _realtimeTotalMemAllocatedBytes;
+  }
+
+  @Override
+  public void setRealtimeTotalMemAllocatedBytes(long realtimeTotalMemAllocatedBytes) {
+    _realtimeTotalMemAllocatedBytes = realtimeTotalMemAllocatedBytes;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -126,6 +126,24 @@ public interface RequestContext {
 
   long getRealtimeThreadCpuTimeNs();
 
+  long getOfflineThreadMemAllocatedBytes();
+  void setOfflineThreadMemAllocatedBytes(long offlineThreadMemAllocatedBytes);
+
+  long getRealtimeThreadMemAllocatedBytes();
+  void setRealtimeThreadMemAllocatedBytes(long realtimeThreadMemAllocatedBytes);
+
+  long getOfflineResponseSerMemAllocatedBytes();
+  void setOfflineResponseSerMemAllocatedBytes(long offlineResponseSerMemAllocatedBytes);
+
+  long getRealtimeResponseSerMemAllocatedBytes();
+  void setRealtimeResponseSerMemAllocatedBytes(long realtimeResponseSerMemAllocatedBytes);
+
+  long getOfflineTotalMemAllocatedBytes();
+  void setOfflineTotalMemAllocatedBytes(long offlineTotalMemAllocatedBytes);
+
+  long getRealtimeTotalMemAllocatedBytes();
+  void setRealtimeTotalMemAllocatedBytes(long realtimeTotalMemAllocatedBytes);
+
   boolean isNumGroupsLimitReached();
 
   int getNumExceptions();


### PR DESCRIPTION
This PR adds memoryAllocated stats per query (similar to threadCPUTime). 
 
At the leaf servers, this collects the total heap memory allocated for query execution (runner + worker threads) and response  serialization. 

This is collected only if Thread Memory Allocation is enabled. 
