### PR TITLE
Allow RealtimeSegmentValidationManager to fix error segments for partial upsert and dedup tables.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -2386,7 +2386,8 @@ public class PinotLLCRealtimeSegmentManager {
    * If segment is in ERROR state in only few replicas but has download URL, we instead trigger a segment reset
    * @param tableConfig The table config
    */
-  public void repairSegmentsInErrorStateForPauselessConsumption(TableConfig tableConfig) {
+  public void repairSegmentsInErrorStateForPauselessConsumption(TableConfig tableConfig,
+      boolean repairErrorSegmentsForPartialUpsertOrDedup) {
     String realtimeTableName = tableConfig.getTableName();
     // Fetch ideal state and external view
     IdealState idealState = getIdealState(realtimeTableName);
@@ -2468,7 +2469,7 @@ public class PinotLLCRealtimeSegmentManager {
     boolean isPartialUpsertEnabled =
         tableConfig.getUpsertConfig() != null && tableConfig.getUpsertConfig().getMode() == UpsertConfig.Mode.PARTIAL;
     boolean isDedupEnabled = tableConfig.getDedupConfig() != null && tableConfig.getDedupConfig().isDedupEnabled();
-    if ((isPartialUpsertEnabled || isDedupEnabled)) {
+    if ((isPartialUpsertEnabled || isDedupEnabled) && !repairErrorSegmentsForPartialUpsertOrDedup) {
       // We do not run reingestion for dedup and partial upsert tables in pauseless as it can
       // lead to data inconsistencies
       _controllerMetrics.setOrUpdateTableGauge(realtimeTableName,
@@ -2477,6 +2478,11 @@ public class PinotLLCRealtimeSegmentManager {
           realtimeTableName);
       return;
     } else {
+      if ((isPartialUpsertEnabled || isDedupEnabled)) {
+        LOGGER.info(
+            "Repairing error segments in table: {} as repairErrorSegmentForPartialUpsertOrDedup is set to true",
+            realtimeTableName);
+      }
       _controllerMetrics.setOrUpdateTableGauge(realtimeTableName,
           ControllerGauge.PAUSELESS_SEGMENTS_IN_ERROR_COUNT, segmentsInErrorStateInAllReplicas.size());
     }


### PR DESCRIPTION

## Scope of the PR

The RealtimeSegmentValidationManager can now take parameters for it's manual runs: https://github.com/apache/pinot/pull/14915

The PR aims to introduce the ability to fix error segments for tables that have partial upsert or dedup enabled. 

The manual run of `RealtimeSegmentValidationManager` can be provided with the parameter: 
`"repairErrorSegmentsForPartialUpsertOrDedup" : true.`

### Reason for disabling it by default

Running DR (re-ingestion)/ Resetting error segments can lead to wrong metadata for tables. Thus, repairing error segments was disabled by default for partial upsert and dedup enabled tables. 

A different recovery mechanism that involved deleting and ingesting the segments again was relied on. 

### Reason for providing the flag

To allow user to quickly recover errored segments if discrepancy in data correctness is acceptable. 

