### PR TITLE
Enable Correct GROUP BY-Only Processing with accurateGroupByWithoutOrderBy

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -374,9 +374,9 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.IS_SECONDARY_WORKLOAD));
   }
 
-  public static boolean isEnableDeterministicGroupTrim(Map<String, String> queryOptions) {
+  public static boolean isEnableAccurateGroupTrim(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(
-        queryOptions.getOrDefault(QueryOptionKey.ENABLE_DETERMINISTIC_GROUP_TRIM, "false"));
+        queryOptions.getOrDefault(QueryOptionKey.ACCURATE_GROUP_BY_WITHOUT_ORDER_BY, "false"));
   }
 
   public static Boolean isUseMSEToFillEmptySchema(Map<String, String> queryOptions, boolean defaultValue) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -374,7 +374,7 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.IS_SECONDARY_WORKLOAD));
   }
 
-  public static boolean isEnableAccurateGroupTrim(Map<String, String> queryOptions) {
+  public static boolean isAccurateGroupByWithoutOrderByEnabled(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(
         queryOptions.getOrDefault(QueryOptionKey.ACCURATE_GROUP_BY_WITHOUT_ORDER_BY, "false"));
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -374,7 +374,7 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.IS_SECONDARY_WORKLOAD));
   }
 
-  public static boolean isAccurateGroupByWithoutOrderByEnabled(Map<String, String> queryOptions) {
+  public static boolean isAccurateGroupByWithoutOrderBy(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(
         queryOptions.getOrDefault(QueryOptionKey.ACCURATE_GROUP_BY_WITHOUT_ORDER_BY, "false"));
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -374,6 +374,11 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.IS_SECONDARY_WORKLOAD));
   }
 
+  public static boolean isEnableDeterministicGroupTrim(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(
+        queryOptions.getOrDefault(QueryOptionKey.ENABLE_DETERMINISTIC_GROUP_TRIM, "false"));
+  }
+
   public static Boolean isUseMSEToFillEmptySchema(Map<String, String> queryOptions, boolean defaultValue) {
     String useMSEToFillEmptySchema = queryOptions.get(QueryOptionKey.USE_MSE_TO_FILL_EMPTY_RESPONSE_SCHEMA);
     return useMSEToFillEmptySchema != null ? Boolean.parseBoolean(useMSEToFillEmptySchema) : defaultValue;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
@@ -43,9 +43,13 @@ public class DeterministicConcurrentIndexedTable extends IndexedTable {
   }
 
   protected void upsertWithoutOrderBy(Key key, Record record) {
-    addOrUpdateRecord(key, record);
-    if (_lookupMap.size() > _resultSize) {
-      ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry(); // evict largest key
+    ConcurrentSkipListMap<Key, Record> map = (ConcurrentSkipListMap<Key, Record>) _lookupMap;
+
+    if (map.size() < _resultSize) {
+      addOrUpdateRecord(key, record);
+    } else if (!map.isEmpty() && key.compareTo(map.lastKey()) < 0) {
+      addOrUpdateRecord(key, record);
+      map.pollLastEntry(); // evict the largest key after insertion
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
@@ -73,14 +73,9 @@ public class DeterministicConcurrentIndexedTable extends IndexedTable {
   }
 
   protected void upsertWithoutOrderBy(Key key, Record record) {
-    if (_noMoreNewRecords.get()) {
-      updateExistingRecord(key, record);
-    } else {
-      addOrUpdateRecord(key, record);
-      if (_lookupMap.size() > _resultSize) {
-        ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry();
-        _noMoreNewRecords.set(_lookupMap.size() >= _resultSize);
-      }
+    addOrUpdateRecord(key, record);
+    if (_lookupMap.size() > _resultSize) {
+      ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry(); // evict largest key
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.table;
 
 
+import java.util.Comparator;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +36,7 @@ public class DeterministicConcurrentIndexedTable extends IndexedTable {
       QueryContext queryContext, int resultSize,
       int trimSize, int trimThreshold, int initialCapacity, ExecutorService executorService) {
     super(dataSchema, hasFinalInput, queryContext, resultSize, trimSize, trimThreshold,
-        new ConcurrentSkipListMap<>(), executorService);
+        new ConcurrentSkipListMap<>(Comparator.comparing(Key::toString)), executorService);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+public class DeterministicConcurrentIndexedTable extends IndexedTable {
+  private final AtomicBoolean _noMoreNewRecords = new AtomicBoolean();
+  private final ReentrantReadWriteLock _readWriteLock = new ReentrantReadWriteLock();
+
+  public DeterministicConcurrentIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize,
+      int trimSize, int trimThreshold, int initialCapacity, ExecutorService executorService) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, trimSize, trimThreshold,
+        new ConcurrentSkipListMap<>(), executorService);
+  }
+
+  /**
+   * Thread safe implementation of upsert for inserting {@link Record} into {@link Table}
+   */
+  @Override
+  public boolean upsert(Key key, Record record) {
+    if (_hasOrderBy) {
+      upsertWithOrderBy(key, record);
+    } else {
+      upsertWithoutOrderBy(key, record);
+    }
+    return true;
+  }
+
+  protected void upsertWithOrderBy(Key key, Record record) {
+    _readWriteLock.readLock().lock();
+    try {
+      addOrUpdateRecord(key, record);
+    } finally {
+      _readWriteLock.readLock().unlock();
+    }
+
+    if (_lookupMap.size() >= _trimThreshold) {
+      _readWriteLock.writeLock().lock();
+      try {
+        if (_lookupMap.size() >= _trimThreshold) {
+          resize();
+        }
+      } finally {
+        _readWriteLock.writeLock().unlock();
+      }
+    }
+  }
+
+  protected void upsertWithoutOrderBy(Key key, Record record) {
+    if (_noMoreNewRecords.get()) {
+      updateExistingRecord(key, record);
+    } else {
+      addOrUpdateRecord(key, record);
+      if (_lookupMap.size() > _resultSize) {
+        ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry();
+        _noMoreNewRecords.set(_lookupMap.size() >= _resultSize);
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
  *
  * TODO: Consider replacing Key with Record as the concept is very close and the implementation is the same
  */
-public class Key {
+public class Key implements Comparable<Key> {
   private final Object[] _values;
 
   public Key(Object[] values) {
@@ -62,5 +62,15 @@ public class Key {
   @Override
   public String toString() {
     return Arrays.toString(_values);
+  }
+  @Override
+  public int compareTo(Key other) {
+    for (int i = 0; i < _values.length; i++) {
+      int cmp = ((Comparable<Object>) _values[i]).compareTo(other._values[i]);
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    return 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -66,7 +66,16 @@ public class Key implements Comparable<Key> {
   @Override
   public int compareTo(Key other) {
     for (int i = 0; i < _values.length; i++) {
-      int cmp = ((Comparable<Object>) _values[i]).compareTo(other._values[i]);
+      Object a = _values[i];
+      Object b = other._values[i];
+      if (a == null && b == null) {
+        continue;
+      } else if (a == null) {
+        return 1;   // null > non-null
+      } else if (b == null) {
+        return -1;  // non-null < null
+      }
+      int cmp = ((Comparable<Object>) a).compareTo(b);
       if (cmp != 0) {
         return cmp;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -63,6 +63,7 @@ public class Key implements Comparable<Key> {
   public String toString() {
     return Arrays.toString(_values);
   }
+
   @Override
   public int compareTo(Key other) {
     for (int i = 0; i < _values.length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -217,6 +217,9 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     // Set skipStarTree
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
 
+    queryContext.setEnableDeterministicGroupTrim(
+        QueryOptionsUtils.isEnableDeterministicGroupTrim(queryOptions));
+
     // Set skipScanFilterReorder
     queryContext.setSkipScanFilterReorder(QueryOptionsUtils.isSkipScanFilterReorder(queryOptions));
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -218,8 +218,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
 
     // Set accurateGroupByWithoutOrderBy
-    queryContext.setEnableAccurateGroupTrim(
-        QueryOptionsUtils.isEnableAccurateGroupTrim(queryOptions));
+    queryContext.setAccurateGroupByWithoutOrderByEnabled(
+        QueryOptionsUtils.isAccurateGroupByWithoutOrderByEnabled(queryOptions));
 
     // Set skipScanFilterReorder
     queryContext.setSkipScanFilterReorder(QueryOptionsUtils.isSkipScanFilterReorder(queryOptions));

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -217,8 +217,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     // Set skipStarTree
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
 
-    queryContext.setEnableDeterministicGroupTrim(
-        QueryOptionsUtils.isEnableDeterministicGroupTrim(queryOptions));
+    queryContext.setEnableAccurateGroupTrim(
+        QueryOptionsUtils.isEnableAccurateGroupTrim(queryOptions));
 
     // Set skipScanFilterReorder
     queryContext.setSkipScanFilterReorder(QueryOptionsUtils.isSkipScanFilterReorder(queryOptions));

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -218,8 +218,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
 
     // Set accurateGroupByWithoutOrderBy
-    queryContext.setAccurateGroupByWithoutOrderByEnabled(
-        QueryOptionsUtils.isAccurateGroupByWithoutOrderByEnabled(queryOptions));
+    queryContext.setAccurateGroupByWithoutOrderBy(
+        QueryOptionsUtils.isAccurateGroupByWithoutOrderBy(queryOptions));
 
     // Set skipScanFilterReorder
     queryContext.setSkipScanFilterReorder(QueryOptionsUtils.isSkipScanFilterReorder(queryOptions));

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -217,6 +217,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     // Set skipStarTree
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
 
+    // Set accurateGroupByWithoutOrderBy
     queryContext.setEnableAccurateGroupTrim(
         QueryOptionsUtils.isEnableAccurateGroupTrim(queryOptions));
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -138,7 +138,7 @@ public class QueryContext {
   private boolean _serverReturnFinalResult;
   // Whether server returns the final result with unpartitioned group key
   private boolean _serverReturnFinalResultKeyUnpartitioned;
-  private boolean _enableDeterministicGroupTrim;
+  private boolean _enableAccurateGroupTrim;
   // Collection of index types to skip per column
   private Map<String, Set<FieldConfig.IndexType>> _skipIndexes;
 
@@ -272,12 +272,12 @@ public class QueryContext {
     return _explain != ExplainMode.NONE;
   }
 
-  public boolean isEnableDeterministicGroupTrim() {
-    return _enableDeterministicGroupTrim;
+  public boolean isEnableAccurateGroupTrim() {
+    return _enableAccurateGroupTrim;
   }
 
-  public void setEnableDeterministicGroupTrim(boolean enable) {
-    _enableDeterministicGroupTrim = enable;
+  public void setEnableAccurateGroupTrim(boolean enable) {
+    _enableAccurateGroupTrim = enable;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -279,6 +279,17 @@ public class QueryContext {
   }
 
   /**
+   * Return true in-case deterministic result is expected
+   * @return
+   */
+  public boolean isEnableDeterministicGroupTrim() {
+    return Boolean.parseBoolean(_queryOptions.getOrDefault("enableDeterministicGroupTrim", "false"));
+  }
+
+
+
+
+  /**
    * Returns the aggregation functions for the query, or {@code null} if the query does not have any aggregation.
    */
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -138,6 +138,7 @@ public class QueryContext {
   private boolean _serverReturnFinalResult;
   // Whether server returns the final result with unpartitioned group key
   private boolean _serverReturnFinalResultKeyUnpartitioned;
+  private boolean _enableDeterministicGroupTrim;
   // Collection of index types to skip per column
   private Map<String, Set<FieldConfig.IndexType>> _skipIndexes;
 
@@ -271,19 +272,19 @@ public class QueryContext {
     return _explain != ExplainMode.NONE;
   }
 
+  public boolean isEnableDeterministicGroupTrim() {
+    return _enableDeterministicGroupTrim;
+  }
+
+  public void setEnableDeterministicGroupTrim(boolean enable) {
+    _enableDeterministicGroupTrim = enable;
+  }
+
   /**
    * Returns the explain mode of the query.
    */
   public ExplainMode getExplain() {
     return _explain;
-  }
-
-  /**
-   * Return true in-case deterministic result is expected
-   * @return
-   */
-  public boolean isEnableDeterministicGroupTrim() {
-    return Boolean.parseBoolean(_queryOptions.getOrDefault("enableDeterministicGroupTrim", "false"));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -286,9 +286,6 @@ public class QueryContext {
     return Boolean.parseBoolean(_queryOptions.getOrDefault("enableDeterministicGroupTrim", "false"));
   }
 
-
-
-
   /**
    * Returns the aggregation functions for the query, or {@code null} if the query does not have any aggregation.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -138,7 +138,7 @@ public class QueryContext {
   private boolean _serverReturnFinalResult;
   // Whether server returns the final result with unpartitioned group key
   private boolean _serverReturnFinalResultKeyUnpartitioned;
-  private boolean _enableAccurateGroupTrim;
+  private boolean _accurateGroupByWithoutOrderByEnabled;
   // Collection of index types to skip per column
   private Map<String, Set<FieldConfig.IndexType>> _skipIndexes;
 
@@ -272,12 +272,13 @@ public class QueryContext {
     return _explain != ExplainMode.NONE;
   }
 
-  public boolean isEnableAccurateGroupTrim() {
-    return _enableAccurateGroupTrim;
+
+  public boolean isAccurateGroupByWithoutOrderByEnabled() {
+    return _accurateGroupByWithoutOrderByEnabled;
   }
 
-  public void setEnableAccurateGroupTrim(boolean enable) {
-    _enableAccurateGroupTrim = enable;
+  public void setAccurateGroupByWithoutOrderByEnabled(boolean enable) {
+    _accurateGroupByWithoutOrderByEnabled = enable;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -138,7 +138,7 @@ public class QueryContext {
   private boolean _serverReturnFinalResult;
   // Whether server returns the final result with unpartitioned group key
   private boolean _serverReturnFinalResultKeyUnpartitioned;
-  private boolean _accurateGroupByWithoutOrderByEnabled;
+  private boolean _accurateGroupByWithoutOrderBy;
   // Collection of index types to skip per column
   private Map<String, Set<FieldConfig.IndexType>> _skipIndexes;
 
@@ -273,12 +273,12 @@ public class QueryContext {
   }
 
 
-  public boolean isAccurateGroupByWithoutOrderByEnabled() {
-    return _accurateGroupByWithoutOrderByEnabled;
+  public boolean isAccurateGroupByWithoutOrderBy() {
+    return _accurateGroupByWithoutOrderBy;
   }
 
-  public void setAccurateGroupByWithoutOrderByEnabled(boolean enable) {
-    _accurateGroupByWithoutOrderByEnabled = enable;
+  public void setAccurateGroupByWithoutOrderBy(boolean enable) {
+    _accurateGroupByWithoutOrderBy = enable;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
+import org.apache.pinot.core.data.table.DeterministicConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
 import org.apache.pinot.core.data.table.SimpleIndexedTable;
 import org.apache.pinot.core.data.table.UnboundedConcurrentIndexedTable;
@@ -185,6 +186,10 @@ public final class GroupByUtils {
 
   private static IndexedTable getTrimDisabledIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
       QueryContext queryContext, int resultSize, int initialCapacity, int numThreads, ExecutorService executorService) {
+    if (queryContext.isEnableDeterministicGroupTrim() && queryContext.getOrderByExpressions() == null) {
+      return new DeterministicConcurrentIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize,
+          Integer.MAX_VALUE, Integer.MAX_VALUE, initialCapacity, executorService);
+    }
     if (numThreads == 1) {
       return new SimpleIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize, Integer.MAX_VALUE,
           Integer.MAX_VALUE, initialCapacity, executorService);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -186,7 +186,8 @@ public final class GroupByUtils {
 
   private static IndexedTable getTrimDisabledIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
       QueryContext queryContext, int resultSize, int initialCapacity, int numThreads, ExecutorService executorService) {
-    if (queryContext.isEnableDeterministicGroupTrim() && queryContext.getOrderByExpressions() == null) {
+    if (queryContext.isEnableDeterministicGroupTrim() && queryContext.getOrderByExpressions() == null
+        && queryContext.getHavingFilter() == null) {
       return new DeterministicConcurrentIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize,
           Integer.MAX_VALUE, Integer.MAX_VALUE, initialCapacity, executorService);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -186,7 +186,7 @@ public final class GroupByUtils {
 
   private static IndexedTable getTrimDisabledIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
       QueryContext queryContext, int resultSize, int initialCapacity, int numThreads, ExecutorService executorService) {
-    if (queryContext.isAccurateGroupByWithoutOrderByEnabled() && queryContext.getOrderByExpressions() == null
+    if (queryContext.isAccurateGroupByWithoutOrderBy() && queryContext.getOrderByExpressions() == null
         && queryContext.getHavingFilter() == null) {
       return new DeterministicConcurrentIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize,
           Integer.MAX_VALUE, Integer.MAX_VALUE, initialCapacity, executorService);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -186,7 +186,7 @@ public final class GroupByUtils {
 
   private static IndexedTable getTrimDisabledIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
       QueryContext queryContext, int resultSize, int initialCapacity, int numThreads, ExecutorService executorService) {
-    if (queryContext.isEnableAccurateGroupTrim() && queryContext.getOrderByExpressions() == null
+    if (queryContext.isAccurateGroupByWithoutOrderByEnabled() && queryContext.getOrderByExpressions() == null
         && queryContext.getHavingFilter() == null) {
       return new DeterministicConcurrentIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize,
           Integer.MAX_VALUE, Integer.MAX_VALUE, initialCapacity, executorService);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -186,7 +186,7 @@ public final class GroupByUtils {
 
   private static IndexedTable getTrimDisabledIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
       QueryContext queryContext, int resultSize, int initialCapacity, int numThreads, ExecutorService executorService) {
-    if (queryContext.isEnableDeterministicGroupTrim() && queryContext.getOrderByExpressions() == null
+    if (queryContext.isEnableAccurateGroupTrim() && queryContext.getOrderByExpressions() == null
         && queryContext.getHavingFilter() == null) {
       return new DeterministicConcurrentIndexedTable(dataSchema, hasFinalInput, queryContext, resultSize,
           Integer.MAX_VALUE, Integer.MAX_VALUE, initialCapacity, executorService);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/DeterministicIndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/DeterministicIndexedTableTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DeterministicIndexedTableTest {
+
+  @Test
+  public void testLexicographicEviction() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 LIMIT 3 OPTION(enableDeterministicGroupTrim=true)");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    DeterministicConcurrentIndexedTable table = new DeterministicConcurrentIndexedTable(
+        dataSchema, false, queryContext, 3, Integer.MAX_VALUE, Integer.MAX_VALUE, 16, executor);
+
+    // Insert out-of-order keys
+    upsert(table, new Object[]{"zebra", 1L});
+    upsert(table, new Object[]{"apple", 1L});
+    upsert(table, new Object[]{"banana", 1L});
+    upsert(table, new Object[]{"cherry", 1L});
+    upsert(table, new Object[]{"yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[] expected = {"apple", "banana", "cherry"};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+  private void upsert(DeterministicConcurrentIndexedTable table, Object[] row) {
+    Object[] key = new Object[]{row[0]};
+    table.upsert(new Key(key), new Record(row));
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDeterministicIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDeterministicIndexedTable.java
@@ -215,8 +215,8 @@ public class BenchmarkDeterministicIndexedTable {
 
       // make 10 indexed tables
       IndexedTable deterministicIndexedTable =
-          new DeterministicConcurrentIndexedTable(_dataSchema, false, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD,
-              TRIM_THRESHOLD, _executorService);
+          new DeterministicConcurrentIndexedTable(_dataSchema, false,
+              _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD, TRIM_THRESHOLD, _executorService);
       deterministicIndexedTables.add(deterministicIndexedTable);
 
       // put 10k records in each indexed table, in parallel
@@ -250,10 +250,10 @@ public class BenchmarkDeterministicIndexedTable {
   public static void main(String[] args)
       throws Exception {
     ChainedOptionsBuilder opt =
-        new OptionsBuilder().include(BenchmarkDeterministicIndexedTable.class.getSimpleName()).warmupTime(TimeValue.seconds(10))
+        new OptionsBuilder().include(BenchmarkDeterministicIndexedTable.class.getSimpleName())
+            .warmupTime(TimeValue.seconds(10))
             .warmupIterations(1).measurementTime(TimeValue.seconds(30)).measurementIterations(3).forks(1);
 
     new Runner(opt.build()).run();
   }
 }
-

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDeterministicIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDeterministicIndexedTable.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
+import org.apache.pinot.core.data.table.DeterministicConcurrentIndexedTable;
+import org.apache.pinot.core.data.table.IndexedTable;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.data.table.SimpleIndexedTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.util.trace.TraceRunnable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkDeterministicIndexedTable {
+  private static final int TRIM_SIZE = 800;
+  private static final int TRIM_THRESHOLD = TRIM_SIZE * 4;
+  private static final int NUM_RECORDS = 1000;
+  private static final Random RANDOM = new Random();
+
+  private QueryContext _queryContext;
+  private DataSchema _dataSchema;
+
+  private List<String> _d1;
+  private List<Integer> _d2;
+
+  private ExecutorService _executorService;
+
+  @Setup
+  public void setup() {
+    // create data
+    int cardinalityD1 = 100;
+    Set<String> d1 = new HashSet<>(cardinalityD1);
+    while (d1.size() < cardinalityD1) {
+      d1.add(RandomStringUtils.randomAlphabetic(3));
+    }
+    _d1 = new ArrayList<>(cardinalityD1);
+    _d1.addAll(d1);
+
+    int cardinalityD2 = 100;
+    _d2 = new ArrayList<>(cardinalityD2);
+    for (int i = 0; i < cardinalityD2; i++) {
+      _d2.add(i);
+    }
+
+    _queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 LIMIT 500");
+    _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"}, new DataSchema.ColumnDataType[]{
+        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE,
+        DataSchema.ColumnDataType.DOUBLE
+    });
+
+    _executorService = Executors.newFixedThreadPool(10);
+  }
+
+  @TearDown
+  public void destroy() {
+    _executorService.shutdown();
+  }
+
+  private Record getNewRecord() {
+    Object[] columns = new Object[]{
+        _d1.get(RANDOM.nextInt(_d1.size())), _d2.get(RANDOM.nextInt(_d2.size())), (double) RANDOM.nextInt(1000),
+        (double) RANDOM.nextInt(1000)
+    };
+    return new Record(columns);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void concurrentIndexedTable()
+      throws InterruptedException {
+    int numSegments = 10;
+
+    // make 1 concurrent table
+    IndexedTable concurrentIndexedTable =
+        new ConcurrentIndexedTable(_dataSchema, false, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD,
+            TRIM_THRESHOLD, _executorService);
+
+    // 10 parallel threads putting 10k records into the table
+
+    CountDownLatch operatorLatch = new CountDownLatch(numSegments);
+    Future[] futures = new Future[numSegments];
+    for (int i = 0; i < numSegments; i++) {
+      futures[i] = _executorService.submit(new TraceRunnable() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public void runJob() {
+          for (int r = 0; r < NUM_RECORDS; r++) {
+            concurrentIndexedTable.upsert(getNewRecord());
+          }
+          operatorLatch.countDown();
+        }
+      });
+    }
+
+    try {
+      boolean opCompleted = operatorLatch.await(30, TimeUnit.SECONDS);
+      if (!opCompleted) {
+        System.out.println("Timed out............");
+      }
+      concurrentIndexedTable.finish(false);
+    } finally {
+      // Cancel all ongoing jobs
+      for (Future future : futures) {
+        if (!future.isDone()) {
+          future.cancel(true);
+        }
+      }
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void simpleIndexedTable()
+      throws InterruptedException, TimeoutException, ExecutionException {
+    int numSegments = 10;
+
+    List<IndexedTable> simpleIndexedTables = new ArrayList<>(numSegments);
+    List<Callable<Void>> innerSegmentCallables = new ArrayList<>(numSegments);
+
+    for (int i = 0; i < numSegments; i++) {
+
+      // make 10 indexed tables
+      IndexedTable simpleIndexedTable =
+          new SimpleIndexedTable(_dataSchema, false, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD,
+              TRIM_THRESHOLD, _executorService);
+      simpleIndexedTables.add(simpleIndexedTable);
+
+      // put 10k records in each indexed table, in parallel
+      Callable<Void> callable = () -> {
+        for (int r = 0; r < NUM_RECORDS; r++) {
+          simpleIndexedTable.upsert(getNewRecord());
+        }
+        simpleIndexedTable.finish(false);
+        return null;
+      };
+      innerSegmentCallables.add(callable);
+    }
+
+    List<Future<Void>> futures = _executorService.invokeAll(innerSegmentCallables);
+    for (Future<Void> future : futures) {
+      future.get(10, TimeUnit.SECONDS);
+    }
+
+    // merge all indexed tables into 1
+    IndexedTable mergedTable = null;
+    for (IndexedTable indexedTable : simpleIndexedTables) {
+      if (mergedTable == null) {
+        mergedTable = indexedTable;
+      } else {
+        mergedTable.merge(indexedTable);
+      }
+    }
+    mergedTable.finish(false);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void deterministicIndexedTable()
+      throws InterruptedException, TimeoutException, ExecutionException {
+    int numSegments = 10;
+
+    List<IndexedTable> deterministicIndexedTables = new ArrayList<>(numSegments);
+    List<Callable<Void>> innerSegmentCallables = new ArrayList<>(numSegments);
+
+    for (int i = 0; i < numSegments; i++) {
+
+      // make 10 indexed tables
+      IndexedTable deterministicIndexedTable =
+          new DeterministicConcurrentIndexedTable(_dataSchema, false, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD,
+              TRIM_THRESHOLD, _executorService);
+      deterministicIndexedTables.add(deterministicIndexedTable);
+
+      // put 10k records in each indexed table, in parallel
+      Callable<Void> callable = () -> {
+        for (int r = 0; r < NUM_RECORDS; r++) {
+          deterministicIndexedTable.upsert(getNewRecord());
+        }
+        deterministicIndexedTable.finish(false);
+        return null;
+      };
+      innerSegmentCallables.add(callable);
+    }
+
+    List<Future<Void>> futures = _executorService.invokeAll(innerSegmentCallables);
+    for (Future<Void> future : futures) {
+      future.get(10, TimeUnit.SECONDS);
+    }
+
+    // merge all indexed tables into 1
+    IndexedTable mergedTable = null;
+    for (IndexedTable indexedTable : deterministicIndexedTables) {
+      if (mergedTable == null) {
+        mergedTable = indexedTable;
+      } else {
+        mergedTable.merge(indexedTable);
+      }
+    }
+    mergedTable.finish(false);
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt =
+        new OptionsBuilder().include(BenchmarkDeterministicIndexedTable.class.getSimpleName()).warmupTime(TimeValue.seconds(10))
+            .warmupIterations(1).measurementTime(TimeValue.seconds(30)).measurementIterations(3).forks(1);
+
+    new Runner(opt.build()).run();
+  }
+}
+

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -499,10 +499,10 @@ public class CommonConstants {
         public static final String MSE_MIN_GROUP_TRIM_SIZE = "mseMinGroupTrimSize";
 
         /**
-         * This will help in getting deterministic and correct result for queries
+         * This will help in getting accurate and correct result for queries
          * with group by and limit but  without order by
          */
-        public static final String ENABLE_DETERMINISTIC_GROUP_TRIM = "enableDeterministicGroupTrim";
+        public static final String ACCURATE_GROUP_BY_WITHOUT_ORDER_BY = "accurateGroupByWithoutOrderBy";
 
         /** Number of threads used in the final reduce.
          * This is useful for expensive aggregation functions. E.g. Funnel queries are considered as expensive

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -499,7 +499,8 @@ public class CommonConstants {
         public static final String MSE_MIN_GROUP_TRIM_SIZE = "mseMinGroupTrimSize";
 
         /**
-         * This will help in getting deterministic and correct result for queries with group by and limit but  without order by
+         * This will help in getting deterministic and correct result for queries
+         * with group by and limit but  without order by
          */
         public static final String ENABLE_DETERMINISTIC_GROUP_TRIM = "enableDeterministicGroupTrim";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -498,6 +498,11 @@ public class CommonConstants {
         public static final String MIN_BROKER_GROUP_TRIM_SIZE = "minBrokerGroupTrimSize";
         public static final String MSE_MIN_GROUP_TRIM_SIZE = "mseMinGroupTrimSize";
 
+        /**
+         * This will help in getting deterministic and correct result for queries with group by and limit but  without order by
+         */
+        public static final String ENABLE_DETERMINISTIC_GROUP_TRIM = "enableDeterministicGroupTrim";
+
         /** Number of threads used in the final reduce.
          * This is useful for expensive aggregation functions. E.g. Funnel queries are considered as expensive
          * aggregation functions. */


### PR DESCRIPTION
https://docs.google.com/document/d/1M5OLUkW0eqn6ZnRYH1gg7lh7VrrJyu43gubix8xHm-s/edit?tab=t.0#heading=h.hf2hyt32vsis

https://github.com/apache/pinot/issues/11706


Group-by without ordering on aggregate 


Problem statement : 


In distributed group-by queries that apply a LIMIT without an accompanying ORDER BY clause, each server arbitrarily selects a subset of groups, which can lead to non-deterministic behavior and incorrect final aggregations when the total number of groups exceeds the limit; this randomness in group selection may omit important groups from the final result and compromise query accuracy, thereby necessitating a deterministic mechanism that ensures all non-ordering group keys are uniformly considered across all servers to guarantee the correctness and consistency of the aggregated output.






For instance, consider the query:

SELECT COUNT(*) FROM myTable GROUP BY someColumn LIMIT 3;

Imagine the data has five distinct groups: A, B, C, D, and E. Now, suppose the dataset is distributed across two servers:
Server 1 sees groups A, B, C, D and randomly selects groups A, B, and C (because of the limit of 3).
Server 2 sees groups B, C, D, E and randomly selects groups B, D, and E.
When merging these results, the inconsistent group selection (Server 1 providing A, B, C and Server 2 providing B, D, E) can lead to a final aggregated result that may omit group keys like C or include duplicates and inconsistent counts. This non-deterministic behavior means the final merge does not reliably represent the true aggregation across the entire dataset.



In another example, consider:
SELECT COUNT(*) FROM Transactions GROUP BY transactionType LIMIT 2;




Let’s assume there are three transaction types: Sale, Refund, and Chargeback. Different servers might partition the data unevenly:


Server A might select {Sale, Refund}
Server B might select {Refund, Chargeback}




Thus, the final aggregation might inadvertently skew results by either missing a transaction type or incorrectly combining partial aggregates. This shows how, without a deterministic mechanism (like implicitly appending all non-ordering group keys), the arbitrary selection of groups on each server can lead to unpredictable and incorrect outcomes.
By ensuring that every server considers all non-ordering group keys—even if only a subset is returned initially—we guarantee that the merged result across servers is both consistent and correct.






**Approach** : 




The intuitive solution is to maintain a priority queue for each server with the key as a group-key [like - Sale value on which the group is happening ] This will make sure that the selection is deterministic and complete. 


The existing solution to aggregate the data from different segments is built on top of HashMaps - IndexedTable. IndexedTable is Base implementation of Map-based Table for indexed lookup.
This takes care of the segment resizing and pruning. As this uses ConcurrentHashMap the keys are not sorted which causes the non-deterministic behavior in the result. Hence the intuitive solution is to bring in a Map which is sorted by Key - so that sort by key with limit will provide correct deterministic behavior.


Hence TreeMap is the first data-structure that comes to mind to fix this problem, having said that TreeMap is not thread safe. ConcurrentSkipListMap - ConcurrentSkipListMap is a thread-safe, sorted map based on a skip list data structure, maintaining keys in their natural or comparator-defined order.It supports efficient concurrent access and logarithmic time complexity for most operations like get, put, and remove.


The tradeoff with this data structure compared to ConcurrentHashMap - Is Time and Space vs Consistency (Deterministic and correctness). The time complexity for all the operations (add , get and remove is O(logN)) in ConcurrentSkipListMap. Hence its better to support the correctness using Options in query accurateGroupByWithoutOrderBy :
 
SELECT COUNT(*) FROM testTable GROUP BY d1 LIMIT 3 OPTION(accurateGroupByWithoutOrderBy=true).






Hence in the PR - I have introduced DeterministicConcurrentIndexedTable -  It will be not be injected in normal flow of group by queries but specifically for cases where user provides the option accurateGroupByWithoutOrderBy  and group by is with limit and without orderby and having filter. 



Benchmark                                                     Mode  Cnt      Score      Error  Units
BenchmarkDeterministicIndexedTable.concurrentIndexedTable     avgt    3  10394.142 ± 3703.863  us/op
BenchmarkDeterministicIndexedTable.deterministicIndexedTable  avgt    3  12908.535 ± 5678.687  us/op
BenchmarkDeterministicIndexedTable.simpleIndexedTable         avgt    3   8966.736 ± 1420.956  us/op


