### PR TITLE
Fix PinotZKChanger HelixManager instance names

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/ClusterStateVerifier.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/ClusterStateVerifier.java
@@ -39,7 +39,7 @@ public class ClusterStateVerifier extends PinotZKChanger {
   private static final int MAX_SLEEP_BETWEEN_CHECKS_MILLIS = 30_000;
 
   public ClusterStateVerifier(String zkAddress, String clusterName) {
-    super(zkAddress, clusterName);
+    super("ClusterStateVerifier", zkAddress, clusterName);
   }
 
   /**

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotIdealStateChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotIdealStateChanger.java
@@ -26,13 +26,13 @@ import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 
 
-public class PinotIdealstateChanger extends PinotZKChanger {
+public class PinotIdealStateChanger extends PinotZKChanger {
 
   private final String _tableNameWithType;
   private final boolean _dryRun;
 
-  public PinotIdealstateChanger(String zkAddress, String clusterName, String tableNameWithType, boolean dryRun) {
-    super(zkAddress, clusterName);
+  public PinotIdealStateChanger(String zkAddress, String clusterName, String tableNameWithType, boolean dryRun) {
+    super("PinotIdealStateChanger", zkAddress, clusterName);
     _tableNameWithType = tableNameWithType;
     _dryRun = dryRun;
   }
@@ -60,7 +60,7 @@ public class PinotIdealstateChanger extends PinotZKChanger {
     final String clusterName = "LLCRealtimeClusterIntegrationTest";
     final String tableName = "mytable_REALTIME";
 
-    PinotIdealstateChanger changer = new PinotIdealstateChanger(zkAddress, clusterName, tableName, dryRun);
+    PinotIdealStateChanger changer = new PinotIdealStateChanger(zkAddress, clusterName, tableName, dryRun);
     changer.updateIdealState();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
@@ -38,7 +38,7 @@ public class PinotNumReplicaChanger extends PinotZKChanger {
   private boolean _dryRun;
 
   public PinotNumReplicaChanger(String zkAddress, String clusterName, boolean dryRun) {
-    super(zkAddress, clusterName);
+    super("PinotNumReplicaChanger", zkAddress, clusterName);
     _dryRun = dryRun;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -37,7 +37,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
       boolean includeConsuming, Enablement minimizeDataMovement, boolean bootstrap, boolean downtime,
       int minReplicasToKeepUpForNoDowntime, int batchSizePerServer, boolean lowDiskMode, boolean bestEffort,
       long externalViewCheckIntervalInMs, long externalViewStabilizationTimeoutInMs) {
-    super(zkAddress, clusterName);
+    super("PinotTableRebalancer", zkAddress, clusterName);
     _rebalanceConfig.setDryRun(dryRun);
     _rebalanceConfig.setReassignInstances(reassignInstances);
     _rebalanceConfig.setIncludeConsuming(includeConsuming);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotZKChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotZKChanger.java
@@ -49,11 +49,11 @@ public class PinotZKChanger {
   protected String _clusterName;
   protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
-  public PinotZKChanger(String zkAddress, String clusterName) {
+  public PinotZKChanger(String name, String zkAddress, String clusterName) {
     _clusterName = clusterName;
     _helixAdmin = new ZKHelixAdmin(zkAddress);
     _helixManager = HelixManagerFactory
-        .getZKHelixManager(clusterName, "PinotNumReplicaChanger", InstanceType.ADMINISTRATOR, zkAddress);
+        .getZKHelixManager(clusterName, name, InstanceType.ADMINISTRATOR, zkAddress);
     try {
       _helixManager.connect();
     } catch (Exception e) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
@@ -119,7 +119,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
       throws IOException, InterruptedException {
     validateParams();
 
-    _zkChanger = new PinotZKChanger(_zkHost, _zkPath);
+    _zkChanger = new PinotZKChanger("MoveReplicaGroup", _zkHost, _zkPath);
     _helix = _zkChanger.getHelixAdmin();
 
     if (!isExistingTable(_tableName)) {


### PR DESCRIPTION
- The instance name was always set to `PinotNumReplicaChanger` regardless of the actual use case. This patch refactors it to use the appropriate name based on the use case instead.