### PR TITLE
[WIP] Ensure Consistent Upsert Tie-Breaking using ZK Segment Creation Time from Controller ZK metadata

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -136,8 +136,8 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               // current value, but the segment has a larger sequence number (the segment is newer than the current
               // segment).
               if (comparisonResult > 0 || (comparisonResult == 0 && shouldReplaceOnComparisonTie(segmentName,
-                  currentSegmentName, segment.getSegmentMetadata().getIndexCreationTime(),
-                  currentSegment.getSegmentMetadata().getIndexCreationTime()))) {
+                  currentSegmentName, getSegmentCreationTime(segment),
+                  getSegmentCreationTime(currentSegment)))) {
                 replaceDocId(segment, validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
                 return new RecordLocation(segment, newDocId, newComparisonValue);
               } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -166,8 +166,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
               // current value, but the segment has a larger sequence number (the segment is newer than the current
               // segment).
               if (comparisonResult > 0 || (comparisonResult == 0 && shouldReplaceOnComparisonTie(segmentName,
-                  currentSegmentName, segment.getSegmentMetadata().getIndexCreationTime(),
-                  currentSegment.getSegmentMetadata().getIndexCreationTime()))) {
+                  currentSegmentName, getSegmentCreationTime(segment),
+                  getSegmentCreationTime(currentSegment)))) {
                 replaceDocId(segment, validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
                 return new RecordLocation(segment, newDocId, newComparisonValue,
                     RecordLocation.incrementSegmentCount(currentDistinctSegmentCount));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -55,6 +56,8 @@ public class UpsertContext {
   private final long _newSegmentTrackingTimeMs;
   @Nullable
   private final Map<String, String> _metadataManagerConfigs;
+  @Nullable
+  private final Function<String, Long> _segmentZKCreationTimeProvider;
 
   /// @deprecated use {@link org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy)} instead.
   @Deprecated
@@ -72,7 +75,8 @@ public class UpsertContext {
       boolean enableDeletedKeysCompactionConsistency, UpsertConfig.ConsistencyMode consistencyMode,
       long upsertViewRefreshIntervalMs, long newSegmentTrackingTimeMs,
       @Nullable Map<String, String> metadataManagerConfigs, boolean allowPartialUpsertConsumptionDuringCommit,
-      @Nullable TableDataManager tableDataManager, File tableIndexDir) {
+      @Nullable TableDataManager tableDataManager, File tableIndexDir,
+      @Nullable Function<String, Long> segmentZKCreationTimeProvider) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
@@ -94,6 +98,7 @@ public class UpsertContext {
     _allowPartialUpsertConsumptionDuringCommit = allowPartialUpsertConsumptionDuringCommit;
     _tableDataManager = tableDataManager;
     _tableIndexDir = tableIndexDir;
+    _segmentZKCreationTimeProvider = segmentZKCreationTimeProvider;
   }
 
   public TableConfig getTableConfig() {
@@ -190,6 +195,11 @@ public class UpsertContext {
     return _tableIndexDir;
   }
 
+  @Nullable
+  public Function<String, Long> getSegmentZKCreationTimeProvider() {
+    return _segmentZKCreationTimeProvider;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -211,6 +221,7 @@ public class UpsertContext {
         .append("metadataManagerConfigs", _metadataManagerConfigs)
         .append("allowPartialUpsertConsumptionDuringCommit", _allowPartialUpsertConsumptionDuringCommit)
         .append("tableIndexDir", _tableIndexDir)
+        .append("segmentZKCreationTimeProvider", _segmentZKCreationTimeProvider)
         .toString();
   }
 
@@ -237,6 +248,7 @@ public class UpsertContext {
     private boolean _allowPartialUpsertConsumptionDuringCommit;
     private TableDataManager _tableDataManager;
     private File _tableIndexDir;
+    private Function<String, Long> _segmentZKCreationTimeProvider;
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -344,6 +356,11 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setSegmentZKCreationTimeProvider(Function<String, Long> segmentZKCreationTimeProvider) {
+      _segmentZKCreationTimeProvider = segmentZKCreationTimeProvider;
+      return this;
+    }
+
     public UpsertContext build() {
       Preconditions.checkState(_tableConfig != null, "Table config must be set");
       Preconditions.checkState(_schema != null, "Schema must be set");
@@ -359,7 +376,8 @@ public class UpsertContext {
           _partialUpsertHandler, _deleteRecordColumn, _dropOutOfOrderRecord, _outOfOrderRecordColumn, _enableSnapshot,
           _enablePreload, _metadataTTL, _deletedKeysTTL, _enableDeletedKeysCompactionConsistency, _consistencyMode,
           _upsertViewRefreshIntervalMs, _newSegmentTrackingTimeMs, _metadataManagerConfigs,
-          _allowPartialUpsertConsumptionDuringCommit, _tableDataManager, _tableIndexDir);
+          _allowPartialUpsertConsumptionDuringCommit, _tableDataManager, _tableIndexDir,
+          _segmentZKCreationTimeProvider);
     }
   }
 }


### PR DESCRIPTION
This PR addresses an issue discovered in #15846 where inconsistent segment.creation.time across replicas and due to reliance on server-local creation.meta files, can lead to divergent replica during upsert tie-breaking.

To ensure consistency, this change modifies the `shouldReplaceOnComparisonTie` logic to use `segment.creation.time` from controller ZK metadata as the single source of truth.

Key changes:

- Introduces a _segmentCreationTimeCache (Map of segmentName to creationTime) within BasePartitionUpsertMetadataManager.
- Adds a segmentZKCreationTimeProvider that fetches ZK metadata using TableDataManager.fetchZKMetadata().
- The cache is populated and maintained during segment lifecycle operations:
   - doAddSegment(): Caches creation time for new segments.
   - doPreloadSegment(): Caches creation time during preloading.
   - doReplaceSegment(): Updates cache for the new segment and removes the old.
   - doRemoveSegment(): Removes the entry for deleted segments.
- The lookup strategy prioritizes the cached ZK creation time, with lazy loading from PinotHelixResourceManager (fetching from ZK) on a cache miss. If the creation time is not found from controller, we rely on creation.meta stored on server.

This approach ensures that all replicas use the same creation time for tie-breaking, leading to a consistent state across the cluster.

RFC doc: https://docs.google.com/document/d/1KCMfPPI3RSvsadm1GvrhXNB-MpnEAewbvK_S8k6FlSA/edit?usp=sharing

Putting this out for early review. I am currently testing this in and will also add required UTs for this soon.