### PR TITLE
[multistage] Enable Tests for New Optimizer + Bug Fixes

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
@@ -31,12 +31,14 @@ import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.core.Window;
 import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.query.context.PhysicalPlannerContext;
 import org.apache.pinot.query.planner.physical.v2.PRelNode;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAsOfJoin;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalProject;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalSort;
@@ -75,6 +77,8 @@ public class TraitAssignment {
       return (PRelNode) assignSort((PhysicalSort) relNode);
     } else if (relNode instanceof PhysicalJoin) {
       return (PRelNode) assignJoin((PhysicalJoin) relNode);
+    } else if (relNode instanceof PhysicalAsOfJoin) {
+      return (PRelNode) assignJoin((PhysicalAsOfJoin) relNode);
     } else if (relNode instanceof PhysicalAggregate) {
       return (PRelNode) assignAggregate((PhysicalAggregate) relNode);
     } else if (relNode instanceof PhysicalWindow) {
@@ -105,7 +109,7 @@ public class TraitAssignment {
    * </p>
    */
   @VisibleForTesting
-  RelNode assignJoin(PhysicalJoin join) {
+  RelNode assignJoin(Join join) {
     // Case-1: Handle lookup joins.
     if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
       return assignLookupJoin(join);
@@ -216,7 +220,7 @@ public class TraitAssignment {
     return window.copy(window.getTraitSet(), ImmutableList.of(input));
   }
 
-  private RelNode assignLookupJoin(PhysicalJoin join) {
+  private RelNode assignLookupJoin(Join join) {
     /*
      * Lookup join expects right input to have project and table-scan nodes exactly. Moreover, lookup join is used
      * with Dimension tables only. Given this, we expect the entire right input to be available in all workers

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
@@ -121,8 +121,8 @@ public class TraitAssignment {
         "Always expect left and right keys to be same size. Found: %s and %s",
         joinInfo.leftKeys, joinInfo.rightKeys);
     // Case-3: Default case.
-    RelDistribution rightDistribution = joinInfo.isEqui() && !joinInfo.rightKeys.isEmpty()
-        ? RelDistributions.hash(joinInfo.rightKeys) : RelDistributions.BROADCAST_DISTRIBUTED;
+    RelDistribution rightDistribution = !joinInfo.rightKeys.isEmpty() ? RelDistributions.hash(joinInfo.rightKeys)
+        : RelDistributions.BROADCAST_DISTRIBUTED;
     RelDistribution leftDistribution;
     if (joinInfo.leftKeys.isEmpty() || rightDistribution == RelDistributions.BROADCAST_DISTRIBUTED) {
       leftDistribution = RelDistributions.RANDOM_DISTRIBUTED;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -50,6 +50,7 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAsOfJoin;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
@@ -96,6 +97,8 @@ public class PRelToPlanNodeConverter {
       result = convertPhysicalExchange((PhysicalExchange) node);
     } else if (node instanceof PhysicalJoin) {
       result = convertJoin((PhysicalJoin) node);
+    } else if (node instanceof PhysicalAsOfJoin) {
+      result = convertAsOfJoin((PhysicalAsOfJoin) node);
     } else if (node instanceof Window) {
       result = convertWindow((Window) node);
     } else if (node instanceof Values) {
@@ -243,6 +246,33 @@ public class PRelToPlanNodeConverter {
     return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(join.getHints()), inputs, joinType,
         joinInfo.leftKeys, joinInfo.rightKeys, RexExpressionUtils.fromRexNodes(joinInfo.nonEquiConditions),
         joinStrategy);
+  }
+
+  public static JoinNode convertAsOfJoin(PhysicalAsOfJoin join) {
+    JoinInfo joinInfo = join.analyzeCondition();
+    DataSchema dataSchema = toDataSchema(join.getRowType());
+    List<PlanNode> inputs = new ArrayList<>();
+    JoinRelType joinType = join.getJoinType();
+    // Basic validations
+    Preconditions.checkState(joinInfo.nonEquiConditions.isEmpty(),
+        "Non-equi conditions are not supported for ASOF join, got: %s", joinInfo.nonEquiConditions);
+    Preconditions.checkState(joinType == JoinRelType.ASOF || joinType == JoinRelType.LEFT_ASOF,
+        "Join type should be ASOF or LEFT_ASOF, got: %s", joinType);
+    RexExpression matchCondition = RexExpressionUtils.fromRexNode(join.getMatchCondition());
+    Preconditions.checkState(matchCondition != null, "ASOF_JOIN must have a match condition");
+    Preconditions.checkState(matchCondition instanceof RexExpression.FunctionCall,
+        "ASOF JOIN only supports function call match condition, got: %s", matchCondition);
+    List<RexExpression> matchKeys = ((RexExpression.FunctionCall) matchCondition).getFunctionOperands();
+    // TODO: Add support for MATCH_CONDITION containing two columns of different types. In that case, there would be
+    //       a CAST RexExpression.FunctionCall on top of the RexExpression.InputRef, and the physical ASOF join operator
+    //       can't currently handle that.
+    Preconditions.checkState(
+        matchKeys.size() == 2 && matchKeys.get(0) instanceof RexExpression.InputRef
+            && matchKeys.get(1) instanceof RexExpression.InputRef,
+        "ASOF_JOIN only supports match conditions with a comparison between two columns of the same type");
+    return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(join.getHints()), inputs, joinType,
+        joinInfo.leftKeys, joinInfo.rightKeys, RexExpressionUtils.fromRexNodes(joinInfo.nonEquiConditions),
+        JoinNode.JoinStrategy.ASOF, RexExpressionUtils.fromRexNode(join.getMatchCondition()));
   }
 
   public static DataSchema toDataSchema(RelDataType rowType) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAsOfJoin.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/nodes/PhysicalAsOfJoin.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.nodes;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AsofJoin;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rex.RexNode;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+
+
+public class PhysicalAsOfJoin extends AsofJoin implements PRelNode {
+  private final int _nodeId;
+  private final List<PRelNode> _pRelInputs;
+  @Nullable
+  private final PinotDataDistribution _pinotDataDistribution;
+
+  public PhysicalAsOfJoin(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints, RexNode condition,
+      RexNode matchCondition, Set<CorrelationId> variablesSet, JoinRelType joinType, int nodeId, PRelNode left,
+      PRelNode right, @Nullable PinotDataDistribution pinotDataDistribution) {
+    super(cluster, traitSet, hints, left.unwrap(), right.unwrap(), condition, matchCondition, variablesSet, joinType);
+    _nodeId = nodeId;
+    _pRelInputs = List.of(left, right);
+    _pinotDataDistribution = pinotDataDistribution;
+  }
+
+  @Override
+  public int getNodeId() {
+    return _nodeId;
+  }
+
+  @Override
+  public List<PRelNode> getPRelInputs() {
+    return _pRelInputs;
+  }
+
+  @Override
+  public RelNode unwrap() {
+    return this;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataDistribution getPinotDataDistribution() {
+    return _pinotDataDistribution;
+  }
+
+  @Override
+  public boolean isLeafStage() {
+    return false;
+  }
+
+  @Override
+  public PRelNode with(int newNodeId, List<PRelNode> newInputs, PinotDataDistribution newDistribution) {
+    return new PhysicalAsOfJoin(getCluster(), getTraitSet(), getHints(), getCondition(), getMatchCondition(),
+        getVariablesSet(), getJoinType(), newNodeId, newInputs.get(0), newInputs.get(1), newDistribution);
+  }
+
+  @Override
+  public Join copy(RelTraitSet relTraitSet, RexNode rexNode, RelNode newLeft, RelNode newRight, JoinRelType joinRelType,
+      boolean semiJoinDone) {
+    return new PhysicalAsOfJoin(getCluster(), relTraitSet, getHints(), rexNode, getMatchCondition(),
+        getVariablesSet(), joinRelType, _nodeId, (PRelNode) newLeft, (PRelNode) newRight, _pinotDataDistribution);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/AggregatePushdownRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/AggregatePushdownRule.java
@@ -282,7 +282,7 @@ public class AggregatePushdownRule extends PRelOptRule {
     relNode = PinotRuleUtils.unboxRel(relNode);
     if (relNode instanceof Project) {
       return ((Project) relNode).getProjects();
-    } else if (relNode instanceof Union) {
+    } else if (relNode instanceof Union || relNode instanceof Exchange) {
       return findImmediateProjects(relNode.getInput(0));
     }
     return null;

--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -75,10 +75,10 @@
           "Execution Plan",
           "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
           "\n  PhysicalJoin(condition=[AND(=($0, $10), >($2, $11))], joinType=[inner])",
-          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n    PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
           "\n      PhysicalFilter(condition=[>=($2, 0)])",
           "\n        PhysicalTableScan(table=[[default, a]])",
-          "\n    PhysicalExchange(exchangeStrategy=[BROADCAST_EXCHANGE])",
+          "\n    PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[1]])",
           "\n      PhysicalTableScan(table=[[default, b]])",
           "\n"
         ]

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -209,17 +209,16 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   }
 
   protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows) {
-    compareRowEquals(resultTable, expectedRows, false, "", "");
+    compareRowEquals(resultTable, expectedRows, false);
   }
 
-  protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows, boolean keepOutputRowsInOrder,
-      String testCaseName, String sql) {
+  protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows, boolean keepOutputRowsInOrder) {
     List<Object[]> resultRows = resultTable.getRows();
     int numRows = resultRows.size();
     assertEquals(numRows, expectedRows.size(),
-        String.format("Mismatched number of results.\nExpected Rows:\n%s\nActual Rows:\n%s. query:\n%s",
+        String.format("Mismatched number of results.\nExpected Rows:\n%s\nActual Rows:\n%s",
             expectedRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n")),
-            resultRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n")), sql));
+            resultRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n"))));
 
     DataSchema dataSchema = resultTable.getDataSchema();
     resultRows.forEach(row -> canonicalizeRow(dataSchema, row));
@@ -236,8 +235,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
               Arrays.toString(expectedRow), Arrays.toString(resultRow)));
       for (int j = 0; j < resultRow.length; j++) {
         assertTrue(typeCompatibleFuzzyEquals(dataSchema.getColumnDataType(j), resultRow[j], expectedRow[j]),
-            String.format("Mismatched value in case: %s. row: %d, column id: %d. Expected Row: %s, Actual Row: %s. query: %s",
-                testCaseName, i, j, Arrays.toString(expectedRow), Arrays.toString(resultRow), sql));
+            String.format("Mismatched value at row id: %d, column id: %d. Expected Row: %s, Actual Row: %s", i, j,
+                Arrays.toString(expectedRow), Arrays.toString(resultRow)));
       }
     }
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -209,16 +209,17 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   }
 
   protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows) {
-    compareRowEquals(resultTable, expectedRows, false);
+    compareRowEquals(resultTable, expectedRows, false, "", "");
   }
 
-  protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows, boolean keepOutputRowsInOrder) {
+  protected void compareRowEquals(ResultTable resultTable, List<Object[]> expectedRows, boolean keepOutputRowsInOrder,
+      String testCaseName, String sql) {
     List<Object[]> resultRows = resultTable.getRows();
     int numRows = resultRows.size();
     assertEquals(numRows, expectedRows.size(),
-        String.format("Mismatched number of results.\nExpected Rows:\n%s\nActual Rows:\n%s",
+        String.format("Mismatched number of results.\nExpected Rows:\n%s\nActual Rows:\n%s. query:\n%s",
             expectedRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n")),
-            resultRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n"))));
+            resultRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n")), sql));
 
     DataSchema dataSchema = resultTable.getDataSchema();
     resultRows.forEach(row -> canonicalizeRow(dataSchema, row));
@@ -235,8 +236,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
               Arrays.toString(expectedRow), Arrays.toString(resultRow)));
       for (int j = 0; j < resultRow.length; j++) {
         assertTrue(typeCompatibleFuzzyEquals(dataSchema.getColumnDataType(j), resultRow[j], expectedRow[j]),
-            String.format("Mismatched value at row id: %d, column id: %d. Expected Row: %s, Actual Row: %s", i, j,
-                Arrays.toString(expectedRow), Arrays.toString(resultRow)));
+            String.format("Mismatched value in case: %s. row: %d, column id: %d. Expected Row: %s, Actual Row: %s. query: %s",
+                testCaseName, i, j, Arrays.toString(expectedRow), Arrays.toString(resultRow), sql));
       }
     }
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -295,6 +295,16 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
             finalSql));
   }
 
+  @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
+  public void testQueryTestCasesWithLiteModeWithOutput(String testCaseName, boolean isIgnored, String sql,
+      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder)
+      throws Exception {
+    final String finalSql = String.format("SET usePhysicalOptimizer=true; SET useLiteMode=true; %s", sql);
+    runQuery(finalSql, expect, false).ifPresent(
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, testCaseName,
+            finalSql));
+  }
+
   private Map<String, JsonNode> tableToStats(String sql, QueryDispatcher.QueryResult queryResult) {
 
     Map<Integer, DispatchablePlanFragment> planNodes = planQuery(sql).getQueryPlan().getQueryStageMap();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -270,7 +270,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     // query pinot
     runQuery(sql, expect, false).ifPresent(queryResult -> {
       try {
-        compareRowEquals(queryResult.getResultTable(), queryH2(h2Sql), keepOutputRowOrder, "", "");
+        compareRowEquals(queryResult.getResultTable(), queryH2(h2Sql), keepOutputRowOrder);
       } catch (Exception e) {
         Assert.fail(e.getMessage(), e);
       }
@@ -282,7 +282,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder)
       throws Exception {
     runQuery(sql, expect, false).ifPresent(
-        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, "", ""));
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder));
   }
 
   @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
@@ -291,8 +291,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       throws Exception {
     final String finalSql = String.format("SET usePhysicalOptimizer=true; %s", sql);
     runQuery(finalSql, expect, false).ifPresent(
-        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, testCaseName,
-            finalSql));
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder));
   }
 
   @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
@@ -301,8 +300,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       throws Exception {
     final String finalSql = String.format("SET usePhysicalOptimizer=true; SET useLiteMode=true; %s", sql);
     runQuery(finalSql, expect, false).ifPresent(
-        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, testCaseName,
-            finalSql));
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder));
   }
 
   private Map<String, JsonNode> tableToStats(String sql, QueryDispatcher.QueryResult queryResult) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -270,7 +270,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     // query pinot
     runQuery(sql, expect, false).ifPresent(queryResult -> {
       try {
-        compareRowEquals(queryResult.getResultTable(), queryH2(h2Sql), keepOutputRowOrder);
+        compareRowEquals(queryResult.getResultTable(), queryH2(h2Sql), keepOutputRowOrder, "", "");
       } catch (Exception e) {
         Assert.fail(e.getMessage(), e);
       }
@@ -282,7 +282,17 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder)
       throws Exception {
     runQuery(sql, expect, false).ifPresent(
-        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder));
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, "", ""));
+  }
+
+  @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
+  public void testQueryTestCasesWithNewOptimizerWithOutput(String testCaseName, boolean isIgnored, String sql,
+      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder)
+      throws Exception {
+    final String finalSql = String.format("SET usePhysicalOptimizer=true; %s", sql);
+    runQuery(finalSql, expect, false).ifPresent(
+        queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder, testCaseName,
+            finalSql));
   }
 
   private Map<String, JsonNode> tableToStats(String sql, QueryDispatcher.QueryResult queryResult) {


### PR DESCRIPTION
# Summary

Adds the required fixes to make all tests in `ResourceBasedQueriesTest` pass with the new optimizer (both with and without lite mode).

## Bugs Fixed / Gaps Addressed

* Ensures Window groups are converted to RexLiteral. Logic is same as `PinotWindowExchangeNodeInsertRule`, and I have abstracted out the common code to a utils class. It's not a super clean approach code-style wise and I am open to feedback here.
* Added support for As Of Join.
* Fixed some trait assignment code.
* Fixes `AggregatePushdownRule` to allow it to find Projects under Exchange. This was causing failure of some complex agg functions due to incorrect agg call generation.

# Test Plan

Added E2E tests in `ResourceBasedQueriesTest`.