### PR TITLE
Enhance TableConfig and Schema validation

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
@@ -359,8 +359,9 @@ public class TextMatchTransformFunctionTest {
                 + "PROJECT(agent, startTime, part) | 5 | 4\n"
                 + "DOC_ID_SET | 6 | 5\n"
                 + "FILTER_AND | 7 | 6\n"
-                + "FILTER_FULL_SCAN(operator:RANGE,predicate:startTime BETWEEN '0' AND '1000000') | 8 | 7\n"
-                + "FILTER_FULL_SCAN(operator:EQ,predicate:customerId = 'XYZ') | 9 | 7"
+                + "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:customerId = 'XYZ') | 8 | 7\n"
+                + "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:startTime BETWEEN '0' AND "
+                + "'1000000') | 9 | 7"
         ).whenQuery(query)
         .thenResultTextIs("val[STRING]\n"
             + "N/A\n"

--- a/pinot-core/src/test/resources/TableIndexingTest.csv
+++ b/pinot-core/src/test/resources/TableIndexingTest.csv
@@ -1,507 +1,507 @@
 data_type;cardinality;encoding;index_type;success;error
-INT;sv;raw;timestamp_index;true;
+INT;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 INT;sv;raw;bloom_filter;true;
-INT;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-INT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-INT;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-INT;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+INT;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+INT;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+INT;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+INT;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+INT;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;sv;raw;range_index;true;
-INT;sv;raw;startree_index;false;Dimension: col does not have dictionary
-INT;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-INT;mv;raw;timestamp_index;true;
+INT;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+INT;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+INT;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 INT;mv;raw;bloom_filter;true;
-INT;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-INT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-INT;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-INT;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+INT;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+INT;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+INT;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+INT;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+INT;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;mv;raw;range_index;true;
-INT;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-INT;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
-INT;sv;dict;timestamp_index;true;
+INT;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+INT;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+INT;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 INT;sv;dict;bloom_filter;true;
-INT;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+INT;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+INT;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 INT;sv;dict;inverted_index;true;
-INT;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-INT;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+INT;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+INT;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;sv;dict;range_index;true;
 INT;sv;dict;startree_index;true;
-INT;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-INT;mv;dict;timestamp_index;true;
+INT;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+INT;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 INT;mv;dict;bloom_filter;true;
-INT;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+INT;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+INT;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 INT;mv;dict;inverted_index;true;
-INT;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-INT;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+INT;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+INT;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;mv;dict;range_index;true;
-INT;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-INT;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
+INT;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+INT;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
 LONG;sv;raw;timestamp_index;true;
 LONG;sv;raw;bloom_filter;true;
-LONG;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-LONG;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-LONG;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-LONG;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+LONG;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+LONG;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+LONG;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+LONG;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+LONG;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;sv;raw;range_index;true;
-LONG;sv;raw;startree_index;false;Dimension: col does not have dictionary
-LONG;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-LONG;mv;raw;timestamp_index;true;
+LONG;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+LONG;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+LONG;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on multi-value column: col
 LONG;mv;raw;bloom_filter;true;
-LONG;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-LONG;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-LONG;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-LONG;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+LONG;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+LONG;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+LONG;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+LONG;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+LONG;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;mv;raw;range_index;true;
-LONG;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-LONG;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
+LONG;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+LONG;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
 LONG;sv;dict;timestamp_index;true;
 LONG;sv;dict;bloom_filter;true;
-LONG;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+LONG;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+LONG;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 LONG;sv;dict;inverted_index;true;
-LONG;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-LONG;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+LONG;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+LONG;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;sv;dict;range_index;true;
 LONG;sv;dict;startree_index;true;
-LONG;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-LONG;mv;dict;timestamp_index;true;
+LONG;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+LONG;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on multi-value column: col
 LONG;mv;dict;bloom_filter;true;
-LONG;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+LONG;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+LONG;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 LONG;mv;dict;inverted_index;true;
-LONG;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-LONG;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+LONG;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+LONG;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;mv;dict;range_index;true;
-LONG;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-LONG;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
-FLOAT;sv;raw;timestamp_index;true;
+LONG;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+LONG;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+FLOAT;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 FLOAT;sv;raw;bloom_filter;true;
-FLOAT;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-FLOAT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-FLOAT;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-FLOAT;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+FLOAT;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+FLOAT;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+FLOAT;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+FLOAT;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+FLOAT;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;sv;raw;range_index;true;
-FLOAT;sv;raw;startree_index;false;Dimension: col does not have dictionary
-FLOAT;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-FLOAT;mv;raw;timestamp_index;true;
+FLOAT;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+FLOAT;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+FLOAT;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 FLOAT;mv;raw;bloom_filter;true;
-FLOAT;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-FLOAT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-FLOAT;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-FLOAT;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+FLOAT;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+FLOAT;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+FLOAT;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+FLOAT;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+FLOAT;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;mv;raw;range_index;true;
-FLOAT;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
+FLOAT;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
 FLOAT;mv;raw;vector_index;true;
-FLOAT;sv;dict;timestamp_index;true;
+FLOAT;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 FLOAT;sv;dict;bloom_filter;true;
-FLOAT;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+FLOAT;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+FLOAT;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 FLOAT;sv;dict;inverted_index;true;
-FLOAT;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-FLOAT;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+FLOAT;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+FLOAT;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;sv;dict;range_index;true;
 FLOAT;sv;dict;startree_index;true;
-FLOAT;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-FLOAT;mv;dict;timestamp_index;true;
+FLOAT;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+FLOAT;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 FLOAT;mv;dict;bloom_filter;true;
-FLOAT;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+FLOAT;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+FLOAT;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 FLOAT;mv;dict;inverted_index;true;
-FLOAT;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-FLOAT;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+FLOAT;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+FLOAT;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;mv;dict;range_index;true;
-FLOAT;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
+FLOAT;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
 FLOAT;mv;dict;vector_index;true;
-DOUBLE;sv;raw;timestamp_index;true;
+DOUBLE;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DOUBLE;sv;raw;bloom_filter;true;
-DOUBLE;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-DOUBLE;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-DOUBLE;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DOUBLE;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+DOUBLE;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DOUBLE;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+DOUBLE;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;sv;raw;range_index;true;
-DOUBLE;sv;raw;startree_index;false;Dimension: col does not have dictionary
-DOUBLE;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-DOUBLE;mv;raw;timestamp_index;true;
+DOUBLE;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+DOUBLE;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+DOUBLE;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DOUBLE;mv;raw;bloom_filter;true;
-DOUBLE;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-DOUBLE;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-DOUBLE;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DOUBLE;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+DOUBLE;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DOUBLE;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+DOUBLE;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;mv;raw;range_index;true;
-DOUBLE;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-DOUBLE;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
-DOUBLE;sv;dict;timestamp_index;true;
+DOUBLE;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+DOUBLE;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+DOUBLE;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DOUBLE;sv;dict;bloom_filter;true;
-DOUBLE;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+DOUBLE;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+DOUBLE;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 DOUBLE;sv;dict;inverted_index;true;
-DOUBLE;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-DOUBLE;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DOUBLE;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+DOUBLE;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;sv;dict;range_index;true;
 DOUBLE;sv;dict;startree_index;true;
-DOUBLE;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-DOUBLE;mv;dict;timestamp_index;true;
+DOUBLE;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+DOUBLE;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DOUBLE;mv;dict;bloom_filter;true;
-DOUBLE;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+DOUBLE;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+DOUBLE;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 DOUBLE;mv;dict;inverted_index;true;
-DOUBLE;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-DOUBLE;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DOUBLE;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+DOUBLE;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;mv;dict;range_index;true;
-DOUBLE;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-DOUBLE;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
-DECIMAL;sv_BIG;raw;timestamp_index;true;
+DOUBLE;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+DOUBLE;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+DECIMAL;sv_BIG;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DECIMAL;sv_BIG;raw;bloom_filter;true;
-DECIMAL;sv_BIG;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DECIMAL;sv_BIG;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-DECIMAL;sv_BIG;raw;json_index;false;Json index is currently only supported on STRING columns
-DECIMAL;sv_BIG;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DECIMAL;sv_BIG;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DECIMAL;sv_BIG;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+DECIMAL;sv_BIG;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DECIMAL;sv_BIG;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+DECIMAL;sv_BIG;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DECIMAL;sv_BIG;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DECIMAL;sv_BIG;raw;range_index;false;Unsupported data type: BIG_DECIMAL
-DECIMAL;sv_BIG;raw;startree_index;false;Dimension: col does not have dictionary
-DECIMAL;sv_BIG;raw;vector_index;false;Vector index is currently only supported on float array columns
-DECIMAL;sv_BIG;dict;timestamp_index;true;
+DECIMAL;sv_BIG;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+DECIMAL;sv_BIG;raw;vector_index;false;Cannot create vector index on single-value column: col
+DECIMAL;sv_BIG;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 DECIMAL;sv_BIG;dict;bloom_filter;true;
-DECIMAL;sv_BIG;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DECIMAL;sv_BIG;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+DECIMAL;sv_BIG;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+DECIMAL;sv_BIG;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 DECIMAL;sv_BIG;dict;inverted_index;true;
-DECIMAL;sv_BIG;dict;json_index;false;Json index is currently only supported on STRING columns
-DECIMAL;sv_BIG;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DECIMAL;sv_BIG;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DECIMAL;sv_BIG;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+DECIMAL;sv_BIG;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DECIMAL;sv_BIG;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DECIMAL;sv_BIG;dict;range_index;true;
 DECIMAL;sv_BIG;dict;startree_index;true;
-DECIMAL;sv_BIG;dict;vector_index;false;Vector index is currently only supported on float array columns
-BOOLEAN;sv;raw;timestamp_index;true;
-BOOLEAN;sv;raw;bloom_filter;false;Cannot create a bloom filter on boolean column col
-BOOLEAN;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BOOLEAN;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-BOOLEAN;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-BOOLEAN;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BOOLEAN;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+DECIMAL;sv_BIG;dict;vector_index;false;Cannot create vector index on single-value column: col
+BOOLEAN;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+BOOLEAN;sv;raw;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
+BOOLEAN;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+BOOLEAN;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BOOLEAN;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+BOOLEAN;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BOOLEAN;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;sv;raw;range_index;true;
-BOOLEAN;sv;raw;startree_index;false;Dimension: col does not have dictionary
-BOOLEAN;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-BOOLEAN;mv;raw;timestamp_index;false;Caught exception while reading data
-BOOLEAN;mv;raw;bloom_filter;false;Cannot create a bloom filter on boolean column col
-BOOLEAN;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BOOLEAN;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-BOOLEAN;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-BOOLEAN;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BOOLEAN;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+BOOLEAN;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+BOOLEAN;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+BOOLEAN;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+BOOLEAN;mv;raw;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
+BOOLEAN;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+BOOLEAN;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BOOLEAN;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+BOOLEAN;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BOOLEAN;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;mv;raw;range_index;true;
-BOOLEAN;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-BOOLEAN;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
-BOOLEAN;sv;dict;timestamp_index;true;
-BOOLEAN;sv;dict;bloom_filter;false;Cannot create a bloom filter on boolean column col
-BOOLEAN;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BOOLEAN;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+BOOLEAN;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+BOOLEAN;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+BOOLEAN;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+BOOLEAN;sv;dict;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
+BOOLEAN;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+BOOLEAN;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 BOOLEAN;sv;dict;inverted_index;true;
-BOOLEAN;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-BOOLEAN;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BOOLEAN;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+BOOLEAN;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+BOOLEAN;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BOOLEAN;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;sv;dict;range_index;true;
 BOOLEAN;sv;dict;startree_index;true;
-BOOLEAN;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-BOOLEAN;mv;dict;timestamp_index;false;Caught exception while reading data
-BOOLEAN;mv;dict;bloom_filter;false;Cannot create a bloom filter on boolean column col
-BOOLEAN;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BOOLEAN;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+BOOLEAN;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+BOOLEAN;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+BOOLEAN;mv;dict;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
+BOOLEAN;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+BOOLEAN;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 BOOLEAN;mv;dict;inverted_index;true;
-BOOLEAN;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-BOOLEAN;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BOOLEAN;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+BOOLEAN;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+BOOLEAN;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BOOLEAN;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;mv;dict;range_index;true;
-BOOLEAN;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-BOOLEAN;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
+BOOLEAN;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+BOOLEAN;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
 TIMESTAMP;sv;raw;timestamp_index;true;
 TIMESTAMP;sv;raw;bloom_filter;true;
-TIMESTAMP;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-TIMESTAMP;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-TIMESTAMP;sv;raw;json_index;false;Json index is currently only supported on STRING columns
-TIMESTAMP;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-TIMESTAMP;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+TIMESTAMP;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+TIMESTAMP;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+TIMESTAMP;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+TIMESTAMP;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+TIMESTAMP;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;sv;raw;range_index;true;
-TIMESTAMP;sv;raw;startree_index;false;Dimension: col does not have dictionary
-TIMESTAMP;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-TIMESTAMP;mv;raw;timestamp_index;true;
+TIMESTAMP;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+TIMESTAMP;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+TIMESTAMP;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on multi-value column: col
 TIMESTAMP;mv;raw;bloom_filter;true;
-TIMESTAMP;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-TIMESTAMP;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-TIMESTAMP;mv;raw;json_index;false;Json index is currently only supported on single-value columns
-TIMESTAMP;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-TIMESTAMP;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+TIMESTAMP;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+TIMESTAMP;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+TIMESTAMP;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+TIMESTAMP;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+TIMESTAMP;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;mv;raw;range_index;true;
-TIMESTAMP;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-TIMESTAMP;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
+TIMESTAMP;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+TIMESTAMP;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
 TIMESTAMP;sv;dict;timestamp_index;true;
 TIMESTAMP;sv;dict;bloom_filter;true;
-TIMESTAMP;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-TIMESTAMP;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+TIMESTAMP;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+TIMESTAMP;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 TIMESTAMP;sv;dict;inverted_index;true;
-TIMESTAMP;sv;dict;json_index;false;Json index is currently only supported on STRING columns
-TIMESTAMP;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-TIMESTAMP;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+TIMESTAMP;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+TIMESTAMP;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+TIMESTAMP;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;sv;dict;range_index;true;
 TIMESTAMP;sv;dict;startree_index;true;
-TIMESTAMP;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-TIMESTAMP;mv;dict;timestamp_index;true;
+TIMESTAMP;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+TIMESTAMP;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on multi-value column: col
 TIMESTAMP;mv;dict;bloom_filter;true;
-TIMESTAMP;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-TIMESTAMP;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+TIMESTAMP;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+TIMESTAMP;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 TIMESTAMP;mv;dict;inverted_index;true;
-TIMESTAMP;mv;dict;json_index;false;Json index is currently only supported on single-value columns
-TIMESTAMP;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-TIMESTAMP;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+TIMESTAMP;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+TIMESTAMP;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+TIMESTAMP;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;mv;dict;range_index;true;
-TIMESTAMP;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-TIMESTAMP;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
-STRING;sv;raw;timestamp_index;false;Caught exception while reading data
+TIMESTAMP;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+TIMESTAMP;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+STRING;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 STRING;sv;raw;bloom_filter;true;
-STRING;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-STRING;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-STRING;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+STRING;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+STRING;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 STRING;sv;raw;json_index;false;Column: col Unrecognized token 'str': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 15]
 STRING;sv;raw;native_text_index;true;
 STRING;sv;raw;text_index;true;
-STRING;sv;raw;range_index;false;Unsupported data type: STRING
-STRING;sv;raw;startree_index;false;Dimension: col does not have dictionary
-STRING;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-STRING;mv;raw;timestamp_index;false;Caught exception while reading data
+STRING;sv;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+STRING;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+STRING;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+STRING;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 STRING;mv;raw;bloom_filter;true;
-STRING;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-STRING;mv;raw;h3_index;false;H3 index is currently only supported on single-value columns
-STRING;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
-STRING;mv;raw;json_index;false;Json index is currently only supported on single-value columns
+STRING;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+STRING;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+STRING;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+STRING;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 STRING;mv;raw;native_text_index;true;
 STRING;mv;raw;text_index;true;
-STRING;mv;raw;range_index;false;Cannot get number of bytes for: STRING
-STRING;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-STRING;mv;raw;vector_index;false;Vector index is currently only supported on float array columns
-STRING;sv;dict;timestamp_index;false;Caught exception while reading data
+STRING;mv;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+STRING;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+STRING;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+STRING;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 STRING;sv;dict;bloom_filter;true;
 STRING;sv;dict;fst_index;true;
-STRING;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+STRING;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 STRING;sv;dict;inverted_index;true;
 STRING;sv;dict;json_index;false;Column: col Unrecognized token 'str': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 15]
 STRING;sv;dict;native_text_index;true;
 STRING;sv;dict;text_index;true;
 STRING;sv;dict;range_index;true;
 STRING;sv;dict;startree_index;false;class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
-STRING;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-STRING;mv;dict;timestamp_index;false;Caught exception while reading data
+STRING;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+STRING;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 STRING;mv;dict;bloom_filter;true;
-STRING;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-STRING;mv;dict;h3_index;false;H3 index is currently only supported on single-value columns
+STRING;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+STRING;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 STRING;mv;dict;inverted_index;true;
-STRING;mv;dict;json_index;false;Json index is currently only supported on single-value columns
+STRING;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
 STRING;mv;dict;native_text_index;true;
 STRING;mv;dict;text_index;true;
 STRING;mv;dict;range_index;true;
-STRING;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-STRING;mv;dict;vector_index;false;Vector index is currently only supported on float array columns
-JSON;sv;raw;timestamp_index;false;Caught exception while reading data
+STRING;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+STRING;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+JSON;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 JSON;sv;raw;bloom_filter;true;
-JSON;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-JSON;sv;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-JSON;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+JSON;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+JSON;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+JSON;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 JSON;sv;raw;json_index;true;
 JSON;sv;raw;native_text_index;false;expected [1] but found [0]
 JSON;sv;raw;text_index;false;expected [1] but found [0]
-JSON;sv;raw;range_index;false;Unsupported data type: JSON
-JSON;sv;raw;startree_index;false;Dimension: col does not have dictionary
-JSON;sv;raw;vector_index;false;Vector index is currently only supported on float array columns
-JSON;sv;dict;timestamp_index;false;Caught exception while reading data
+JSON;sv;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+JSON;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+JSON;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+JSON;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 JSON;sv;dict;bloom_filter;true;
 JSON;sv;dict;fst_index;true;
-JSON;sv;dict;h3_index;false;H3 index is currently only supported on BYTES columns
+JSON;sv;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
 JSON;sv;dict;inverted_index;true;
 JSON;sv;dict;json_index;true;
 JSON;sv;dict;native_text_index;false;expected [1] but found [0]
 JSON;sv;dict;text_index;false;expected [1] but found [0]
 JSON;sv;dict;range_index;true;
 JSON;sv;dict;startree_index;false;class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
-JSON;sv;dict;vector_index;false;Vector index is currently only supported on float array columns
-BYTES;sv;raw;timestamp_index;false;Caught exception while reading data
+JSON;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+BYTES;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 BYTES;sv;raw;bloom_filter;false;Caught exception while reading data
-BYTES;sv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
+BYTES;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 BYTES;sv;raw;h3_index;false;Caught exception while reading data
-BYTES;sv;raw;inverted_index;false;Caught exception while reading data
-BYTES;sv;raw;json_index;false;Caught exception while reading data
-BYTES;sv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;sv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;sv;raw;range_index;false;Caught exception while reading data
-BYTES;sv;raw;startree_index;false;Caught exception while reading data
-BYTES;sv;raw;vector_index;false;Caught exception while reading data
-BYTES;mv;raw;timestamp_index;false;Caught exception while reading data
+BYTES;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BYTES;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+BYTES;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;sv;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+BYTES;sv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+BYTES;sv;raw;vector_index;false;Cannot create vector index on single-value column: col
+BYTES;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 BYTES;mv;raw;bloom_filter;false;Caught exception while reading data
-BYTES;mv;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BYTES;mv;raw;h3_index;false;Caught exception while reading data
-BYTES;mv;raw;inverted_index;false;Caught exception while reading data
-BYTES;mv;raw;json_index;false;Caught exception while reading data
-BYTES;mv;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;mv;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;mv;raw;range_index;false;Caught exception while reading data
-BYTES;mv;raw;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-BYTES;mv;raw;vector_index;false;Caught exception while reading data
-BYTES;sv;dict;timestamp_index;false;Caught exception while reading data
+BYTES;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+BYTES;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
+BYTES;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BYTES;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
+BYTES;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;mv;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+BYTES;mv;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+BYTES;mv;raw;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+BYTES;sv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 BYTES;sv;dict;bloom_filter;false;Caught exception while reading data
-BYTES;sv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
+BYTES;sv;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
 BYTES;sv;dict;h3_index;false;Caught exception while reading data
 BYTES;sv;dict;inverted_index;false;Caught exception while reading data
-BYTES;sv;dict;json_index;false;Caught exception while reading data
-BYTES;sv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;sv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+BYTES;sv;dict;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
+BYTES;sv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;sv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BYTES;sv;dict;range_index;false;Caught exception while reading data
 BYTES;sv;dict;startree_index;false;Caught exception while reading data
-BYTES;sv;dict;vector_index;false;Caught exception while reading data
-BYTES;mv;dict;timestamp_index;false;Caught exception while reading data
+BYTES;sv;dict;vector_index;false;Cannot create vector index on single-value column: col
+BYTES;mv;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
 BYTES;mv;dict;bloom_filter;false;Caught exception while reading data
-BYTES;mv;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-BYTES;mv;dict;h3_index;false;Caught exception while reading data
+BYTES;mv;dict;fst_index;false;Cannot create FST index on multi-value column: col
+BYTES;mv;dict;h3_index;false;Cannot create H3 index on multi-value column: col
 BYTES;mv;dict;inverted_index;false;Caught exception while reading data
-BYTES;mv;dict;json_index;false;Caught exception while reading data
-BYTES;mv;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-BYTES;mv;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
+BYTES;mv;dict;json_index;false;Cannot create JSON index on multi-value column: col
+BYTES;mv;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+BYTES;mv;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BYTES;mv;dict;range_index;false;Caught exception while reading data
-BYTES;mv;dict;startree_index;false;Column Name col defined in StarTreeIndex Config must be a single value column
-BYTES;mv;dict;vector_index;false;Caught exception while reading data
-STRING;map;raw;timestamp_index;false;Caught exception while reading data
-STRING;map;raw;bloom_filter;true;
-STRING;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-STRING;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-STRING;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+BYTES;mv;dict;startree_index;false;Star-tree index can only be created on single-value columns, but found multi-value column: col
+BYTES;mv;dict;vector_index;false;Cannot create vector index on column: col of stored type other than FLOAT
+STRING;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+STRING;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
+STRING;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+STRING;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+STRING;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 STRING;map;raw;json_index;true;
-STRING;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-STRING;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-STRING;map;raw;range_index;false;Unsupported data type: MAP
-STRING;map;raw;startree_index;false;Dimension: col does not have dictionary
-STRING;map;raw;vector_index;false;Vector index is currently only supported on float array columns
-STRING;map;dict;timestamp_index;false;Caught exception while reading data
-STRING;map;dict;bloom_filter;true;
-STRING;map;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-STRING;map;dict;h3_index;false;H3 index is currently only supported on BYTES columns
-STRING;map;dict;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+STRING;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+STRING;map;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+STRING;map;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+STRING;map;raw;vector_index;false;Cannot create vector index on single-value column: col
+STRING;map;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+STRING;map;dict;bloom_filter;false;Cannot create bloom filter on MAP column: col
+STRING;map;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+STRING;map;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+STRING;map;dict;inverted_index;false;Cannot create inverted index on MAP column: col
 STRING;map;dict;json_index;true;
-STRING;map;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-STRING;map;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-STRING;map;dict;range_index;false;Unsupported data type: MAP
-STRING;map;dict;startree_index;false;Dimension: col does not have dictionary
-STRING;map;dict;vector_index;false;Vector index is currently only supported on float array columns
-INT;map;raw;timestamp_index;false;Caught exception while reading data
-INT;map;raw;bloom_filter;true;
-INT;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-INT;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+STRING;map;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+STRING;map;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+STRING;map;dict;range_index;false;Cannot create range index on MAP column: col
+STRING;map;dict;startree_index;false;Star-tree index cannot be created on MAP column: col
+STRING;map;dict;vector_index;false;Cannot create vector index on single-value column: col
+INT;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+INT;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
+INT;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+INT;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+INT;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 INT;map;raw;json_index;true;
-INT;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;map;raw;range_index;false;Unsupported data type: MAP
-INT;map;raw;startree_index;false;Dimension: col does not have dictionary
-INT;map;raw;vector_index;false;Vector index is currently only supported on float array columns
-INT;map;dict;timestamp_index;false;Caught exception while reading data
-INT;map;dict;bloom_filter;true;
-INT;map;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-INT;map;dict;h3_index;false;H3 index is currently only supported on BYTES columns
-INT;map;dict;inverted_index;false;Cannot create inverted index for raw index column: col
+INT;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;map;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+INT;map;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+INT;map;raw;vector_index;false;Cannot create vector index on single-value column: col
+INT;map;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+INT;map;dict;bloom_filter;false;Cannot create bloom filter on MAP column: col
+INT;map;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+INT;map;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+INT;map;dict;inverted_index;false;Cannot create inverted index on MAP column: col
 INT;map;dict;json_index;true;
-INT;map;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;map;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-INT;map;dict;range_index;false;Unsupported data type: MAP
-INT;map;dict;startree_index;false;Dimension: col does not have dictionary
-INT;map;dict;vector_index;false;Vector index is currently only supported on float array columns
-LONG;map;raw;timestamp_index;false;Caught exception while reading data
-LONG;map;raw;bloom_filter;true;
-LONG;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-LONG;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+INT;map;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;map;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+INT;map;dict;range_index;false;Cannot create range index on MAP column: col
+INT;map;dict;startree_index;false;Star-tree index cannot be created on MAP column: col
+INT;map;dict;vector_index;false;Cannot create vector index on single-value column: col
+LONG;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+LONG;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
+LONG;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+LONG;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+LONG;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 LONG;map;raw;json_index;true;
-LONG;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;map;raw;range_index;false;Unsupported data type: MAP
-LONG;map;raw;startree_index;false;Dimension: col does not have dictionary
-LONG;map;raw;vector_index;false;Vector index is currently only supported on float array columns
-LONG;map;dict;timestamp_index;false;Caught exception while reading data
-LONG;map;dict;bloom_filter;true;
-LONG;map;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-LONG;map;dict;h3_index;false;H3 index is currently only supported on BYTES columns
-LONG;map;dict;inverted_index;false;Cannot create inverted index for raw index column: col
+LONG;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;map;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+LONG;map;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+LONG;map;raw;vector_index;false;Cannot create vector index on single-value column: col
+LONG;map;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+LONG;map;dict;bloom_filter;false;Cannot create bloom filter on MAP column: col
+LONG;map;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+LONG;map;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+LONG;map;dict;inverted_index;false;Cannot create inverted index on MAP column: col
 LONG;map;dict;json_index;true;
-LONG;map;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;map;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-LONG;map;dict;range_index;false;Unsupported data type: MAP
-LONG;map;dict;startree_index;false;Dimension: col does not have dictionary
-LONG;map;dict;vector_index;false;Vector index is currently only supported on float array columns
-FLOAT;map;raw;timestamp_index;false;Caught exception while reading data
-FLOAT;map;raw;bloom_filter;true;
-FLOAT;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-FLOAT;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+LONG;map;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;map;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+LONG;map;dict;range_index;false;Cannot create range index on MAP column: col
+LONG;map;dict;startree_index;false;Star-tree index cannot be created on MAP column: col
+LONG;map;dict;vector_index;false;Cannot create vector index on single-value column: col
+FLOAT;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+FLOAT;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
+FLOAT;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+FLOAT;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+FLOAT;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 FLOAT;map;raw;json_index;true;
-FLOAT;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;map;raw;range_index;false;Unsupported data type: MAP
-FLOAT;map;raw;startree_index;false;Dimension: col does not have dictionary
-FLOAT;map;raw;vector_index;false;Vector index is currently only supported on float array columns
-FLOAT;map;dict;timestamp_index;false;Caught exception while reading data
-FLOAT;map;dict;bloom_filter;true;
-FLOAT;map;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-FLOAT;map;dict;h3_index;false;H3 index is currently only supported on BYTES columns
-FLOAT;map;dict;inverted_index;false;Cannot create inverted index for raw index column: col
+FLOAT;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;map;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+FLOAT;map;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+FLOAT;map;raw;vector_index;false;Cannot create vector index on single-value column: col
+FLOAT;map;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+FLOAT;map;dict;bloom_filter;false;Cannot create bloom filter on MAP column: col
+FLOAT;map;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+FLOAT;map;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+FLOAT;map;dict;inverted_index;false;Cannot create inverted index on MAP column: col
 FLOAT;map;dict;json_index;true;
-FLOAT;map;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;map;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-FLOAT;map;dict;range_index;false;Unsupported data type: MAP
-FLOAT;map;dict;startree_index;false;Dimension: col does not have dictionary
-FLOAT;map;dict;vector_index;false;Vector index is currently only supported on float array columns
-DOUBLE;map;raw;timestamp_index;false;Caught exception while reading data
-DOUBLE;map;raw;bloom_filter;true;
-DOUBLE;map;raw;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;map;raw;h3_index;false;H3 index is currently only supported on BYTES columns
-DOUBLE;map;raw;inverted_index;false;Cannot create inverted index for raw index column: col
+FLOAT;map;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;map;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+FLOAT;map;dict;range_index;false;Cannot create range index on MAP column: col
+FLOAT;map;dict;startree_index;false;Star-tree index cannot be created on MAP column: col
+FLOAT;map;dict;vector_index;false;Cannot create vector index on single-value column: col
+DOUBLE;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+DOUBLE;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
+DOUBLE;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
+DOUBLE;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+DOUBLE;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
 DOUBLE;map;raw;json_index;true;
-DOUBLE;map;raw;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;map;raw;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;map;raw;range_index;false;Unsupported data type: MAP
-DOUBLE;map;raw;startree_index;false;Dimension: col does not have dictionary
-DOUBLE;map;raw;vector_index;false;Vector index is currently only supported on float array columns
-DOUBLE;map;dict;timestamp_index;false;Caught exception while reading data
-DOUBLE;map;dict;bloom_filter;true;
-DOUBLE;map;dict;fst_index;false;Cannot create FST index on column: col, it can only be applied to dictionary encoded single value string columns
-DOUBLE;map;dict;h3_index;false;H3 index is currently only supported on BYTES columns
-DOUBLE;map;dict;inverted_index;false;Cannot create inverted index for raw index column: col
+DOUBLE;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;map;raw;range_index;false;Cannot create range index on non-numeric column: col without dictionary
+DOUBLE;map;raw;startree_index;false;Cannot create star-tree index on dimension column: col without dictionary
+DOUBLE;map;raw;vector_index;false;Cannot create vector index on single-value column: col
+DOUBLE;map;dict;timestamp_index;false;Cannot create TIMESTAMP index on column: col of stored type other than LONG
+DOUBLE;map;dict;bloom_filter;false;Cannot create bloom filter on MAP column: col
+DOUBLE;map;dict;fst_index;false;Cannot create FST index on column: col of stored type other than STRING
+DOUBLE;map;dict;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
+DOUBLE;map;dict;inverted_index;false;Cannot create inverted index on MAP column: col
 DOUBLE;map;dict;json_index;true;
-DOUBLE;map;dict;native_text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;map;dict;text_index;false;Cannot create text index on column: col, it can only be applied to string columns
-DOUBLE;map;dict;range_index;false;Unsupported data type: MAP
-DOUBLE;map;dict;startree_index;false;Dimension: col does not have dictionary
-DOUBLE;map;dict;vector_index;false;Vector index is currently only supported on float array columns
+DOUBLE;map;dict;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;map;dict;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
+DOUBLE;map;dict;range_index;false;Cannot create range index on MAP column: col
+DOUBLE;map;dict;startree_index;false;Star-tree index cannot be created on MAP column: col
+DOUBLE;map;dict;vector_index;false;Cannot create vector index on single-value column: col

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TextIndicesTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TextIndicesTest.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.avro.file.DataFileWriter;
@@ -81,27 +80,9 @@ public class TextIndicesTest extends CustomDataQueryClusterIntegrationTest {
     return null;
   }
 
-  @Nullable
-  @Override
-  protected List<String> getInvertedIndexColumns() {
-    return Collections.singletonList(TEXT_COLUMN_NAME_NATIVE);
-  }
-
   @Override
   protected List<String> getNoDictionaryColumns() {
     return List.of(TEXT_COLUMN_NAME, TEXT_COLUMN_NAME_CASE_SENSITIVE);
-  }
-
-  @Nullable
-  @Override
-  protected List<String> getRangeIndexColumns() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  protected List<String> getBloomFilterColumns() {
-    return null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.segment.local.segment.index.bloom;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,8 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -67,20 +70,30 @@ public class BloomIndexType extends AbstractIndexType<BloomFilterConfig, BloomFi
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    BloomFilterConfig bloomFilterConfig = indexConfigs.getConfig(StandardIndexes.bloomFilter());
+    if (bloomFilterConfig.isEnabled()) {
+      DataType dataType = fieldSpec.getDataType();
+      Preconditions.checkState(dataType != DataType.BOOLEAN, "Cannot create bloom filter on BOOLEAN column: %s",
+          fieldSpec.getName());
+      Preconditions.checkState(dataType != DataType.MAP, "Cannot create bloom filter on MAP column: %s",
+          fieldSpec.getName());
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<BloomFilterConfig> createDeserializer() {
-    ColumnConfigDeserializer<BloomFilterConfig> fromIndexes =
-        IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
+  protected ColumnConfigDeserializer<BloomFilterConfig> createDeserializerForLegacyConfigs() {
     ColumnConfigDeserializer<BloomFilterConfig> fromBloomFilterConfigs =
         IndexConfigDeserializer.fromMap(tableConfig -> tableConfig.getIndexingConfig().getBloomFilterConfigs());
     ColumnConfigDeserializer<BloomFilterConfig> fromBloomFilterColumns =
         IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getBloomFilterColumns(),
             (accum, column) -> accum.put(column, BloomFilterConfig.DEFAULT));
-    return fromIndexes.withExclusiveAlternative(fromBloomFilterConfigs.withFallbackAlternative(fromBloomFilterColumns));
+    return fromBloomFilterConfigs.withFallbackAlternative(fromBloomFilterColumns);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
@@ -79,20 +79,31 @@ public class FstIndexType extends AbstractIndexType<FstIndexConfig, TextIndexRea
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    FstIndexConfig fstIndexConfig = indexConfigs.getConfig(StandardIndexes.fst());
+    if (fstIndexConfig.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(indexConfigs.getConfig(StandardIndexes.dictionary()).isEnabled(),
+          "Cannot create FST index on column: %s without dictionary", column);
+      Preconditions.checkState(fieldSpec.isSingleValueField(), "Cannot create FST index on multi-value column: %s",
+          column);
+      Preconditions.checkState(fieldSpec.getDataType().getStoredType() == FieldSpec.DataType.STRING,
+          "Cannot create FST index on column: %s of stored type other than STRING", column);
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<FstIndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass())
-        .withExclusiveAlternative(IndexConfigDeserializer.fromIndexTypes(
-            FieldConfig.IndexType.FST,
-            (tableConfig, fieldConfig) -> {
-              IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-              FSTType fstIndexType = indexingConfig != null ? indexingConfig.getFSTIndexType() : null;
-              return new FstIndexConfig(fstIndexType);
-            }));
+  protected ColumnConfigDeserializer<FstIndexConfig> createDeserializerForLegacyConfigs() {
+    return IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.FST, (tableConfig, fieldConfig) -> {
+      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+      FSTType fstIndexType = indexingConfig != null ? indexingConfig.getFSTIndexType() : null;
+      return new FstIndexConfig(fstIndexType);
+    });
   }
 
   @Override
@@ -134,6 +145,7 @@ public class FstIndexType extends AbstractIndexType<FstIndexConfig, TextIndexRea
 
   private static class ReaderFactory extends IndexReaderFactory.Default<FstIndexConfig, TextIndexReader> {
     public static final ReaderFactory INSTANCE = new ReaderFactory();
+
     @Override
     protected IndexType<FstIndexConfig, TextIndexReader, ?> getIndexType() {
       return StandardIndexes.fst();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
@@ -50,8 +50,11 @@ import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.SortedIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -76,18 +79,31 @@ public class InvertedIndexType
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    IndexConfig invertedIndexConfig = indexConfigs.getConfig(StandardIndexes.inverted());
+    if (invertedIndexConfig.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(indexConfigs.getConfig(StandardIndexes.dictionary()).isEnabled(),
+          "Cannot create inverted index on column: %s without dictionary", column);
+      Preconditions.checkState(fieldSpec.getDataType() != DataType.MAP,
+          "Cannot create inverted index on MAP column: %s", column);
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
-    ColumnConfigDeserializer<IndexConfig> fromIndexes =
-        IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
+  protected ColumnConfigDeserializer<IndexConfig> createDeserializerForLegacyConfigs() {
     ColumnConfigDeserializer<IndexConfig> fromInvertedIndexColumns =
         IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getInvertedIndexColumns(),
             (acum, column) -> acum.put(column, IndexConfig.ENABLED));
-    return fromIndexes.withExclusiveAlternative(fromInvertedIndexColumns);
+    ColumnConfigDeserializer<IndexConfig> fromFieldConfigs =
+        IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.INVERTED,
+            (tableConfig, fieldConfig) -> IndexConfig.ENABLED);
+    return fromInvertedIndexColumns.withFallbackAlternative(fromFieldConfigs);
   }
 
   public DictionaryBasedInvertedIndexCreator createIndexCreator(IndexCreationContext context)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -48,9 +48,11 @@ import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -74,29 +76,43 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    JsonIndexConfig jsonIndexConfig = indexConfigs.getConfig(StandardIndexes.json());
+    if (jsonIndexConfig.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(fieldSpec.isSingleValueField(), "Cannot create JSON index on multi-value column: %s",
+          column);
+      DataType storedType = fieldSpec.getDataType().getStoredType();
+      Preconditions.checkState(storedType == DataType.STRING || storedType == DataType.MAP,
+          "Cannot create JSON index on column: %s of stored type other than STRING or MAP", column);
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<JsonIndexConfig> createDeserializer() {
-    ColumnConfigDeserializer<JsonIndexConfig> fromIndexes =
-        IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
+  protected ColumnConfigDeserializer<JsonIndexConfig> createDeserializerForLegacyConfigs() {
     ColumnConfigDeserializer<JsonIndexConfig> fromJsonIndexConfigs =
         IndexConfigDeserializer.fromMap(tableConfig -> tableConfig.getIndexingConfig().getJsonIndexConfigs());
     ColumnConfigDeserializer<JsonIndexConfig> fromJsonIndexColumns =
         IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getJsonIndexColumns(),
             (accum, column) -> accum.put(column, JsonIndexConfig.DEFAULT));
-    return fromIndexes.withExclusiveAlternative(fromJsonIndexConfigs.withFallbackAlternative(fromJsonIndexColumns));
+    ColumnConfigDeserializer<JsonIndexConfig> fromFieldConfigs =
+        IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.JSON,
+            (tableConfig, fieldConfig) -> JsonIndexConfig.DEFAULT);
+    return fromJsonIndexConfigs.withFallbackAlternative(fromJsonIndexColumns).withFallbackAlternative(fromFieldConfigs);
   }
 
   @Override
   public JsonIndexCreator createIndexCreator(IndexCreationContext context, JsonIndexConfig indexConfig)
       throws IOException {
-    FieldSpec.DataType storedType = context.getFieldSpec().getDataType().getStoredType();
+    DataType storedType = context.getFieldSpec().getDataType().getStoredType();
     Preconditions.checkState(context.getFieldSpec().isSingleValueField(),
         "Json index is currently only supported on single-value columns");
-    Preconditions.checkState(storedType == FieldSpec.DataType.STRING || storedType == FieldSpec.DataType.MAP,
+    Preconditions.checkState(storedType == DataType.STRING || storedType == DataType.MAP,
         "Json index is currently only supported on STRING columns");
     return context.isOnHeap() ? new OnHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
         indexConfig)
@@ -148,8 +164,8 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
         throw new IndexReaderConstraintException(metadata.getColumnName(), StandardIndexes.json(),
             "Json index is currently only supported on single-value columns");
       }
-      FieldSpec.DataType storedType = metadata.getFieldSpec().getDataType().getStoredType();
-      if (storedType != FieldSpec.DataType.STRING && storedType != FieldSpec.DataType.MAP) {
+      DataType storedType = metadata.getFieldSpec().getDataType().getStoredType();
+      if (storedType != DataType.STRING && storedType != DataType.MAP) {
         throw new IndexReaderConstraintException(metadata.getColumnName(), StandardIndexes.json(),
             "Json index is currently only supported on STRING columns");
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -79,19 +79,18 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   }
 
   @Override
-  public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
+  public ColumnConfigDeserializer<IndexConfig> createDeserializerForLegacyConfigs() {
     return (TableConfig tableConfig, Schema schema) -> {
       Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
       Map<String, IndexConfig> configMap = Maps.newHashMapWithExpectedSize(allFieldSpecs.size());
 
-      boolean enableColumnBasedNullHandling = schema.isEnableColumnBasedNullHandling();
-      boolean nullHandlingEnabled = tableConfig.getIndexingConfig() != null
-          && tableConfig.getIndexingConfig().isNullHandlingEnabled();
+      boolean columnBasedNullHandlingEnabled = schema.isEnableColumnBasedNullHandling();
+      boolean nullHandlingEnabled = tableConfig.getIndexingConfig().isNullHandlingEnabled();
 
       for (FieldSpec fieldSpec : allFieldSpecs) {
         IndexConfig indexConfig;
         boolean enabled;
-        if (enableColumnBasedNullHandling) {
+        if (columnBasedNullHandlingEnabled) {
           enabled = fieldSpec.isNullable();
         } else {
           enabled = nullHandlingEnabled;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.segment.local.segment.index.range;
 
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,8 +48,10 @@ import org.apache.pinot.segment.spi.index.creator.CombinedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -73,38 +76,57 @@ public class RangeIndexType
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    RangeIndexConfig rangeIndexConfig = indexConfigs.getConfig(StandardIndexes.range());
+    if (rangeIndexConfig.isEnabled()) {
+      String column = fieldSpec.getName();
+      DataType storedType = fieldSpec.getDataType().getStoredType();
+      Preconditions.checkState(
+          storedType.isNumeric() || indexConfigs.getConfig(StandardIndexes.dictionary()).isEnabled(),
+          "Cannot create range index on non-numeric column: %s without dictionary", column);
+      Preconditions.checkState(storedType != DataType.MAP, "Cannot create range index on MAP column: %s", column);
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<RangeIndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass())
-        .withExclusiveAlternative((tableConfig, schema) -> {
-          if (tableConfig.getIndexingConfig() == null) {
-            return Collections.emptyMap();
-          }
-          List<String> rangeIndexColumns = tableConfig.getIndexingConfig().getRangeIndexColumns();
-          if (rangeIndexColumns == null) {
-            return Collections.emptyMap();
-          }
-          int rangeVersion = tableConfig.getIndexingConfig().getRangeIndexVersion();
-          if (rangeVersion == 0) {
-            rangeVersion = RangeIndexConfig.DEFAULT.getVersion();
-          }
-          Map<String, RangeIndexConfig> result = new HashMap<>();
-          for (String col : rangeIndexColumns) {
-            result.put(col, new RangeIndexConfig(rangeVersion));
-          }
-          return result;
-        });
+  protected ColumnConfigDeserializer<RangeIndexConfig> createDeserializerForLegacyConfigs() {
+    ColumnConfigDeserializer<RangeIndexConfig> fromRangeIndexColumns = (tableConfig, schema) -> {
+      List<String> rangeIndexColumns = tableConfig.getIndexingConfig().getRangeIndexColumns();
+      if (rangeIndexColumns == null) {
+        return Collections.emptyMap();
+      }
+      int rangeVersion = tableConfig.getIndexingConfig().getRangeIndexVersion();
+      if (rangeVersion == 0) {
+        rangeVersion = RangeIndexConfig.DEFAULT.getVersion();
+      }
+      Map<String, RangeIndexConfig> result = new HashMap<>();
+      for (String col : rangeIndexColumns) {
+        result.put(col, new RangeIndexConfig(rangeVersion));
+      }
+      return result;
+    };
+    ColumnConfigDeserializer<RangeIndexConfig> fromIndexTypes =
+        IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.RANGE,
+            (tableConfig, fieldConfig) -> new RangeIndexConfig(getRangeIndexVersion(tableConfig)));
+    return fromRangeIndexColumns.withFallbackAlternative(fromIndexTypes);
+  }
+
+  private static int getRangeIndexVersion(TableConfig tableConfig) {
+    int rangeIndexVersion = tableConfig.getIndexingConfig().getRangeIndexVersion();
+    return rangeIndexVersion > 0 ? rangeIndexVersion : RangeIndexConfig.DEFAULT.getVersion();
   }
 
   @Override
-  public CombinedInvertedIndexCreator createIndexCreator(IndexCreationContext context, RangeIndexConfig indexConfig)
+  public CombinedInvertedIndexCreator createIndexCreator(IndexCreationContext context,
+      RangeIndexConfig rangeIndexConfig)
       throws IOException {
     FieldSpec fieldSpec = context.getFieldSpec();
-    if (indexConfig.getVersion() == BitSlicedRangeIndexCreator.VERSION && fieldSpec.isSingleValueField()) {
+    if (rangeIndexConfig.getVersion() == BitSlicedRangeIndexCreator.VERSION && fieldSpec.isSingleValueField()) {
       if (context.hasDictionary()) {
         return new BitSlicedRangeIndexCreator(context.getIndexDir(), fieldSpec, context.getCardinality());
       }
@@ -113,7 +135,7 @@ public class RangeIndexType
     }
     // default to RangeIndexCreator for the time being
     return new RangeIndexCreator(context.getIndexDir(), fieldSpec,
-        context.hasDictionary() ? FieldSpec.DataType.INT : fieldSpec.getDataType().getStoredType(), -1, -1,
+        context.hasDictionary() ? DataType.INT : fieldSpec.getDataType().getStoredType(), -1, -1,
         context.getTotalDocs(), context.getTotalNumberOfEntries());
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexType.java
@@ -74,15 +74,29 @@ public class VectorIndexType extends AbstractIndexType<VectorIndexConfig, Vector
   }
 
   @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    VectorIndexConfig vectorIndexConfig = indexConfigs.getConfig(StandardIndexes.vector());
+    if (vectorIndexConfig.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(!fieldSpec.isSingleValueField(), "Cannot create vector index on single-value column: %s",
+          column);
+      Preconditions.checkState(fieldSpec.getDataType().getStoredType() == FieldSpec.DataType.FLOAT,
+          "Cannot create vector index on column: %s of stored type other than FLOAT", column);
+      String vectorIndexType = vectorIndexConfig.getVectorIndexType();
+      Preconditions.checkState("HNSW".equals(vectorIndexType),
+          "Unsupported vector index type: %s for column: %s, only 'HNSW' is supported", vectorIndexType, column);
+    }
+  }
+
+  @Override
   public String getPrettyName() {
     return INDEX_DISPLAY_NAME;
   }
 
   @Override
-  public ColumnConfigDeserializer<VectorIndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass()).withExclusiveAlternative(
-        IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.VECTOR,
-            (tableConfig, fieldConfig) -> new VectorIndexConfig(fieldConfig.getProperties())));
+  protected ColumnConfigDeserializer<VectorIndexConfig> createDeserializerForLegacyConfigs() {
+    return IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.VECTOR,
+        (tableConfig, fieldConfig) -> new VectorIndexConfig(fieldConfig.getProperties()));
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -41,7 +42,17 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
   private ColumnConfigDeserializer<C> _deserializer;
   private IndexReaderFactory<IR> _readerFactory;
 
-  protected abstract ColumnConfigDeserializer<C> createDeserializer();
+  protected ColumnConfigDeserializer<C> createDeserializer() {
+    ColumnConfigDeserializer<C> fromIndexes =
+        IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
+    ColumnConfigDeserializer<C> fromLegacyConfigs = createDeserializerForLegacyConfigs();
+    return fromLegacyConfigs != null ? fromIndexes.withExclusiveAlternative(fromLegacyConfigs) : fromIndexes;
+  }
+
+  @Nullable
+  protected ColumnConfigDeserializer<C> createDeserializerForLegacyConfigs() {
+    return null;
+  }
 
   protected abstract IndexReaderFactory<IR> createReaderFactory();
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -77,6 +77,7 @@ public class DictionaryIndexConfig extends IndexConfig {
     return _onHeap;
   }
 
+  // TODO: Rename it to isUseVarLengthDictionary
   public boolean getUseVarLengthDictionary() {
     return _useVarLengthDictionary;
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -68,6 +69,11 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
   C getDefaultConfig();
 
   Map<String, C> getConfig(TableConfig tableConfig, Schema schema);
+
+  /// Validates if the index config is valid for the given field spec and other index configs. [IllegalStateException]
+  /// is thrown if the validation fails.
+  default void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+  }
 
   default String getPrettyName() {
     return getId();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -127,6 +127,7 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   // If null, there won't be any index
+  // NOTE: TIMESTAMP is ignored. In order to create TIMESTAMP index, configure 'timestampConfig' instead.
   public enum IndexType {
     INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, VECTOR, RANGE
   }


### PR DESCRIPTION
- Use the new Index SPI to validate the TableConfig and Schema for index type check, to ensure cross checks for new config and legacy config
- Add `validate()` into `IndexType` so that the validation logic is also pluggable, and self-contained
- Fix the bug where `INVERTED`, `JSON` and `RANGE` are not honored within the `FieldConfig.IndexTypes`
- Add some extra checks, and checks for MAP type
- The effect of the new validation can be found in `TableIndexingTest.csv`