### PR TITLE
[multistage] Add Support for inferRealtimeSegmentPartition

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -406,6 +406,10 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.INFER_INVALID_SEGMENT_PARTITION, "false"));
   }
 
+  public static boolean isInferRealtimeSegmentPartition(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.INFER_REALTIME_SEGMENT_PARTITION, "false"));
+  }
+
   @Nullable
   private static Integer uncheckedParseInt(String optionName, @Nullable String optionValue) {
     if (optionValue == null) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRuleTest.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.query.planner.physical.v2.HashDistributionDesc;
 import org.apache.pinot.query.planner.physical.v2.PRelNode;
@@ -74,7 +76,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   @Test
   public void testAssignTableScanWithUnPartitionedOfflineTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
-        OFFLINE_INSTANCE_ID_TO_SEGMENTS, Map.of(), false);
+        OFFLINE_INSTANCE_ID_TO_SEGMENTS, Map.of(), false, false);
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.RANDOM_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
     assertEquals(result._pinotDataDistribution.getCollation(), RelCollations.EMPTY);
@@ -85,7 +87,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   @Test
   public void testAssignTableScanWithUnPartitionedRealtimeTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
-        REALTIME_INSTANCE_ID_TO_SEGMENTS, Map.of(), false);
+        REALTIME_INSTANCE_ID_TO_SEGMENTS, Map.of(), false, false);
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.RANDOM_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
     assertEquals(result._pinotDataDistribution.getCollation(), RelCollations.EMPTY);
@@ -96,7 +98,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   @Test
   public void testAssignTableScanWithUnPartitionedHybridTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
-        HYBRID_INSTANCE_ID_TO_SEGMENTS, Map.of(), false);
+        HYBRID_INSTANCE_ID_TO_SEGMENTS, Map.of(), false, false);
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.RANDOM_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
     assertEquals(result._pinotDataDistribution.getCollation(), RelCollations.EMPTY);
@@ -108,7 +110,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   @Test
   public void testAssignTableScanPartitionedOfflineTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
-        OFFLINE_INSTANCE_ID_TO_SEGMENTS, Map.of("OFFLINE", createOfflineTablePartitionInfo()), false);
+        OFFLINE_INSTANCE_ID_TO_SEGMENTS, Map.of("OFFLINE", createOfflineTablePartitionInfo()), false, false);
     // Basic checks.
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.HASH_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
@@ -124,7 +126,7 @@ public class LeafStageWorkerAssignmentRuleTest {
   @Test
   public void testAssignTableScanPartitionedRealtimeTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
-        REALTIME_INSTANCE_ID_TO_SEGMENTS, Map.of("REALTIME", createRealtimeTablePartitionInfo()), false);
+        REALTIME_INSTANCE_ID_TO_SEGMENTS, Map.of("REALTIME", createRealtimeTablePartitionInfo()), false, false);
     // Basic checks.
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.HASH_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
@@ -146,7 +148,7 @@ public class LeafStageWorkerAssignmentRuleTest {
       // Case-1: When inferInvalidPartitionSegment is set to true.
       TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
           REALTIME_INSTANCE_ID_TO_SEGMENTS_WITH_INVALID_PARTITIONS, Map.of("REALTIME",
-              createRealtimeTablePartitionInfo(List.of(INVALID_SEGMENT_PARTITION))), true);
+              createRealtimeTablePartitionInfo(List.of(INVALID_SEGMENT_PARTITION))), true, false);
       // Basic checks.
       assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.HASH_DISTRIBUTED);
       assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
@@ -163,7 +165,7 @@ public class LeafStageWorkerAssignmentRuleTest {
       // Case-2: When inferInvalidPartitionSegment is set to false.
       TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
           REALTIME_INSTANCE_ID_TO_SEGMENTS_WITH_INVALID_PARTITIONS, Map.of("REALTIME",
-              createRealtimeTablePartitionInfo(List.of(INVALID_SEGMENT_PARTITION))), false);
+              createRealtimeTablePartitionInfo(List.of(INVALID_SEGMENT_PARTITION))), false, false);
       // Basic checks.
       assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.RANDOM_DISTRIBUTED);
       assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
@@ -178,13 +180,57 @@ public class LeafStageWorkerAssignmentRuleTest {
   public void testAssignTableScanPartitionedHybridTable() {
     TableScanWorkerAssignmentResult result = LeafStageWorkerAssignmentRule.assignTableScan(TABLE_NAME, FIELDS_IN_SCAN,
         HYBRID_INSTANCE_ID_TO_SEGMENTS, Map.of("OFFLINE", createOfflineTablePartitionInfo(),
-            "REALTIME", createRealtimeTablePartitionInfo()), false);
+            "REALTIME", createRealtimeTablePartitionInfo()), false, false);
     assertEquals(result._pinotDataDistribution.getType(), RelDistribution.Type.RANDOM_DISTRIBUTED);
     assertEquals(result._pinotDataDistribution.getWorkers().size(), 4);
     assertEquals(result._pinotDataDistribution.getCollation(), RelCollations.EMPTY);
     assertEquals(result._pinotDataDistribution.getHashDistributionDesc().size(), 0);
     validateTableScanAssignment(result, HYBRID_INSTANCE_ID_TO_SEGMENTS._offlineTableSegmentsMap, "OFFLINE");
     validateTableScanAssignment(result, HYBRID_INSTANCE_ID_TO_SEGMENTS._realtimeTableSegmentsMap, "REALTIME");
+  }
+
+  @Test
+  public void testBuildTablePartitionInfoWithInferredPartitionsWhenRealtimeSegments() {
+    final LLCSegmentName segment1 = new LLCSegmentName(TABLE_NAME, 3, 35,
+        System.currentTimeMillis() / 1000);
+    final LLCSegmentName segment2 = new LLCSegmentName(TABLE_NAME, 2, 35,
+        System.currentTimeMillis() / 1000);
+    final UploadedRealtimeSegmentName segment3 = new UploadedRealtimeSegmentName(
+        String.format("uploaded__%s__0__20240530T0000Z__suffix", TABLE_NAME));
+    final List<String> segments = List.of(segment1.getSegmentName(), segment2.getSegmentName(),
+        segment3.getSegmentName());
+    final String tableNameWithType = "foobar_REALTIME";
+    final int numPartitions = 4;
+    // Create input table partition info and set all segments to invalid partition. Simulating case when the
+    // segmentPartitionConfig has just been added to a Realtime table.
+    final TablePartitionInfo inputTablePartitionInfo = new TablePartitionInfo(tableNameWithType, PARTITION_COLUMN,
+        PARTITION_FUNCTION, numPartitions, List.of(), segments /* invalid partition segments */);
+    // Setup other test inputs.
+    Map<String, List<String>> instanceIdToSegmentsMap = new HashMap<>();
+    instanceIdToSegmentsMap.put("instance-0", segments);
+    TablePartitionInfo tpi = LeafStageWorkerAssignmentRule.buildTablePartitionInfoWithInferredPartitions(
+        TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME), instanceIdToSegmentsMap, inputTablePartitionInfo);
+    assertNotNull(tpi);
+    assertEquals(tpi.getNumPartitions(), numPartitions);
+    assertEquals(tpi.getSegmentsWithInvalidPartition(), List.of());
+    assertEquals(tpi.getSegmentsByPartition().get(0), List.of(segment3.getSegmentName()));
+    assertEquals(tpi.getSegmentsByPartition().get(1), List.of());
+    assertEquals(tpi.getSegmentsByPartition().get(2), List.of(segment2.getSegmentName()));
+    assertEquals(tpi.getSegmentsByPartition().get(3), List.of(segment1.getSegmentName()));
+  }
+
+  @Test
+  public void testBuildTablePartitionInfoWithInferredPartitionsWhenInvalidRealtimeSegmentName() {
+    final List<String> segments = List.of("foobar_101_35__20250509T1Z");
+    final String tableNameWithType = "foobar_REALTIME";
+    final int numPartitions = 4;
+    final TablePartitionInfo inputTablePartitionInfo = new TablePartitionInfo(tableNameWithType, PARTITION_COLUMN,
+        PARTITION_FUNCTION, numPartitions, List.of(), segments /* invalid partition segments */);
+    // Setup other test inputs.
+    Map<String, List<String>> instanceIdToSegmentsMap = new HashMap<>();
+    instanceIdToSegmentsMap.put("instance-0", segments);
+    assertNull(LeafStageWorkerAssignmentRule.buildTablePartitionInfoWithInferredPartitions(
+        TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME), instanceIdToSegmentsMap, inputTablePartitionInfo));
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -632,6 +632,7 @@ public class CommonConstants {
         // records to stream partitions, which can make a segment have multiple partitions. The scale of this is
         // usually low, and this query option allows the MSE Optimizer to infer the partition of a segment based on its
         // name, when that segment has multiple partitions in its columnPartitionMap.
+        @Deprecated
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
         // For realtime tables, this infers the segment partition for all segments. The partition column, function,
         // and number of partitions still rely on the Table's segmentPartitionConfig. This is useful if you have

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -633,6 +633,14 @@ public class CommonConstants {
         // usually low, and this query option allows the MSE Optimizer to infer the partition of a segment based on its
         // name, when that segment has multiple partitions in its columnPartitionMap.
         public static final String INFER_INVALID_SEGMENT_PARTITION = "inferInvalidSegmentPartition";
+        // For realtime tables, this infers the segment partition for all segments. The partition column, function,
+        // and number of partitions still rely on the Table's segmentPartitionConfig. This is useful if you have
+        // scenarios where the stream doesn't guarantee 100% accuracy for stream partition assignment. In such
+        // scenarios, if you don't have upsert compaction enabled, inferInvalidSegmentPartition will suffice. But when
+        // you have compaction enabled, it's possible that after compaction you are only left with invalid partition
+        // records, which can change the partition of a segment from something like [1, 3, 5] to [5], for a segment
+        // that was supposed to be in partition-1.
+        public static final String INFER_REALTIME_SEGMENT_PARTITION = "inferRealtimeSegmentPartition";
         public static final String USE_LITE_MODE = "useLiteMode";
         // Used by the MSE Engine to determine whether to use the broker pruning logic. Only supported by the
         // new MSE query optimizer.


### PR DESCRIPTION
# Summary

In #15760 we had added support for inferring invalid segment partition id. That didn't work completely for us because we one of our colocated join use-cases also leverages upsert compaction, and we are seeing a behavior where after compaction and segment only has invalid segment partition records, which changes that segment's partition. Since segment assignment is not done again as part of compaction, this leads to segments for a given partition to span multiple servers.

In this PR I have marked the old query option as Deprecated and added a new one which is broader and is capable of handling this edge case too.

# Test Plan

Added quite a bit of unit-tests. We also have existing unit-tests which do sanity testing. Testing this particular scenario E2E is hard but we are planning to deploy this patch to our cluster within a few days itself.