### PR TITLE
[multistage] Add Support for Broker Server/Segment Pruning

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
@@ -122,6 +122,10 @@ public class PhysicalPlannerContext {
     return _useLiteMode;
   }
 
+  private QueryServerInstance getBrokerQueryServerInstance() {
+    return new QueryServerInstance(_instanceId, _hostName, _port, _port);
+  }
+
   public static boolean isUsePhysicalOptimizer(@Nullable Map<String, String> queryOptions) {
     if (queryOptions == null) {
       return false;
@@ -129,8 +133,11 @@ public class PhysicalPlannerContext {
     return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.USE_PHYSICAL_OPTIMIZER, "false"));
   }
 
-  private QueryServerInstance getBrokerQueryServerInstance() {
-    return new QueryServerInstance(_instanceId, _hostName, _port, _port);
+  public static boolean isUseBrokerPruning(@Nullable Map<String, String> queryOptions) {
+    if (queryOptions == null) {
+      return false;
+    }
+    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.USE_BROKER_PRUNING, "false"));
   }
 
   private static boolean useLiteMode(@Nullable Map<String, String> queryOptions) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.logical;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.pinot.common.request.DataSource;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.query.parser.CalciteRexExpressionParser;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+
+/**
+ * Utility to convert a leaf stage to a {@link PinotQuery}.
+ */
+public class LeafStageToPinotQuery {
+  private LeafStageToPinotQuery() {
+  }
+
+  /**
+   * Converts a leaf stage root to a {@link PinotQuery}.
+   *
+   * @param tableName the name of the table. Needs to be provided separately since it needs TableCache.
+   * @param leafStageRoot the root of the leaf stage
+   * @param skipFilter whether to skip the filter in the query
+   * @return a {@link PinotQuery} representing the leaf stage
+   */
+  public static PinotQuery createPinotQuery(String tableName, RelNode leafStageRoot, boolean skipFilter) {
+    List<RelNode> nodesTopToBottom = new ArrayList<>();
+    accumulateParentNodes(leafStageRoot, nodesTopToBottom);
+    Preconditions.checkState(!nodesTopToBottom.isEmpty()
+        && nodesTopToBottom.get(nodesTopToBottom.size() - 1) instanceof TableScan, "Could not find table scan");
+    TableScan tableScan = (TableScan) nodesTopToBottom.get(nodesTopToBottom.size() - 1);
+    PinotQuery pinotQuery = initializePinotQueryForTableScan(tableName, tableScan);
+    for (RelNode parentNode : nodesTopToBottom) {
+      if (parentNode instanceof Filter) {
+        if (!skipFilter) {
+          handleFilter((Filter) parentNode, pinotQuery);
+        }
+      } else if (parentNode instanceof Project) {
+        handleProject((Project) parentNode, pinotQuery);
+      }
+    }
+    return pinotQuery;
+  }
+
+  private static void accumulateParentNodes(RelNode root, List<RelNode> parentNodes) {
+    parentNodes.add(root);
+    for (RelNode input : root.getInputs()) {
+      accumulateParentNodes(input, parentNodes);
+    }
+  }
+
+  private static PinotQuery initializePinotQueryForTableScan(String tableName, TableScan tableScan) {
+    PinotQuery pinotQuery = new PinotQuery();
+    pinotQuery.setDataSource(new DataSource());
+    pinotQuery.getDataSource().setTableName(tableName);
+    pinotQuery.setSelectList(tableScan.getRowType().getFieldNames().stream().map(
+        CalciteSqlParser::compileToExpression).collect(Collectors.toList()));
+    return pinotQuery;
+  }
+
+  private static void handleProject(Project project, PinotQuery pinotQuery) {
+    if (project != null) {
+      List<RexExpression> rexExpressions = RexExpressionUtils.fromRexNodes(project.getProjects());
+      List<Expression> selectList = CalciteRexExpressionParser.convertRexNodes(rexExpressions,
+          pinotQuery.getSelectList());
+      pinotQuery.setSelectList(selectList);
+    }
+  }
+
+  private static void handleFilter(Filter filter, PinotQuery pinotQuery) {
+    if (filter != null) {
+      RexExpression rexExpression = RexExpressionUtils.fromRexNode(filter.getCondition());
+      pinotQuery.setFilterExpression(CalciteRexExpressionParser.toExpression(rexExpression,
+          pinotQuery.getSelectList()));
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
@@ -50,7 +50,7 @@ public class LeafStageToPinotQuery {
    */
   public static PinotQuery createPinotQuery(String tableName, RelNode leafStageRoot, boolean skipFilter) {
     List<RelNode> bottomToTopNodes = new ArrayList<>();
-    accumulateParentNodes(leafStageRoot, bottomToTopNodes);
+    accumulateBottomToTop(leafStageRoot, bottomToTopNodes);
     Preconditions.checkState(!bottomToTopNodes.isEmpty() && bottomToTopNodes.get(0) instanceof TableScan,
         "Could not find table scan");
     TableScan tableScan = (TableScan) bottomToTopNodes.get(0);
@@ -67,9 +67,11 @@ public class LeafStageToPinotQuery {
     return pinotQuery;
   }
 
-  private static void accumulateParentNodes(RelNode root, List<RelNode> parentNodes) {
+  private static void accumulateBottomToTop(RelNode root, List<RelNode> parentNodes) {
+    Preconditions.checkState(root.getInputs().size() <= 1,
+        "Leaf stage nodes should have at most one input, found: %s", root.getInputs().size());
     for (RelNode input : root.getInputs()) {
-      accumulateParentNodes(input, parentNodes);
+      accumulateBottomToTop(input, parentNodes);
     }
     parentNodes.add(root);
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
@@ -41,14 +41,15 @@ public class LeafStageToPinotQuery {
   }
 
   /**
-   * Converts a leaf stage root to a {@link PinotQuery}.
+   * Converts a leaf stage root to a {@link PinotQuery}. This method only handles Project, Filter and TableScan nodes.
+   * Other node types are ignored since they don't impact routing.
    *
    * @param tableName the name of the table. Needs to be provided separately since it needs TableCache.
    * @param leafStageRoot the root of the leaf stage
    * @param skipFilter whether to skip the filter in the query
    * @return a {@link PinotQuery} representing the leaf stage
    */
-  public static PinotQuery createPinotQuery(String tableName, RelNode leafStageRoot, boolean skipFilter) {
+  public static PinotQuery createPinotQueryForRouting(String tableName, RelNode leafStageRoot, boolean skipFilter) {
     List<RelNode> bottomToTopNodes = new ArrayList<>();
     accumulateBottomToTop(leafStageRoot, bottomToTopNodes);
     Preconditions.checkState(!bottomToTopNodes.isEmpty() && bottomToTopNodes.get(0) instanceof TableScan,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -118,7 +118,7 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
       PRelNode leafStageRoot = extractCurrentLeafStageParent(call._parents);
       leafStageRoot = leafStageRoot == null ? call._currentNode : leafStageRoot;
       String tableName = getActualTableName((TableScan) call._currentNode.unwrap());
-      PinotQuery pinotQuery = LeafStageToPinotQuery.createPinotQuery(tableName, leafStageRoot.unwrap(),
+      PinotQuery pinotQuery = LeafStageToPinotQuery.createPinotQueryForRouting(tableName, leafStageRoot.unwrap(),
           !PhysicalPlannerContext.isUseBrokerPruning(_physicalPlannerContext.getQueryOptions()));
       return assignTableScan((PhysicalTableScan) call._currentNode, _physicalPlannerContext.getRequestId(),
           pinotQuery);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -119,7 +119,7 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
       leafStageRoot = leafStageRoot == null ? call._currentNode : leafStageRoot;
       String tableName = getActualTableName((TableScan) call._currentNode.unwrap());
       PinotQuery pinotQuery = LeafStageToPinotQuery.createPinotQuery(tableName, leafStageRoot.unwrap(),
-          PhysicalPlannerContext.isUseBrokerPruning(_physicalPlannerContext.getQueryOptions()));
+          !PhysicalPlannerContext.isUseBrokerPruning(_physicalPlannerContext.getQueryOptions()));
       return assignTableScan((PhysicalTableScan) call._currentNode, _physicalPlannerContext.getRequestId(),
           pinotQuery);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -115,8 +115,8 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
   @Override
   public PRelNode onMatch(PRelOptRuleCall call) {
     if (call._currentNode.unwrap() instanceof TableScan) {
-      PRelNode leafStageRoot = Objects.requireNonNull(extractCurrentLeafStageParent(call._parents),
-          "Unable to find root of leaf stage");
+      PRelNode leafStageRoot = extractCurrentLeafStageParent(call._parents);
+      leafStageRoot = leafStageRoot == null ? call._currentNode : leafStageRoot;
       String tableName = getActualTableName((TableScan) call._currentNode.unwrap());
       PinotQuery pinotQuery = LeafStageToPinotQuery.createPinotQuery(tableName, leafStageRoot.unwrap(),
           PhysicalPlannerContext.isUseBrokerPruning(_physicalPlannerContext.getQueryOptions()));

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRuleTest.java
@@ -247,7 +247,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   }
 
   @Test
-  public void testGetLeafParentNodes() {
+  public void testExtractLeafStageRoot() {
     // Create parents mock RelNodes. The first node is not part of the leaf stage, while the last two nodes are.
     PRelNode pRelNode1 = mock(PRelNode.class);
     PRelNode pRelNode2 = mock(PRelNode.class);
@@ -260,11 +260,8 @@ public class LeafStageWorkerAssignmentRuleTest {
     parents.addLast(pRelNode1);
     parents.addLast(pRelNode2);
     parents.addLast(pRelNode3);
-    List<PRelNode> leafParentNodes = LeafStageWorkerAssignmentRule.getLeafParentNodes(parents);
-    // nodes should be from bottom to top.
-    assertEquals(leafParentNodes.get(0), pRelNode3);
-    assertEquals(leafParentNodes.get(1), pRelNode2);
-    assertEquals(leafParentNodes.size(), 2);
+    PRelNode leafStageRoot = LeafStageWorkerAssignmentRule.extractCurrentLeafStageParent(parents);
+    assertEquals(leafStageRoot, pRelNode2);
   }
 
   private static void validateTableScanAssignment(TableScanWorkerAssignmentResult assignmentResult,

--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -603,5 +603,23 @@
         ]
       }
     ]
+  },
+  "physical_opt_broker_pruning": {
+    "queries": [
+      {
+        "description": "Broker pruning example (smoke test)",
+        "sql": "SET usePhysicalOptimizer=true; SET useBrokerPruning=true; EXPLAIN PLAN FOR SELECT col2, col3 FROM a WHERE col1 = 'foo' ORDER BY col2",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalSort(sort0=[$0], dir0=[ASC])",
+          "\n    PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n      PhysicalProject(col2=[$1], col3=[$2])",
+          "\n        PhysicalFilter(condition=[=($0, _UTF-8'foo')])",
+          "\n          PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      }
+    ]
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
@@ -78,7 +78,7 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
         pinotQuery.setGroupByList(groupByList);
       }
       List<Expression> selectList = CalciteRexExpressionParser.convertAggregateList(groupByList, node.getAggCalls(),
-          node.getFilterArgs(), pinotQuery);
+          node.getFilterArgs(), pinotQuery.getSelectList());
       for (Expression expression : selectList) {
         applyTimestampIndex(expression, pinotQuery);
       }
@@ -131,7 +131,8 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
     if (visit(node.getInputs().get(0), context)) {
       PinotQuery pinotQuery = context.getPinotQuery();
       if (pinotQuery.getFilterExpression() == null) {
-        Expression expression = CalciteRexExpressionParser.toExpression(node.getCondition(), pinotQuery);
+        Expression expression = CalciteRexExpressionParser.toExpression(node.getCondition(),
+            pinotQuery.getSelectList());
         applyTimestampIndex(expression, pinotQuery);
         pinotQuery.setFilterExpression(expression);
       } else {
@@ -197,7 +198,8 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
   public Void visitProject(ProjectNode node, ServerPlanRequestContext context) {
     if (visit(node.getInputs().get(0), context)) {
       PinotQuery pinotQuery = context.getPinotQuery();
-      List<Expression> selectList = CalciteRexExpressionParser.convertRexNodes(node.getProjects(), pinotQuery);
+      List<Expression> selectList = CalciteRexExpressionParser.convertRexNodes(node.getProjects(),
+          pinotQuery.getSelectList());
       for (Expression expression : selectList) {
         applyTimestampIndex(expression, pinotQuery);
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -634,6 +634,8 @@ public class CommonConstants {
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
         public static final String USE_LITE_MODE = "useLiteMode";
+
+        public static final String USE_BROKER_PRUNING = "useBrokerPruning";
       }
 
       public static class QueryOptionValue {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -634,7 +634,10 @@ public class CommonConstants {
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
         public static final String USE_LITE_MODE = "useLiteMode";
-
+        // Used by the MSE Engine to determine whether to use the broker pruning logic. Only supported by the
+        // new MSE query optimizer.
+        // TODO(mse-physical): Consider removing this query option and making this the default, since there's already
+        //   a table config to enable broker pruning (it is disabled by default).
         public static final String USE_BROKER_PRUNING = "useBrokerPruning";
       }
 


### PR DESCRIPTION
# Summary

Adds support for enabling broker pruning (for servers and segments). This can especially be beneficial for MSE Lite Mode that aims to mimic the scatter gather pattern of the V1 Engine to enable high-qps use-cases.

# Test Plan

Added some unit-tests and tested on Colocated Join Quickstart. I had to add the routing config to enable partition pruning in the broker to enable this.

```
SET useMultistageEngine=true;
SET usePhysicalOptimizer=true;
-- SET useBrokerPruning=true;

explain implementation plan for select count(*)
from userAttributes
where userUUID = 'user-1'

[0]@10.24.6.236:33955|[0] MAIL_RECEIVE(SINGLETON)
└── [1]@10.24.6.236:33321|[0] MAIL_SEND(SINGLETON)->{[0]@10.24.6.236:33955|[0]}
    └── [1]@10.24.6.236:33321|[0] AGGREGATE_FINAL
        └── [1]@10.24.6.236:33321|[0] MAIL_RECEIVE(SINGLETON)
            ├── [2]@10.24.6.236:38493|[1] MAIL_SEND(SINGLETON)->{[1]@10.24.6.236:35465|[0]} (Subtree Omitted)
            └── [2]@10.24.6.236:33321|[0] MAIL_SEND(SINGLETON)->{[1]@10.24.6.236:35465|[0]}
                └── [2]@10.24.6.236:33321|[0] AGGREGATE_LEAF
                    └── [2]@10.24.6.236:33321|[0] FILTER
                        └── [2]@10.24.6.236:33321|[0] TABLE SCAN (userAttributes) null
```

```
SET useMultistageEngine=true;
SET usePhysicalOptimizer=true;
SET useBrokerPruning=true;

explain implementation plan for select count(*)
from userAttributes
where userUUID = 'user-1'

[0]@10.24.6.236:33955|[0] MAIL_RECEIVE(SINGLETON)
└── [1]@10.24.6.236:44355|[0] MAIL_SEND(SINGLETON)->{[0]@10.24.6.236:33955|[0]}
    └── [1]@10.24.6.236:44355|[0] AGGREGATE_DIRECT
        └── [1]@10.24.6.236:44355|[0] FILTER
            └── [1]@10.24.6.236:44355|[0] TABLE SCAN (userAttributes) null
```

