### PR TITLE
Reduce reflection overhead of ByteBufferUtil::newDirectByteBuffer

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferUtil.java
@@ -46,11 +46,9 @@ public class ByteBufferUtil {
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE, Object.class, memorySegmentProxyClass);
         dbbCC.setAccessible(true);
-        MethodHandle dbbCCMh = MethodHandles.lookup().unreflectConstructor(dbbCC)
-            .asType(MethodType.methodType(
-                ByteBuffer.class,
-                long.class, int.class, Object.class, Object.class
-            ));
+        MethodHandle dbbCCMh = MethodHandles.lookup()
+            .unreflectConstructor(dbbCC)
+            .asType(MethodType.methodType(ByteBuffer.class, long.class, int.class, Object.class, Object.class));
         return (addr, size, att) -> {
           try {
             return (ByteBuffer) dbbCCMh.invokeExact(addr, size, att, (Object) null);
@@ -65,7 +63,8 @@ public class ByteBufferUtil {
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE, Object.class);
         dbbCC.setAccessible(true);
-        MethodHandle dbbCCMh = MethodHandles.lookup().unreflectConstructor(dbbCC)
+        MethodHandle dbbCCMh = MethodHandles.lookup()
+            .unreflectConstructor(dbbCC)
             .asType(MethodType.methodType(ByteBuffer.class, long.class, int.class, Object.class));
         return (addr, size, att) -> {
           try {
@@ -81,7 +80,8 @@ public class ByteBufferUtil {
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE);
         dbbCC.setAccessible(true);
-        MethodHandle dbbCCMh = MethodHandles.lookup().unreflectConstructor(dbbCC)
+        MethodHandle dbbCCMh = MethodHandles.lookup()
+            .unreflectConstructor(dbbCC)
             .asType(MethodType.methodType(ByteBuffer.class, long.class, int.class));
         return (addr, size, att) -> {
           try {
@@ -120,7 +120,8 @@ public class ByteBufferUtil {
   }
 
   private interface CreatorSupplier {
-    ByteBufferCreator createCreator() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException;
+    ByteBufferCreator createCreator()
+        throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException;
   }
 
   private interface ByteBufferCreator {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/ByteBufferUtil.java
@@ -42,8 +42,8 @@ public class ByteBufferUtil {
         Constructor<? extends ByteBuffer> dbbCC =
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE, Object.class, memorySegmentProxyClass);
+        dbbCC.setAccessible(true);
         return (addr, size, att) -> {
-          dbbCC.setAccessible(true);
           try {
             return dbbCC.newInstance(Long.valueOf(addr), Integer.valueOf(size), att, null);
           } catch (Exception e) {
@@ -56,8 +56,8 @@ public class ByteBufferUtil {
         Constructor<? extends ByteBuffer> dbbCC =
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE, Object.class);
+        dbbCC.setAccessible(true);
         return (addr, size, att) -> {
-          dbbCC.setAccessible(true);
           try {
             return dbbCC.newInstance(Long.valueOf(addr), Integer.valueOf(size), att);
           } catch (Exception e) {
@@ -70,8 +70,8 @@ public class ByteBufferUtil {
         Constructor<? extends ByteBuffer> dbbCC =
             (Constructor<? extends ByteBuffer>) Class.forName("java.nio.DirectByteBuffer")
                 .getDeclaredConstructor(Long.TYPE, Integer.TYPE);
+        dbbCC.setAccessible(true);
         return (addr, size, att) -> {
-          dbbCC.setAccessible(true);
           try {
             return dbbCC.newInstance(Long.valueOf(addr), Integer.valueOf(size));
           } catch (Exception e) {


### PR DESCRIPTION
We found a fairly substantial performance regression on one usecase when migrating to set `pinot.offheap.prioritize.bytebuffer -> false`.

<img width="855" alt="Screenshot 2025-05-22 at 3 40 15 PM" src="https://github.com/user-attachments/assets/cc928e5b-f300-4998-97b2-ed5fd0829516" />

Reverting the config to false fixes the latency with no other changes.

Instance using ByteBuffers:
<img width="1427" alt="Screenshot 2025-05-22 at 3 37 15 PM" src="https://github.com/user-attachments/assets/53100001-85ec-4211-b912-b9290d92b77a" />

Instance with UnsafePinotDataBuffer:
<img width="1427" alt="Screenshot 2025-05-22 at 3 13 17 PM" src="https://github.com/user-attachments/assets/e41581fd-ded2-45bf-826f-c714777a2ab8" />

Still trying to fully understand the root cause -- it's very odd we have only seen this in a single case so far, but definitely we see some substantial time spent on `setAccessible(true)` calls which should only need to be called once statically to make the constructor available.

Some benchmarking from tweaking the BenchmarkPinotDataBuffer.batchRead benchmark:

`jdk21`:
```
BenchmarkPinotDataBuffer.copyTo        bytebuffer               1  avgt   10   4.358 ±  0.088  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer              32  avgt   10  11.759 ±  7.221  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer            1024  avgt   10  30.253 ±  2.402  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe               1  avgt   10   4.477 ±  0.067  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe              32  avgt   10   9.149 ±  0.087  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe            1024  avgt   10  29.491 ±  0.240  ns/op
BenchmarkPinotDataBuffer.copyTo          original               1  avgt   10   4.341 ±  0.067  ns/op
BenchmarkPinotDataBuffer.copyTo          original              32  avgt   10  43.050 ± 16.011  ns/op
BenchmarkPinotDataBuffer.copyTo          original            1024  avgt   10  54.949 ± 11.809  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible               1  avgt   10   4.346 ±  0.048  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible              32  avgt   10  37.694 ± 14.258  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible            1024  avgt   10  58.232 ± 28.683  ns/op
```

`jdk17`:
```
Benchmark                         (_bufferLibrary)  (_valueLength)  Mode  Cnt    Score    Error  Units
BenchmarkPinotDataBuffer.copyTo        bytebuffer               1  avgt   10    4.327 ±  0.034  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer              32  avgt   10    9.783 ±  0.154  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer            1024  avgt   10   35.355 ± 23.169  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe               1  avgt   10    4.475 ±  0.116  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe              32  avgt   10    8.824 ±  0.070  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe            1024  avgt   10   30.090 ±  0.313  ns/op
BenchmarkPinotDataBuffer.copyTo          original               1  avgt   10    4.313 ±  0.036  ns/op
BenchmarkPinotDataBuffer.copyTo          original              32  avgt   10   86.750 ± 34.681  ns/op
BenchmarkPinotDataBuffer.copyTo          original            1024  avgt   10  103.254 ± 40.648  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible               1  avgt   10    4.361 ±  0.112  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible              32  avgt   10   47.829 ± 14.724  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible            1024  avgt   10   70.134 ± 26.604  ns/op
```

`jdk11`:
```
Benchmark                         (_bufferLibrary)  (_valueLength)  Mode  Cnt   Score    Error  Units
BenchmarkPinotDataBuffer.copyTo        bytebuffer               1  avgt   10   4.365 ±  0.030  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer              32  avgt   10  10.876 ±  3.184  ns/op
BenchmarkPinotDataBuffer.copyTo        bytebuffer            1024  avgt   10  29.759 ±  0.373  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe               1  avgt   10   4.334 ±  0.027  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe              32  avgt   10   9.001 ±  0.183  ns/op
BenchmarkPinotDataBuffer.copyTo            unsafe            1024  avgt   10  29.740 ±  0.465  ns/op
BenchmarkPinotDataBuffer.copyTo          original               1  avgt   10   4.333 ±  0.039  ns/op
BenchmarkPinotDataBuffer.copyTo          original              32  avgt   10  93.556 ± 34.848  ns/op
BenchmarkPinotDataBuffer.copyTo          original            1024  avgt   10  86.205 ± 11.368  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible               1  avgt   10   4.336 ±  0.051  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible              32  avgt   10  35.676 ± 16.370  ns/op
BenchmarkPinotDataBuffer.copyTo        accessible            1024  avgt   10  63.308 ± 22.069  ns/op
```

* `original` -> master
* `unsafe` -> both changes
* `accessible` -> only changing setAccessible to be called once statically

labels: `performance`