### PR TITLE
Enhance MultiStageReplicaGroupSelector to Tolerate Partial Replica Failures Across Instance Partitions

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -20,6 +20,7 @@ package org.apache.pinot.broker.routing.instanceselector;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -99,57 +100,138 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
     } else {
       replicaGroupSelected = requestId % instancePartitions.getNumReplicaGroups();
     }
-    for (int iteration = 0; iteration < instancePartitions.getNumReplicaGroups(); iteration++) {
-      int replicaGroup = (replicaGroupSelected + iteration) % instancePartitions.getNumReplicaGroups();
-      try {
-        return tryAssigning(segments, segmentStates, instancePartitions, replicaGroup);
-      } catch (Exception e) {
-        LOGGER.warn("Unable to select replica-group {} for table: {}", replicaGroup, _tableNameWithType, e);
-      }
-    }
-    throw new RuntimeException(
-        String.format("Unable to find any replica-group to serve table: %s", _tableNameWithType));
+
+    return tryAssigning(Sets.newHashSet(segments), segmentStates, instancePartitions, replicaGroupSelected);
   }
 
   /**
-   * Returns a map from the segmentName to the corresponding server in the given replica-group. If the is not enabled,
-   * we throw an exception.
+   * Returns a map from the segmentName to the corresponding server. It tries to select all servers from the
+   * preferredReplicaGroup, but if it fails, it will try to select the relevant server from other instance partitions.
    */
-  private Pair<Map<String, String>, Map<String, String>> tryAssigning(List<String> segments,
-      SegmentStates segmentStates, InstancePartitions instancePartitions, int replicaId) {
-    Set<String> instanceLookUpSet = new HashSet<>();
-    for (int partition = 0; partition < instancePartitions.getNumPartitions(); partition++) {
-      List<String> instances = instancePartitions.getInstances(partition, replicaId);
-      instanceLookUpSet.addAll(instances);
-    }
-    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>();
-    Map<String, String> optionalSegmentToInstanceMap = new HashMap<>();
+  private Pair<Map<String, String>, Map<String, String>> tryAssigning(
+    Set<String> segments,
+    SegmentStates segmentStates,
+    InstancePartitions instancePartitions,
+    int preferredReplicaId) {
+
+    Map<String, Integer> instanceToPartitionMap = instancePartitions.getInstanceToPartitionIdMap();
+    Map<String, Set<String>> instanceToSegmentsMap = new HashMap<>();
+
+    // instanceToSegmentsMap stores the mapping from instance to the active segments it can serve.
     for (String segment : segments) {
+      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
+      Preconditions.checkState(candidates != null, "Failed to find servers for segment: %s", segment);
+      for (SegmentInstanceCandidate candidate : candidates) {
+        instanceToSegmentsMap
+          .computeIfAbsent(candidate.getInstance(), k -> new HashSet<>())
+          .add(segment);
+      }
+    }
+
+    // partitionToRequiredSegmentsMap stores the mapping from partition to the segments that need to be served. This
+    // is necessary to select appropriate replica group at the instance partition level.
+    Map<Integer, Set<String>> partitionToRequiredSegmentsMap = new HashMap<>();
+    for (Map.Entry<String, Set<String>> entry : instanceToSegmentsMap.entrySet()) {
+      Integer partitionId = instanceToPartitionMap.get(entry.getKey());
+      partitionToRequiredSegmentsMap
+        .computeIfAbsent(partitionId, k -> new HashSet<>())
+        .addAll(entry.getValue());
+    }
+
+    // Assign segments to instances based on the partitionToRequiredSegmentsMap. This ensures that we select the
+    // appropriate replica group for each set of segments belonging to the same instance partition.
+    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>();
+    int numPartitions = instancePartitions.getNumPartitions();
+    for (int partition = 0; partition < numPartitions; partition++) {
+      Set<String> requiredSegments = partitionToRequiredSegmentsMap.get(partition);
+      if (requiredSegments != null) {
+        segmentToSelectedInstanceMap.putAll(
+          getSelectedInstancesForPartition(instanceToSegmentsMap, requiredSegments, partition, preferredReplicaId));
+      }
+    }
+
+    return computeOptionalSegments(segmentToSelectedInstanceMap, segmentStates);
+  }
+
+  /**
+   * This method selects the instances for the given partition and segments. It iterates over the replica groups
+   * in a round-robin fashion, starting from the preferred replica group. It only selects the replica group if all
+   * the segments are available in the selected instances.
+   * If no replica group is found, it throws an exception.
+   */
+  private Map<String, String> getSelectedInstancesForPartition(
+    Map<String, Set<String>> instanceToSegmentsMap,
+    Set<String> requiredSegments,
+    int partitionId,
+    int preferredReplicaId) {
+
+    int numReplicaGroups = _instancePartitions.getNumReplicaGroups();
+
+    for (int i = 0; i < numReplicaGroups; i += 1) {
+      int selectedReplicaGroup = (i + preferredReplicaId) % numReplicaGroups;
+      List<String> selectedInstances = _instancePartitions.getInstances(partitionId, selectedReplicaGroup);
+
+      Set<String> segmentsFromSelectedInstances = new HashSet<>();
+      for (String instance : selectedInstances) {
+        Set<String> servedSegments = instanceToSegmentsMap.get(instance);
+        if (servedSegments != null) {
+          segmentsFromSelectedInstances.addAll(servedSegments);
+        }
+      }
+
+      if (segmentsFromSelectedInstances.containsAll(requiredSegments)) {
+        Map<String, String> segmentToInstance = new HashMap<>();
+        for (String segment : requiredSegments) {
+          for (String instance : selectedInstances) {
+            Set<String> servedSegments = instanceToSegmentsMap.get(instance);
+            if (servedSegments != null && servedSegments.contains(segment)) {
+              segmentToInstance.put(segment, instance);
+              break;
+            }
+          }
+        }
+        return segmentToInstance;
+      }
+    }
+
+    throw new RuntimeException(
+      String.format("Unable to find any replica-group to serve table: %s", _tableNameWithType));
+  }
+
+  /**
+   * Based on whether the selected instance for the segment is online to serve that segment or not,
+   * this method computes the segments that are optional and the segments that are not.
+   */
+  private Pair<Map<String, String>, Map<String, String>> computeOptionalSegments(
+    Map<String, String> segmentToSelectedInstanceMap,
+    SegmentStates segmentStates) {
+
+    Map<String, String> segmentsToInstanceMap = new HashMap<>();
+    Map<String, String> optionalSegmentToInstanceMap = new HashMap<>();
+
+    for (Map.Entry<String, String> entry : segmentToSelectedInstanceMap.entrySet()) {
+      String segment = entry.getKey();
+      String selectedInstance = entry.getValue();
+
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
       // If candidates are null, we will throw an exception and log a warning.
       Preconditions.checkState(candidates != null, "Failed to find servers for segment: %s", segment);
-      boolean found = false;
-      // candidates array is always sorted
+
       for (SegmentInstanceCandidate candidate : candidates) {
-        String instance = candidate.getInstance();
-        if (instanceLookUpSet.contains(instance)) {
-          found = true;
-          // This can only be offline when it is a new segment. And such segment is marked as optional segment so that
-          // broker or server can skip it upon any issue to process it.
+        if (selectedInstance.equals(candidate.getInstance())) {
           if (candidate.isOnline()) {
-            segmentToSelectedInstanceMap.put(segment, instance);
+            segmentsToInstanceMap.put(segment, selectedInstance);
           } else {
-            optionalSegmentToInstanceMap.put(segment, instance);
+            optionalSegmentToInstanceMap.put(segment, selectedInstance);
           }
           break;
         }
       }
-      if (!found) {
-        throw new RuntimeException(String.format("Unable to find an enabled instance for segment: %s", segment));
-      }
     }
-    return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
+
+    return Pair.of(segmentsToInstanceMap, optionalSegmentToInstanceMap);
   }
+
 
   @VisibleForTesting
   protected InstancePartitions getInstancePartitions() {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1094,6 +1094,112 @@ public class InstanceSelectorTest {
   }
 
   @Test
+  public void testMultiStageStrictReplicaGroupSelectorForSomeErrorSegments() {
+    String offlineTableName = "testTable_OFFLINE";
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+
+    // Create instance-partitions with two replica-groups and 2 partitions. Each replica-group has 2 instances.
+    Map<String, List<String>> partitionToInstances = ImmutableMap.of(
+      "0_0", ImmutableList.of("instance-0"),
+      "0_1", ImmutableList.of("instance-2"),
+      "1_0", ImmutableList.of("instance-1"),
+      "1_1", ImmutableList.of("instance-3"));
+    InstancePartitions instancePartitions = new InstancePartitions(offlineTableName);
+    instancePartitions.setInstances(0, 0, partitionToInstances.get("0_0"));
+    instancePartitions.setInstances(0, 1, partitionToInstances.get("0_1"));
+    instancePartitions.setInstances(1, 0, partitionToInstances.get("1_0"));
+    instancePartitions.setInstances(1, 1, partitionToInstances.get("1_1"));
+
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    Map<String, String> queryOptions = new HashMap<>();
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
+
+    MultiStageReplicaGroupSelector multiStageSelector =
+      new MultiStageReplicaGroupSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(),
+        false, 300);
+    multiStageSelector = spy(multiStageSelector);
+    doReturn(instancePartitions).when(multiStageSelector).getInstancePartitions();
+
+    List<String> enabledInstances = new ArrayList<>();
+    IdealState idealState = new IdealState(offlineTableName);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+
+    // Mark all instances as enabled
+    for (int i = 0; i < 4; i++) {
+      enabledInstances.add(String.format("instance-%d", i));
+    }
+
+    List<String> segments = getSegments();
+
+    // Create two idealState and externalView maps. One is used for segments with replica-group=0 and the other for rg=1
+    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+    Map<String, String> idealStateInstanceStateMap1 = new TreeMap<>();
+    Map<String, String> externalViewInstanceStateMap1 = new TreeMap<>();
+
+    // instance-0 and instance-2 mirror each other in the two replica-groups. Same for instance-1 and instance-3.
+    for (int i = 0; i < 4; i++) {
+      String instance = enabledInstances.get(i);
+      if (i % 2 == 0) {
+        idealStateInstanceStateMap0.put(instance, ONLINE);
+        externalViewInstanceStateMap0.put(instance, ONLINE);
+      } else {
+        idealStateInstanceStateMap1.put(instance, ONLINE);
+        externalViewInstanceStateMap1.put(instance, ONLINE);
+      }
+    }
+
+    // Even numbered segments get assigned to [instance-0, instance-2], and odd numbered segments get assigned to
+    // [instance-1,instance-3].
+    for (int segmentNum = 0; segmentNum < segments.size(); segmentNum++) {
+      String segment = segments.get(segmentNum);
+      if (segmentNum % 2 == 0) {
+        idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
+        externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
+      } else {
+        idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap1);
+        externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap1);
+      }
+      onlineSegments.add(segment);
+    }
+
+    // Set one segment in each replica group to ERROR state.
+    externalViewSegmentAssignment.get("segment1").put("instance-1", "ERROR");
+    externalViewSegmentAssignment.get("segment2").put("instance-2", "ERROR");
+
+    multiStageSelector.init(new HashSet<>(enabledInstances), idealState, externalView, onlineSegments);
+
+    // Even though instance-0 and instance-3 belong to different replica groups, they handle exclusive sets of segments
+    // and hence they can together serve all segments.
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    for (int segmentNum = 0; segmentNum < segments.size(); segmentNum++) {
+      if (segmentNum % 2 == 0) {
+        expectedReplicaGroupInstanceSelectorResult.put(segments.get(segmentNum), "instance-0");
+      } else {
+        expectedReplicaGroupInstanceSelectorResult.put(segments.get(segmentNum), "instance-3");
+      }
+    }
+    InstanceSelector.SelectionResult selectionResult = multiStageSelector.select(brokerRequest, segments, 0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+
+    // If instance-3 has an error segment as well, there is no replica group available to serve complete set of
+    // segments.
+    externalViewSegmentAssignment.get("segment3").put("instance-3", "ERROR");
+    multiStageSelector.init(new HashSet<>(enabledInstances), idealState, externalView, onlineSegments);
+    try {
+      multiStageSelector.select(brokerRequest, segments, 0);
+      fail("Method call above should have failed");
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
   public void testUnavailableSegments() {
     String offlineTableName = "testTable_OFFLINE";
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1160,11 +1160,11 @@ public class InstanceSelectorTest {
     for (int segmentNum = 0; segmentNum < segments.size(); segmentNum++) {
       String segment = segments.get(segmentNum);
       if (segmentNum % 2 == 0) {
-        idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
-        externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
+        idealStateSegmentAssignment.put(segment, new HashMap<>(idealStateInstanceStateMap0));
+        externalViewSegmentAssignment.put(segment, new HashMap<>(externalViewInstanceStateMap0));
       } else {
-        idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap1);
-        externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap1);
+        idealStateSegmentAssignment.put(segment, new HashMap<>(idealStateInstanceStateMap1));
+        externalViewSegmentAssignment.put(segment, new HashMap<>(externalViewInstanceStateMap1));
       }
       onlineSegments.add(segment);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -78,9 +80,9 @@ public class InstancePartitions {
     _instancePartitionsName = instancePartitionsName;
     _partitionToInstancesMap = partitionToInstancesMap;
     for (String key : partitionToInstancesMap.keySet()) {
-      int separatorIndex = key.indexOf(PARTITION_REPLICA_GROUP_SEPARATOR);
-      int partitionId = Integer.parseInt(key.substring(0, separatorIndex));
-      int replicaGroupId = Integer.parseInt(key.substring(separatorIndex + 1));
+      Pair<Integer, Integer> partitionIdAndReplicaGroupId = getPartitionIdAndReplicaGroupId(key);
+      int partitionId = partitionIdAndReplicaGroupId.getLeft();
+      int replicaGroupId = partitionIdAndReplicaGroupId.getRight();
       _numPartitions = Integer.max(_numPartitions, partitionId + 1);
       _numReplicaGroups = Integer.max(_numReplicaGroups, replicaGroupId + 1);
     }
@@ -109,6 +111,21 @@ public class InstancePartitions {
   public List<String> getInstances(int partitionId, int replicaGroupId) {
     return _partitionToInstancesMap
         .get(Integer.toString(partitionId) + PARTITION_REPLICA_GROUP_SEPARATOR + replicaGroupId);
+  }
+
+  public Map<String, Integer> getInstanceToPartitionIdMap() {
+    Map<String, Integer> instanceToPartitionIdMap = new HashMap<>();
+
+    for (Map.Entry<String, List<String>> entry : _partitionToInstancesMap.entrySet()) {
+      Pair<Integer, Integer> partitionIdAndReplicaGroupId = getPartitionIdAndReplicaGroupId(entry.getKey());
+      int partitionId = partitionIdAndReplicaGroupId.getLeft();
+
+      List<String> instances = entry.getValue();
+      for (String instance : instances) {
+        instanceToPartitionIdMap.put(instance, partitionId);
+      }
+    }
+    return instanceToPartitionIdMap;
   }
 
   public void setInstances(int partitionId, int replicaGroupId, List<String> instances) {
@@ -164,5 +181,12 @@ public class InstancePartitions {
   @Override
   public int hashCode() {
     return Objects.hash(_instancePartitionsName, _partitionToInstancesMap);
+  }
+
+  private Pair<Integer, Integer> getPartitionIdAndReplicaGroupId(String key) {
+    int separatorIndex = key.indexOf(PARTITION_REPLICA_GROUP_SEPARATOR);
+    int partitionId = Integer.parseInt(key.substring(0, separatorIndex));
+    int replicaGroupId = Integer.parseInt(key.substring(separatorIndex + 1));
+    return Pair.of(partitionId, replicaGroupId);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstancePartitions.java
@@ -113,13 +113,19 @@ public class InstancePartitions {
         .get(Integer.toString(partitionId) + PARTITION_REPLICA_GROUP_SEPARATOR + replicaGroupId);
   }
 
+  /**
+   * Generates a mapping from instance names to their corresponding partition IDs.
+   * This method iterates over the `_partitionToInstancesMap`, which maps partition-replica group keys
+   * (e.g., "0_0", "1_1") to lists of instances. For each entry, it extracts the partition ID from the key
+   * and associates each instance in the list with that partition ID in the resulting map.
+   *
+   * @return A mapping from instance names to the corresponding partition ID they belong to.
+   */
   public Map<String, Integer> getInstanceToPartitionIdMap() {
     Map<String, Integer> instanceToPartitionIdMap = new HashMap<>();
-
     for (Map.Entry<String, List<String>> entry : _partitionToInstancesMap.entrySet()) {
       Pair<Integer, Integer> partitionIdAndReplicaGroupId = getPartitionIdAndReplicaGroupId(entry.getKey());
       int partitionId = partitionIdAndReplicaGroupId.getLeft();
-
       List<String> instances = entry.getValue();
       for (String instance : instances) {
         instanceToPartitionIdMap.put(instance, partitionId);


### PR DESCRIPTION
This change enhances the robustness of MultiStageReplicaGroupSelector by enabling segment-to-instance assignment on a per-partition basis, rather than enforcing selection from a single replica group across all partitions. Fixed as part of https://github.com/apache/pinot/issues/15833.

### Previous Behavior:
The existing implementation attempted to assign all segments for a query from a single replica group. If any instance within that group was unable to serve one or more segments, due to segments being in an ERROR state or otherwise unavailable - the selector would attempt the next replica group. If no single replica group could fully satisfy the query, the request would fail.

This approach lacked resilience in scenarios involving partial unavailability within replica groups. Even when other replica groups could serve portions of the data, the selector would not utilize them unless they could serve the complete set of segments.

### Updated Behavior:
With this refactor, replica group selection is now performed independently for each instance partition. The selector attempts to assign segments for each partition from the preferred replica group, but if that group cannot fully serve the required segments, it falls back to alternate replica groups for that partition only.

The segment-to-instance assignment is therefore allowed to span multiple replica groups—one per partition-provided that each partition is internally consistent and all required segments can be served.

### Implementation Details:
- Introduced `InstancePartitions::getInstanceToPartitionIdMap()` to support partition resolution for instances.
- Refactored `tryAssigning` to build a mapping of instance partitions to the segments they require, and to perform replica group selection per instance partition.
- Added `getSelectedInstancesForPartition()` to encapsulate partition-level fallback logic.
- Extracted `computeOptionalSegments()` to separate the logic for handling segments that are served by instances in a non-online state.

### Testing
Verified in Quickstart by manually setting one segment in each replica group to ERROR state and validating that the query correctly executes.

Added a comprehensive test case verifying fallback behavior across replica groups when some segments are unavailable due to errors.