### PR TITLE
Add APIs to IndexSegment as a preparation to support virtual DataSource

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
 import org.slf4j.Logger;
@@ -85,7 +86,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
 
     _minMaxValueContexts = new ArrayList<>(_numOperators);
     for (Operator<BaseResultsBlock> operator : _operators) {
-      _minMaxValueContexts.add(new MinMaxValueContext(operator, firstOrderByColumn));
+      _minMaxValueContexts.add(new MinMaxValueContext(operator, firstOrderByColumn, queryContext.getSchema()));
     }
     if (firstOrderByExpression.isAsc()) {
       // For ascending order, sort on column min value in ascending order
@@ -313,9 +314,10 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
     final Comparable _minValue;
     final Comparable _maxValue;
 
-    MinMaxValueContext(Operator<BaseResultsBlock> operator, String column) {
+    MinMaxValueContext(Operator<BaseResultsBlock> operator, String column, Schema schema) {
       _operator = operator;
-      DataSourceMetadata dataSourceMetadata = operator.getIndexSegment().getDataSource(column).getDataSourceMetadata();
+      DataSourceMetadata dataSourceMetadata =
+          operator.getIndexSegment().getDataSource(column, schema).getDataSourceMetadata();
       _minValue = dataSourceMetadata.getMinValue();
       _maxValue = dataSourceMetadata.getMaxValue();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -64,7 +64,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
     _dataSourceMap = new HashMap<>(mapCapacity);
     Map<String, ColumnContext> columnContextMap = new HashMap<>(mapCapacity);
     columns.forEach(column -> {
-      DataSource dataSource = segment.getDataSource(column);
+      DataSource dataSource = segment.getDataSource(column, queryContext.getSchema());
       _dataSourceMap.put(column, dataSource);
       columnContextMap.put(column, ColumnContext.fromDataSource(dataSource));
     });

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -279,7 +279,7 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
     int numColumns = columns.size();
     Map<String, DataSource> dataSourceMap = new HashMap<>();
     for (String column : columns) {
-      dataSourceMap.put(column, _indexSegment.getDataSource(column));
+      dataSourceMap.put(column, _indexSegment.getDataSource(column, _queryContext.getSchema()));
     }
 
     try (ProjectionOperator projectionOperator =

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
@@ -54,7 +54,7 @@ public class DistinctPlanNode implements PlanNode {
     if (_queryContext.getFilter() == null && expressions.size() == 1) {
       String column = expressions.get(0).getIdentifier();
       if (column != null) {
-        DataSource dataSource = _indexSegment.getDataSource(column);
+        DataSource dataSource = _indexSegment.getDataSource(column, _queryContext.getSchema());
         if (dataSource.getDictionary() != null) {
           if (!_queryContext.isNullHandlingEnabled()) {
             return new DictionaryBasedDistinctOperator(dataSource, _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -146,8 +146,12 @@ public class FilterPlanNode implements PlanNode {
         findLiteral = true;
       }
     }
-    return columnName != null && _indexSegment.getDataSource(columnName).getH3Index() != null && findLiteral
-        && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
+    if (columnName == null || !findLiteral) {
+      return false;
+    }
+    DataSource dataSource = _indexSegment.getDataSourceNullable(columnName);
+    return dataSource != null && dataSource.getH3Index() != null && _queryContext.isIndexUseAllowed(columnName,
+        FieldConfig.IndexType.H3);
   }
 
   /**
@@ -177,16 +181,18 @@ public class FilterPlanNode implements PlanNode {
       if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(1).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(0).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null
-            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
+        DataSource dataSource = _indexSegment.getDataSourceNullable(columnName);
+        return dataSource != null && dataSource.getH3Index() != null && _queryContext.isIndexUseAllowed(columnName,
+            FieldConfig.IndexType.H3);
       }
       return false;
     } else {
       if (arguments.get(1).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(0).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(1).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null
-            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
+        DataSource dataSource = _indexSegment.getDataSourceNullable(columnName);
+        return dataSource != null && dataSource.getH3Index() != null && _queryContext.isIndexUseAllowed(columnName,
+            FieldConfig.IndexType.H3);
       }
       return false;
     }
@@ -244,7 +250,7 @@ public class FilterPlanNode implements PlanNode {
           }
         } else {
           String column = lhs.getIdentifier();
-          DataSource dataSource = _indexSegment.getDataSource(column);
+          DataSource dataSource = _indexSegment.getDataSource(column, _queryContext.getSchema());
           PredicateEvaluator predicateEvaluator;
           switch (predicate.getType()) {
             case TEXT_CONTAINS:

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -75,7 +75,8 @@ public class ProjectPlanNode implements PlanNode {
       }
     }
     Map<String, DataSource> dataSourceMap = new HashMap<>(HashUtil.getHashMapCapacity(projectionColumns.size()));
-    projectionColumns.forEach(column -> dataSourceMap.put(column, _indexSegment.getDataSource(column)));
+    projectionColumns.forEach(
+        column -> dataSourceMap.put(column, _indexSegment.getDataSource(column, _queryContext.getSchema())));
     // NOTE: Skip creating DocIdSetOperator when maxDocsPerCall is 0 (for selection query with LIMIT 0)
     DocIdSetOperator docIdSetOperator =
         _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_segmentContext, _queryContext, _maxDocsPerCall,

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -158,7 +158,7 @@ public class SelectionPlanNode implements PlanNode {
           return false;
         }
         String column = orderByExpression.getExpression().getIdentifier();
-        DataSource dataSource = _indexSegment.getDataSource(column);
+        DataSource dataSource = _indexSegment.getDataSource(column, _queryContext.getSchema());
         // If there are null values, we cannot trust DataSourceMetadata.isSorted
         if (isNullHandlingEnabled) {
           NullValueVectorReader nullValueVector = dataSource.getNullValueVector();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfo.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,12 @@ public class LogicalTableExecutionInfo implements TableExecutionInfo {
 
   public LogicalTableExecutionInfo(List<SingleTableExecutionInfo> tableExecutionInfos) {
     _tableExecutionInfos = tableExecutionInfos;
+  }
+
+  @Override
+  public Schema getSchema() {
+    // TODO: Return the schema of the logical table
+    return _tableExecutionInfos.get(0).getSchema();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -216,6 +216,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
               .collect(Collectors.toList()));
     }
 
+    queryContext.setSchema(executionInfo.getSchema());
+
     // Gather stats for realtime consuming segments
     // TODO: the freshness time should not be collected at query time because there is no guarantee that the consuming
     //       segment is queried (consuming segment might be pruned, or the server only contains relocated committed

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -45,6 +45,7 @@ import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,18 +152,18 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
     _notAcquiredSegments = notAcquiredSegments;
   }
 
-  @Override
-  public boolean hasRealtime() {
-    return _tableDataManager instanceof RealtimeTableDataManager;
-  }
-
-
   public TableDataManager getTableDataManager() {
     return _tableDataManager;
   }
 
-  public List<SegmentDataManager> getSegmentDataManagers() {
-    return _segmentDataManagers;
+  @Override
+  public Schema getSchema() {
+    return _tableDataManager.getCachedTableConfigAndSchema().getRight();
+  }
+
+  @Override
+  public boolean hasRealtime() {
+    return _tableDataManager instanceof RealtimeTableDataManager;
   }
 
   @Override
@@ -189,12 +190,19 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
     return _providedSegmentContexts;
   }
 
+  @Override
   public List<String> getSegmentsToQuery() {
     return _segmentsToQuery;
   }
 
+  @Override
   public List<String> getOptionalSegments() {
     return _optionalSegments;
+  }
+
+  @Override
+  public List<SegmentDataManager> getSegmentDataManagers() {
+    return _segmentDataManagers;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
@@ -30,9 +30,14 @@ import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.spi.data.Schema;
 
 
 public interface TableExecutionInfo {
+
+  /// Returns the latest [Schema] for the table.
+  Schema getSchema();
+
   /**
    * Check if consuming segments are being queried.
    * @return true if consuming segments are being queried, false otherwise

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
@@ -48,8 +48,8 @@ public class DefaultFetchPlanner implements FetchPlanner {
     extractEqInColumns(Objects.requireNonNull(queryContext.getFilter()), eqInColumns);
     Map<String, List<IndexType<?, ?, ?>>> columnToIndexList = new HashMap<>();
     for (String column : eqInColumns) {
-      DataSource dataSource = indexSegment.getDataSource(column);
-      if (dataSource.getBloomFilter() != null) {
+      DataSource dataSource = indexSegment.getDataSourceNullable(column);
+      if (dataSource != null && dataSource.getBloomFilter() != null) {
         columnToIndexList.put(column, Collections.singletonList(StandardIndexes.bloomFilter()));
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -42,6 +42,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFacto
 import org.apache.pinot.core.util.MemoizedClassAssociation;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 
 
@@ -98,6 +99,8 @@ public class QueryContext {
   private Set<String> _columns;
 
   // Other properties to be shared across all the segments
+  // Latest table schema at query time
+  private Schema _schema;
   // End time in milliseconds for the query
   private long _endTimeMs;
   // Whether to enable prefetch for the query
@@ -312,6 +315,14 @@ public class QueryContext {
    */
   public Set<String> getColumns() {
     return _columns;
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+
+  public void setSchema(Schema schema) {
+    _schema = schema;
   }
 
   public long getEndTimeMs() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.indexsegment.immutable;
 
-import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -59,14 +58,6 @@ public class EmptyIndexSegment implements ImmutableSegment {
   }
 
   @Override
-  public DataSource getDataSource(String column) {
-    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-    Preconditions.checkNotNull(columnMetadata,
-        "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
-    return new EmptyDataSource(columnMetadata);
-  }
-
-  @Override
   public Set<String> getColumnNames() {
     return _segmentMetadata.getSchema().getColumnNames();
   }
@@ -84,6 +75,14 @@ public class EmptyIndexSegment implements ImmutableSegment {
   public void destroy() {
   }
 
+  @Nullable
+  @Override
+  public DataSource getDataSourceNullable(String column) {
+    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+    return columnMetadata != null ? new EmptyDataSource(columnMetadata) : null;
+  }
+
+  @Nullable
   @Override
   public List<StarTreeV2> getStarTrees() {
     return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -235,14 +235,6 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   }
 
   @Override
-  public DataSource getDataSource(String column) {
-    DataSource result = _dataSources.get(column);
-    Preconditions.checkNotNull(result,
-        "DataSource for %s should not be null. Potentially invalid column name specified.", column);
-    return result;
-  }
-
-  @Override
   public Set<String> getColumnNames() {
     return _segmentMetadata.getSchema().getColumnNames();
   }
@@ -306,6 +298,13 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     }
   }
 
+  @Nullable
+  @Override
+  public DataSource getDataSourceNullable(String column) {
+    return _dataSources.get(column);
+  }
+
+  @Nullable
   @Override
   public List<StarTreeV2> getStarTrees() {
     return _starTreeIndexContainer != null ? _starTreeIndexContainer.getStarTrees() : null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1048,24 +1048,27 @@ public class MutableSegmentImpl implements MutableSegment {
     return physicalColumnNames;
   }
 
+  @Nullable
   @Override
-  public DataSource getDataSource(String column) {
+  public DataSource getDataSourceNullable(String column) {
     IndexContainer indexContainer = _indexContainerMap.get(column);
     if (indexContainer != null) {
       // Physical column
       return indexContainer.toDataSource();
-    } else {
+    }
+    FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
+    if (fieldSpec != null && fieldSpec.isVirtualColumn()) {
       // Virtual column
-      FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
-      Preconditions.checkState(fieldSpec != null && fieldSpec.isVirtualColumn(), "Failed to find column: %s", column);
       // TODO: Refactor virtual column provider to directly generate data source
       VirtualColumnContext virtualColumnContext = new VirtualColumnContext(fieldSpec, _numDocsIndexed);
       VirtualColumnProvider virtualColumnProvider = VirtualColumnProviderFactory.buildProvider(virtualColumnContext);
       return new ImmutableDataSource(virtualColumnProvider.buildMetadata(virtualColumnContext),
           virtualColumnProvider.buildColumnIndexContainer(virtualColumnContext));
     }
+    return null;
   }
 
+  @Nullable
   @Override
   public List<StarTreeV2> getStarTrees() {
     return null;


### PR DESCRIPTION
This is a preparation for #15350

Before this PR, in `IndexSegment`, `DataSource getDataSource(String column)` can only fetch `DataSource` for existing columns.

This PR adds 2 APIs:
- `@Nullable DataSource getDataSourceNullable(String column)`
- `DataSource getDataSource(String column, Schema schema)`

With this PR, we can add the logic to create a virtual `DataSource` when the column doesn't exist in the segment