### PR TITLE
Enable ZK-based progress tracking for SegmentRelocator rebalances

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -696,18 +696,19 @@ public class PinotTableRestletResource {
       if (dryRun || preChecks || downtime) {
         // For dry-run, preChecks or rebalance with downtime, it's fine to run the rebalance synchronously since it
         // should be a really short operation.
-        return _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId, false);
+        return _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId, false, false);
       } else {
         // Make a dry-run first to get the target assignment
         rebalanceConfig.setDryRun(true);
         RebalanceResult dryRunResult =
-            _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId, false);
+            _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig, rebalanceJobId, false, false);
 
         if (dryRunResult.getStatus() == RebalanceResult.Status.DONE) {
           // If dry-run succeeded, run rebalance asynchronously
           rebalanceConfig.setDryRun(false);
           CompletableFuture<RebalanceResult> rebalanceResultFuture =
-              _tableRebalanceManager.rebalanceTableAsync(tableNameWithType, rebalanceConfig, rebalanceJobId, true);
+              _tableRebalanceManager.rebalanceTableAsync(tableNameWithType, rebalanceConfig, rebalanceJobId, true,
+                  true);
           rebalanceResultFuture.whenComplete((rebalanceResult, throwable) -> {
             if (throwable != null) {
               String errorMsg = String.format("Caught exception/error while rebalancing table: %s", tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
@@ -279,6 +279,10 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
       }
       TableRebalanceProgressStats jobStats = JsonUtils.stringToObject(jobStatsInStr, TableRebalanceProgressStats.class);
       TableRebalanceContext jobCtx = JsonUtils.stringToObject(jobCtxInStr, TableRebalanceContext.class);
+      if (!jobCtx.getAllowRetries()) {
+        LOGGER.debug("Skip rebalance job: {} as it does not allow retries", jobId);
+        continue;
+      }
       long jobStartTimeMs = jobStats.getStartTimeMs();
       if (latestStartedJob == null || latestStartedJob.getRight() < jobStartTimeMs) {
         latestStartedJob = Pair.of(jobId, jobStartTimeMs);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
@@ -111,6 +111,11 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
   @VisibleForTesting
   void retryRebalanceTable(String tableNameWithType, Map<String, Map<String, String>> allJobMetadata)
       throws Exception {
+    // We first check for rebalance jobs that are stuck - i.e., those that are IN_PROGRESS but haven't updated their
+    // status in ZK within the heartbeat timeout. This could occur if a controller crashes while running a rebalance job
+    // for instance. These stuck jobs are always aborted here. They will also be retried if it's allowed as per the
+    // rebalance context.
+    //
     // Skip retry for the table if rebalance job is still running or has completed, in specific:
     // 1) Skip retry if any rebalance job is actively running. Being actively running means the job is at IN_PROGRESS
     // status, and has updated its status kept in ZK within the heartbeat timeout. It's possible that more than one
@@ -118,11 +123,23 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
     // 2) Skip retry if the most recently started rebalance job has completed with DONE or NO_OP. It's possible that
     // jobs started earlier may be still running, but they are ignored here.
     //
-    // Otherwise, we can get a list of failed rebalance jobs, i.e. those at FAILED status; or IN_PROGRESS status but
-    // haven't updated their status kept in ZK within the heartbeat timeout. For those candidate jobs to retry:
+    // Note that it should be very unlikely to have scenarios where there are more than one rebalance jobs running
+    // for a table at the same time, or to have a rebalance job that started earlier but completed later than the one
+    // started most recently since we try to prevent new rebalances from being triggered while a rebalance is in
+    // progress by checking ZK metadata. Such scenarios can only occur if multiple rebalance jobs are triggered at the
+    // same time and the second one is started before the first one updates its status in ZK.
+    //
+    // If we detect that a retry is required based on the above criteria, we can get a list of failed rebalance jobs,
+    // i.e. those at FAILED status; or IN_PROGRESS status but haven't updated their status kept in ZK within the
+    // heartbeat timeout. For those candidate jobs to retry:
     // 1) Firstly, group them by the original jobIds they retry for so that we can skip those exceeded maxRetry.
     // 2) For the remaining jobs, we take the one started most recently and retry it with its original configs.
     // 3) If configured, we can abort the other rebalance jobs for the table by setting their status to FAILED.
+
+    if (hasStuckInProgressJobs(tableNameWithType, allJobMetadata)) {
+      abortExistingJobs(tableNameWithType, _pinotHelixResourceManager);
+    }
+
     Map<String/*original jobId*/, Set<Pair<TableRebalanceContext/*job attempts*/, Long
         /*startTime*/>>> candidateJobs = getCandidateJobs(tableNameWithType, allJobMetadata);
     if (candidateJobs.isEmpty()) {
@@ -147,7 +164,7 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
           retryDelayMs);
       return;
     }
-    abortExistingJobs(tableNameWithType, _pinotHelixResourceManager);
+
     // Get tableConfig only when the table needs to retry rebalance, and get it before submitting rebalance to another
     // thread, in order to avoid unnecessary ZK reads and making too many ZK reads in a short time.
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
@@ -250,6 +267,47 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
     return candidateJobRun;
   }
 
+  /**
+   * Check if there are any rebalance jobs that are stuck in IN_PROGRESS status, i.e., they have not updated their
+   * status in ZK within the configured heartbeat timeout.
+   * @param tableNameWithType the table name with type
+   * @param allJobMetadata the metadata of all rebalance jobs for the table
+   * @return true if there are stuck rebalance jobs, false otherwise
+   */
+  @VisibleForTesting
+  static boolean hasStuckInProgressJobs(String tableNameWithType, Map<String, Map<String, String>> allJobMetadata)
+      throws Exception {
+    for (Map.Entry<String, Map<String, String>> entry : allJobMetadata.entrySet()) {
+      String jobId = entry.getKey();
+      Map<String, String> jobMetadata = entry.getValue();
+      long statsUpdatedAt = Long.parseLong(jobMetadata.get(CommonConstants.ControllerJob.SUBMISSION_TIME_MS));
+      String jobStatsInStr = jobMetadata.get(RebalanceJobConstants.JOB_METADATA_KEY_REBALANCE_PROGRESS_STATS);
+      if (StringUtils.isEmpty(jobStatsInStr)) {
+        // Skip rebalance job as it has no job progress stats
+        continue;
+      }
+      String jobCtxInStr = jobMetadata.get(RebalanceJobConstants.JOB_METADATA_KEY_REBALANCE_CONTEXT);
+      if (StringUtils.isEmpty(jobCtxInStr)) {
+        // Skip rebalance job: {} as it has no job context
+        continue;
+      }
+      TableRebalanceProgressStats jobStats = JsonUtils.stringToObject(jobStatsInStr, TableRebalanceProgressStats.class);
+      TableRebalanceContext jobCtx = JsonUtils.stringToObject(jobCtxInStr, TableRebalanceContext.class);
+
+      if (jobStats.getStatus() == RebalanceResult.Status.IN_PROGRESS) {
+        long heartbeatTimeoutMs = jobCtx.getConfig().getHeartbeatTimeoutInMs();
+        if (System.currentTimeMillis() - statsUpdatedAt >= heartbeatTimeoutMs) {
+          LOGGER.info("Found stuck rebalance job: {} for table: {} that has not updated its status in ZK within "
+              + "heartbeat timeout: {}", jobId, tableNameWithType, heartbeatTimeoutMs);
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
   @VisibleForTesting
   static Map<String, Set<Pair<TableRebalanceContext, Long>>> getCandidateJobs(String tableNameWithType,
       Map<String, Map<String, String>> allJobMetadata)
@@ -280,7 +338,7 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
       TableRebalanceProgressStats jobStats = JsonUtils.stringToObject(jobStatsInStr, TableRebalanceProgressStats.class);
       TableRebalanceContext jobCtx = JsonUtils.stringToObject(jobCtxInStr, TableRebalanceContext.class);
       if (!jobCtx.getAllowRetries()) {
-        LOGGER.debug("Skip rebalance job: {} as it does not allow retries", jobId);
+        LOGGER.info("Skip rebalance job: {} as it does not allow retries", jobId);
         continue;
       }
       long jobStartTimeMs = jobStats.getStartTimeMs();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
@@ -61,7 +61,8 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
         RebalanceConfig rebalanceConfig = RebalanceConfig.copy(config);
         rebalanceConfig.setDryRun(true);
         rebalanceResult.put(table,
-            _tableRebalanceManager.rebalanceTable(table, rebalanceConfig, createUniqueRebalanceJobIdentifier(), false));
+            _tableRebalanceManager.rebalanceTable(table, rebalanceConfig, createUniqueRebalanceJobIdentifier(), false,
+                false));
       } catch (TableNotFoundException | RebalanceInProgressException exception) {
         rebalanceResult.put(table, new RebalanceResult(null, RebalanceResult.Status.FAILED, exception.getMessage(),
             null, null, null, null, null));
@@ -203,7 +204,7 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
       TenantRebalanceObserver observer) {
     try {
       observer.onTrigger(TenantRebalanceObserver.Trigger.REBALANCE_STARTED_TRIGGER, tableName, rebalanceJobId);
-      RebalanceResult result = _tableRebalanceManager.rebalanceTable(tableName, config, rebalanceJobId, true);
+      RebalanceResult result = _tableRebalanceManager.rebalanceTable(tableName, config, rebalanceJobId, true, true);
       if (result.getStatus().equals(RebalanceResult.Status.DONE)) {
         observer.onTrigger(TenantRebalanceObserver.Trigger.REBALANCE_COMPLETED_TRIGGER, tableName, null);
       } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -233,7 +233,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       // We're not using the async rebalance API here because we want to run this on a separate thread pool from the
       // rebalance thread pool that is used for user initiated rebalances.
       RebalanceResult rebalance = _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig,
-          TableRebalancer.createUniqueRebalanceJobIdentifier(), false);
+          TableRebalancer.createUniqueRebalanceJobIdentifier(), true, false);
       switch (rebalance.getStatus()) {
         case NO_OP:
           LOGGER.info("All segments are already relocated for table: {}", tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -232,6 +232,9 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
       // We're not using the async rebalance API here because we want to run this on a separate thread pool from the
       // rebalance thread pool that is used for user initiated rebalances.
+
+      // Retries are disabled because SegmentRelocator itself is a periodic controller task, so we don't want the
+      // RebalanceChecker to unnecessarily retry any such failed rebalances.
       RebalanceResult rebalance = _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig,
           TableRebalancer.createUniqueRebalanceJobIdentifier(), true, false);
       switch (rebalance.getStatus()) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceCheckerTest.java
@@ -87,7 +87,7 @@ public class RebalanceCheckerTest {
     TableRebalanceProgressStats stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.FAILED);
     stats.setStartTimeMs(1000);
-    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg);
+    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg, true);
     Map<String, String> jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job1", stats, jobCtx);
     allJobMetadata.put("job1", jobMetadata);
     // 3 failed retry runs for job1
@@ -104,7 +104,7 @@ public class RebalanceCheckerTest {
     stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.FAILED);
     stats.setStartTimeMs(2000);
-    jobCtx = TableRebalanceContext.forInitialAttempt("job2", jobCfg);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job2", jobCfg, true);
     jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job2", stats, jobCtx);
     allJobMetadata.put("job2", jobMetadata);
     jobMetadata = createDummyJobMetadata(tableName, "job2", 2, 2100, RebalanceResult.Status.DONE);
@@ -116,7 +116,7 @@ public class RebalanceCheckerTest {
     stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.IN_PROGRESS);
     stats.setStartTimeMs(3000);
-    jobCtx = TableRebalanceContext.forInitialAttempt("job3", jobCfg);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job3", jobCfg, true);
     jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job3", stats, jobCtx);
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, "3000");
     allJobMetadata.put("job3", jobMetadata);
@@ -152,11 +152,37 @@ public class RebalanceCheckerTest {
     stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.DONE);
     stats.setStartTimeMs(5000);
-    jobCtx = TableRebalanceContext.forInitialAttempt("job5", jobCfg);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job5", jobCfg, true);
     jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job5", stats, jobCtx);
     allJobMetadata.put("job5", jobMetadata);
     jobs = RebalanceChecker.getCandidateJobs(tableName, allJobMetadata);
     assertEquals(jobs.size(), 0);
+
+    // Add job6 that doesn't support retries as per its rebalance context (used by system initiated rebalances in
+    // practice).
+    jobCfg = new RebalanceConfig();
+    jobCfg.setMaxAttempts(4);
+    stats = new TableRebalanceProgressStats();
+    stats.setStatus(RebalanceResult.Status.FAILED);
+    stats.setStartTimeMs(5000);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job6", jobCfg, false);
+    jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job6", stats, jobCtx);
+    allJobMetadata.put("job6", jobMetadata);
+    jobs = RebalanceChecker.getCandidateJobs(tableName, allJobMetadata);
+    assertEquals(jobs.size(), 0);
+
+    // Ensure that a job serialized using an older version of TableRebalanceContext without the allowRetries field is
+    // retriable by default.
+    jobMetadata.put(RebalanceJobConstants.JOB_METADATA_KEY_REBALANCE_CONTEXT,
+        "{\"jobId\":\"job6\",\"attemptId\":1,\"config\":{\"maxAttempts\":4,\"dryRun\":false,\"preChecks\":false,"
+            + "\"bootstrap\":false,\"downtime\":false,\"lowDiskMode\":false,\"bestEfforts\":false,"
+            + "\"reassignInstances\":false,\"includeConsuming\":false,\"batchSizePerServer\":-1,"
+            + "\"updateTargetTier\":false,\"externalViewCheckIntervalInMs\":1000,\"minAvailableReplicas\":1,"
+            + "\"heartbeatIntervalInMs\":300000,\"heartbeatTimeoutInMs\":3600000,\"retryInitialDelayInMs\":300000,"
+            + "\"minimizeDataMovement\":\"ENABLE\",\"externalViewStabilizationTimeoutInMs\":3600000},"
+            + "\"originalJobId\":\"job6\"}, tableName=table01}");
+    jobs = RebalanceChecker.getCandidateJobs(tableName, Map.of("job6", jobMetadata));
+    assertEquals(jobs.size(), 1);
   }
 
   @Test
@@ -208,7 +234,7 @@ public class RebalanceCheckerTest {
     TableRebalanceProgressStats stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.FAILED);
     stats.setStartTimeMs(1000);
-    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg);
+    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg, true);
     Map<String, String> jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job1", stats, jobCtx);
     allJobMetadata.put("job1", jobMetadata);
     // 3 failed retry runs for job1
@@ -225,7 +251,7 @@ public class RebalanceCheckerTest {
     stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.FAILED);
     stats.setStartTimeMs(2000);
-    jobCtx = TableRebalanceContext.forInitialAttempt("job2", jobCfg);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job2", jobCfg, true);
     jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job2", stats, jobCtx);
     allJobMetadata.put("job2", jobMetadata);
     jobMetadata = createDummyJobMetadata(tableName, "job2", 2, 2100, RebalanceResult.Status.DONE);
@@ -237,7 +263,7 @@ public class RebalanceCheckerTest {
     stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.IN_PROGRESS);
     stats.setStartTimeMs(3000);
-    jobCtx = TableRebalanceContext.forInitialAttempt("job3", jobCfg);
+    jobCtx = TableRebalanceContext.forInitialAttempt("job3", jobCfg, true);
     jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job3", stats, jobCtx);
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, "3000");
     allJobMetadata.put("job3", jobMetadata);
@@ -284,7 +310,7 @@ public class RebalanceCheckerTest {
     TableRebalanceProgressStats stats = new TableRebalanceProgressStats();
     stats.setStatus(RebalanceResult.Status.FAILED);
     stats.setStartTimeMs(nowMs);
-    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg);
+    TableRebalanceContext jobCtx = TableRebalanceContext.forInitialAttempt("job1", jobCfg, true);
     Map<String, String> jobMetadata = ZkBasedTableRebalanceObserver.createJobMetadata(tableName, "job1", stats, jobCtx);
     allJobMetadata.put("job1", jobMetadata);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -71,7 +71,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
     }
 
     ZkBasedTableRebalanceObserver rebalanceObserver = new ZkBasedTableRebalanceObserver(tableNameWithType, jobId,
-        TableRebalanceContext.forInitialAttempt(jobId, _rebalanceConfig), _propertyStore);
+        TableRebalanceContext.forInitialAttempt(jobId, _rebalanceConfig, true), _propertyStore);
 
     return new TableRebalancer(_helixManager, rebalanceObserver, null, null, null)
         .rebalance(tableConfig, _rebalanceConfig, jobId);


### PR DESCRIPTION
- Builds on top of the refactors in https://github.com/apache/pinot/pull/15990.
- Initially, the main purpose of the rebalance stats in ZK was to support automatic retries of failed and stuck rebalances through the `RebalanceChecker` periodic controller job. Since `SegmentRelocator` is itself a periodic controller job, it was deemed unnecessary to track these rebalances in ZK.
- However, with https://github.com/apache/pinot/issues/15683 / https://github.com/apache/pinot/pull/15990, we're also going to be using the ZK stats to prevent multiple concurrent rebalances for the same table and this should extend to rebalances triggered by the `SegmentRelocator` as well.
- This patch enables ZK-based progress tracking for `SegmentRelocator` rebalances, and also makes some changes to the rebalance context to ensure that `RebalanceChecker` ignores rebalance jobs initiated by the `SegmentRelocator`.
- Since `SegmentRelocator` is a periodic controller job (1 hour frequency by default), this could lead to a number of rebalance jobs being stored in ZK, so we're planning to also improve the cleanup logic for controller job ZK metadata (https://github.com/apache/pinot/issues/16005).