### PR TITLE
[Refactor] Handling Multi Table Auth Properly

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -25,7 +25,8 @@ import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
-import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 
 
@@ -106,18 +107,24 @@ public interface AccessControl extends FineGrainedAccessControl {
 
   /**
    * Verify access control on pinot tables.
-   * The default implementation returns a {@link TableAuthorizationResult} with the result of the hasAccess() of the
+   * The default implementation returns a {@link MultiTableAuthResultImpl} with the result of the hasAccess() of the
    * implementation
    *
    * @param requesterIdentity requester identity
    * @param tables Set of pinot tables used in the query. Table name can be with or without tableType.
    *
-   * @return {@code TableAuthorizationResult} with the result of the access control check
+   * @return {@link MultiTableAuthResultImpl} with the result of the access control check
    */
-  default TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
+  default MultiTableAuthResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
     // Taking all tables when hasAccess Failed , to not break existing implementations
     // It will say all tables names failed AuthZ even only some failed AuthZ - which is same as just boolean output
-    return hasAccess(requesterIdentity, tables) ? TableAuthorizationResult.success()
-        : new TableAuthorizationResult(tables);
+    return hasAccess(requesterIdentity, tables) ? MultiTableAuthResultImpl.success()
+        : new MultiTableAuthResultImpl(tables);
+  }
+
+  default AuthorizationResult authorize(RequesterIdentity requesterIdentity, String table) {
+    MultiTableAuthResult multiTableAuthResult = authorize(requesterIdentity, Set.of(table));
+    //hack to create the failure message quickly
+    return new BasicAuthorizationResultImpl(multiTableAuthResult.hasAccess(), multiTableAuthResult.getFailureMessage());
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
-import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 
 
@@ -107,19 +107,19 @@ public interface AccessControl extends FineGrainedAccessControl {
 
   /**
    * Verify access control on pinot tables.
-   * The default implementation returns a {@link MultiTableAuthResultImpl} with the result of the hasAccess() of the
+   * The default implementation returns a {@link TableAuthorizationResult} with the result of the hasAccess() of the
    * implementation
    *
    * @param requesterIdentity requester identity
    * @param tables Set of pinot tables used in the query. Table name can be with or without tableType.
    *
-   * @return {@link MultiTableAuthResultImpl} with the result of the access control check
+   * @return {@link TableAuthorizationResult} with the result of the access control check
    */
   default MultiTableAuthResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
     // Taking all tables when hasAccess Failed , to not break existing implementations
     // It will say all tables names failed AuthZ even only some failed AuthZ - which is same as just boolean output
-    return hasAccess(requesterIdentity, tables) ? MultiTableAuthResultImpl.success()
-        : new MultiTableAuthResultImpl(tables);
+    return hasAccess(requesterIdentity, tables) ? TableAuthorizationResult.success()
+        : new TableAuthorizationResult(tables);
   }
 
   default AuthorizationResult authorize(RequesterIdentity requesterIdentity, String table) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/ResponseStoreResource.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/ResponseStoreResource.java
@@ -53,7 +53,7 @@ import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
-import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.Request;
@@ -187,7 +187,7 @@ public class ResponseStoreResource {
     if (_responseStore.exists(requestId)) {
       CursorResponse response = _responseStore.readResponse(requestId);
       AccessControl accessControl = _accessControlFactory.create();
-      TableAuthorizationResult result = accessControl.authorize(
+      MultiTableAuthResult result = accessControl.authorize(
           PinotClientRequest.makeHttpIdentity(requestContext),
           response.getTablesQueried());
       if (!result.hasAccess()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -23,7 +23,8 @@ import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
-import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -49,8 +50,8 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
-    public TableAuthorizationResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
-      return TableAuthorizationResult.success();
+    public MultiTableAuthResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
+      return MultiTableAuthResultImpl.success();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -24,7 +24,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
-import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -51,7 +51,7 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
 
     @Override
     public MultiTableAuthResult authorize(RequesterIdentity requesterIdentity, Set<String> tables) {
-      return MultiTableAuthResultImpl.success();
+      return TableAuthorizationResult.success();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -89,6 +89,8 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public AuthorizationResult authorize(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+      //Although this var is unused, the method call checks for a precondition on requester identity
+      Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
       if (brokerRequest == null || !brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource()
           .isSetTableName()) {
         // no table restrictions? accept

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -35,7 +35,7 @@ import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
-import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -108,7 +108,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
       }
 
       if (tables == null || tables.isEmpty()) {
-        return MultiTableAuthResultImpl.success();
+        return TableAuthorizationResult.success();
       }
       BasicAuthPrincipal principal = principalOpt.get();
       Set<String> failedTables = new HashSet<>();
@@ -118,9 +118,9 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
         }
       }
       if (failedTables.isEmpty()) {
-        return MultiTableAuthResultImpl.success();
+        return TableAuthorizationResult.success();
       }
-      return new MultiTableAuthResultImpl(failedTables);
+      return new TableAuthorizationResult(failedTables);
     }
 
     private Optional<BasicAuthPrincipal> getPrincipalOpt(RequesterIdentity requesterIdentity) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -40,7 +40,7 @@ import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.BasicAuthorizationResultImpl;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
-import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -107,7 +107,7 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
         throw new NotAuthorizedException("Basic");
       }
       if (tables == null || tables.isEmpty()) {
-        return MultiTableAuthResultImpl.success();
+        return TableAuthorizationResult.success();
       }
 
       ZkBasicAuthPrincipal principal = principalOpt.get();
@@ -118,9 +118,9 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
         }
       }
       if (failedTables.isEmpty()) {
-        return MultiTableAuthResultImpl.success();
+        return TableAuthorizationResult.success();
       }
-      return new MultiTableAuthResultImpl(failedTables);
+      return new TableAuthorizationResult(failedTables);
     }
 
     private Optional<ZkBasicAuthPrincipal> getPrincipalAuth(RequesterIdentity requesterIdentity) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -55,7 +55,7 @@ import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
-import org.apache.pinot.spi.auth.MultiTableAuthResultImpl;
+import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListener;
@@ -236,9 +236,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     failedTables.addAll(tableAuthorizationResult.getFailedTables());
 
     if (!failedTables.isEmpty()) {
-      tableAuthorizationResult = new MultiTableAuthResultImpl(failedTables);
+      tableAuthorizationResult = new TableAuthorizationResult(failedTables);
     } else {
-      tableAuthorizationResult = MultiTableAuthResultImpl.success();
+      tableAuthorizationResult = TableAuthorizationResult.success();
     }
 
     if (!tableAuthorizationResult.hasAccess()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -81,7 +81,7 @@ import org.apache.pinot.query.runtime.MultiStageStatsTreeBuilder;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -299,7 +299,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       HttpHeaders httpHeaders, QueryEnvironment.CompiledQuery compiledQuery) {
     Set<String> tables = compiledQuery.getTableNames();
     if (tables != null && !tables.isEmpty()) {
-      TableAuthorizationResult tableAuthorizationResult =
+      MultiTableAuthResult tableAuthorizationResult =
           hasTableAccess(requesterIdentity, tables, requestContext, httpHeaders);
       if (!tableAuthorizationResult.hasAccess()) {
         throwTableAccessError(tableAuthorizationResult);
@@ -393,7 +393,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     updatePhaseTimingForTables(tableNames, BrokerQueryPhase.REQUEST_COMPILATION, compilationTimeNs);
 
     // Validate table access.
-    TableAuthorizationResult tableAuthorizationResult =
+    MultiTableAuthResult tableAuthorizationResult =
         hasTableAccess(requesterIdentity, tableNames, requestContext, httpHeaders);
     if (!tableAuthorizationResult.hasAccess()) {
       throwTableAccessError(tableAuthorizationResult);
@@ -522,7 +522,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     }
   }
 
-  private static void throwTableAccessError(TableAuthorizationResult tableAuthorizationResult) {
+  private static void throwTableAccessError(MultiTableAuthResult tableAuthorizationResult) {
     String failureMessage = tableAuthorizationResult.getFailureMessage();
     if (StringUtils.isNotBlank(failureMessage)) {
       failureMessage = "Reason: " + failureMessage;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.broker.api;
 
 import java.util.Set;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.MultiTableAuthResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.testng.annotations.Test;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/AccessControlBackwardCompatibleTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.api;
 import java.util.Set;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.testng.annotations.Test;
 
@@ -43,7 +44,7 @@ public class AccessControlBackwardCompatibleTest {
     AccessControl accessControl = new AllFalseAccessControlImpl();
     HttpRequesterIdentity identity = new HttpRequesterIdentity();
     Set<String> tables = Set.of("table1", "table2");
-    AuthorizationResult result = accessControl.authorize(identity, tables);
+    MultiTableAuthResult result = accessControl.authorize(identity, tables);
     assertFalse(result.hasAccess());
     assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.QuerySource;
 import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.MultiTableAuthResult;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -122,19 +123,22 @@ public class BasicAuthAccessControlTest {
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
-    authorizationResult = _accessControl.authorize(identity, tableNames);
-    Assert.assertFalse(authorizationResult.hasAccess());
-    Assert.assertEquals(authorizationResult.getFailureMessage(),
+
+    MultiTableAuthResult multiTableAuthResult;
+
+    multiTableAuthResult = _accessControl.authorize(identity, tableNames);
+    Assert.assertFalse(multiTableAuthResult.hasAccess());
+    Assert.assertEquals(multiTableAuthResult.getFailureMessage(),
         "Authorization Failed for tables: [veryImportantStuff]");
     tableNames.add("lessImportantStuff");
-    authorizationResult = _accessControl.authorize(identity, tableNames);
-    Assert.assertFalse(authorizationResult.hasAccess());
-    Assert.assertEquals(authorizationResult.getFailureMessage(),
+    multiTableAuthResult = _accessControl.authorize(identity, tableNames);
+    Assert.assertFalse(multiTableAuthResult.hasAccess());
+    Assert.assertEquals(multiTableAuthResult.getFailureMessage(),
         "Authorization Failed for tables: [veryImportantStuff]");
     tableNames.add("lesserImportantStuff");
-    authorizationResult = _accessControl.authorize(identity, tableNames);
-    Assert.assertFalse(authorizationResult.hasAccess());
-    Assert.assertEquals(authorizationResult.getFailureMessage(),
+    multiTableAuthResult = _accessControl.authorize(identity, tableNames);
+    Assert.assertFalse(multiTableAuthResult.hasAccess());
+    Assert.assertEquals(multiTableAuthResult.getFailureMessage(),
         "Authorization Failed for tables: [veryImportantStuff]");
   }
 
@@ -160,9 +164,9 @@ public class BasicAuthAccessControlTest {
     tableNames.add("veryImportantStuff");
     tableNames.add("lesserImportantStuff");
 
-    authorizationResult = _accessControl.authorize(identity, tableNames);
-    Assert.assertTrue(authorizationResult.hasAccess());
-    Assert.assertEquals(authorizationResult.getFailureMessage(), "");
+    MultiTableAuthResult multiTableAuthResult = _accessControl.authorize(identity, tableNames);
+    Assert.assertTrue(multiTableAuthResult.hasAccess());
+    Assert.assertEquals(multiTableAuthResult.getFailureMessage(), "");
   }
 
   @Test
@@ -178,8 +182,9 @@ public class BasicAuthAccessControlTest {
     Assert.assertTrue(authorizationResult.hasAccess());
 
     Set<String> tableNames = new HashSet<>();
-    authorizationResult = _accessControl.authorize(identity, tableNames);
-    Assert.assertTrue(authorizationResult.hasAccess());
+
+    MultiTableAuthResult multiTableAuthResult = _accessControl.authorize(identity, tableNames);
+    Assert.assertTrue(multiTableAuthResult.hasAccess());
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/MultiTableAuthResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/MultiTableAuthResult.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.auth;
+
+import java.util.Optional;
+import java.util.Set;
+
+
+public interface MultiTableAuthResult {
+  /**
+   * Indicates whether the access is granted.
+   *
+   * @return true if access is granted, false otherwise.
+   */
+  boolean hasAccess();
+
+  Optional<Boolean> hasAccess(String tableName);
+
+  Set<String> getFailedTables();
+
+  /**
+   * Provides the failure message if access is denied.
+   *
+   * @return A string containing the failure message if access is denied, otherwise an empty string or null.
+   */
+  String getFailureMessage();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/MultiTableAuthResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/MultiTableAuthResult.java
@@ -31,8 +31,17 @@ public interface MultiTableAuthResult {
    */
   boolean hasAccess();
 
+  /**
+   * Checks auth status of a single table.
+   * @param tableName the table name.
+   * @return empty optional if that table is not present, optional of the auth status otherwise
+   */
   Optional<Boolean> hasAccess(String tableName);
 
+  /**
+   * Returns the set of tables that failed auth.
+   * @return the set of tables that failed auth
+   */
   Set<String> getFailedTables();
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -30,20 +30,20 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 
-public class MultiTableAuthResultImpl implements MultiTableAuthResult {
+public class TableAuthorizationResult implements MultiTableAuthResult {
 
-  private static final MultiTableAuthResult SUCCESS = new MultiTableAuthResultImpl(Map.of());
+  private static final MultiTableAuthResult SUCCESS = new TableAuthorizationResult(Map.of());
 
   private final Map<String, Boolean> _authResult;
   private final Set<String> _failedTables;
 
-  public MultiTableAuthResultImpl(Map<String, Boolean> authResult) {
+  public TableAuthorizationResult(Map<String, Boolean> authResult) {
     _authResult = authResult;
     _failedTables =
         _authResult.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).collect(Collectors.toSet());
   }
 
-  public MultiTableAuthResultImpl(Set<String> failedTables) {
+  public TableAuthorizationResult(Set<String> failedTables) {
     Map<String, Boolean> authResult = new HashMap<>();
     for (String tableName : failedTables) {
       authResult.put(tableName, false);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/TableAuthorizationResult.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class TableAuthorizationResult implements MultiTableAuthResult {
 
-  private static final MultiTableAuthResult SUCCESS = new TableAuthorizationResult(Map.of());
+  private static final TableAuthorizationResult SUCCESS = new TableAuthorizationResult(Map.of());
 
   private final Map<String, Boolean> _authResult;
   private final Set<String> _failedTables;
@@ -78,7 +78,7 @@ public class TableAuthorizationResult implements MultiTableAuthResult {
     return "Authorization Failed for tables: " + failedTablesList;
   }
 
-  public static MultiTableAuthResult success() {
+  public static TableAuthorizationResult success() {
     return SUCCESS;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/MultiTableAuthResultTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/MultiTableAuthResultTest.java
@@ -25,20 +25,20 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class TableAuthorizationResultTest {
+public class MultiTableAuthResultTest {
 
   @Test
   public void testParameterizedConstructor() {
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
-    TableAuthorizationResult result = new TableAuthorizationResult(failedTables);
+    MultiTableAuthResult result = new MultiTableAuthResultImpl(failedTables);
     Assert.assertFalse(result.hasAccess());
     Assert.assertTrue(result.getFailureMessage().contains("table1"));
   }
 
   @Test
   public void testAddFailedTable() {
-    TableAuthorizationResult result = new TableAuthorizationResult(Set.of("table1"));
+    MultiTableAuthResult result = new MultiTableAuthResultImpl(Set.of("table1"));
     Assert.assertFalse(result.hasAccess());
     Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1]");
   }
@@ -48,20 +48,20 @@ public class TableAuthorizationResultTest {
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
     failedTables.add("table2");
-    TableAuthorizationResult result = new TableAuthorizationResult(failedTables);
+    MultiTableAuthResult result = new MultiTableAuthResultImpl(failedTables);
     Assert.assertFalse(result.hasAccess());
     Assert.assertEquals(result.getFailedTables(), failedTables);
   }
 
   @Test
   public void testGetFailureMessage() {
-    TableAuthorizationResult result = new TableAuthorizationResult(Set.of("table1", "table2"));
+    MultiTableAuthResult result = new MultiTableAuthResultImpl(Set.of("table1", "table2"));
     Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }
 
   @Test
   public void testNoFailureResult() {
-    TableAuthorizationResult result = TableAuthorizationResult.success();
+    MultiTableAuthResult result = MultiTableAuthResultImpl.success();
     Assert.assertTrue(result.hasAccess());
     Assert.assertEquals("", result.getFailureMessage());
   }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/auth/MultiTableAuthResultTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/auth/MultiTableAuthResultTest.java
@@ -31,14 +31,14 @@ public class MultiTableAuthResultTest {
   public void testParameterizedConstructor() {
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
-    MultiTableAuthResult result = new MultiTableAuthResultImpl(failedTables);
+    MultiTableAuthResult result = new TableAuthorizationResult(failedTables);
     Assert.assertFalse(result.hasAccess());
     Assert.assertTrue(result.getFailureMessage().contains("table1"));
   }
 
   @Test
   public void testAddFailedTable() {
-    MultiTableAuthResult result = new MultiTableAuthResultImpl(Set.of("table1"));
+    MultiTableAuthResult result = new TableAuthorizationResult(Set.of("table1"));
     Assert.assertFalse(result.hasAccess());
     Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1]");
   }
@@ -48,20 +48,20 @@ public class MultiTableAuthResultTest {
     Set<String> failedTables = new HashSet<>();
     failedTables.add("table1");
     failedTables.add("table2");
-    MultiTableAuthResult result = new MultiTableAuthResultImpl(failedTables);
+    MultiTableAuthResult result = new TableAuthorizationResult(failedTables);
     Assert.assertFalse(result.hasAccess());
     Assert.assertEquals(result.getFailedTables(), failedTables);
   }
 
   @Test
   public void testGetFailureMessage() {
-    MultiTableAuthResult result = new MultiTableAuthResultImpl(Set.of("table1", "table2"));
+    MultiTableAuthResult result = new TableAuthorizationResult(Set.of("table1", "table2"));
     Assert.assertEquals(result.getFailureMessage(), "Authorization Failed for tables: [table1, table2]");
   }
 
   @Test
   public void testNoFailureResult() {
-    MultiTableAuthResult result = MultiTableAuthResultImpl.success();
+    MultiTableAuthResult result = TableAuthorizationResult.success();
     Assert.assertTrue(result.hasAccess());
     Assert.assertEquals("", result.getFailureMessage());
   }


### PR DESCRIPTION
Currently, we use the `TableAuthorizationResult` class to encapsulate authorization results for multiple tables by tracking `_failedTables`. However, this class implements `AuthorizationResult`, which is semantically incorrect - `AuthorizationResult` is intended to represent the result of a single resource, not a collection. Additionally, `TableAuthorizationResult` is not future-proof. For example, it doesn’t allow querying the authorization status of a specific table, which limits its usability.

This PR introduces a new interface, `MultiTableAuthResult`, to correctly represent multi-table authorization outcomes. It provides the following methods:

1. `boolean hasAccess()`: Returns true if all tables have access; false otherwise.

2. `Optional<Boolean> hasAccess(String tableName)`: Returns the access result for a specific table. If the table is not part of the result, returns Optional.empty().

3. `Set<String> getFailedTables()`: Returns the set of tables that failed authorization.

 4. `String getFailureMessage()`: Returns a consolidated failure message, similar to `TableAuthorizationResult`.

`TableAuthorizationResult` implements this new interface `MultiTableAuthResult`. It improves correctness, extensibility, and clarity when handling multi-table authorization logic.