### PR TITLE
Reduce ZK access for SendStatsPredicate

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/worker/WorkerQueryServer.java
@@ -41,7 +41,7 @@ public class WorkerQueryServer {
     _queryServicePort = _configuration.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_SERVER_PORT,
         CommonConstants.MultiStageQueryRunner.DEFAULT_QUERY_SERVER_PORT);
     QueryRunner queryRunner = new QueryRunner();
-    queryRunner.init(_configuration, instanceDataManager, tlsConfig, sendStats::getSendStats);
+    queryRunner.init(_configuration, instanceDataManager, tlsConfig, sendStats::isSendStats);
     _queryWorkerService = new QueryServer(_queryServicePort, queryRunner, tlsConfig, configuration);
   }
 


### PR DESCRIPTION
Fix #15890 

- For `ALWAYS` and `NEVER`, no need to register it as listener
- For `SAFE`, disable pre-fetch and only read the changed instance config

No extra test is added, but the existing integration tests should cover the changed code