### PR TITLE
Refactor authorization code to reduce duplication and inconsistency

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AbstractBasicAuthAccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AbstractBasicAuthAccessControl.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.ws.rs.NotAuthorizedException;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.broker.api.HttpRequesterIdentity;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.core.auth.BasicAuthPrincipal;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.broker.RequesterIdentity;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/**
+ * Abstract class for basic authentication access control implementations of the broker.
+ */
+abstract class AbstractBasicAuthAccessControl implements AccessControl {
+  protected static final String HEADER_AUTHORIZATION = "authorization";
+  protected static final String BASIC_AUTH = "Basic";
+
+  /**
+   * Returns whether the client has permission to access the endpoints which are not table level for the given access
+   * type.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - Else, returns success.
+   *
+   * @param requesterIdentity requester identity
+   */
+  @Override
+  public AuthorizationResult authorize(RequesterIdentity requesterIdentity) {
+    return authorize(requesterIdentity, (BrokerRequest) null);
+  }
+
+  /**
+   * Authorizes the requester identity to access the given broker request.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - If the broker request is null or does not have a table name, returns success.
+   * - If the principal has access to the table, returns success.
+   * - If the principal does not have access to the table, returns failure.
+   *
+   * @param requesterIdentity Requester identity
+   * @param brokerRequest Broker request to authorize
+   */
+  @Override
+  public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+    Optional<? extends BasicAuthPrincipal> principalOpt = getPrincipal(requesterIdentity);
+    if (!principalOpt.isPresent()) {
+      throw new NotAuthorizedException(BASIC_AUTH);
+    }
+
+    // Return success if broker request is null or does not have a table name
+    if (brokerRequest == null
+        || !brokerRequest.isSetQuerySource()
+        || !brokerRequest.getQuerySource().isSetTableName()) {
+      // No table restrictions? Accept
+      return TableAuthorizationResult.success();
+    }
+
+    // If table name is present, check if the principal has access to it
+    return authorizeInternal(principalOpt, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
+  }
+
+  /**
+   * Authorizes the requester identity to access the given tables.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - If the tables are null or empty, returns success.
+   * - If the principal has access to all the tables, returns success.
+   * - If the principal does not have access to all the tables, returns failure with the failed tables.
+   *
+   * @param requesterIdentity Requester identity
+   * @param tables Tables to authorize
+   */
+  @Override
+  public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
+    Optional<? extends BasicAuthPrincipal> principalOpt = getPrincipal(requesterIdentity);
+    if (!principalOpt.isPresent()) {
+      throw new NotAuthorizedException(BASIC_AUTH);
+    }
+
+    return authorizeInternal(principalOpt, tables);
+  }
+
+  private TableAuthorizationResult authorizeInternal(Optional<? extends BasicAuthPrincipal> principalOpt,
+      Set<String> tables) {
+    // Return success, if tables is null or empty
+    if (CollectionUtils.isEmpty(tables)) {
+      return TableAuthorizationResult.success();
+    }
+
+    // Check if the principal has access to all the tables
+    BasicAuthPrincipal principal = principalOpt.get();
+    Set<String> failedTables = new HashSet<>();
+    for (String table : tables) {
+      if (!principal.hasTable(TableNameBuilder.extractRawTableName(table))) {
+        failedTables.add(table);
+      }
+    }
+
+    // Return success if all tables are accessible
+    if (failedTables.isEmpty()) {
+      return TableAuthorizationResult.success();
+    }
+
+    // Return failed tables
+    return new TableAuthorizationResult(failedTables);
+  }
+
+  /**
+   * Returns the tokens from the requester identity.
+   * @param requesterIdentity Requester identity
+   */
+  protected List<String> getTokens(RequesterIdentity requesterIdentity) {
+    Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity,
+        "HttpRequesterIdentity required");
+    Multimap<String, String> headers = ((HttpRequesterIdentity) requesterIdentity).getHttpHeaders();
+    return headers != null ? new ArrayList<>(headers.get(HEADER_AUTHORIZATION)) : Collections.emptyList();
+  }
+
+  /**
+   * Returns the principal for the given requester identity.
+   * @param requesterIdentity Requester identity
+   */
+  protected abstract Optional<? extends BasicAuthPrincipal> getPrincipal(RequesterIdentity requesterIdentity);
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AccessControlFactory.java
@@ -31,14 +31,15 @@ public abstract class AccessControlFactory {
   public static final String ACCESS_CONTROL_CLASS_CONFIG = "class";
 
   public void init(PinotConfiguration configuration) {
-  };
+    // left blank
+  }
 
   /**
    * Extend original init method inorder to support Zookeeper BasicAuthAccessControlFactory
-   * Because ZKBasicAuthAccessControlFactory need to acquire users info from HelixPropertyStore
+   * Because ZKBasicAuthAccessControlFactory need to acquire users info from ZkHelixPropertyStore
    *
    * @param configuration pinot configuration
-   * @param propertyStore Helix PropertyStore
+   * @param propertyStore Helix property store
    */
   public void init(PinotConfiguration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore) {
      init(configuration);
@@ -46,6 +47,9 @@ public abstract class AccessControlFactory {
 
   public abstract AccessControl create();
 
+  /**
+   * Utility to load the desired AccessControlFactory, either from config or defaulting to AllowAllAccessControlFactory.
+   */
   public static AccessControlFactory loadFactory(PinotConfiguration configuration,
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     AccessControlFactory accessControlFactory;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -25,24 +25,13 @@ import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
-import org.apache.pinot.spi.env.PinotConfiguration;
 
-
+/**
+ * An access control factory for brokers that allows all requests. This is the default access control.
+ */
 public class AllowAllAccessControlFactory extends AccessControlFactory {
-  private final AccessControl _accessControl;
 
-  public AllowAllAccessControlFactory() {
-    _accessControl = new AllowAllAccessControl();
-  }
-
-  public void init(PinotConfiguration configuration) {
-  }
-
-  public AccessControl create() {
-    return _accessControl;
-  }
-
-  private static class AllowAllAccessControl implements AccessControl {
+  private static final AccessControl ALLOW_ALL_ACCESS = new AccessControl() {
     @Override
     public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       return BasicAuthorizationResultImpl.success();
@@ -52,5 +41,9 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
     public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
       return TableAuthorizationResult.success();
     }
+  };
+
+  public AccessControl create() {
+    return ALLOW_ALL_ACCESS;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -555,15 +555,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(),
             new ControllerUserDefinedMessageHandlerFactory(_periodicTaskScheduler));
 
-    String accessControlFactoryClass = _config.getAccessControlFactoryClass();
-    LOGGER.info("Use class: {} as the AccessControlFactory", accessControlFactoryClass);
-    final AccessControlFactory accessControlFactory;
-    try {
-      accessControlFactory = (AccessControlFactory) Class.forName(accessControlFactoryClass).newInstance();
-      accessControlFactory.init(_config, _helixResourceManager);
-    } catch (Exception e) {
-      throw new RuntimeException("Caught exception while creating new AccessControlFactory instance", e);
-    }
+    final AccessControlFactory accessControlFactory = AccessControlFactory.loadFactory(_config, _helixResourceManager);
 
     final MetadataEventNotifierFactory metadataEventNotifierFactory =
         MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX), _helixResourceManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AbstractBasicAuthAccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AbstractBasicAuthAccessControl.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.core.auth.BasicAuthPrincipal;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/**
+ * Abstract class for basic authentication access control implementations of the controller.
+ */
+abstract class AbstractBasicAuthAccessControl implements AccessControl {
+  protected static final String HEADER_AUTHORIZATION = "authorization";
+  protected static final String BASIC_AUTH = AccessControl.WORKFLOW_BASIC;
+
+  /**
+   * Return whether the client has permission to access the endpoints which are not table level for
+   * the given access type and endpoint URL.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - Else, returns success.
+   *
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity
+   * @param endpointUrl the request url for which this access control is called
+   */
+  @Override
+  public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    Optional<? extends BasicAuthPrincipal> principalOpt = getPrincipal(httpHeaders);
+    if (!principalOpt.isPresent()) {
+      throw new NotAuthorizedException(AccessControl.WORKFLOW_BASIC);
+    }
+
+    return true;
+  }
+
+  /**
+   * Return whether the client has permission to access the given table for the given access type and
+   * endpoint URL.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - If the principal has the required access to the table, returns success.
+   * - If the principal does not have the required access to the table, returns failure.
+   *
+   * @param tableName name of the table to be accessed
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity
+   * @param endpointUrl the request url for which this access control is called
+   */
+  @Override
+  public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    Optional<? extends BasicAuthPrincipal> principalOpt = getPrincipal(httpHeaders);
+    if (!principalOpt.isPresent()) {
+      throw new NotAuthorizedException(BASIC_AUTH);
+    }
+
+    return principalOpt
+        .filter(p -> p.hasTable(TableNameBuilder.extractRawTableName(tableName))
+            && p.hasPermission(Objects.toString(accessType)))
+        .isPresent();
+  }
+
+  @Override
+  public boolean protectAnnotatedOnly() {
+    return false;
+  }
+
+  @Override
+  public AuthWorkflowInfo getAuthWorkflowInfo() {
+    return new AuthWorkflowInfo(BASIC_AUTH);
+  }
+
+  /**
+   * Return the tokens from the given HTTP headers.
+   * @param httpHeaders HTTP headers containing requester identity
+   */
+  protected List<String> getTokens(HttpHeaders httpHeaders) {
+    if (httpHeaders == null) {
+      return Collections.emptyList();
+    }
+
+    return httpHeaders.getRequestHeader(HEADER_AUTHORIZATION);
+  }
+
+  /**
+   * Return the principal for the given HTTP headers.
+   * @param httpHeaders HTTP headers containing requester identity
+   */
+  protected abstract Optional<? extends BasicAuthPrincipal> getPrincipal(HttpHeaders httpHeaders);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AllowAllAccessFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AllowAllAccessFactory.java
@@ -18,7 +18,13 @@
  */
 package org.apache.pinot.controller.api.access;
 
+/**
+ * An access control factory for controllers that allows all requests. This is the default access control.
+ */
 public class AllowAllAccessFactory implements AccessControlFactory {
+  /**
+   * We inherit methods from the AccessControl interface, hence we don't need to implement them.
+   */
   private static final AccessControl ALLOW_ALL_ACCESS = new AccessControl() {
   };
 

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/AbstractBasicAuthAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/AbstractBasicAuthAccessControl.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.access;
+
+import io.netty.channel.ChannelHandlerContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.NotAuthorizedException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipal;
+import org.apache.pinot.spi.auth.server.RequesterIdentity;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/**
+ * Abstract class for basic authentication access control implementations of the server.
+ */
+abstract class AbstractBasicAuthAccessControl implements AccessControl {
+  protected static final String HEADER_AUTHORIZATION = "authorization";
+  protected static final String BASIC_AUTH = "Basic";
+
+  /**
+   * Returns whether the client has permission to access the endpoints which are not table level for the given access
+   * type.
+   * - If the requester identity is not authorized, throws a NotAuthorizedException.
+   * - If the table name is not present, returns success.
+   * - Else, returns success if the principal has access to the table.
+   *
+   * @param requesterIdentity Request identity
+   * @param tableName Name of the table to be accessed
+   */
+  @Override
+  public boolean hasDataAccess(RequesterIdentity requesterIdentity, String tableName) {
+    // Get the principal for the first token
+    Optional<? extends BasicAuthPrincipal> principalOpt = getPrincipal(requesterIdentity);
+    if (!principalOpt.isPresent()) {
+      throw new NotAuthorizedException(BASIC_AUTH);
+    }
+
+    // Return success, if tables is null or empty
+    if (StringUtils.isEmpty(tableName)) {
+      return true;
+    }
+
+    // If table name is present, check if the principal has access to it
+    return principalOpt.get().hasTable(TableNameBuilder.extractRawTableName(tableName));
+  }
+
+  @Override
+  public boolean isAuthorizedChannel(ChannelHandlerContext channelHandlerContext) {
+    return true;
+  }
+
+  /**
+   * Return the tokens from the given requester identity.
+   * @param requesterIdentity identity of the requester
+   * @throws UnsupportedOperationException if the requester identity is not an instance of GrpcRequesterIdentity or
+   * HttpRequesterIdentity
+   */
+  protected List<String> getTokens(RequesterIdentity requesterIdentity) {
+    if (requesterIdentity instanceof GrpcRequesterIdentity) {
+      GrpcRequesterIdentity identity = (GrpcRequesterIdentity) requesterIdentity;
+      return new ArrayList<>(identity.getGrpcMetadata().get(HEADER_AUTHORIZATION));
+    }
+    if (requesterIdentity instanceof HttpRequesterIdentity) {
+      HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;
+      return new ArrayList<>(identity.getHttpHeaders().get(HEADER_AUTHORIZATION));
+    }
+    throw new UnsupportedOperationException("GrpcRequesterIdentity or HttpRequesterIdentity is required");
+  }
+
+  /**
+   * Return the principal for the given requester identity.
+   * @param requesterIdentity identity of the requester
+   */
+  protected abstract Optional<? extends BasicAuthPrincipal> getPrincipal(RequesterIdentity requesterIdentity);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/AccessControlFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/AccessControlFactory.java
@@ -29,12 +29,13 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 public interface AccessControlFactory {
 
   default void init(PinotConfiguration configuration) {
-  };
+    // left blank
+  }
 
   /**
    * Extend the original init method to support Zookeeper BasicAuthAccessControlFactory.
-   * Because ZKBasicAuthAccessControlFactory needs to acquire users' info from HelixPropertyStore.
-   * The reason why passed helixManager param other than HelixPropertyStore is that
+   * Because ZKBasicAuthAccessControlFactory needs to acquire users' info from HelixManager.
+   * The reason why we have helixManager param instead of  than ZkHelixPropertyStore is that
    * HelixManager variable hasn't connected to Real Helix manager when invoke init method.
    *
    * @param configuration pinot configuration

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/AllowAllAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/AllowAllAccessFactory.java
@@ -22,6 +22,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.apache.pinot.spi.auth.server.RequesterIdentity;
 
 
+/**
+ * An access control factory for servers that allows all requests. This is the default access control.
+ */
 public class AllowAllAccessFactory implements AccessControlFactory {
   private static final AccessControl ALLOW_ALL_ACCESS = new AccessControl() {
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthUtilsTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.auth;
+
+import com.google.common.cache.Cache;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.pinot.common.config.provider.AccessControlUserCache;
+import org.apache.pinot.common.utils.BcryptUtils;
+import org.apache.pinot.spi.config.user.ComponentType;
+import org.apache.pinot.spi.config.user.RoleType;
+import org.apache.pinot.spi.config.user.UserConfig;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class BasicAuthUtilsTest {
+
+  private MockedStatic<BcryptUtils> _mockedBcryptUtils;
+
+  @BeforeMethod
+  public void setUpMocks() {
+    _mockedBcryptUtils = Mockito.mockStatic(BcryptUtils.class);
+  }
+
+  @AfterMethod
+  public void resetMocks() {
+    _mockedBcryptUtils.close();
+  }
+
+  @Test
+  public void testGetPrincipalWithEmptyAuthHeaders() {
+    AccessControlUserCache userCache = Mockito.mock(AccessControlUserCache.class);
+    List<String> authHeaders = Collections.emptyList();
+
+    Optional<ZkBasicAuthPrincipal> result =
+        BasicAuthUtils.getPrincipal(authHeaders, userCache, ComponentType.CONTROLLER);
+    assertFalse(result.isPresent());
+    Mockito.verifyNoInteractions(BcryptUtils.class);
+  }
+
+  @Test
+  public void testGetPrincipalWithValidAuthHeaders() {
+    AccessControlUserCache userCache = Mockito.mock(AccessControlUserCache.class);
+    UserConfig userConfig =
+        new UserConfig("admin", "admin", ComponentType.CONTROLLER.name(), RoleType.ADMIN.name(), null, null, null);
+    Mockito.when(userCache.getAllControllerUserConfig()).thenReturn(Collections.singletonList(userConfig));
+    Mockito.when(userCache.getUserPasswordAuthCache()).thenReturn(Mockito.mock(Cache.class));
+    _mockedBcryptUtils.when(
+            () -> BcryptUtils.checkpwWithCache(Mockito.anyString(), Mockito.anyString(), Mockito.any(Cache.class)))
+        .thenReturn(true);
+
+    List<String> authHeaders = Collections.singletonList("Basic YWRtaW46YWRtaW4=");
+
+    Optional<ZkBasicAuthPrincipal> result =
+        BasicAuthUtils.getPrincipal(authHeaders, userCache, ComponentType.CONTROLLER);
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getName(), "admin");
+  }
+
+  @Ignore
+  public void testGetPrincipalWithInvalidAuthHeaders() {
+    AccessControlUserCache userCache = Mockito.mock(AccessControlUserCache.class);
+    UserConfig userConfig =
+        new UserConfig("admin", "admin", ComponentType.CONTROLLER.name(), RoleType.ADMIN.name(), null, null, null);
+    Mockito.when(userCache.getAllControllerUserConfig()).thenReturn(Collections.singletonList(userConfig));
+
+    List<String> authHeaders = Collections.singletonList("Basic dummy");
+
+    Optional<ZkBasicAuthPrincipal> result =
+        BasicAuthUtils.getPrincipal(authHeaders, userCache, ComponentType.CONTROLLER);
+    assertFalse(result.isPresent());
+    Mockito.verifyNoInteractions(BcryptUtils.class);
+  }
+
+  @Test
+  public void testGetPrincipalWithIncorrectPassword() {
+    AccessControlUserCache userCache = Mockito.mock(AccessControlUserCache.class);
+    UserConfig userConfig =
+        new UserConfig("admin", "admin", ComponentType.CONTROLLER.name(), RoleType.ADMIN.name(), null, null, null);
+    Mockito.when(userCache.getAllControllerUserConfig()).thenReturn(Collections.singletonList(userConfig));
+    _mockedBcryptUtils.when(
+            () -> BcryptUtils.checkpwWithCache(Mockito.anyString(), Mockito.anyString(), Mockito.any(Cache.class)))
+        .thenReturn(false);
+
+    List<String> authHeaders = Collections.singletonList("Basic YWRtaW46YWRtaW4x");
+
+    Optional<ZkBasicAuthPrincipal> result =
+        BasicAuthUtils.getPrincipal(authHeaders, userCache, ComponentType.CONTROLLER);
+    assertFalse(result.isPresent());
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Broker authorization flow delegates to subclass for getPrincipal, which uses superclass getTokens and utility for principal lookup\.

```mermaid
flowchart TD
  N0["AbstractBasicAuthAccessControl #40;broker#41; #40;F1#41;"]:::stAdded
  N1["BasicAuthAccessControl #40;broker#41; #40;F4#41;"]:::stModified
  N2["BasicAuthUtils #40;F12#41;"]:::stModified
  N0 -->|"authorize #45;#62; getPrincipal"| N1
  N1 -->|"getPrincipal #45;#62; getTokens"| N0
  N1 -->|"getPrincipal #45;#62; util#46;getPrincipal"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/broker/AbstractBasicAuthAccessControl\.java — [after](https://github.com/apache/pinot/blob/8845211d8fcee4c2601cb9a66de1646116612852/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AbstractBasicAuthAccessControl.java)
- F4: pinot\-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory\.java — [before](https://github.com/apache/pinot/blob/2c9b51b8dcd76e378e133b8f855cedf42e3983ac/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java) · [after](https://github.com/apache/pinot/blob/8845211d8fcee4c2601cb9a66de1646116612852/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java)
- F12: pinot\-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils\.java — [before](https://github.com/apache/pinot/blob/2c9b51b8dcd76e378e133b8f855cedf42e3983ac/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java) · [after](https://github.com/apache/pinot/blob/8845211d8fcee4c2601cb9a66de1646116612852/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjJjOWI1MWI4ZGNkNzZlMzc4ZTEzM2I4Zjg1NWNlZGY0MmUzOTgzYWMiLCJjb250ZXh0X2hhc2giOiIxZDA2ODJmNzc4ZjE1NWE1ZGIxNDViNTRhOWRjZTM5NDM0ZWQ2MzI0YThhNGZlNTA4YjQ5MDZjNmMxMTQyZWI1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTExODgyLCJoZWFkX3NoYSI6Ijg4NDUyMTFkOGZjZWU0YzI2MDFjYjlhNjZkZTE2NDYxMTY2MTI4NTIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyYzliNTFiOGRjZDc2ZTM3OGUxMzNiOGY4NTVjZWRmNDJlMzk4M2FjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 39e485b69b12df3bce0e450bc260cca88a6c66b79e5451e8b9fcfd27dfd56d5b -->
<!-- pinot-pr-flow:end -->

To address #14932, this PR extracts the common authorization logic into a superclass `AbstractBasicAuthAccessControl` and makes both `BasicAuthAccessControlFactory.BasicAuthAccessControl` and `ZkBasicAuthAccessFactory.BasicAuthAccessControl` extend this superclass. This ensures that the core authorization logic for basic auth is centralized, making it easier to maintain and update. 

The same has been done across all components and we have extracted shared logic via appropriate utilities or classes wherever needed.

Also several other refactorings have been done to align with existing code.
- `pinot-controller/../AccessControlFactory.java` adds a new method `loadFactory` which is used to init in `BaseControllerStarter.java`
- Extract the `getPrincipal` logic into `BasicAuthUtils.java` for each component and re-use.

These refactoring will streamline maintenance, enhance consistency, and simplify the process of adding new authorization mechanisms.