### PR TITLE
Do not re-generate star-tree when index version changes

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationSpec.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationSpec.java
@@ -82,6 +82,15 @@ public class AggregationSpec {
     return _functionParameters;
   }
 
+  /// Returns `true` if the given [AggregationSpec] does not match the current one, in which case the star-tree index
+  /// needs to be updated, {@code false} otherwise.
+  /// - Update star-tree if the function parameters or compression codec changes.
+  /// - Do not update star-tree when index version or config changes to avoid rebuilding all the star-trees when the
+  /// default index setting changes. This is consistent with the behavior of forward indexes.
+  public boolean shouldModifyStarTree(AggregationSpec that) {
+    return _compressionCodec != that._compressionCodec || !_functionParameters.equals(that._functionParameters);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
Do not re-generate star-tree index when the index version changes. This is to prevent the overhead of re-generating all star-trees when the default setting changes. This also aligns with the behavior of forward index update.