### PR TITLE
Fix GROUP BY-Only Processing with accurateGroupByWithoutOrderBy

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/DeterministicConcurrentIndexedTable.java
@@ -45,7 +45,7 @@ public class DeterministicConcurrentIndexedTable extends IndexedTable {
   protected void upsertWithoutOrderBy(Key key, Record record) {
     ConcurrentSkipListMap<Key, Record> map = (ConcurrentSkipListMap<Key, Record>) _lookupMap;
 
-    if (map.size() < _resultSize) {
+    if (map.size() < _resultSize || map.containsKey(key)) {
       addOrUpdateRecord(key, record);
     } else if (!map.isEmpty() && key.compareTo(map.lastKey()) < 0) {
       addOrUpdateRecord(key, record);


### PR DESCRIPTION
Fix a bug in #15844 (new added feature)

When a segment’s map had already reached _resultSize, and a row arrived whose key was exactly equal to map.lastKey(), the condition key.compareTo(map.lastKey()) < 0 would evaluate to false, causing the update to be dropped. As a result, the stored aggregate for that key never increased—even though additional rows for that key existed. This leads to undercounted aggregates for keys that happen to be lexicographically largest at the moment the limit is reached.


Tested in the local cluster - It is working fine now.