### PR TITLE
[bugfix][ui] Fix: rendering of table sizes in OSS UI when table size returns -1.

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -374,6 +374,7 @@ const encodeString = (str: string) => {
 }
 
 const formatBytes = (bytes: number, decimals = 2) => {
+  if (bytes < 0) return 'N/A';
   if (bytes === 0) return '0 Bytes';
 
   const k = 1024;


### PR DESCRIPTION
## Fix rendering of table sizes in OSS UI when table size returns -1.

### Problem
When the reportedSize and estimatedSize for a table using /size?verbose=false were -1.
<img width="335" alt="Screenshot 2025-05-23 at 20 19 49" src="https://github.com/user-attachments/assets/f64a600c-02b0-475c-998b-229276f2a32d" />

The OSS UI would show NaN undefined for the sizes. 
<img width="1781" alt="Screenshot 2025-05-23 at 20 18 33" src="https://github.com/user-attachments/assets/575fa45f-2fdf-4e45-af21-c3305a1827f4" />
<img width="1664" alt="Screenshot 2025-05-23 at 20 18 45" src="https://github.com/user-attachments/assets/d178c71b-c8f7-4cbe-a011-3b28dae3145d" />

### Fix
This fix would show N/A whenever the reportedSize and estimatedSize are -1 instead of NaN undefined.
<img width="1790" alt="Screenshot 2025-05-23 at 20 18 51" src="https://github.com/user-attachments/assets/7ec6f966-fdce-4357-a9f2-df167e9ba419" />
<img width="1198" alt="Screenshot 2025-05-23 at 20 19 08" src="https://github.com/user-attachments/assets/c4ec5f36-dbbd-495b-b57d-ee0eaf7109a7" />

<img width="762" alt="Screenshot 2025-05-23 at 20 28 47" src="https://github.com/user-attachments/assets/c10476ac-bcb9-47d5-9e54-630beb0ebc06" />

### Impact

This is a non-breaking change that improves error handling in the isObjEmpty function. It does not introduce any new features or alter existing functionality beyond the added validation.