### PR TITLE
Add segmentCreationTimeMillis in validDocIdsMetadata 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -31,12 +31,14 @@ public class ValidDocIdsMetadataInfo {
   private final String _segmentCrc;
   private final ValidDocIdsType _validDocIdsType;
   private final long _segmentSizeInBytes;
+  private final long _segmentCreationTimeMillis;
 
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
       @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
-      @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes) {
+      @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes,
+      @JsonProperty("segmentCreationTimeMillis") long segmentCreationTimeMillis) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -44,6 +46,7 @@ public class ValidDocIdsMetadataInfo {
     _segmentCrc = segmentCrc;
     _validDocIdsType = validDocIdsType;
     _segmentSizeInBytes = segmentSizeInBytes;
+    _segmentCreationTimeMillis = segmentCreationTimeMillis;
   }
 
   public String getSegmentName() {
@@ -72,5 +75,9 @@ public class ValidDocIdsMetadataInfo {
 
   public long getSegmentSizeInBytes() {
     return _segmentSizeInBytes;
+  }
+
+  public long getSegmentCreationTimeMillis() {
+    return _segmentCreationTimeMillis;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -718,6 +718,7 @@ public class TablesResource {
           validDocIdsMetadata.put("segmentSizeInBytes",
               ((ImmutableSegment) segmentDataManager.getSegment()).getSegmentSizeBytes());
         }
+        validDocIdsMetadata.put("segmentCreationTimeMillis", indexSegment.getSegmentMetadata().getIndexCreationTime());
         allValidDocIdsMetadata.add(validDocIdsMetadata);
       }
       if (nonImmutableSegmentCount > 0) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -348,6 +348,8 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdsMetadata.get("segmentCrc").asText(), "1894900283");
     Assert.assertEquals(validDocIdsMetadata.get("validDocIdsType").asText(), "SNAPSHOT");
     Assert.assertEquals(validDocIdsMetadata.get("segmentSizeInBytes").asLong(), 1877636);
+    Assert.assertTrue(validDocIdsMetadata.has("segmentCreationTimeMillis"));
+    Assert.assertTrue(validDocIdsMetadata.get("segmentCreationTimeMillis").asLong() > 0);
   }
 
   // Verify metadata file from segments.


### PR DESCRIPTION
This is a small change to expose segment CreationTimeMillis inside /validDocIdsMetadata API call.

This will be used in #15863 to get the segment creation time from each server where the segment is hosted on and used for setting the max creation time of all servers.

I have tested this in local.
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/3363bc01-9229-4c7b-b1bf-027d13eb8823" />
