### PR TITLE
[bugfix][ui] rename component to MultipleSelectComponent to match filename

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/MultipleSelectComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/MultipleSelectComponent.tsx
@@ -53,7 +53,7 @@ type Props = {
     columnName: Array<string>
 };
 
-export default function AddDeleteComponent({
+export default function MultipleSelectComponent({
     changeHandler,
     streamConfigsObj,
     columnName


### PR DESCRIPTION
Renamed the component from AddDeleteComponent to MultipleSelectComponent to match the filename (MultipleSelectComponent.tsx). This improves consistency and clarity across the codebase, making the component easier to identify and maintain.