### PR TITLE
[BugFix] Handling NPE in VarianceAggregationFunction merger

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
@@ -158,12 +158,10 @@ public class VarianceAggregationFunction extends NullableSingleInputAggregationF
 
   @Override
   public VarianceTuple merge(VarianceTuple intermediateResult1, VarianceTuple intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      } else if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    } else if (intermediateResult2 == null) {
+      return intermediateResult1;
     }
     intermediateResult1.apply(intermediateResult2);
     return intermediateResult1;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

VarianceAggregationFunction merge now handles null inputs unconditionally

```mermaid
flowchart TD
  N0["merge start #40;F1#41;"]:::stAdded
  N1["intermediateResult1 #61;#61; null#63; #40;F1#41;"]:::stModified
  N2["return intermediateResult2 #40;F1#41;"]:::stAdded
  N3["intermediateResult2 #61;#61; null#63; #40;F1#41;"]:::stModified
  N4["return intermediateResult1 #40;F1#41;"]:::stAdded
  N5["intermediateResult1#46;apply#40;intermediateResult2#41; #40;F1#41;"]:::stUnchanged
  N6["return intermediateResult1 #40;F1#41;"]:::stUnchanged
  N0 --> N1
  N1 -->|"true"| N2
  N1 -->|"false"| N3
  N3 -->|"true"| N4
  N3 -->|"false"| N5
  N5 --> N6
  N2 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction\.java — [before](https://github.com/apache/pinot/blob/935be1ea6565b91bcf0107fac8969e9e444ddc92/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java) · [after](https://github.com/apache/pinot/blob/956e7c0ca0ba66903d85b6f88487afc3044e4ba5/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjkzNWJlMWVhNjU2NWI5MWJjZjAxMDdmYWM4OTY5ZTllNDQ0ZGRjOTIiLCJjb250ZXh0X2hhc2giOiI0N2I0ZDE2NWRmZWE2NzgwMTMwZDRhNDg2OWZkMjg4YzZkMWU1ZWIzZjgyMGU5Mzk4YTAyYTk2ZTQ3ZmJlZTBlIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTg4NDY2LCJoZWFkX3NoYSI6Ijk1NmU3YzBjYTBiYTY2OTAzZDg1YjZmODg0ODdhZmMzMDQ0ZTRiYTUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5MzViZTFlYTY1NjViOTFiY2YwMTA3ZmFjODk2OWU5ZTQ0NGRkYzkyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 74e1692be9eadee9339d7b335d32728c3aa76b7a392c5148d8f74b8296976f4f -->
<!-- pinot-pr-flow:end -->

This change fixes a NPE in the VarianceAggregationFunction merger function by handling nulls regardless of `_nullHandlingEnabled`, which may be more robust.

We noticed some NPEs reported internally at Uber:
```
java.lang.NullPointerException:  Cannot  invoke  "org.apache.pinot.segment.local.customobject.VarianceTuple.apply(org.apache.pinot.segment.local.customobject.VarianceTuple)"  because  "intermediateResult1"  is  null
  at  org.apache.pinot.core.query.aggregation.function.VarianceAggregationFunction.merge(VarianceAggregationFunction.java:213)
  at  org.apache.pinot.core.query.aggregation.function.VarianceAggregationFunction.merge(VarianceAggregationFunction.java:43)
  at  org.apache.pinot.core.data.table.IndexedTable.updateRecord(IndexedTable.java:125)
  at  org.apache.pinot.core.data.table.IndexedTable.lambda$updateExistingRecord$1(IndexedTable.java:115)
  at  java.base/java.util.concurrent.ConcurrentHashMap.computeIfPresent(ConcurrentHashMap.java:1828)
  at  org.apache.pinot.core.data.table.IndexedTable.updateExistingRecord(IndexedTable.java:115)
  at  org.apache.pinot.core.data.table.ConcurrentIndexedTable.upsertWithoutOrderBy(ConcurrentIndexedTable.java:80)
  at  org.apache.pinot.core.data.table.ConcurrentIndexedTable.upsert(ConcurrentIndexedTable.java:53)
  at  org.apache.pinot.core.operator.combine.GroupByCombineOperator.processSegments(GroupByCombineOperator.java:178)
......
```