### PR TITLE
Modify primitive lookup tables to accept null values

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -73,8 +73,7 @@ public class HashJoinOperator extends BaseJoinOperator {
     if (joinKeys.size() > 1) {
       return new ObjectLookupTable();
     }
-    DataSchema.ColumnDataType columnDataType = schema.getColumnDataType(joinKeys.get(0));
-    switch (columnDataType.getStoredType()) {
+    switch (schema.getColumnDataType(joinKeys.get(0)).getStoredType()) {
       case INT:
         return new IntLookupTable();
       case LONG:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -260,15 +260,15 @@ public class HashJoinOperator extends BaseJoinOperator {
   protected List<Object[]> buildNonMatchRightRows() {
     List<Object[]> rows = new ArrayList<>();
     if (_rightTable.isKeysUnique()) {
-      for (Map.Entry<Object, Object[]> entry : _rightTable.entrySet()) {
-        Object[] rightRow = entry.getValue();
+      for (Map.Entry<Object, Object> entry : _rightTable.entrySet()) {
+        Object[] rightRow = (Object[]) entry.getValue();
         if (!_matchedRightRows.containsKey(entry.getKey())) {
           rows.add(joinRow(null, rightRow));
         }
       }
     } else {
-      for (Map.Entry<Object, ArrayList<Object[]>> entry : _rightTable.entrySet()) {
-        List<Object[]> rightRows = entry.getValue();
+      for (Map.Entry<Object, Object> entry : _rightTable.entrySet()) {
+        List<Object[]> rightRows = ((List<Object[]>) entry.getValue());
         BitSet matchedIndices = _matchedRightRows.get(entry.getKey());
         if (matchedIndices == null) {
           for (Object[] rightRow : rightRows) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -73,7 +73,8 @@ public class HashJoinOperator extends BaseJoinOperator {
     if (joinKeys.size() > 1) {
       return new ObjectLookupTable();
     }
-    switch (schema.getColumnDataType(joinKeys.get(0)).getStoredType()) {
+    DataSchema.ColumnDataType columnDataType = schema.getColumnDataType(joinKeys.get(0));
+    switch (columnDataType.getStoredType()) {
       case INT:
         return new IntLookupTable();
       case LONG:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
@@ -29,16 +29,16 @@ import javax.annotation.Nullable;
  * The {@code DoubleLookupTable} is a lookup table for double keys.
  */
 @SuppressWarnings("unchecked")
-public class DoubleLookupTable extends LookupTable {
+public class DoubleLookupTable extends PrimitiveLookupTable {
   private final Double2ObjectOpenHashMap<Object> _lookupTable = new Double2ObjectOpenHashMap<>(INITIAL_CAPACITY);
 
   @Override
-  public void addRow(Object key, Object[] row) {
+  public void addRowNotNullKey(Object key, Object[] row) {
     _lookupTable.compute((double) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
-  public void finish() {
+  public void finishNotNullKey() {
     if (!_keysUnique) {
       for (Double2ObjectMap.Entry<Object> entry : _lookupTable.double2ObjectEntrySet()) {
         convertValueToList(entry);
@@ -47,19 +47,19 @@ public class DoubleLookupTable extends LookupTable {
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  public boolean containsNotNullKey(Object key) {
     return _lookupTable.containsKey((double) key);
   }
 
   @Nullable
   @Override
-  public Object lookup(Object key) {
+  public Object lookupNotNullKey(Object key) {
     return _lookupTable.get((double) key);
   }
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
+  public Set<Map.Entry> notNullKeyEntrySet() {
     return (Set) _lookupTable.double2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/DoubleLookupTable.java
@@ -59,7 +59,7 @@ public class DoubleLookupTable extends PrimitiveLookupTable {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> notNullKeyEntrySet() {
+  public Set<Map.Entry<Object, Object>> notNullKeyEntrySet() {
     return (Set) _lookupTable.double2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
@@ -29,16 +29,16 @@ import javax.annotation.Nullable;
  * The {@code FloatLookupTable} is a lookup table for float keys.
  */
 @SuppressWarnings("unchecked")
-public class FloatLookupTable extends LookupTable {
+public class FloatLookupTable extends PrimitiveLookupTable {
   private final Float2ObjectOpenHashMap<Object> _lookupTable = new Float2ObjectOpenHashMap<>(INITIAL_CAPACITY);
 
   @Override
-  public void addRow(Object key, Object[] row) {
+  public void addRowNotNullKey(Object key, Object[] row) {
     _lookupTable.compute((float) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
-  public void finish() {
+  public void finishNotNullKey() {
     if (!_keysUnique) {
       for (Float2ObjectMap.Entry<Object> entry : _lookupTable.float2ObjectEntrySet()) {
         convertValueToList(entry);
@@ -47,19 +47,19 @@ public class FloatLookupTable extends LookupTable {
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  public boolean containsNotNullKey(Object key) {
     return _lookupTable.containsKey((float) key);
   }
 
   @Nullable
   @Override
-  public Object lookup(Object key) {
+  public Object lookupNotNullKey(Object key) {
     return _lookupTable.get((float) key);
   }
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
+  public Set<Map.Entry> notNullKeyEntrySet() {
     return (Set) _lookupTable.float2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/FloatLookupTable.java
@@ -59,7 +59,7 @@ public class FloatLookupTable extends PrimitiveLookupTable {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> notNullKeyEntrySet() {
+  public Set<Map.Entry<Object, Object>> notNullKeyEntrySet() {
     return (Set) _lookupTable.float2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator.join;
 
+import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -29,37 +31,33 @@ import javax.annotation.Nullable;
  * The {@code IntLookupTable} is a lookup table for int keys.
  */
 @SuppressWarnings("unchecked")
-public class IntLookupTable extends LookupTable {
+public class IntLookupTable extends PrimitiveLookupTable {
   private final Int2ObjectOpenHashMap<Object> _lookupTable = new Int2ObjectOpenHashMap<>(INITIAL_CAPACITY);
 
   @Override
-  public void addRow(Object key, Object[] row) {
+  protected void addRowNotNullKey(Object key, Object[] row) {
     _lookupTable.compute((int) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
-  public void finish() {
-    if (!_keysUnique) {
-      for (Int2ObjectMap.Entry<Object> entry : _lookupTable.int2ObjectEntrySet()) {
-        convertValueToList(entry);
-      }
+  protected void finishNotNullKey() {
+    for (Int2ObjectMap.Entry<Object> entry : _lookupTable.int2ObjectEntrySet()) {
+      convertValueToList(entry);
     }
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  protected boolean containsNotNullKey(Object key) {
     return _lookupTable.containsKey((int) key);
   }
 
-  @Nullable
   @Override
-  public Object lookup(Object key) {
+  protected Object lookupNotNullKey(Object key) {
     return _lookupTable.get((int) key);
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
+  protected Set<Map.Entry> notNullKeyEntrySet() {
     return (Set) _lookupTable.int2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
@@ -54,7 +54,7 @@ public class IntLookupTable extends PrimitiveLookupTable {
   }
 
   @Override
-  protected Set<Map.Entry> notNullKeyEntrySet() {
+  protected Set<Map.Entry<Object, Object>> notNullKeyEntrySet() {
     return (Set) _lookupTable.int2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/IntLookupTable.java
@@ -18,13 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator.join;
 
-import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 
 /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
@@ -59,7 +59,7 @@ public class LongLookupTable extends PrimitiveLookupTable {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> notNullKeyEntrySet() {
+  public Set<Map.Entry<Object, Object>> notNullKeyEntrySet() {
     return (Set) _lookupTable.long2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LongLookupTable.java
@@ -29,16 +29,16 @@ import javax.annotation.Nullable;
  * The {@code LongLookupTable} is a lookup table for long keys.
  */
 @SuppressWarnings("unchecked")
-public class LongLookupTable extends LookupTable {
+public class LongLookupTable extends PrimitiveLookupTable {
   private final Long2ObjectOpenHashMap<Object> _lookupTable = new Long2ObjectOpenHashMap<>(INITIAL_CAPACITY);
 
   @Override
-  public void addRow(Object key, Object[] row) {
+  public void addRowNotNullKey(Object key, Object[] row) {
     _lookupTable.compute((long) key, (k, v) -> computeNewValue(row, v));
   }
 
   @Override
-  public void finish() {
+  public void finishNotNullKey() {
     if (!_keysUnique) {
       for (Long2ObjectMap.Entry<Object> entry : _lookupTable.long2ObjectEntrySet()) {
         convertValueToList(entry);
@@ -47,19 +47,19 @@ public class LongLookupTable extends LookupTable {
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  public boolean containsNotNullKey(Object key) {
     return _lookupTable.containsKey((long) key);
   }
 
   @Nullable
   @Override
-  public Object lookup(Object key) {
+  public Object lookupNotNullKey(Object key) {
     return _lookupTable.get((long) key);
   }
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
+  public Set<Map.Entry> notNullKeyEntrySet() {
     return (Set) _lookupTable.long2ObjectEntrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -103,5 +103,5 @@ public abstract class LookupTable {
    * entries is a list of rows ({@code List<Object[]>}).
    */
   @SuppressWarnings("rawtypes")
-  public abstract Set<Map.Entry> entrySet();
+  public abstract Set<Map.Entry<Object, Object>> entrySet();
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -68,7 +68,7 @@ public abstract class LookupTable {
     }
   }
 
-  protected static Object convertArrayToList(Object value) {
+  protected static Object convertValueToList(Object value) {
     if (value instanceof Object[]) {
       return Collections.singletonList(value);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -35,7 +35,7 @@ public abstract class LookupTable {
   /**
    * Adds a row to the lookup table.
    */
-  public abstract void addRow(Object key, Object[] row);
+  public abstract void addRow(@Nullable Object key, Object[] row);
 
   @SuppressWarnings("unchecked")
   protected Object computeNewValue(Object[] row, @Nullable Object currentValue) {
@@ -68,6 +68,13 @@ public abstract class LookupTable {
     }
   }
 
+  protected static Object convertArrayToList(Object value) {
+    if (value instanceof Object[]) {
+      return Collections.singletonList(value);
+    }
+    return value;
+  }
+
   /**
    * Returns {@code true} when all the keys added to the lookup table are unique.
    * When all keys are unique, the value of the lookup table is a single row ({@code Object[]}). When keys are not
@@ -80,7 +87,7 @@ public abstract class LookupTable {
   /**
    * Returns {@code true} if the lookup table contains the given key.
    */
-  public abstract boolean containsKey(Object key);
+  public abstract boolean containsKey(@Nullable Object key);
 
   /**
    * Returns the row/rows for the given key. When {@link #isKeysUnique} returns {@code true}, this method returns a
@@ -88,7 +95,7 @@ public abstract class LookupTable {
    * ({@code List<Object[]>}). Returns {@code null} if the key does not exist in the lookup table.
    */
   @Nullable
-  public abstract Object lookup(Object key);
+  public abstract Object lookup(@Nullable Object key);
 
   /**
    * Returns all the entries in the lookup table. When {@link #isKeysUnique} returns {@code true}, the value of the

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
@@ -58,7 +58,7 @@ public class ObjectLookupTable extends LookupTable {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
-    return (Set) _lookupTable.entrySet();
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    return _lookupTable.entrySet();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
@@ -32,7 +32,7 @@ public class ObjectLookupTable extends LookupTable {
   private final Map<Object, Object> _lookupTable = Maps.newHashMapWithExpectedSize(INITIAL_CAPACITY);
 
   @Override
-  public void addRow(Object key, Object[] row) {
+  public void addRow(@Nullable Object key, Object[] row) {
     _lookupTable.compute(key, (k, v) -> computeNewValue(row, v));
   }
 
@@ -46,13 +46,13 @@ public class ObjectLookupTable extends LookupTable {
   }
 
   @Override
-  public boolean containsKey(Object key) {
+  public boolean containsKey(@Nullable Object key) {
     return _lookupTable.containsKey(key);
   }
 
   @Nullable
   @Override
-  public Object lookup(Object key) {
+  public Object lookup(@Nullable Object key) {
     return _lookupTable.get(key);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.query.runtime.operator.join;
 
 import com.google.common.collect.Sets;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.operator.join;
 
 import com.google.common.collect.Sets;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -75,8 +74,8 @@ public abstract class PrimitiveLookupTable extends LookupTable {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public Set<Map.Entry> entrySet() {
-    Set notNullSet = notNullKeyEntrySet();
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    Set<Map.Entry<Object, Object>> notNullSet = notNullKeyEntrySet();
     if (_valueForNullKey != null) {
       Set<Map.Entry<Object, Object>> nullEntry = Set.of(new Map.Entry<>() {
         @Override
@@ -100,5 +99,5 @@ public abstract class PrimitiveLookupTable extends LookupTable {
     }
   }
 
-  protected abstract Set<Map.Entry> notNullKeyEntrySet();
+  protected abstract Set<Map.Entry<Object, Object>> notNullKeyEntrySet();
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -42,7 +42,7 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   public void finish() {
     if (!_keysUnique) {
       if (_valueForNullKey != null) {
-        _valueForNullKey = convertArrayToList(_valueForNullKey);
+        _valueForNullKey = convertValueToList(_valueForNullKey);
       }
       finishNotNullKey();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -78,7 +78,7 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   public Set<Map.Entry> entrySet() {
     Set notNullSet = notNullKeyEntrySet();
     if (_valueForNullKey != null) {
-      HashSet<Map.Entry<Object, Object>> nullEntry = Sets.newHashSet(new Map.Entry<Object, Object>() {
+      Set<Map.Entry<Object, Object>> nullEntry = Set.of(new Map.Entry<>() {
         @Override
         public Object getKey() {
           return null;

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -67,23 +67,23 @@
       },
       {
         "description": "Joining with nullable int column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable long column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable float column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable double column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       }
     ]
   },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -64,6 +64,26 @@
         "description": "LEFT JOIN and GROUP BY with AGGREGATE AND SORT",
         "sql": "SELECT {tbl1}.strCol2, COUNT({tbl2}.intCol1), MIN({tbl2}.intCol1) AS minCol, MAX({tbl2}.doubleCol1) AS maxCol, SUM({tbl2}.doubleCol1) FROM {tbl1} LEFT OUTER JOIN {tbl2} ON {tbl1}.strCol1 = {tbl2}.strCol1 GROUP BY {tbl1}.strCol2 ORDER BY minCol DESC NULLS LAST, maxCol ASC NULLS LAST",
         "keepOutputRowOrder": true
+      },
+      {
+        "description": "Joining with nullable int column",
+        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as INT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as INT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as INT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as INT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+      },
+      {
+        "description": "Joining with nullable long column",
+        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as LONG) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as LONG)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as LONG) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as LONG)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+      },
+      {
+        "description": "Joining with nullable float column",
+        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as FLOAT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as FLOAT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as FLOAT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as FLOAT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+      },
+      {
+        "description": "Joining with nullable double column",
+        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as DOUBLE) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as DOUBLE)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as DOUBLE) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as DOUBLE)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
       }
     ]
   },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -67,23 +67,23 @@
       },
       {
         "description": "Joining with nullable int column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE; WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                             WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable long column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE; WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                             WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable float column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE; WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                             WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable double column",
-        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1 JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE; WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                             WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1 FROM tableWithNull AS t1 JOIN tableWithNull AS t2 ON t1.col1 = t2.nullableCol1"
       }
     ]
   },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -67,23 +67,23 @@
       },
       {
         "description": "Joining with nullable int column",
-        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as INT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as INT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as INT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as INT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT) END AS nullableCol1 FROM {tbl1}) SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as INT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as INT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable long column",
-        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as LONG) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as LONG)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as LONG) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as LONG)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as LONG) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as LONG)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable float column",
-        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as FLOAT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as FLOAT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as FLOAT) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as FLOAT)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as FLOAT) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as FLOAT)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       },
       {
         "description": "Joining with nullable double column",
-        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT cast(intCol1 as DOUBLE) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as DOUBLE)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1",
-        "h2Sql": "                            \nWITH tableWithNull AS (\n    SELECT cast(intCol1 as DOUBLE) col1,\n           CASE\n               WHEN intCol1 > 0 THEN NULL\n               ELSE cast(intCol1 as DOUBLE)\n           END AS nullableCol1\n    FROM {tbl1}\n)\nSELECT t1.col1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.col1 = t2.nullableCol1"
+        "sql": "SET enableNullHandling = TRUE;WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1",
+        "h2Sql": "                            WITH tableWithNull AS (SELECT cast(intCol1 as DOUBLE) col1, CASE WHEN intCol1 > 0 THEN NULL ELSE cast(intCol1 as DOUBLE)END AS nullableCol1 FROM {tbl1})SELECT t1.col1FROM tableWithNull as t1JOIN tableWithNull as t2ON t1.col1 = t2.nullableCol1"
       }
     ]
   },


### PR DESCRIPTION
PR #14972 increased the performance when joins use a single numeric column. But it looks like it didn’t consider that nulls can be sent. This error can be reproduced in different ways:

## Option 1
Execute:
```sql
SET enableNullHandling = TRUE;
WITH tableWithNull AS (
    SELECT totalTrips, CASE
        WHEN totalTrips > 0 THEN NULL
        ELSE totalTrips
    END AS nullableIntCol1
    FROM userAttributes
)
SELECT t1.totalTrips
FROM tableWithNull as t1
JOIN tableWithNull as t2
ON t1.totalTrips = t2.nullableIntCol1
```

In ColocatedJoinQuickStart (the bug is not related to colocation but that quickstart is easier to use than MultistageEngineQuickStart).

Or by adding the following json into NullHandling.json
```
      {
        "description": "Joining with nullable int column",
        "sql": "SET enableNullHandling = TRUE;\nWITH tableWithNull AS (\n    SELECT intCol1, CASE\n                           WHEN intCol1 > 0 THEN NULL\n                           ELSE intCol1\n        END AS nullableIntCol1\n    FROM {tbl1}\n)\nSELECT t1.intCol1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.intCol1 = t2.nullableIntCol1",
        "h2Sql": "                              WITH tableWithNull AS (\n    SELECT intCol1, CASE\n                           WHEN intCol1 > 0 THEN NULL\n                           ELSE intCol1\n        END AS nullableIntCol1\n    FROM {tbl1}\n)\nSELECT t1.intCol1\nFROM tableWithNull as t1\nJOIN tableWithNull as t2\nON t1.intCol1 = t2.nullableIntCol1"
      }
```

This PR fixes the issue by changing all primitive (Int/Float/Long/Double)LookupTable to support null values. It also includes some regression tests.