### PR TITLE
Adds Inverted Index config validation check

### DIFF
--- a/pinot-core/src/test/resources/TableIndexingTest.csv
+++ b/pinot-core/src/test/resources/TableIndexingTest.csv
@@ -3,7 +3,7 @@ INT;sv;raw;timestamp_index;true;
 INT;sv;raw;bloom_filter;true;
 INT;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 INT;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-INT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+INT;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 INT;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 INT;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 INT;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -14,7 +14,7 @@ INT;mv;raw;timestamp_index;true;
 INT;mv;raw;bloom_filter;true;
 INT;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 INT;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-INT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+INT;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 INT;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 INT;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 INT;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -47,7 +47,7 @@ LONG;sv;raw;timestamp_index;true;
 LONG;sv;raw;bloom_filter;true;
 LONG;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 LONG;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-LONG;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+LONG;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 LONG;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 LONG;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 LONG;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -58,7 +58,7 @@ LONG;mv;raw;timestamp_index;true;
 LONG;mv;raw;bloom_filter;true;
 LONG;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 LONG;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-LONG;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+LONG;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 LONG;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 LONG;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 LONG;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -91,7 +91,7 @@ FLOAT;sv;raw;timestamp_index;true;
 FLOAT;sv;raw;bloom_filter;true;
 FLOAT;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 FLOAT;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-FLOAT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+FLOAT;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 FLOAT;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 FLOAT;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 FLOAT;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -102,7 +102,7 @@ FLOAT;mv;raw;timestamp_index;true;
 FLOAT;mv;raw;bloom_filter;true;
 FLOAT;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 FLOAT;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-FLOAT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+FLOAT;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 FLOAT;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 FLOAT;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 FLOAT;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -135,7 +135,7 @@ DOUBLE;sv;raw;timestamp_index;true;
 DOUBLE;sv;raw;bloom_filter;true;
 DOUBLE;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 DOUBLE;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 DOUBLE;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 DOUBLE;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 DOUBLE;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -146,7 +146,7 @@ DOUBLE;mv;raw;timestamp_index;true;
 DOUBLE;mv;raw;bloom_filter;true;
 DOUBLE;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 DOUBLE;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 DOUBLE;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 DOUBLE;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 DOUBLE;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -179,7 +179,7 @@ DECIMAL;sv_BIG;raw;timestamp_index;true;
 DECIMAL;sv_BIG;raw;bloom_filter;true;
 DECIMAL;sv_BIG;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 DECIMAL;sv_BIG;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 DECIMAL;sv_BIG;raw;json_index;false;Json index is currently only supported on STRING columns
 DECIMAL;sv_BIG;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 DECIMAL;sv_BIG;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -201,7 +201,7 @@ BOOLEAN;sv;raw;timestamp_index;true;
 BOOLEAN;sv;raw;bloom_filter;false;Cannot create a bloom filter on boolean column col
 BOOLEAN;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 BOOLEAN;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 BOOLEAN;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 BOOLEAN;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 BOOLEAN;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -212,7 +212,7 @@ BOOLEAN;mv;raw;timestamp_index;false;Caught exception while reading data
 BOOLEAN;mv;raw;bloom_filter;false;Cannot create a bloom filter on boolean column col
 BOOLEAN;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 BOOLEAN;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 BOOLEAN;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 BOOLEAN;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 BOOLEAN;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -245,7 +245,7 @@ TIMESTAMP;sv;raw;timestamp_index;true;
 TIMESTAMP;sv;raw;bloom_filter;true;
 TIMESTAMP;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 TIMESTAMP;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 TIMESTAMP;sv;raw;json_index;false;Json index is currently only supported on STRING columns
 TIMESTAMP;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 TIMESTAMP;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -256,7 +256,7 @@ TIMESTAMP;mv;raw;timestamp_index;true;
 TIMESTAMP;mv;raw;bloom_filter;true;
 TIMESTAMP;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 TIMESTAMP;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 TIMESTAMP;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 TIMESTAMP;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 TIMESTAMP;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -289,7 +289,7 @@ STRING;sv;raw;timestamp_index;false;Caught exception while reading data
 STRING;sv;raw;bloom_filter;true;
 STRING;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 STRING;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-STRING;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 STRING;sv;raw;json_index;false;Column: col Unrecognized token 'str': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 15]
 STRING;sv;raw;native_text_index;true;
 STRING;sv;raw;text_index;true;
@@ -300,7 +300,7 @@ STRING;mv;raw;timestamp_index;false;Caught exception while reading data
 STRING;mv;raw;bloom_filter;true;
 STRING;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 STRING;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-STRING;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 STRING;mv;raw;json_index;false;Json index is currently only supported on single-value columns
 STRING;mv;raw;native_text_index;true;
 STRING;mv;raw;text_index;true;
@@ -333,7 +333,7 @@ JSON;sv;raw;timestamp_index;false;Caught exception while reading data
 JSON;sv;raw;bloom_filter;true;
 JSON;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 JSON;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-JSON;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+JSON;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 JSON;sv;raw;json_index;true;
 JSON;sv;raw;native_text_index;false;expected [1] but found [0]
 JSON;sv;raw;text_index;false;expected [1] but found [0]
@@ -355,7 +355,7 @@ BYTES;sv;raw;timestamp_index;false;Caught exception while reading data
 BYTES;sv;raw;bloom_filter;false;Caught exception while reading data
 BYTES;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 BYTES;sv;raw;h3_index;false;Caught exception while reading data
-BYTES;sv;raw;inverted_index;false;Caught exception while reading data
+BYTES;sv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 BYTES;sv;raw;json_index;false;Caught exception while reading data
 BYTES;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 BYTES;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -366,7 +366,7 @@ BYTES;mv;raw;timestamp_index;false;Caught exception while reading data
 BYTES;mv;raw;bloom_filter;false;Caught exception while reading data
 BYTES;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 BYTES;mv;raw;h3_index;false;Caught exception while reading data
-BYTES;mv;raw;inverted_index;false;Caught exception while reading data
+BYTES;mv;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 BYTES;mv;raw;json_index;false;Caught exception while reading data
 BYTES;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 BYTES;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -399,7 +399,7 @@ STRING;map;raw;timestamp_index;false;Caught exception while reading data
 STRING;map;raw;bloom_filter;true;
 STRING;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 STRING;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-STRING;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;map;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 STRING;map;raw;json_index;true;
 STRING;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 STRING;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -421,7 +421,7 @@ INT;map;raw;timestamp_index;false;Caught exception while reading data
 INT;map;raw;bloom_filter;true;
 INT;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 INT;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-INT;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+INT;map;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 INT;map;raw;json_index;true;
 INT;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 INT;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -443,7 +443,7 @@ LONG;map;raw;timestamp_index;false;Caught exception while reading data
 LONG;map;raw;bloom_filter;true;
 LONG;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 LONG;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-LONG;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+LONG;map;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 LONG;map;raw;json_index;true;
 LONG;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 LONG;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -465,7 +465,7 @@ FLOAT;map;raw;timestamp_index;false;Caught exception while reading data
 FLOAT;map;raw;bloom_filter;true;
 FLOAT;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 FLOAT;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-FLOAT;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+FLOAT;map;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 FLOAT;map;raw;json_index;true;
 FLOAT;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 FLOAT;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
@@ -487,7 +487,7 @@ DOUBLE;map;raw;timestamp_index;false;Caught exception while reading data
 DOUBLE;map;raw;bloom_filter;true;
 DOUBLE;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
 DOUBLE;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DOUBLE;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+DOUBLE;map;raw;inverted_index;false;Cannot create inverted index on column: col, it can only be applied to dictionary encoded columns
 DOUBLE;map;raw;json_index;true;
 DOUBLE;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
 DOUBLE;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1297,9 +1297,16 @@ public final class TableConfigUtils {
       validateForwardIndexDisabledIndexCompatibility(columnName, fieldConfig, indexingConfig, schema, tableType);
 
       // Validate bloom filter is not added to boolean column
-      if (fieldConfig.getIndexes() != null && fieldConfig.getIndexes().has("bloom")) {
-        Preconditions.checkState(fieldSpec.getDataType() != FieldSpec.DataType.BOOLEAN,
-          "Cannot create a bloom filter on boolean column " + columnName);
+      if (fieldConfig.getIndexes() != null) {
+        if (fieldConfig.getIndexes().has("bloom")) {
+          Preconditions.checkState(fieldSpec.getDataType() != FieldSpec.DataType.BOOLEAN,
+              "Cannot create a bloom filter on boolean column " + columnName);
+        }
+        if (fieldConfig.getIndexes().has("inverted")) {
+          Preconditions.checkState(fieldConfig.getEncodingType() == EncodingType.DICTIONARY,
+              "Cannot create inverted index on column: %s, it can only be applied to dictionary encoded columns",
+              columnName);
+        }
       }
 
       if (CollectionUtils.isNotEmpty(fieldConfig.getIndexTypes())) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1324,6 +1324,25 @@ public class TableConfigUtilsTest {
       Assert.assertEquals(e.getMessage(),
           "Cannot disable forward index for column intCol, as the table type is REALTIME.");
     }
+
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setStreamConfigs(streamConfigs)
+        .build();
+    try {
+      ObjectNode invertedIndexProps = JsonNodeFactory.instance.objectNode();
+      invertedIndexProps.put("enabled", true);
+      ObjectNode indexNode = JsonNodeFactory.instance.objectNode();
+      indexNode.set("inverted", invertedIndexProps);
+      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT,
+          List.of(FieldConfig.IndexType.TEXT), null, null, indexNode, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for having inverted index with RAW encoding type.");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create inverted index on column: myCol1, it can only be applied to dictionary encoded columns");
+    }
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -74,6 +74,10 @@ public class FieldConfig extends BaseJsonConfig {
 
   private final String _name;
   private final EncodingType _encodingType;
+  /**
+   * @deprecated Use {@link #_indexes} instead.
+   */
+  @Deprecated
   private final List<IndexType> _indexTypes;
   private final JsonNode _indexes;
   private final JsonNode _tierOverwrites;
@@ -182,6 +186,10 @@ public class FieldConfig extends BaseJsonConfig {
     return !_indexTypes.isEmpty() ? _indexTypes.get(0) : null;
   }
 
+  /**
+   * @deprecated Use {@link #getIndexes()} instead.
+   */
+  @Deprecated
   public List<IndexType> getIndexTypes() {
     return _indexTypes;
   }
@@ -212,6 +220,7 @@ public class FieldConfig extends BaseJsonConfig {
   public static class Builder {
     private String _name;
     private EncodingType _encodingType;
+    @Deprecated
     private List<IndexType> _indexTypes;
     private JsonNode _indexes;
     private CompressionCodec _compressionCodec;
@@ -249,6 +258,7 @@ public class FieldConfig extends BaseJsonConfig {
       return this;
     }
 
+    @Deprecated
     public Builder withIndexTypes(List<IndexType> indexTypes) {
       _indexTypes = indexTypes;
       return this;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Added validation for inverted index requiring dictionary encoding

```mermaid
flowchart TD
  N0["Check indexes exist #40;F1#41;"]:::stModified
  N1["Check inverted index #40;F1#41;"]:::stModified
  N2["Check encoding DICTIONARY #40;F1#41;"]:::stModified
  N3["Throw exception #40;F1#41;"]:::stModified
  N0 -->|"indexes not null"| N1
  N1 -->|"inverted index present"| N2
  N2 -->|"encoding not DICTIONARY"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils\.java — [before](https://github.com/apache/pinot/blob/f409633af79613fa7e650aee9a2d7ab1029e4110/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java) · [after](https://github.com/apache/pinot/blob/1b0252c860ff0b3a15239185446f50aa9310c39d/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImY0MDk2MzNhZjc5NjEzZmE3ZTY1MGFlZTlhMmQ3YWIxMDI5ZTQxMTAiLCJjb250ZXh0X2hhc2giOiJmNWYwZjZkZDRiYTBkNzAyOGYzZjA0YzBjMTQxNmQyN2RiNjU2MjU5NDdiMzUzYmJlOWE1Y2NjNjY0YWMxMjc1IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTc3NzY2LCJoZWFkX3NoYSI6IjFiMDI1MmM4NjBmZjBiM2ExNTIzOTE4NTQ0NmY1MGFhOTMxMGMzOWQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmNDA5NjMzYWY3OTYxM2ZhN2U2NTBhZWU5YTJkN2FiMTAyOWU0MTEwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f337003e6ce9dd6921f7ea1c2e20ecd4b766de56c6a96c56b3a0dfc34ccf4d4e -->
<!-- pinot-pr-flow:end -->

**Problem:**
There is only bloom filter index validation for `indexes` field in `FieldConfig`.

Below config is considered valid before this PR:
```

      {
        "name": "request_method",
        "encodingType": "RAW",
        "indexType": "TEXT",
        "indexTypes": [
          "TEXT"
        ],
        "indexes": {
          "inverted": {
            "enabled": "true"
          }
        },
        "tierOverwrites": null
      },

```
Due to above, Realtime Ingestion gets stopped during segment build as there is a Precondition check in build which fails (`java.lang.IllegalStateException: Cannot create inverted index for raw index column`).

**PR:**
This PR add validation for inverted index when set in `indexes` field. 
Validation rule: Do not allow inverted index for RAW encoded columns, i.e., `fieldConfig.getEncodingType()` must be `DICTIONARY`.