### PR TITLE
Change Pinot UI to be able to show json on error and MSE stats if any

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -56,6 +56,12 @@ enum ResultViewType {
   VISUAL = 'visual',
 }
 
+enum ErrorViewType {
+  EXCEPTION = 'exception',
+  JSON = 'json',
+  VISUAL = 'visual',
+}
+
 const useStyles = makeStyles((theme) => ({
   title: {
     flexGrow: 1,
@@ -182,7 +188,7 @@ const QueryPage = () => {
     columns: [],
     records: [],
   });
-  const [showException, setShowException] = useState<boolean>(false);
+  const [showErrorType, setShowErrorType] = useState<ErrorViewType>(ErrorViewType.EXCEPTION);
 
   const [tableSchema, setTableSchema] = useState<TableData>({
     columns: [],
@@ -608,9 +614,22 @@ const QueryPage = () => {
                         className={classes.sqlError} 
                         severity="error" 
                         action={
+
                           <FormControlLabel
-                            control={<Switch color="primary" checked={showException} onChange={(e) => setShowException(e.target.checked)} name="checkedA" />}
-                            label={<Typography variant='body2'>Show Exceptions</Typography>}
+                              labelPlacement='start'
+                              control={
+                                <ButtonGroup color='primary' size='small'>
+                                  <Button onClick={() => setShowErrorType(ErrorViewType.EXCEPTION)} variant={showErrorType === ErrorViewType.EXCEPTION ? "contained" : "outlined"}>Exception</Button>
+                                  <Button onClick={() => setShowErrorType(ErrorViewType.JSON)} variant={showErrorType === ErrorViewType.JSON ? "contained" : "outlined"}>Json</Button>
+                                  {
+                                    stageStats && Object.keys(stageStats).length > 0 &&
+                                    <Button onClick={() => setShowErrorType(ErrorViewType.VISUAL)} variant={showErrorType === ErrorViewType.VISUAL ? "contained" : "outlined"}>Visual</Button>
+                                  }
+                                </ButtonGroup>
+                              }
+                              label={<Typography style={{marginRight: "8px"}}>View</Typography>}
+                              style={{marginRight: 0}}
+                              className={classes.runNowBtn}
                           />
                         }
                       >
@@ -624,16 +643,37 @@ const QueryPage = () => {
                       </Alert>
                       <Box m={"16px"}></Box>
 
-                      {
-                        showException && resultError.map((error) => (
-                          <Box style={{paddingBottom: "10px"}}>
-                            <Alert className={classes.sqlError} severity="error">
-                              {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
-                              {error.message}
-                            </Alert>
-                          </Box>
-                        ))
-                      }
+                      {showErrorType === ErrorViewType.EXCEPTION && (
+                          resultError.map((error) => (
+                              <Box style={{paddingBottom: "10px"}}>
+                                <Alert className={classes.sqlError} severity="error">
+                                  {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
+                                  {error.message}
+                                </Alert>
+                              </Box>
+                          ))
+                      )}
+                      {showErrorType === ErrorViewType.JSON && (
+                          <SimpleAccordion
+                              headerTitle="Query Result (JSON Format)"
+                              showSearchBox={false}
+                          >
+                            <CodeMirror
+                                options={jsonoptions}
+                                value={outputResult}
+                                className={classes.queryOutput}
+                                autoCursor={false}
+                            />
+                          </SimpleAccordion>
+                      )}
+                      {showErrorType === ErrorViewType.VISUAL && (
+                          <SimpleAccordion
+                              headerTitle="Query Stats Visualized"
+                              showSearchBox={false}
+                          >
+                            <VisualizeQueryStageStats stageStats={stageStats} />
+                          </SimpleAccordion>
+                      )}
                     </>
                   )
                 }

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -644,8 +644,8 @@ const QueryPage = () => {
                       <Box m={"16px"}></Box>
 
                       {showErrorType === ErrorViewType.EXCEPTION && (
-                          resultError.map((error) => (
-                              <Box style={{paddingBottom: "10px"}}>
+                          resultError.map((error, index) => (
+                              <Box key={error.errorCode ? error.errorCode : `error-${index}`} style={{paddingBottom: "10px"}}>
                                 <Alert className={classes.sqlError} severity="error">
                                   {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
                                   {error.message}


### PR DESCRIPTION
This PR modifies Pinot UI when queries fail. Instead of showing/not showing the error message, now we provide up to three options:
1. Show the exception (the new default)
2. Show the JSON payload (similar to what we do in case of success)
3. Show the visual MSE stats (just in case there are stats, right now they are only included in MSE queries that fail due to a timeout)

Snapshot of the previous default
![image](https://github.com/user-attachments/assets/039e3913-1cd1-466f-acdc-f98c20a2843b)

Snapshot of the new default
![image](https://github.com/user-attachments/assets/cbbe3edc-9b4d-4473-8df9-52b0bf47ba85)
Snapshot of the new JSON _tab_
![image](https://github.com/user-attachments/assets/25d89d58-bb0e-4e14-9671-fec20ef9f3d9)
Snapshot of the new Visual _tab_
![image](https://github.com/user-attachments/assets/195a060c-be9f-431c-b25d-e0631a311b32)
