### PR TITLE
include exception messages chain on broker response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -184,16 +184,17 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         LOGGER.warn("Request {} failed with exception", requestId, e);
       } else {
         // a _green_ error (see handleRequestThrowing javadoc)
-        LOGGER.info("Request {} failed with message {}", requestId, e.getMessage());
+        LOGGER.info("Request {} failed with messages {}", requestId, ExceptionUtils.consolidateExceptionMessages(e));
       }
-      BrokerResponseNative brokerResponseNative = new BrokerResponseNative(e.getErrorCode(), e.getMessage());
+      BrokerResponseNative brokerResponseNative = new BrokerResponseNative(
+          e.getErrorCode(), ExceptionUtils.consolidateExceptionMessages(e));
       onFailedRequest(brokerResponseNative.getExceptions());
       return brokerResponseNative;
     } catch (RuntimeException e) {
       // a _red_ error (see handleRequestThrowing javadoc)
       LOGGER.warn("Request {} failed in an uncontrolled manner", requestId, e);
-      String subStackTrace = ExceptionUtils.consolidateExceptionMessages(e);
-      BrokerResponseNative brokerResponseNative = new BrokerResponseNative(QueryErrorCode.UNKNOWN, subStackTrace);
+      BrokerResponseNative brokerResponseNative = new BrokerResponseNative(
+          QueryErrorCode.UNKNOWN, ExceptionUtils.consolidateExceptionMessages(e));
       onFailedRequest(brokerResponseNative.getExceptions());
       return brokerResponseNative;
     }
@@ -437,7 +438,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         throw e;
       } catch (Throwable t) {
         QueryErrorCode queryErrorCode = QueryErrorCode.QUERY_EXECUTION;
-        String consolidatedMessage = ExceptionUtils.consolidateExceptionMessages(t);
+        String consolidatedMessage = ExceptionUtils.consolidateExceptionTraces(t);
         LOGGER.error("Caught exception executing request {}: {}, {}", requestId, query, consolidatedMessage);
         requestContext.setErrorCode(queryErrorCode);
         return new BrokerResponseNative(queryErrorCode, consolidatedMessage);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.common.utils;
 
+import org.apache.commons.lang3.StringUtils;
+
+
 public class ExceptionUtils {
 
   private ExceptionUtils() {
   }
 
-  public static String consolidateExceptionMessages(Throwable e) {
+  public static String consolidateExceptionTraces(Throwable e) {
     StringBuilder sb = new StringBuilder();
     // No more than 10 causes
     int maxCauses = 10;
@@ -33,6 +36,21 @@ public class ExceptionUtils {
     }
     return sb.toString();
   }
+
+  public static String consolidateExceptionMessages(Throwable e) {
+    StringBuilder sb = new StringBuilder();
+    while (e != null) {
+      if (StringUtils.isNotBlank(e.getMessage())) {
+        if (sb.length() > 0) {
+          sb.append(". ");
+        }
+        sb.append(e.getMessage());
+      }
+      e = e.getCause();
+    }
+    return sb.toString();
+  }
+
 
   public static String getStackTrace(Throwable e) {
     return getStackTrace(e, Integer.MAX_VALUE);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
@@ -32,7 +32,9 @@ public class ExceptionUtils {
     int maxCauses = 10;
     while (e != null && maxCauses-- > 0) {
       sb.append(getStackTrace(e, 3));
-      if (e.getCause() == e) break;
+      if (e.getCause() == e) {
+        break;
+      }
       e = e.getCause();
     }
     return sb.toString();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
@@ -47,7 +47,9 @@ public class ExceptionUtils {
         }
         sb.append(e.getMessage());
       }
-      if (e.getCause() == e) break;
+      if (e.getCause() == e) {
+        break;
+      }
       e = e.getCause();
     }
     return sb.toString();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ExceptionUtils.java
@@ -32,6 +32,7 @@ public class ExceptionUtils {
     int maxCauses = 10;
     while (e != null && maxCauses-- > 0) {
       sb.append(getStackTrace(e, 3));
+      if (e.getCause() == e) break;
       e = e.getCause();
     }
     return sb.toString();
@@ -46,6 +47,7 @@ public class ExceptionUtils {
         }
         sb.append(e.getMessage());
       }
+      if (e.getCause() == e) break;
       e = e.getCause();
     }
     return sb.toString();


### PR DESCRIPTION
As part of the efforts to avoid redundancy and verbosity ([link](https://github.com/apache/pinot/pull/15533)) some error scenarios now return a too vague description of what happened as part of the Broker Response.

This PR addresses this and, for this scenarios, at least builds a concatenated string with the chain of messages for the raised exception.