### PR TITLE
Check `batchSizePerServer` in Rebalance Config Pre-check

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -398,15 +398,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     }
 
     // --- Batch size per server recommendation check using summary ---
-    int maxSegmentsToAddOnServer = 0;
-    if (rebalanceSummaryResult.getServerInfo() != null
-        && rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo() != null) {
-      for (RebalanceSummaryResult.ServerSegmentChangeInfo info : rebalanceSummaryResult.getServerInfo()
-          .getServerSegmentChangeInfo()
-          .values()) {
-        maxSegmentsToAddOnServer = Math.max(maxSegmentsToAddOnServer, info.getSegmentsAdded());
-      }
-    }
+    int maxSegmentsToAddOnServer = rebalanceSummaryResult.getSegmentInfo().getMaxSegmentsAddedToASingleServer();
     int batchSizePerServer = rebalanceConfig.getBatchSizePerServer();
     if (maxSegmentsToAddOnServer > SEGMENT_ADD_THRESHOLD) {
       if (batchSizePerServer == RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -59,6 +59,9 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   public static final String REBALANCE_CONFIG_OPTIONS = "rebalanceConfigOptions";
   public static final String REPLICA_GROUPS_INFO = "replicaGroupsInfo";
 
+  public static final int SEGMENT_ADD_THRESHOLD = 200;
+  public static final int RECOMMENDED_BATCH_SIZE = 200;
+
   private static double _diskUtilizationThreshold;
 
   protected PinotHelixResourceManager _pinotHelixResourceManager;
@@ -405,8 +408,6 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
       }
     }
     int batchSizePerServer = rebalanceConfig.getBatchSizePerServer();
-    final int SEGMENT_ADD_THRESHOLD = 500;
-    final int RECOMMENDED_BATCH_SIZE = 200;
     if (maxSegmentsToAddOnServer > SEGMENT_ADD_THRESHOLD) {
       if (batchSizePerServer == RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER
           || batchSizePerServer > RECOMMENDED_BATCH_SIZE) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -399,8 +399,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
 
     // --- Batch size per server recommendation check using summary ---
     int maxSegmentsToAddOnServer = 0;
-    if (rebalanceSummaryResult.getServerInfo() != null &&
-        rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo() != null) {
+    if (rebalanceSummaryResult.getServerInfo() != null
+        && rebalanceSummaryResult.getServerInfo().getServerSegmentChangeInfo() != null) {
       for (RebalanceSummaryResult.ServerSegmentChangeInfo info : rebalanceSummaryResult.getServerInfo()
           .getServerSegmentChangeInfo()
           .values()) {
@@ -489,4 +489,3 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     return tableSizePerReplicaInBytes / ((long) currentAssignment.size());
   }
 }
-

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
@@ -38,10 +38,12 @@ public interface RebalancePreChecker {
     private final Map<String, Map<String, String>> _targetAssignment;
     private final TableSizeReader.TableSubTypeSizeDetails _tableSubTypeSizeDetails;
     private final RebalanceConfig _rebalanceConfig;
+    private final RebalanceSummaryResult _rebalanceSummaryResult;
 
     public PreCheckContext(String rebalanceJobId, String tableNameWithType, TableConfig tableConfig,
         Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
-        @Nullable TableSizeReader.TableSubTypeSizeDetails tableSubTypeSizeDetails, RebalanceConfig rebalanceConfig) {
+        @Nullable TableSizeReader.TableSubTypeSizeDetails tableSubTypeSizeDetails, RebalanceConfig rebalanceConfig,
+        RebalanceSummaryResult rebalanceSummaryResult) {
       _rebalanceJobId = rebalanceJobId;
       _tableNameWithType = tableNameWithType;
       _tableConfig = tableConfig;
@@ -49,6 +51,7 @@ public interface RebalancePreChecker {
       _targetAssignment = targetAssignment;
       _tableSubTypeSizeDetails = tableSubTypeSizeDetails;
       _rebalanceConfig = rebalanceConfig;
+      _rebalanceSummaryResult = rebalanceSummaryResult;
     }
 
     public String getRebalanceJobId() {
@@ -77,6 +80,10 @@ public interface RebalancePreChecker {
 
     public RebalanceConfig getRebalanceConfig() {
       return _rebalanceConfig;
+    }
+
+    public RebalanceSummaryResult getRebalanceSummaryResult() {
+      return _rebalanceSummaryResult;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -339,22 +339,24 @@ public class TableRebalancer {
         fetchTableSizeDetails(tableNameWithType, tableRebalanceLogger);
 
     Map<String, RebalancePreCheckerResult> preChecksResult = null;
+
+    // Calculate summary here itself so that even if the table is already balanced, the caller can verify whether that
+    // is expected or not based on the summary results
+    RebalanceSummaryResult summaryResult =
+        calculateDryRunSummary(currentAssignment, targetAssignment, tableNameWithType, tableSubTypeSizeDetails,
+            tableConfig, tableRebalanceLogger);
+
     if (preChecks) {
       if (_rebalancePreChecker == null) {
         tableRebalanceLogger.warn(
             "Pre-checks are enabled but the pre-checker is not set, skipping pre-checks");
       } else {
         RebalancePreChecker.PreCheckContext preCheckContext =
-            new RebalancePreChecker.PreCheckContext(rebalanceJobId, tableNameWithType,
-                tableConfig, currentAssignment, targetAssignment, tableSubTypeSizeDetails, rebalanceConfig);
+            new RebalancePreChecker.PreCheckContext(rebalanceJobId, tableNameWithType, tableConfig, currentAssignment,
+                targetAssignment, tableSubTypeSizeDetails, rebalanceConfig, summaryResult);
         preChecksResult = _rebalancePreChecker.check(preCheckContext);
       }
     }
-    // Calculate summary here itself so that even if the table is already balanced, the caller can verify whether that
-    // is expected or not based on the summary results
-    RebalanceSummaryResult summaryResult =
-        calculateDryRunSummary(currentAssignment, targetAssignment, tableNameWithType, tableSubTypeSizeDetails,
-            tableConfig, tableRebalanceLogger);
 
     if (segmentAssignmentUnchanged) {
       tableRebalanceLogger.info("Table is already balanced");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -1103,6 +1103,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         .getServerSegmentChangeInfo()
         .get(instanceId)
         .getSegmentsAdded(), expectedNumSegmentsToAdd);
+    assertEquals(rebalanceResult.getRebalanceSummaryResult().getSegmentInfo().getMaxSegmentsAddedToASingleServer(),
+        expectedNumSegmentsToAdd);
     preCheckerResult = rebalanceResult.getPreChecksResult().get(DefaultRebalancePreChecker.REBALANCE_CONFIG_OPTIONS);
     assertNotNull(preCheckerResult);
     assertEquals(preCheckerResult.getPreCheckStatus(), RebalancePreCheckerResult.PreCheckStatus.WARN);


### PR DESCRIPTION
## Description

For the newly added rebalance config `batchSizePerServer` (https://github.com/apache/pinot/pull/15617), this PR adds a new logic in rebalance config pre-check in table rebalance pre-checker to warn user when this parameter is recommended to be set. 

When the number of segments to add to a single server is too large, `batchSizePerServer` is expected to be set to protect the server from stranded by helix messages. Currently this pre-check warns when any server will have more than `200` segments to add to, showing message to recommend user to set `batchSizePerServer` to `200` or lower.

## Examples

Rebalance a table with `batchSizePerServer=-1`
<img width="907" alt="image" src="https://github.com/user-attachments/assets/275eb386-3c22-4d9d-89d9-665bd48665ea" />

Rebalance a table with `batchSizePerServer=500`
<img width="907" alt="image" src="https://github.com/user-attachments/assets/275eb386-3c22-4d9d-89d9-665bd48665ea" />

The same table with `batchSizePerServer=200`
<img width="336" alt="image" src="https://github.com/user-attachments/assets/f85fa18c-674b-4cd3-819a-3fcb2199a7a1" />

