### PR TITLE
Handle null Geometry gracefully In H3Index

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -108,6 +108,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NO_TABLE_ACCESS("tables", true),
   INDEXING_FAILURES("attributeValues", true),
 
+  /** Number of rows skipped due to null or invalid geometry */
+  NULL_GEOMETRY_ROWS("rows", true),
+
   READINESS_CHECK_OK_CALLS("readinessCheck", true),
   READINESS_CHECK_BAD_CALLS("readinessCheck", true),
   QUERIES_KILLED("query", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -108,9 +108,6 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NO_TABLE_ACCESS("tables", true),
   INDEXING_FAILURES("attributeValues", true),
 
-  /** Number of rows skipped due to null or invalid geometry */
-  NULL_GEOMETRY_ROWS("rows", true),
-
   READINESS_CHECK_OK_CALLS("readinessCheck", true),
   READINESS_CHECK_BAD_CALLS("readinessCheck", true),
   QUERIES_KILLED("query", true),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.GeoSpatialIndexCreator;
@@ -116,6 +118,10 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
   public void add(Geometry geometry)
       throws IOException {
     if (geometry == null) {
+      ServerMetrics metrics = ServerMetrics.get();
+      if (metrics != null) {
+        metrics.addMeteredGlobalValue(ServerMeter.NULL_GEOMETRY_ROWS, 1);
+      }
       _nextDocId++;
       return;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -104,12 +104,21 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
 
   @Override
   public Geometry deserialize(byte[] bytes) {
-    return GeometrySerializer.deserialize(bytes);
+    try {
+      return GeometrySerializer.deserialize(bytes);
+    } catch (Exception e) {
+      // For invalid serialized geometry, return null so that the doc can be skipped
+      return null;
+    }
   }
 
   @Override
   public void add(Geometry geometry)
       throws IOException {
+    if (geometry == null) {
+      _nextDocId++;
+      return;
+    }
     Preconditions.checkState(geometry instanceof Point, "H3 index can only be applied to Point, got: %s",
         geometry.getGeometryType());
     Coordinate coordinate = geometry.getCoordinate();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -30,9 +30,9 @@ import java.nio.channels.FileChannel;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.GeoSpatialIndexCreator;
@@ -120,7 +120,7 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
     if (geometry == null) {
       ServerMetrics metrics = ServerMetrics.get();
       if (metrics != null) {
-        metrics.addMeteredGlobalValue(ServerMeter.NULL_GEOMETRY_ROWS, 1);
+        metrics.addMeteredGlobalValue(ServerMeter.INDEXING_FAILURES, 1);
       }
       _nextDocId++;
       return;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -123,6 +123,34 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
     }
   }
 
+  @Test
+  public void testSkipNullOrInvalidGeometry()
+      throws Exception {
+    String columnName = "skipInvalid";
+    int res = 5;
+    H3IndexResolution resolution = new H3IndexResolution(Collections.singletonList(res));
+
+    try (GeoSpatialIndexCreator creator = new OnHeapH3IndexCreator(TEMP_DIR, columnName, resolution)) {
+      Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20));
+      creator.add(point);
+
+      // Invalid serialized bytes should be skipped without throwing exception
+      creator.add(new byte[]{1, 2, 3}, -1);
+
+      // Explicit null geometry should also be skipped
+      creator.add((Geometry) null);
+
+      creator.seal();
+    }
+
+    File indexFile = new File(TEMP_DIR, columnName + V1Constants.Indexes.H3_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        H3IndexReader reader = new ImmutableH3IndexReader(buffer)) {
+      long h3Id = H3Utils.H3_CORE.latLngToCell(20, 10, res);
+      Assert.assertEquals(reader.getDocIds(h3Id).getCardinality(), 1);
+    }
+  }
+
   public static class ConfTest extends AbstractSerdeIndexContract {
 
     protected void assertEquals(H3IndexConfig expected) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -138,7 +138,7 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
       creator.add(new byte[]{1, 2, 3}, -1);
 
       // Explicit null geometry should also be skipped
-      creator.add((Geometry) null);
+      creator.add(null);
 
       creator.seal();
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/GeoSpatialIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/GeoSpatialIndexCreator.java
@@ -35,7 +35,14 @@ public interface GeoSpatialIndexCreator extends IndexCreator {
   @Override
   default void add(@Nonnull Object value, int dictId)
       throws IOException {
-    add(deserialize((byte[]) value));
+    Geometry geometry = null;
+    try {
+      geometry = deserialize((byte[]) value);
+    } catch (Exception e) {
+      // Swallow the exception and treat the geometry as null
+      geometry = null;
+    }
+    add(geometry);
   }
 
   @Override


### PR DESCRIPTION
This pull request introduces enhancements to the H3 indexing functionality, focusing on improved error handling for invalid or null geometries and adding corresponding test coverage. The key changes include updates to the `BaseH3IndexCreator` and `GeoSpatialIndexCreator` classes, as well as the addition of a new test case to validate the behavior.

### Enhancements to error handling for geometries:

* [`BaseH3IndexCreator.java`](diffhunk://#diff-fc821d06c7c68283deebde35f8066ec59f1a7027a7e6ea011a45b6743858be70R109-R127): Modified the `deserialize` method to catch exceptions during deserialization and return `null` for invalid serialized geometries. Updated the `add` method to skip indexing for `null` geometries while incrementing the document ID and logging the failure using `ServerMetrics`.

* [`GeoSpatialIndexCreator.java`](diffhunk://#diff-e17cfcd9e4693b850863f267d618f8cb8804d64fe13e1ebd3787bb5c9b01b87dL38-R45): Updated the default `add` method to handle exceptions during deserialization gracefully by treating invalid geometries as `null` and passing them to the `add` method.

### Test coverage for new functionality:

* [`H3IndexTest.java`](diffhunk://#diff-0ea94f95fe6ca53944a51cccd85dca927ba21c670efcae330397f9d4d4c44ce7R126-R153): Added a new test case, `testSkipNullOrInvalidGeometry`, to verify that invalid serialized geometries and explicit `null` geometries are skipped without throwing exceptions. The test ensures that valid geometries are still indexed correctly.

### Dependency updates:

* [`BaseH3IndexCreator.java`](diffhunk://#diff-fc821d06c7c68283deebde35f8066ec59f1a7027a7e6ea011a45b6743858be70R33-R34): Added imports for `ServerMeter` and `ServerMetrics` to facilitate logging of indexing failures.