### PR TITLE
Disable japicmp by default. Add a CI execution that just runs that.

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -89,6 +89,15 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Verify with binary-compatibility-check profile
         run: mvn verify -DskipTests -Pbinary-compat-check -T1C
   unit-test:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -76,6 +76,21 @@ jobs:
             --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
         run: .github/workflows/scripts/.pinot_linter.sh
+
+  binary-compat-check:
+    if: github.repository == 'apache/pinot'
+    runs-on: ubuntu-latest
+    name: Pinot Binary Compatibility Check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Verify with binary-compatibility-check profile
+        run: mvn verify -DskipTests -Pbinary-compat-check -T1C
   unit-test:
     if: github.repository == 'apache/pinot'
     runs-on: ubuntu-latest

--- a/pinot-segment-spi/pom.xml
+++ b/pinot-segment-spi/pom.xml
@@ -41,6 +41,7 @@
         <artifactId>japicmp-maven-plugin</artifactId>
         <version>0.23.1</version>
         <configuration>
+          <skip>${japicmp.skip}</skip> <!-- This is the default config, but set here to be explicit. It is set on the parent pom -->
           <!-- If oldVersion were left blank, 1.3.0 would be the baseline version for japicmp's comparing. However, we already
           introduced back-incompatible changes since the release of 1.4.0-SNAPSHOT, so we are using a baseline .jar of the repo here
           (with version as of PR #15737).

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -129,6 +129,7 @@
         <artifactId>japicmp-maven-plugin</artifactId>
         <version>0.23.1</version>
         <configuration>
+          <skip>${japicmp.skip}</skip> <!-- This is the default config, but set here to be explicit. It is set on the parent pom -->
           <!-- If oldVersion were left blank, 1.3.0 would be the baseline version for japicmp's comparing. However, we already
           introduced back-incompatible changes since the release of 1.4.0-SNAPSHOT, so we are using a baseline .jar of the repo here
           (with version as of PR #15684).

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.31.46</aws.sdk.version>
+    <aws.sdk.version>2.31.48</aws.sdk.version>
     <azure.sdk.version>1.2.34</azure.sdk.version>
     <azure.msal4j.version>1.20.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>
@@ -253,7 +253,7 @@
 
     <!-- Solve conflicts and vulnerabilities -->
     <kerby.version>2.1.0</kerby.version>
-    <jline.version>3.30.2</jline.version>
+    <jline.version>3.30.3</jline.version>
     <wildfly.version>2.0.1</wildfly.version>
     <jettison.version>1.5.4</jettison.version>
     <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2581,7 +2581,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.23.1</version>
+            <version>10.24.0</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.31.48</aws.sdk.version>
+    <aws.sdk.version>2.31.46</aws.sdk.version>
     <azure.sdk.version>1.2.34</azure.sdk.version>
     <azure.msal4j.version>1.20.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>
@@ -253,7 +253,7 @@
 
     <!-- Solve conflicts and vulnerabilities -->
     <kerby.version>2.1.0</kerby.version>
-    <jline.version>3.30.3</jline.version>
+    <jline.version>3.30.2</jline.version>
     <wildfly.version>2.0.1</wildfly.version>
     <jettison.version>1.5.4</jettison.version>
     <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
@@ -312,6 +312,8 @@
     <assertj.version>3.27.3</assertj.version>
     <archiver.compress>true</archiver.compress>
     <archiver.recompressZippedFiles>true</archiver.recompressZippedFiles>
+
+    <japicmp.skip>true</japicmp.skip>
   </properties>
 
   <profiles>
@@ -479,6 +481,16 @@
       <properties>
         <scala.version>2.13.16</scala.version>
         <scala.compat.version>2.13</scala.compat.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>binary-compat-check</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <japicmp.skip>false</japicmp.skip>
       </properties>
     </profile>
   </profiles>
@@ -2569,7 +2581,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.24.0</version>
+            <version>10.23.1</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
This PR moves the japicmp plugin, added in https://github.com/apache/pinot/pull/15737, to its own profile. It also creates a new GHA check that only runs that profile. **This check is executed on each PR**

