### PR TITLE
Fix an issue while deserializing stats on error

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/ZeroCopyDataBlockSerde.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/ZeroCopyDataBlockSerde.java
@@ -201,10 +201,10 @@ public class ZeroCopyDataBlockSerde implements DataBlockSerde {
               bufferView(buffer, header._variableSizeDataStart + offset, header._variableSizeDataLength));
         case METADATA: {
           Map<Integer, String> exceptions = deserializeExceptions(stream, header);
+          List<DataBuffer> metadata = deserializeMetadata(buffer, header);
           if (!exceptions.isEmpty()) {
-            return MetadataBlock.newError(exceptions);
+            return MetadataBlock.newErrorWithStats(exceptions, metadata);
           } else {
-            List<DataBuffer> metadata = deserializeMetadata(buffer, header);
             return new MetadataBlock(metadata);
           }
         }


### PR DESCRIPTION
Stats on error were not correctly deserialized when read from upstream. They only worked when obtained using the cancellation mechanism.

Anyway, remember this method up-to-downstream mechanism is very imprecise