### PR TITLE
Modify MSE operators to release memory once computation finished

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -73,8 +73,10 @@ public class AggregateOperator extends MultiStageOperator {
   private final MultiStageOperator _input;
   private final DataSchema _resultSchema;
   private final AggregationFunction<?, ?>[] _aggFunctions;
-  private final MultistageAggregationExecutor _aggregationExecutor;
-  private final MultistageGroupByExecutor _groupByExecutor;
+  @Nullable
+  private MultistageAggregationExecutor _aggregationExecutor;
+  @Nullable
+  private MultistageGroupByExecutor _groupByExecutor;
 
   @Nullable
   private MseBlock.Eos _eosBlock;
@@ -205,13 +207,17 @@ public class AggregateOperator extends MultiStageOperator {
     if (finalBlock.isError()) {
       return finalBlock;
     }
-    return produceAggregatedBlock();
+    MseBlock mseBlock = produceAggregatedBlock();
+    _aggregationExecutor = null;
+    _groupByExecutor = null;
+    return mseBlock;
   }
 
   private MseBlock produceAggregatedBlock() {
     if (_aggregationExecutor != null) {
       return new RowHeapDataBlock(_aggregationExecutor.getResult(), _resultSchema, _aggFunctions);
     } else {
+      assert _groupByExecutor != null;
       List<Object[]> rows;
       if (_comparator != null) {
         rows = _groupByExecutor.getResult(_comparator, _groupTrimSize);
@@ -253,6 +259,7 @@ public class AggregateOperator extends MultiStageOperator {
    * @return the last block, which must always be either an error or the end of the stream
    */
   private MseBlock.Eos consumeGroupBy() {
+    assert _groupByExecutor != null;
     MseBlock block = _input.nextBlock();
     while (block.isData()) {
       _groupByExecutor.processBlock((MseBlock.Data) block);
@@ -268,6 +275,7 @@ public class AggregateOperator extends MultiStageOperator {
    * @return the last block, which must always be either an error or the end of the stream
    */
   private MseBlock.Eos consumeAggregation() {
+    assert _aggregationExecutor != null;
     MseBlock block = _input.nextBlock();
     while (block.isData()) {
       _aggregationExecutor.processBlock((MseBlock.Data) block);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -169,8 +169,14 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     }
     MseBlock mseBlock = buildJoinedDataBlock();
     LOGGER.trace("Returning {} for join operator", mseBlock);
+    if (mseBlock.isEos()) {
+      _eos = (MseBlock.Eos) mseBlock;
+      onEosProduced();
+    }
     return mseBlock;
   }
+
+  protected abstract void onEosProduced();
 
   protected void buildRightTable() {
     LOGGER.trace("Building right table for join operator");


### PR DESCRIPTION
This PR fixes the performance regression detected on https://github.com/apache/pinot/pull/15609. Contrary to https://github.com/apache/pinot/pull/15967, this change doesn't reduce stats precision and may also increase performance in other situations (like using pipeline breakers or the new physical planner).

The root reason why https://github.com/apache/pinot/pull/15609 affected performance is that we keep pointers to MultiStageOperators. Some of these operators (more explicitly: joins, aggregates and window functions) were implemented in a way that they kept large maps on the heap. These maps are used to calculate blocks while the operator is being executed and they are not used once EOS is returned. Local variables could substitute these attributes, but we would need to add new parameters to different methods.

To simplify the change, this PR sets these attributes to null once they are not needed. In future redesigns, we may want to split the operator class from its execution (in the same way we have plan nodes and operators in SSE).