### PR TITLE
Enable dynamically turning on/off optProgram rules

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -118,6 +118,8 @@ public class PinotQueryRuleSets {
       CoreRules.FILTER_MERGE,
       CoreRules.AGGREGATE_REMOVE,
       CoreRules.SORT_REMOVE,
+      PruneEmptyRules.CORRELATE_LEFT_INSTANCE,
+      PruneEmptyRules.CORRELATE_RIGHT_INSTANCE,
       PruneEmptyRules.AGGREGATE_INSTANCE,
       PruneEmptyRules.FILTER_INSTANCE,
       PruneEmptyRules.JOIN_LEFT_INSTANCE,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -36,6 +36,7 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.plan.hep.HepMatchOrder;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
@@ -94,6 +95,8 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlPhysicalExplain;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -117,6 +120,7 @@ import org.immutables.value.Value;
 @Value.Enclosing
 public class QueryEnvironment {
   private static final CalciteConnectionConfig CONNECTION_CONFIG;
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryEnvironment.class);
 
   static {
     // We set Calcite configuration as case-sensitive at all timesk, even when Pinot is configured as case-insensitive.
@@ -133,7 +137,6 @@ public class QueryEnvironment {
   private final TypeFactory _typeFactory = new TypeFactory();
   private final FrameworkConfig _config;
   private final CalciteCatalogReader _catalogReader;
-  private final HepProgram _optProgram;
   private final Config _envConfig;
   private final PinotCatalog _catalog;
 
@@ -146,7 +149,6 @@ public class QueryEnvironment {
         .defaultSchema(rootSchema.plus()).sqlToRelConverterConfig(PinotRuleUtils.PINOT_SQL_TO_REL_CONFIG).build();
     _catalogReader = new PinotCatalogReader(
         rootSchema, List.of(database), _typeFactory, CONNECTION_CONFIG, config.isCaseSensitive());
-    _optProgram = getOptProgram();
   }
 
   public QueryEnvironment(String database, TableCache tableCache, @Nullable WorkerManager workerManager) {
@@ -163,6 +165,9 @@ public class QueryEnvironment {
    */
   private PlannerContext getPlannerContext(SqlNodeAndOptions sqlNodeAndOptions) {
     WorkerManager workerManager = getWorkerManager(sqlNodeAndOptions);
+    Map<String, Boolean> ruleFlags = PlannerContext.getRuleFlags(sqlNodeAndOptions.getOptions());
+    // dynamically create optProgram according to rule options
+    HepProgram optProgram = getOptProgram(ruleFlags);
     boolean usePhysicalOptimizer = PhysicalPlannerContext.isUsePhysicalOptimizer(sqlNodeAndOptions.getOptions());
     HepProgram traitProgram = getTraitProgram(workerManager, _envConfig, usePhysicalOptimizer);
     SqlExplainFormat format = SqlExplainFormat.DOT;
@@ -179,7 +184,7 @@ public class QueryEnvironment {
           workerManager.getHostName(), workerManager.getPort(), _envConfig.getRequestId(),
           workerManager.getInstanceId(), sqlNodeAndOptions.getOptions());
     }
-    return new PlannerContext(_config, _catalogReader, _typeFactory, _optProgram, traitProgram,
+    return new PlannerContext(_config, _catalogReader, _typeFactory, optProgram, traitProgram,
         sqlNodeAndOptions.getOptions(), _envConfig, format, physicalPlannerContext);
   }
 
@@ -468,34 +473,123 @@ public class QueryEnvironment {
   // utils
   // --------------------------------------------------------------------------
 
-  private static HepProgram getOptProgram() {
+  /**
+   * Creates and returns a HepProgram that performs mostly logical transformations.
+   * It performs several phases of rule application over the parsed decorrelated trimmed plan:
+   * - In the first phase, it prunes the applies BASIC_RULES that are almost always helpful to simplify logical plan
+   * - In the second phase, it performs predicate pushdown -> projection pushdown -> predicate pushdown.
+   * - In the third phase, the logical plan is prune with PRUNE_RULES.
+   *
+   * @param ruleFlags A nullable map from rule name to boolean. a rule is disabled if the
+   *                  corresponding value is set to false.
+   * @return HepProgram that performs logical transformations
+   */
+  private static HepProgram getOptProgram(Map<String, Boolean> ruleFlags) {
     HepProgramBuilder hepProgramBuilder = new HepProgramBuilder();
     // Set the match order as DEPTH_FIRST. The default is arbitrary which works the same as DEPTH_FIRST, but it's
     // best to be explicit.
     hepProgramBuilder.addMatchOrder(HepMatchOrder.DEPTH_FIRST);
 
     // ----
+    // Rules are disabled if its corresponding value is set to false in ruleFlags
+    // construct filtered BASIC_RULES, FILTER_PUSHDOWN_RULES, PROJECT_PUSHDOWN_RULES, PRUNE_RULES
+    List<RelOptRule> basicRules = filterRuleList(PinotQueryRuleSets.BASIC_RULES, ruleFlags);
+    List<RelOptRule> filterPushdownRules = filterRuleList(PinotQueryRuleSets.FILTER_PUSHDOWN_RULES, ruleFlags);
+    List<RelOptRule> projectPushdownRules = filterRuleList(PinotQueryRuleSets.PROJECT_PUSHDOWN_RULES, ruleFlags);
+    List<RelOptRule> pruneRules = filterRuleList(PinotQueryRuleSets.PRUNE_RULES, ruleFlags);
+
     // Run the Calcite CORE rules using 1 HepInstruction per rule. We use 1 HepInstruction per rule for simplicity:
     // the rules used here can rest assured that they are the only ones evaluated in a dedicated graph-traversal.
-    for (RelOptRule relOptRule : PinotQueryRuleSets.BASIC_RULES) {
-      hepProgramBuilder.addRuleInstance(relOptRule);
+    for (RelOptRule relOptRule : basicRules) {
+        hepProgramBuilder.addRuleInstance(relOptRule);
     }
 
     // ----
     // Pushdown filters using a single HepInstruction.
-    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.FILTER_PUSHDOWN_RULES);
+    hepProgramBuilder.addRuleCollection(filterPushdownRules);
 
     // Pushdown projects after first filter pushdown to minimize projected columns.
-    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.PROJECT_PUSHDOWN_RULES);
+    hepProgramBuilder.addRuleCollection(projectPushdownRules);
 
     // Pushdown filters again since filter should be pushed down at the lowest level, after project pushdown.
-    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.FILTER_PUSHDOWN_RULES);
+    hepProgramBuilder.addRuleCollection(filterPushdownRules);
 
     // ----
     // Prune duplicate/unnecessary nodes using a single HepInstruction.
     // TODO: We can consider using HepMatchOrder.TOP_DOWN if we find cases where it would help.
-    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.PRUNE_RULES);
+    hepProgramBuilder.addRuleCollection(pruneRules);
     return hepProgramBuilder.build();
+  }
+
+  /**
+   * Filter static RuleSet according to ruleFlags
+   * The filtering is mostly done via class name, however for config-based rules
+   * (rules with same class but different configs)
+   * check is specially handled via checking its String representation / description.
+   *
+   * @param rules static list of rules
+   * @param ruleFlags map of rule name to boolean flag
+   * @return filtered list of rules
+   */
+  private static List<RelOptRule> filterRuleList(List<RelOptRule> rules, Map<String, Boolean> ruleFlags) {
+    if (ruleFlags.isEmpty()) {
+      return rules;
+    }
+    List<RelOptRule> filteredRules = new ArrayList<>();
+    for (RelOptRule relOptRule : rules) {
+      String ruleName = relOptRule.getClass().getSimpleName();
+      // special cases here:
+      // rules of the same class and different configs could only be distinguished by checking String of its config
+      if (isExtendedAggregateFunctionsPushdownRule(relOptRule)) {
+        ruleName = CommonConstants.Broker.PlannerRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED;
+      } else if (isPruneEmptyRule(relOptRule)) {
+        ruleName = getPruneEmptyRuleName(relOptRule);
+      }
+      // add rule if rule is not present in the map or value is true
+      if (isRuleEnabled(ruleName, ruleFlags)) {
+        filteredRules.add(relOptRule);
+        continue;
+      }
+      LOGGER.debug("[QueryEnvironment] rule disabled: \n{}", relOptRule.getClass().getName());
+    }
+    return filteredRules;
+  }
+
+  // Whether a rule is enabled
+  private static boolean isRuleEnabled(String ruleName, Map<String, Boolean> ruleFlags) {
+    return !Boolean.FALSE.equals(ruleFlags.get(ruleName));
+  }
+
+  // Whether the rule is AGGREGATE_JOIN_TRANSPOSE_EXTENDED
+  private static boolean isExtendedAggregateFunctionsPushdownRule(RelOptRule relOptRule) {
+    return (relOptRule.getClass().getSimpleName().equals(CommonConstants.Broker.PlannerRules.AGGREGATE_JOIN_TRANSPOSE)
+        && ((RelRule<?>) relOptRule).config.toString().contains("allowFunctions=true"));
+  }
+
+  // util for checking PruneEmptyRules type
+  private static boolean isPruneEmptyRule(RelOptRule relOptRule) {
+    return relOptRule.getClass().getName().contains("PruneEmptyRules");
+  }
+
+  // util for getting PruneEmptyRule config description that matches queryOption value
+  private static String getPruneEmptyRuleName(RelOptRule relOptRule) {
+    String desc = ((RelRule<?>) relOptRule).config.description();
+    if (desc == null) {
+      // should be unreachable with current PruneEmtpyRules
+      return "";
+    }
+    switch (desc) {
+      case "PruneEmptyCorrelate(left)":
+        return CommonConstants.Broker.PlannerRules.PRUNE_EMPTY_CORRELATE_LEFT;
+      case "PruneEmptyCorrelate(right)":
+        return CommonConstants.Broker.PlannerRules.PRUNE_EMPTY_CORRELATE_RIGHT;
+      case "PruneEmptyJoin(left)":
+        return CommonConstants.Broker.PlannerRules.PRUNE_EMPTY_JOIN_LEFT;
+      case "PruneEmptyJoin(right)":
+        return CommonConstants.Broker.PlannerRules.PRUNE_EMPTY_JOIN_RIGHT;
+      default:
+        return desc;
+    }
   }
 
   private static HepProgram getTraitProgram(@Nullable WorkerManager workerManager, Config config,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.query.context;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +37,7 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.planner.logical.LogicalPlanner;
 import org.apache.pinot.query.validate.Validator;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /**
@@ -89,6 +92,58 @@ public class PlannerContext implements AutoCloseable {
 
   public Map<String, String> getOptions() {
     return _options;
+  }
+
+  /**
+   * Checks rule enabling options and set ruleFlags correspondingly.
+   * The ruleFlags is passed to {@link QueryEnvironment}'s getOptProgram
+   * to decide which rules are enabled / disabled dynamically.
+   *
+   * Currently, this applies to all rules used in optProgram.
+   * All rules are enabled by default, and disabled if skipXXX option is set to true
+   *
+   * @param options options from sqlNodeAndOptions
+   * @return the ruleFlags map used by getOptProgram of {@link QueryEnvironment}
+   */
+  public static Map<String, Boolean> getRuleFlags(@Nullable Map<String, String> options) {
+    // To disable a rule, put {className, false} into ruleFlags
+    Map<String, Boolean> ruleFlags = new HashMap<>();
+    // iterate through {@link CommonConstants.Broker.Request.QueryOptionKey.RuleOptionKey}
+    try {
+      for (Field declaredField : CommonConstants.Broker.PlannerRules.class.getDeclaredFields()) {
+        if (!declaredField.getType().equals(String.class)) {
+          continue;
+        }
+        int mods = declaredField.getModifiers();
+        if (!(Modifier.isStatic(mods) && Modifier.isFinal(mods))) {
+          continue;
+        }
+        // the class name
+        String ruleName = (String) declaredField.get(null);
+        // check if rule is disabled, put {className, false} if is disabled
+        if (isRuleDisabled(CommonConstants.Broker.PLANNER_RULE_SKIP + ruleName, false, options)) {
+          ruleFlags.put(ruleName, false);
+        }
+      }
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot get RuleOptionKeys constants", e);
+    }
+    return ruleFlags;
+  }
+
+  /**
+   * checks if rule is disabled
+   * @param ruleOptionKey corresponding QueryOptionKey of the rule
+   * @param defaultDisabled is the rule enabled by default
+   * @param options parsed queryOptions, or null
+   * @return whether the rule is enabled
+   */
+  private static boolean isRuleDisabled(String ruleOptionKey, Boolean defaultDisabled,
+      @Nullable Map<String, String> options) {
+    if (options == null) {
+      return defaultDisabled;
+    }
+    return Boolean.parseBoolean(options.getOrDefault(ruleOptionKey, defaultDisabled.toString()));
   }
 
   @Override

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -77,7 +77,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
 
   @Test
   public void testAggregateCaseToFilter() {
-    // Tests that queries like "SELECT SUM(CASE WHEN col1 = 'a' THEN 1 ELSE 0 END) FROM a" are rewritten to
+    // queries like "SELECT SUM(CASE WHEN col1 = 'a' THEN 1 ELSE 0 END) FROM a" are rewritten to
     // "SELECT COUNT(a) FROM a WHERE col1 = 'a'"
     String query = "EXPLAIN PLAN FOR SELECT SUM(CASE WHEN col1 = 'a' THEN 1 ELSE 0 END) FROM a";
 
@@ -91,6 +91,48 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         + "      PinotLogicalAggregate(group=[{}], agg#0=[COUNT() FILTER $0], agg#1=[COUNT()], aggType=[LEAF])\n"
         + "        LogicalProject($f1=[=($0, _UTF-8'a')])\n"
         + "          PinotLogicalTableScan(table=[[default, a]])\n");
+    //@formatter:on
+  }
+
+  @Test
+  public void testAggregateCaseToFilter2() {
+    // queries like "SELECT SUM(CASE WHEN col1 = 'a' THEN cnt ELSE 0 END) FROM a" are rewritten to
+    // "SELECT SUM0(cnt) FROM a WHERE col1 = 'a'"
+    String query = "EXPLAIN PLAN FOR SELECT SUM(CASE WHEN col1 = 'a' THEN 3 ELSE 0 END) FROM a";
+
+    String explain = _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+    //@formatter:off
+    assertEquals(explain,
+      "Execution Plan\n"
+          + "LogicalProject(EXPR$0=[CASE(=($1, 0), null:BIGINT, $0)])\n"
+          + "  PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)], aggType=[FINAL])\n"
+          + "    PinotLogicalExchange(distribution=[hash])\n"
+          + "      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0) FILTER $1], agg#1=[COUNT()], aggType=[LEAF])\n"
+          + "        LogicalProject($f1=[3], $f2=[=($0, _UTF-8'a')])\n"
+          + "          PinotLogicalTableScan(table=[[default, a]])\n");
+    //@formatter:on
+  }
+
+  @Test
+  public void testPruneEmptyCorrelateJoin() {
+    // queries involving correlated join with dummy
+    // should be optimized to dummy by PruneEmptyRules.CORRELATE_LEFT_INSTANCE
+    // or its right equivalence
+    String query = "EXPLAIN PLAN FOR SELECT *\n"
+        + "FROM (\n"
+        + "  SELECT * FROM a WHERE 1 = 0\n"
+        + ") t1\n"
+        + "WHERE EXISTS (\n"
+        + "  SELECT 1\n"
+        + "  FROM a\n"
+        + "  WHERE a.col1 = t1.col1\n"
+        + ");\n";
+
+    String explain = _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+    //@formatter:off
+    assertEquals(explain,
+        "Execution Plan\n"
+            + "LogicalValues(tuples=[[]])\n");
     //@formatter:on
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryPlannerRuleOptionsTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryPlannerRuleOptionsTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.PinotSqlType;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class QueryPlannerRuleOptionsTest extends QueryEnvironmentTestBase {
+
+  private String explainQueryWithRuleDisabled(String query, String skipRule) {
+    SqlNode sqlNode = CalciteSqlParser.compileToSqlNodeAndOptions(query).getSqlNode();
+    Map<String, String> options = new HashMap<>();
+    // disable rule
+    options.put(skipRule, "true");
+    SqlNodeAndOptions sqlNodeAndOptions =
+        new SqlNodeAndOptions(
+            sqlNode,
+            PinotSqlType.DQL,
+            QueryOptionsUtils.resolveCaseInsensitiveOptions(options));
+    return _queryEnvironment
+        .compile(query, sqlNodeAndOptions)
+        .explain(RANDOM_REQUEST_ID_GEN.nextLong(), null)
+        .getExplainPlan();
+  }
+
+  @Test
+  public void testDisableCaseToFilter() {
+    // Tests that when skipAggregateCaseToFilterRule=true,
+    // CASE WHEN should not be optimized
+    String query = "EXPLAIN PLAN FOR SELECT SUM(CASE WHEN col1 = 'a' THEN 1 ELSE 0 END) FROM a";
+    String explain = explainQueryWithRuleDisabled(query,
+        CommonConstants.Broker.Request.QueryOptionKey.RuleOptionKey.SKIP_AGGREGATE_CASE_TO_FILTER_RULE);
+
+    //@formatter:off
+    assertEquals(explain,
+        "Execution Plan\n"
+            + "LogicalProject(EXPR$0=[CASE(=($1, 0), null:BIGINT, $0)])\n"
+            + "  PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)], aggType=[FINAL])\n"
+            + "    PinotLogicalExchange(distribution=[hash])\n"
+            + "      PinotLogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT()], aggType=[LEAF])\n"
+            + "        LogicalProject($f0=[CASE(=($0, _UTF-8'a'), 1, 0)])\n"
+            + "          PinotLogicalTableScan(table=[[default, a]])\n");
+    //@formatter:on
+  }
+
+  @Test
+  public void testDisableReduceFunctions() {
+    // Tests that when skipPinotAggregateReduceFunctionsRule=true,
+    // SUM should not be reduced
+    String query = "EXPLAIN PLAN FOR SELECT SUM(CASE WHEN col1 = 'a' THEN 3 ELSE 0 END) FROM a";
+
+    String explain = explainQueryWithRuleDisabled(query,
+        CommonConstants.Broker.Request.QueryOptionKey.RuleOptionKey.SKIP_PINOT_AGGREGATE_REDUCE_FUNCTIONS_RULE);
+    //@formatter:off
+    assertEquals(explain,
+      "Execution Plan\n"
+          + "PinotLogicalAggregate(group=[{}], agg#0=[SUM($0)], aggType=[FINAL])\n"
+          + "  PinotLogicalExchange(distribution=[hash])\n"
+          + "    PinotLogicalAggregate(group=[{}], agg#0=[SUM($0)], aggType=[LEAF])\n"
+          + "      LogicalProject($f0=[CASE(=($0, _UTF-8'a'), 3, 0)])\n"
+          + "        PinotLogicalTableScan(table=[[default, a]])\n");
+    //@formatter:on
+  }
+
+  @Test
+  public void testDisablePruneEmptyJoinLeft() {
+    // Test that when skipPruneEmptyJoinLeft=true,
+    String query = "EXPLAIN PLAN FOR SELECT *\n"
+        + "FROM (\n"
+        + "  SELECT * FROM a WHERE 1 = 0\n"
+        + ") c\n"
+        + "JOIN a ON c.col1 = a.col1 ;\n";
+
+    String explain = explainQueryWithRuleDisabled(query,
+        CommonConstants.Broker.Request.QueryOptionKey.RuleOptionKey.SKIP_PRUNE_EMPTY_JOIN_LEFT_RULE);
+    //@formatter:off
+    assertEquals(explain,
+      "Execution Plan\n"
+          + "LogicalJoin(condition=[=($0, $9)], joinType=[inner])\n"
+          + "  PinotLogicalExchange(distribution=[hash[0]])\n"
+          + "    LogicalValues(tuples=[[]])\n"
+          + "  PinotLogicalExchange(distribution=[hash[0]])\n"
+          + "    PinotLogicalTableScan(table=[[default, a]])\n");
+    //@formatter:on
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -634,12 +634,158 @@ public class CommonConstants {
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
         public static final String USE_LITE_MODE = "useLiteMode";
+
+        /**
+         * Knobs related to enabling / disabling Calcite rules used in optProgram.
+         *
+         * The naming convention for these knobs mostly follows
+         * `plannerRule.skip + <displayed name in query console>`,
+         * For example, `SET plannerRule.skipPinotFilterIntoJoinRule=true;`,
+         * except those with name `XXX(left)` are converted to `XXXLeft`,
+         * and a special case `skipAggregateJoinTransposeRuleExtended`.
+         *
+         * p.s. The displayed name in the query console is className for most rules and description for
+         * PruneEmptyRules
+         *
+         * These are shown as not-used because `plannerRule.skip + name` is used in logic checking the options,
+         * these constants are kept here so the parser would parse these options
+         */
+        public static final class RuleOptionKey {
+          private static final String SKIP = PLANNER_RULE_SKIP;
+          public static final String SKIP_PINOT_FILTER_INTO_JOIN_RULE =
+              SKIP + PlannerRules.PINOT_FILTER_INTO_JOIN;
+          public static final String SKIP_FILTER_AGGREGATE_TRANSPOSE_RULE =
+              SKIP + PlannerRules.FILTER_AGGREGATE_TRANSPOSE;
+          public static final String SKIP_FILTER_SET_OP_TRANSPOSE_RULE =
+              SKIP + PlannerRules.FILTER_SET_OP_TRANSPOSE;
+          public static final String SKIP_PINOT_PROJECT_JOIN_TRANSPOSE_RULE =
+              SKIP + PlannerRules.PINOT_PROJECT_JOIN_TRANSPOSE;
+          public static final String SKIP_PROJECT_SET_OP_TRANSPOSE_RULE =
+              SKIP + PlannerRules.PROJECT_SET_OP_TRANSPOSE;
+          public static final String SKIP_FILTER_PROJECT_TRANSPOSE_RULE =
+              SKIP + PlannerRules.FILTER_PROJECT_TRANSPOSE;
+          public static final String SKIP_PINOT_JOIN_CONDITION_PUSH_RULE =
+              SKIP + PlannerRules.PINOT_JOIN_CONDITION_PUSH;
+          public static final String SKIP_PROJECT_REMOVE_RULE =
+              SKIP + PlannerRules.PROJECT_REMOVE;
+          public static final String SKIP_PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW_RULE =
+              SKIP + PlannerRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW;
+          public static final String SKIP_PROJECT_WINDOW_TRANSPOSE_RULE =
+              SKIP + PlannerRules.PROJECT_WINDOW_TRANSPOSE;
+          public static final String SKIP_PINOT_EVALUATE_LITERAL_PROJECT_RULE =
+              SKIP + PlannerRules.PINOT_EVALUATE_LITERAL_PROJECT;
+          public static final String SKIP_PINOT_EVALUATE_LITERAL_FILTER_RULE =
+              SKIP + PlannerRules.PINOT_EVALUATE_LITERAL_FILTER;
+          public static final String SKIP_JOIN_PUSH_EXPRESSIONS_RULE =
+              SKIP + PlannerRules.JOIN_PUSH_EXPRESSIONS;
+          public static final String SKIP_PROJECT_TO_SEMI_JOIN_RULE =
+              SKIP + PlannerRules.PROJECT_TO_SEMI_JOIN;
+          public static final String SKIP_PINOT_SEMIN_JOIN_DISTINCT_PROJECT_RULE =
+              SKIP + PlannerRules.PINOT_SEMIN_JOIN_DISTINCT_PROJECT_RULE;
+          public static final String SKIP_UNION_TO_DISTINCT_RULE =
+              SKIP + PlannerRules.UNION_TO_DISTINCT;
+          public static final String SKIP_AGGREGATE_REMOVE_RULE =
+              SKIP + PlannerRules.AGGREGATE_REMOVE;
+          public static final String SKIP_AGGREGATE_JOIN_TRANSPOSE_RULE =
+              SKIP + PlannerRules.AGGREGATE_JOIN_TRANSPOSE;
+          public static final String SKIP_AGGREGATE_UNION_AGGREGATE_RULE =
+              SKIP + PlannerRules.AGGREGATE_UNION_AGGREGATE;
+          public static final String SKIP_PINOT_AGGREGATE_REDUCE_FUNCTIONS_RULE =
+              SKIP + PlannerRules.PINOT_AGGREGATE_REDUCE_FUNCTIONS;
+          public static final String SKIP_AGGREGATE_CASE_TO_FILTER_RULE =
+              SKIP + PlannerRules.AGGREGATE_CASE_TO_FILTER;
+          public static final String SKIP_AGGREGATE_JOIN_TRANSPOSE_RULE_EXTENDED =
+              SKIP + PlannerRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED;
+          public static final String SKIP_AGGREGATE_PROJECT_MERGE_RULE =
+              SKIP + PlannerRules.AGGREGATE_PROJECT_MERGE;
+          public static final String SKIP_FILTER_INTO_JOIN_RULE =
+              SKIP + PlannerRules.FILTER_INTO_JOIN;
+          public static final String SKIP_PROJECT_FILTER_TRANSPOSE_RULE =
+              SKIP + PlannerRules.PROJECT_FILTER_TRANSPOSE;
+          public static final String SKIP_PROJECT_MERGE_RULE =
+              SKIP + PlannerRules.PROJECT_MERGE;
+          public static final String SKIP_FILTER_MERGE_RULE =
+              SKIP + PlannerRules.FILTER_MERGE;
+          public static final String SKIP_SORT_REMOVE_RULE =
+              SKIP + PlannerRules.SORT_REMOVE;
+          public static final String SKIP_PRUNE_EMPTY_CORRELATE_LEFT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_CORRELATE_LEFT;
+          public static final String SKIP_PRUNE_EMPTY_CORRELATE_RIGHT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_CORRELATE_RIGHT;
+          public static final String SKIP_PRUNE_EMPTY_AGGREGATE_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_AGGREGATE;
+          public static final String SKIP_PRUNE_EMPTY_FILTER_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_FILTER;
+          public static final String SKIP_PRUNE_EMPTY_JOIN_LEFT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_JOIN_LEFT;
+          public static final String SKIP_PRUNE_EMPTY_JOIN_RIGHT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_JOIN_RIGHT;
+          public static final String SKIP_PRUNE_EMPTY_PROJECT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_PROJECT;
+          public static final String SKIP_PRUNE_EMPTY_SORT_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_SORT;
+          public static final String SKIP_PRUNE_EMPTY_UNION_RULE =
+              SKIP + PlannerRules.PRUNE_EMPTY_UNION;
+        }
       }
 
       public static class QueryOptionValue {
         public static final int DEFAULT_MAX_STREAMING_PENDING_BLOCKS = 100;
       }
     }
+
+    /**
+     * Calcite and Pinot rule names / descriptions
+     * used for enable and disabling of rules, this will be iterated through in PlannerContext
+     * to check if rule is disabled.
+     */
+    public static class PlannerRules {
+      public static final String PINOT_FILTER_INTO_JOIN = "PinotFilterIntoJoinRule";
+      public static final String FILTER_AGGREGATE_TRANSPOSE = "FilterAggregateTransposeRule";
+      public static final String FILTER_SET_OP_TRANSPOSE = "FilterSetOpTransposeRule";
+      public static final String PINOT_PROJECT_JOIN_TRANSPOSE = "PinotProjectJoinTransposeRule";
+      public static final String PROJECT_SET_OP_TRANSPOSE = "ProjectSetOpTransposeRule";
+      public static final String FILTER_PROJECT_TRANSPOSE = "FilterProjectTransposeRule";
+      public static final String PINOT_JOIN_CONDITION_PUSH = "PinotJoinConditionPushRule";
+      public static final String PROJECT_REMOVE = "ProjectRemoveRule";
+      public static final String PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW = "ProjectToLogicalProjectAndWindowRule";
+      public static final String PROJECT_WINDOW_TRANSPOSE = "ProjectWindowTransposeRule";
+      // TODO: these two rules show on console as `Project` and `Filter` only, which is confusing
+      // but the knobs are not renamed for now for consistency
+      public static final String PINOT_EVALUATE_LITERAL_PROJECT = "Project";
+      public static final String PINOT_EVALUATE_LITERAL_FILTER = "Filter";
+      public static final String JOIN_PUSH_EXPRESSIONS = "JoinPushExpressionsRule";
+      public static final String PROJECT_TO_SEMI_JOIN = "ProjectToSemiJoinRule";
+      public static final String PINOT_SEMIN_JOIN_DISTINCT_PROJECT_RULE = "PinotSeminJoinDistinctProjectRule";
+      public static final String UNION_TO_DISTINCT = "UnionToDistinctRule";
+      public static final String AGGREGATE_REMOVE = "AggregateRemoveRule";
+      public static final String AGGREGATE_JOIN_TRANSPOSE = "AggregateJoinTransposeRule";
+      public static final String AGGREGATE_UNION_AGGREGATE = "AggregateUnionAggregateRule";
+      public static final String PINOT_AGGREGATE_REDUCE_FUNCTIONS = "PinotAggregateReduceFunctionsRule";
+      public static final String AGGREGATE_CASE_TO_FILTER = "AggregateCaseToFilterRule";
+      public static final String FILTER_INTO_JOIN = "FilterIntoJoinRule";
+      public static final String PROJECT_FILTER_TRANSPOSE = "ProjectFilterTransposeRule";
+      public static final String PROJECT_MERGE = "ProjectMergeRule";
+      public static final String AGGREGATE_PROJECT_MERGE = "AggregateProjectMergeRule";
+      public static final String FILTER_MERGE = "FilterMergeRule";
+      public static final String SORT_REMOVE = "SortRemoveRule";
+      // this is config-based
+      public static final String AGGREGATE_JOIN_TRANSPOSE_EXTENDED = "AggregateJoinTransposeRuleExtended";
+      // following PruneEmptyRules are config-based
+      public static final String PRUNE_EMPTY_AGGREGATE = "PruneEmptyAggregate";
+      public static final String PRUNE_EMPTY_FILTER = "PruneEmptyFilter";
+      public static final String PRUNE_EMPTY_PROJECT = "PruneEmptyProject";
+      public static final String PRUNE_EMPTY_SORT = "PruneEmptySort";
+      // TODO: this rule shows on console as `Union` only, which is confusing
+      // but the knobs are not renamed for now for consistency
+      public static final String PRUNE_EMPTY_UNION = "Union";
+      // these rules show as `PruneEmptyXXX(left)`, converted to `PruneEmptyXXXLeft`
+      public static final String PRUNE_EMPTY_CORRELATE_LEFT = "PruneEmptyCorrelateLeft";
+      public static final String PRUNE_EMPTY_CORRELATE_RIGHT = "PruneEmptyCorrelateRight";
+      public static final String PRUNE_EMPTY_JOIN_LEFT = "PruneEmptyJoinLeft";
+      public static final String PRUNE_EMPTY_JOIN_RIGHT = "PruneEmptyJoinRight";
+    }
+    public static final String PLANNER_RULE_SKIP = "plannerRule.skip";
 
     public static class FailureDetector {
       public enum Type {


### PR DESCRIPTION
Implemented knobs as queryOption that controls turning on / off rules per query.
Currently supported all rules in optProgram. One can specify disabling rule like:
```
SET plannerRule.skipPinotAggregateReduceFunctionsRule=true;
SET plannerRule.skipAggregateCaseToFilterRule=true;
```
The purpose of these knobs are for users to turn off rules that are taking too long / produces suboptimal plan.  All rules are enabled by default.

The naming convention here is consistent with the rule name shown on query console from `EXPLAIN PLAN FOR`, it's just `plannerRule.skip<name as shown on console>`.

The only naming exceptions are `PruneEmptyRules` with pattern `XXX(left)` and `XXX(right)` are changed to `XXXLeft` and `XXXRight`, and `plannerRule.skipAggregateJoinTransposeRuleExtended` (this rule will be introduced in future PR). All constants introduced are declared in pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java.

 (A side note here is the query console prints rule description if it's not null, else the simple class name. So there are rules whose names are misleading here, but I'm keeping knob name consistent with them for now. For example, `PinotEvaluateLiteralRule.Project` shows as `Project` only, and the knob would be `plannerRule.skipProject`)

A major change to QueryEnvironment is, the optProgram in PlannerContext is now constructed per-query (to contain only enabled rules), this is acceptable as creating HepProgram is not expensive. TraitProgram is already created per-query before this PR. 
A logger is added to QueryEnvironment, which will be used to debug parsed / decorrelated / trimmed plans in the future.

Another minor improvement made in this commit is the introduction of `PruneEmptyRules.CORRELATE_LEFT_INSTANCE` and its right equivalent into `PRUNE_RULES`.
These help remove the dummy correlated left / right joins produced by decorrelating EXISTS / NOT EXISTS subqueries, which Pinot doesn't support.

Several tests are added to QueryCompilationTest and QueryPlannerRuleOptionsTest to test the new rule and knobs.

P.S. 

A complete list of introduced queryOptions, valid values are `true` or `false`: 
```
plannerRule.skipPinotFilterIntoJoinRule
plannerRule.skipFilterAggregateTransposeRule
plannerRule.skipFilterSetOpTransposeRule
plannerRule.skipPinotProjectJoinTransposeRule
plannerRule.skipProjectSetOpTransposeRule
plannerRule.skipFilterProjectTransposeRule
plannerRule.skipPinotJoinConditionPushRule
plannerRule.skipProjectRemoveRule
plannerRule.skipProjectToLogicalProjectAndWindowRule
plannerRule.skipProjectWindowTransposeRule
plannerRule.skipProject                     // for PinotEvaluateLiteralRule.Project
plannerRule.skipFilter                      // for PinotEvaluateLiteralRule.Filter
plannerRule.skipJoinPushExpressionsRule
plannerRule.skipProjectToSemiJoinRule
plannerRule.skipPinotSeminJoinDistinctProjectRule
plannerRule.skipUnionToDistinctRule
plannerRule.skipAggregateRemoveRule
plannerRule.skipAggregateJoinTransposeRule
plannerRule.skipAggregateUnionAggregateRule
plannerRule.skipPinotAggregateReduceFunctionsRule
plannerRule.skipAggregateCaseToFilterRule
plannerRule.skipFilterIntoJoinRule
plannerRule.skipProjectFilterTransposeRule
plannerRule.skipProjectMergeRule
plannerRule.skipAggregateProjectMergeRule
plannerRule.skipFilterMergeRule
plannerRule.skipSortRemoveRule
plannerRule.skipAggregateJoinTransposeRuleExtended
plannerRule.skipPruneEmptyAggregate
plannerRule.skipPruneEmptyFilter
plannerRule.skipPruneEmptyProject
plannerRule.skipPruneEmptySort
plannerRule.skipUnion                     // for PruneEmptyRules.Union
plannerRule.skipPruneEmptyCorrelateLeft
plannerRule.skipPruneEmptyCorrelateRight
plannerRule.skipPruneEmptyJoinLeft
plannerRule.skipPruneEmptyJoinRight
```