### PR TITLE
MQE rule enhancements

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateReduceFunctionsRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateReduceFunctionsRule.java
@@ -18,35 +18,26 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
-import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRuleCall;
-import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.rules.AggregateCaseToFilterRule;
 import org.apache.calcite.rel.rules.AggregateReduceFunctionsRule;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlPostfixOperator;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.tools.RelBuilder;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 /**
- * Pinot customized version of {@link AggregateReduceFunctionsRule}, which only reduce on SUM and AVG when the produced SUM0 could benefit from rewriting CASE to FILTER. The conditions are copied from {@link AggregateCaseToFilterRule}
+ * Pinot customized version of {@link AggregateReduceFunctionsRule}, which only reduce on SUM and AVG
+ * when the produced SUM0 could benefit from rewriting CASE to FILTER.
+ * The conditions are copied from {@link AggregateCaseToFilterRule}.
  * Mostly we don't want to reduce because Pinot supports all aggregation functions natively,
  * but not REGR_COUNT which can be generated during reduce.
  * But in cases that the below Project contains certain CASE WHEN expression that

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateReduceFunctionsRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotAggregateReduceFunctionsRule.java
@@ -18,27 +18,121 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
+import com.google.common.collect.ImmutableList;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.rules.AggregateCaseToFilterRule;
 import org.apache.calcite.rel.rules.AggregateReduceFunctionsRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlPostfixOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 /**
- * Pinot customized version of {@link AggregateReduceFunctionsRule} which only reduce on SUM and AVG.
- * We don't want to reduce on STDDEV_POP, STDDEV_SAMP, VAR_POP, VAR_SAMP, COVAR_POP, COVAR_SAMP because Pinot supports
- * them natively, but not REGR_COUNT which can be generated during reduce.
+ * Pinot customized version of {@link AggregateReduceFunctionsRule}, which only reduce on SUM and AVG when the produced SUM0 could benefit from rewriting CASE to FILTER. The conditions are copied from {@link AggregateCaseToFilterRule}
+ * Mostly we don't want to reduce because Pinot supports all aggregation functions natively,
+ * but not REGR_COUNT which can be generated during reduce.
+ * But in cases that the below Project contains certain CASE WHEN expression that
+ * reducing SUM or AVG to SUM0 could help AggregateCaseToFilterRule to transform
+ * CASE WHEN to FILTER, reducing might be a good idea.
  */
 public class PinotAggregateReduceFunctionsRule extends AggregateReduceFunctionsRule {
-  public static final PinotAggregateReduceFunctionsRule INSTANCE =
-      new PinotAggregateReduceFunctionsRule(Config.DEFAULT);
 
+  // only consider reducing when possible to do CaseToFilter
+  public static final PinotAggregateReduceFunctionsRule INSTANCE =
+      new PinotAggregateReduceFunctionsRule((Config) Config.DEFAULT
+          .withOperandSupplier(b0 ->
+              b0.operand(Aggregate.class).oneInput(b1 ->
+                  b1.operand(Project.class).anyInputs())
+          ));
   private PinotAggregateReduceFunctionsRule(Config config) {
     super(config);
   }
 
   @Override
   public boolean canReduce(AggregateCall call) {
-    SqlKind kind = call.getAggregation().getKind();
-    return kind == SqlKind.SUM || kind == SqlKind.AVG;
+    // This logic is handled in onMatch()
+    return true;
+  }
+
+  /** The below functions are copied and adapted from {@link AggregateReduceFunctionsRule} */
+  @Override public void onMatch(RelOptRuleCall call) {
+    final Aggregate aggregate = call.rel(0);
+    final Project project = call.rel(1);
+
+    for (AggregateCall aggCall: aggregate.getAggCallList()) {
+      SqlKind kind = aggCall.getAggregation().getKind();
+      // only consider reducing SUM and AVG
+      if (aggCall.isDistinct() || (kind != SqlKind.SUM && kind != SqlKind.AVG)) {
+        continue;
+      }
+      final int singleArg = soleArgument(aggCall);
+      if (singleArg < 0) {
+        continue;
+      }
+      final RexNode rexNode = project.getProjects().get(singleArg);
+      if (!isThreeArgCase(rexNode)) {
+        continue;
+      }
+
+      final RelOptCluster cluster = project.getCluster();
+      final RexBuilder rexBuilder = cluster.getRexBuilder();
+      final RexCall caseCall = (RexCall) rexNode;
+
+      // If one arg is null and the other is not, reverse them and set "flip",
+      // which negates the filter.
+      final boolean flip = RexLiteral.isNullLiteral(caseCall.operands.get(1))
+          && !RexLiteral.isNullLiteral(caseCall.operands.get(2));
+      final RexNode arg1 = caseCall.operands.get(flip ? 2 : 1);
+      final RexNode arg2 = caseCall.operands.get(flip ? 1 : 2);
+
+
+      // If one of the below case matches, reducing SUM to SUM0 would be beneficial when
+      // used with CoreRules.AGGREGATE_CASE_TO_FILTER:
+      // B: SUM0(CASE WHEN x = 'foo' THEN 1 ELSE 0 END)
+      //   => COUNT() FILTER (x = 'foo')
+      // A2: SUM0(CASE WHEN x = 'foo' THEN cnt ELSE 0 END)
+      //   => SUM0(cnt) FILTER (x = 'foo')
+      if ((isIntLiteral(arg1, BigDecimal.ONE) && isIntLiteral(arg2, BigDecimal.ZERO))
+        || (isIntLiteral(arg2, BigDecimal.ZERO))) {
+        super.onMatch(call);
+      }
+    }
+  }
+
+  /** Returns the argument, if an aggregate call has a single argument,
+   * otherwise -1. */
+  private static int soleArgument(AggregateCall aggregateCall) {
+    return aggregateCall.getArgList().size() == 1
+        ? aggregateCall.getArgList().get(0)
+        : -1;
+  }
+
+  private static boolean isThreeArgCase(final RexNode rexNode) {
+    return rexNode.getKind() == SqlKind.CASE
+        && ((RexCall) rexNode).operands.size() == 3;
+  }
+
+  private static boolean isIntLiteral(RexNode rexNode, BigDecimal value) {
+    return rexNode instanceof RexLiteral
+        && SqlTypeName.INT_TYPES.contains(rexNode.getType().getSqlTypeName())
+        && value.equals(((RexLiteral) rexNode).getValueAs(BigDecimal.class));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -92,8 +92,8 @@ public class PinotQueryRuleSets {
       // convert non-all union into all-union + distinct
       CoreRules.UNION_TO_DISTINCT,
 
-      // reduce SUM and AVG
-      // TODO: Consider not reduce at all.
+      // reduce only SUM and AVG only when the resulting SUM0
+      // matches the pattern of AggregateCaseToFilter optimizations
       PinotAggregateReduceFunctionsRule.INSTANCE,
 
       // convert CASE-style filtered aggregates into true filtered aggregates

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -36,7 +36,7 @@ public class PinotQueryRuleSets {
   //@formatter:off
   public static final List<RelOptRule> BASIC_RULES = List.of(
       // push a filter into a join
-      PinotFilterIntoJoinRule.INSTANCE,
+      PinotFilterIntoJoinRule.INSTANCE, // this is modified to enable smart mode to simplify outer join
       // push filter through an aggregation
       CoreRules.FILTER_AGGREGATE_TRANSPOSE,
       // push filter through set operation
@@ -49,7 +49,7 @@ public class PinotQueryRuleSets {
       // push a filter past a project
       CoreRules.FILTER_PROJECT_TRANSPOSE,
       // push parts of the join condition to its inputs
-      PinotJoinConditionPushRule.INSTANCE,
+      PinotJoinConditionPushRule.INSTANCE, // this is modified to enable smart mode to simplify outer join
       // remove identity project
       CoreRules.PROJECT_REMOVE,
 
@@ -57,6 +57,19 @@ public class PinotQueryRuleSets {
       CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW,
       // push project through WINDOW
       CoreRules.PROJECT_WINDOW_TRANSPOSE,
+
+      // aggregate join remove
+      CoreRules.AGGREGATE_JOIN_REMOVE,
+      // remove aggregation if it does not aggregate and input is already distinct
+      CoreRules.AGGREGATE_REMOVE,
+      // also push aggregate function through join
+      CoreRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED,
+      // aggregate union rule
+      CoreRules.AGGREGATE_UNION_AGGREGATE,
+      // push aggregate through join
+      // this one won't be useful because it requires empty aggCalls,
+      // these will be removed by AGGREGATE_REMOVE
+      CoreRules.AGGREGATE_JOIN_TRANSPOSE,
 
       // literal rules
       // TODO: Revisit and see if they can be replaced with
@@ -70,6 +83,7 @@ public class PinotQueryRuleSets {
 
       // join rules
       CoreRules.JOIN_PUSH_EXPRESSIONS,
+      CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES,
 
       // join and semi-join rules
       CoreRules.PROJECT_TO_SEMI_JOIN,
@@ -77,13 +91,6 @@ public class PinotQueryRuleSets {
 
       // convert non-all union into all-union + distinct
       CoreRules.UNION_TO_DISTINCT,
-
-      // remove aggregation if it does not aggregate and input is already distinct
-      CoreRules.AGGREGATE_REMOVE,
-      // push aggregate through join
-      CoreRules.AGGREGATE_JOIN_TRANSPOSE,
-      // aggregate union rule
-      CoreRules.AGGREGATE_UNION_AGGREGATE,
 
       // reduce SUM and AVG
       // TODO: Consider not reduce at all.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -36,7 +36,7 @@ public class PinotQueryRuleSets {
   //@formatter:off
   public static final List<RelOptRule> BASIC_RULES = List.of(
       // push a filter into a join
-      PinotFilterIntoJoinRule.INSTANCE, // this is modified to enable smart mode to simplify outer join
+      PinotFilterIntoJoinRule.INSTANCE,
       // push filter through an aggregation
       CoreRules.FILTER_AGGREGATE_TRANSPOSE,
       // push filter through set operation
@@ -49,7 +49,7 @@ public class PinotQueryRuleSets {
       // push a filter past a project
       CoreRules.FILTER_PROJECT_TRANSPOSE,
       // push parts of the join condition to its inputs
-      PinotJoinConditionPushRule.INSTANCE, // this is modified to enable smart mode to simplify outer join
+      PinotJoinConditionPushRule.INSTANCE,
       // remove identity project
       CoreRules.PROJECT_REMOVE,
 
@@ -125,6 +125,8 @@ public class PinotQueryRuleSets {
       CoreRules.FILTER_MERGE,
       CoreRules.AGGREGATE_REMOVE,
       CoreRules.SORT_REMOVE,
+      PruneEmptyRules.CORRELATE_LEFT_INSTANCE,
+      PruneEmptyRules.CORRELATE_RIGHT_INSTANCE,
       PruneEmptyRules.AGGREGATE_INSTANCE,
       PruneEmptyRules.FILTER_INSTANCE,
       PruneEmptyRules.JOIN_LEFT_INSTANCE,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -399,20 +399,25 @@ public class QueryEnvironment {
         throw new RuntimeException("Failed to convert query to relational expression:\n" + sqlNode, e);
       }
       RelNode rootNode = relRoot.rel;
-      LOGGER.info("[QueryEnvironment] Logical plan after parsing: \n{}", RelOptUtil.toString(rootNode));
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("[QueryEnvironment] Logical plan after parsing: \n{}", RelOptUtil.toString(rootNode));
+      }
       try {
         // NOTE: DO NOT use converter.decorrelate(sqlNode, rootNode) because the converted type check can fail. This is
         //       probably a bug in Calcite.
         RelBuilder relBuilder = PinotRuleUtils.PINOT_REL_FACTORY.create(cluster, null);
         rootNode = RelDecorrelator.decorrelateQuery(rootNode, relBuilder);
-        LOGGER.info("[QueryEnvironment] Logical plan after decorr: \n{}", RelOptUtil.toString(rootNode));
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("[QueryEnvironment] Logical plan after decorr: \n{}", RelOptUtil.toString(rootNode));
+        }
       } catch (Throwable e) {
         throw new RuntimeException("Failed to decorrelate query:\n" + RelOptUtil.toString(rootNode), e);
       }
       try {
         rootNode = converter.trimUnusedFields(false, rootNode);
-        // TODO: log parsed output here
-        LOGGER.info("[QueryEnvironment] Logical plan after decorr & trim: \n{}", RelOptUtil.toString(rootNode));
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("[QueryEnvironment] Logical plan after decorr & trim: \n{}", RelOptUtil.toString(rootNode));
+        }
       } catch (Throwable e) {
         throw new RuntimeException("Failed to trim unused fields from query:\n" + RelOptUtil.toString(rootNode), e);
       }
@@ -507,7 +512,7 @@ public class QueryEnvironment {
 
     // Rules are enabled if its corresponding value is not specified false in ruleFlags
     if (ruleFlags.isEmpty()) {
-      LOGGER.info("[QueryEnvironment] ruleFlags is empty, BASIC_RULES used: \n");
+      LOGGER.debug("[QueryEnvironment] ruleFlags is empty, BASIC_RULES used: \n");
       for (RelOptRule relOptRule : PinotQueryRuleSets.BASIC_RULES) {
         hepProgramBuilder.addRuleInstance(relOptRule);
       }
@@ -524,7 +529,9 @@ public class QueryEnvironment {
           hepProgramBuilder.addRuleInstance(relOptRule);
           continue;
         }
-        LOGGER.info("[QueryEnvironment] Basic rule disabled: \n{}", relOptRule.getClass().getName());
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("[QueryEnvironment] Basic rule disabled: \n{}", relOptRule.getClass().getName());
+        }
       }
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -35,6 +35,7 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.planner.logical.LogicalPlanner;
 import org.apache.pinot.query.validate.Validator;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /**
@@ -89,6 +90,51 @@ public class PlannerContext implements AutoCloseable {
 
   public Map<String, String> getOptions() {
     return _options;
+  }
+
+  /**
+   * Checks rule enabling options and set ruleFlags correspondingly.
+   * The ruleFlags is passed to {@link QueryEnvironment}'s getOptProgram
+   * to decide which rules are enabled / disabled dynamically.
+   *
+   * Currently, this only covers rules that may backfire in BASIC_RULES:
+   * AGGREGATE_JOIN_TRANSPOSE_EXTENDED and PINOT_AGGREGATE_REDUCE_FUNCTIONS
+   * These rules are disabled by default and other rules are all enabled.
+   * The default behavior is controlled by specifying defaultEnabled in ruleDisabled()
+   *
+   * @param options options from sqlNodeAndOptions
+   * @return the ruleFlags map used by getOptProgram of {@link QueryEnvironment}
+   */
+  public static Map<String, Boolean> getRuleFlags(@Nullable Map<String, String> options) {
+    Map<String, Boolean> ruleFlags = new HashMap<>();
+    // To disable a rule, put {className, false} into ruleFlags
+    // Whether to enable extended AggregateJoinTransposeRule that pushes aggregate functions below joins
+    if (isRuleDisabled(CommonConstants.Broker.Request.QueryOptionKey
+        .USE_AGGREGATE_FUNCTIONS_PUSHDOWN_RULE, false, options)) {
+      ruleFlags.put(CommonConstants.Broker.PlannerRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED, false);
+    }
+    // Whether to reduce SUM and AVG to SUM0 when they may benefit CASE WHEN to FILTER conversions
+    if (isRuleDisabled(CommonConstants.Broker.Request.QueryOptionKey
+        .USE_CASE_TO_FILTER_REDUCE_SUM_AND_AVG_RULE, false, options)) {
+      ruleFlags.put(CommonConstants.Broker.PlannerRules.PINOT_AGGREGATE_REDUCE_FUNCTIONS, false);
+    }
+    // TODO: add more knobs
+    return ruleFlags;
+  }
+
+  /**
+   * checks if rule is disabled
+   * @param ruleOptionKey corresponding QueryOptionKey of the rule
+   * @param defaultEnabled is the rule enabled by default
+   * @param options parsed queryOptions, or null
+   * @return whether the rule is enabled
+   */
+  private static boolean isRuleDisabled(String ruleOptionKey, Boolean defaultEnabled,
+      @Nullable Map<String, String> options) {
+    if (options == null) {
+      return defaultEnabled;
+    }
+    return !Boolean.parseBoolean(options.getOrDefault(ruleOptionKey, defaultEnabled.toString()));
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -634,11 +634,24 @@ public class CommonConstants {
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
         public static final String USE_LITE_MODE = "useLiteMode";
+
+        // Knobs related to enabling / disabling Calcite rules used in optProgram
+        // Whether to enable extended AggregateJoinTransposeRule that pushes down aggregate functions
+        public static final String USE_AGGREGATE_FUNCTIONS_PUSHDOWN_RULE = "useAggregateFunctionsPushdownRule";
+        // Whether to enable PinotAggregateReduceFunctionsRule that reduces SUM or AVG to SUM0 when beneficial
+        public static final String USE_CASE_TO_FILTER_REDUCE_SUM_AND_AVG_RULE = "useCaseToFilterReduceSumAndAvgRule";
       }
 
       public static class QueryOptionValue {
         public static final int DEFAULT_MAX_STREAMING_PENDING_BLOCKS = 100;
       }
+    }
+
+    // Calcite and Pinot rule names used for enable and disabling of rules
+    public static class PlannerRules {
+      public static final String AGGREGATE_JOIN_TRANSPOSE = "AggregateJoinTransposeRule";
+      public static final String AGGREGATE_JOIN_TRANSPOSE_EXTENDED = "AggregateJoinTransposeRuleExtended";
+      public static final String PINOT_AGGREGATE_REDUCE_FUNCTIONS = "PinotAggregateReduceFunctionsRule";
     }
 
     public static class FailureDetector {


### PR DESCRIPTION
This PR involves several additions / changes to MQE's pinot-query-planner: 

1. Changes to Rules. 
These changes to rules are tested with customized queries on TPC-H, which show major improvements.
- Introduced `CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES` and `CoreRules.AGGREGATE_JOIN_REMOVE` rule that are mostly risk free and helpful to simplify plan tree.
- Modified `PinotAggregateReduceFunctionsRule` to only reduce SUM and AVG to SUM0 when the resulting SUM0 could possibly benefit from `CoreRules.AGGREGATE_CASE_TO_FILTER`. Enabling of this rule is configurable.
- Introduced `CoreRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED` that pushes aggregate functions below joins when possible. Enabling of this is configurable.
- Added `PruneEmptyRules.CORRELATE_LEFT_INSTANCE` and its right equivalence to remove dummy correlate left / right joins, which aren't supported. 
- Added a round of `PRUNE_RULES` before applying `BASIC_RULES` to simplify the operator tree for better rule matching.
- Minor re-ordering of `BASIC_RULES`
- For more detail and examples see 2af8808cd4791ede8f5af9b67a9c4230e9d042ac and 19ba1022c4cd3302bc58241717fee2af8e709dda, the correlate remove rules are added in 8f3619cf9c7ed9f3cb7f1895f2c202044e463d1e.

2. Enabled dynamically turning on / off rules with queryOptions.
Currently supported knobs `useAggregateFunctionsPushdownRule` and `useCaseToFilterReduceSumAndAvgRule` as a PoC. This introduced a change that now `optProgram` is also rebuilt per query (same as `traitProgram` now), this simply iterate through the rule List and checks whether it is enabled. Takes ~3 ms on my laptop and should be fine. 
For detail see 8f3619cf9c7ed9f3cb7f1895f2c202044e463d1e

3. Introduced a logger into QueryEnvironment that logs the parsed, decorrelated, and trimmed plan, this is helpful for debugging QO process along with Calcite logs.

The above changes are mostly tested by building and running queries.