### PR TITLE
Invalidate from cache the stats of opchains that finish successfully.

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -96,6 +96,7 @@ public class OpChainSchedulerService {
             LOGGER.error("({}): Completed erroneously {} {}", operatorChain, stats, errorBlock.getErrorMessages());
           } else {
             LOGGER.debug("({}): Completed {}", operatorChain, stats);
+            _opChainCache.invalidate(operatorChain.getId());
           }
         } catch (Exception e) {
           LOGGER.error("({}): Failed to execute operator chain!", operatorChain, e);


### PR DESCRIPTION
We have detected that some large queries may end up consuming too much memory for too long in the stats cache used to return stats on timeout.

A way to solve that is to remove the stats as soon as the opchain finishes successfully. This should keep the cache almost empty (given most of the time opchains don't fail) at the cost of losing the stats of fast stages when other stage timeouts.

This is not the best solution but one that is very easy to implement. We will work in better long term solutions.
