### PR TITLE
add test scope for assertj-core in pinot-core

### DIFF
--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -168,6 +168,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The pull request [apache/pinot#15975](https://github.com/apache/pinot/pull/15975) modified the pom.xml file in the pinot-core module to explicitly include assertj-core as a dependency. This change inadvertently altered the scope of `net.bytebuddy:byte-buddy:jar:1.17.5` from `test` to `compile`. This shift caused issues within Stripe where we have a plugin, which utilizes the Maven Shade Plugin (version 3.6.0) for shading. Unfortunately, this version of the plugin does not support JDK 24, leading to compile errors because net.bytebuddy:byte-buddy is a multi-release JAR. The error encountered is:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.6.0:shade (default) on project <OUR PLUGIN>: Error creating shaded jar: Problem shading JAR
  entry META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassReader.class: java.lang.IllegalArgumentException: Unsupported class file major version 68
```
​
To resolve this, the pull request adjusts the scope of assertj-core back to `test`. This aligns with the intended configuration, as all other test-related dependencies above it are scoped to `test`.