### PR TITLE
Expose metrics for transformation errors in SegmentProcessorFramework

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMeter.java
@@ -38,7 +38,10 @@ public enum MinionMeter implements AbstractMetrics.Meter {
   SEGMENT_BYTES_UPLOADED("bytes", false),
   RECORDS_PROCESSED_COUNT("rows", false),
   RECORDS_PURGED_COUNT("rows", false),
-  COMPACTED_RECORDS_COUNT("rows", false);
+  COMPACTED_RECORDS_COUNT("rows", false),
+  TRANSFORMATION_ERROR_COUNT("rows", false),
+  DROPPED_RECORD_COUNT("rows", false),
+  CORRUPTED_RECORD_COUNT("rows", false);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -116,9 +116,13 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     List<File> outputSegmentDirs;
     try {
       _eventObserver.notifyProgress(_pinotTaskConfig, "Generating segments");
-      outputSegmentDirs = new SegmentProcessorFramework(segmentProcessorConfig, workingDir,
+      SegmentProcessorFramework framework = new SegmentProcessorFramework(segmentProcessorConfig, workingDir,
           SegmentProcessorFramework.convertRecordReadersToRecordReaderFileConfig(recordReaders),
-          customRecordTransformers, null).process();
+          customRecordTransformers, null);
+      outputSegmentDirs = framework.process();
+      _eventObserver.notifyProgress(_pinotTaskConfig,
+          "transformation stats - incomplete:" + framework.getIncompleteRowsFound()
+              + ", dropped:" + framework.getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
     } finally {
       for (RecordReader recordReader : recordReaders) {
         recordReader.close();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -120,9 +120,9 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
           SegmentProcessorFramework.convertRecordReadersToRecordReaderFileConfig(recordReaders),
           customRecordTransformers, null);
       outputSegmentDirs = framework.process();
-      _eventObserver.notifyProgress(_pinotTaskConfig,
-          "transformation stats - incomplete:" + framework.getIncompleteRowsFound()
-              + ", dropped:" + framework.getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
+      _eventObserver.notifyProgress(pinotTaskConfig,
+          "Segment processing stats - incomplete rows:" + framework.getIncompleteRowsFound() + ", dropped rows:"
+              + framework.getSkippedRowsFound() + ", sanitized rows:" + framework.getSanitizedRowsFound());
     } finally {
       for (RecordReader recordReader : recordReaders) {
         recordReader.close();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -175,7 +175,12 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     List<File> outputSegmentDirs;
     try {
       _eventObserver.notifyProgress(_pinotTaskConfig, "Generating segments");
-      outputSegmentDirs = new SegmentProcessorFramework(recordReaders, segmentProcessorConfig, workingDir).process();
+      SegmentProcessorFramework framework =
+          new SegmentProcessorFramework(recordReaders, segmentProcessorConfig, workingDir);
+      outputSegmentDirs = framework.process();
+      _eventObserver.notifyProgress(_pinotTaskConfig,
+          "transformation stats - incomplete:" + framework.getIncompleteRowsFound()
+              + ", dropped:" + framework.getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
     } finally {
       for (RecordReader recordReader : recordReaders) {
         recordReader.close();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -178,9 +178,9 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
       SegmentProcessorFramework framework =
           new SegmentProcessorFramework(recordReaders, segmentProcessorConfig, workingDir);
       outputSegmentDirs = framework.process();
-      _eventObserver.notifyProgress(_pinotTaskConfig,
-          "transformation stats - incomplete:" + framework.getIncompleteRowsFound()
-              + ", dropped:" + framework.getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
+      _eventObserver.notifyProgress(pinotTaskConfig,
+          "Segment processing stats - incomplete rows:" + framework.getIncompleteRowsFound() + ", dropped rows:"
+              + framework.getSkippedRowsFound() + ", sanitized rows:" + framework.getSanitizedRowsFound());
     } finally {
       for (RecordReader recordReader : recordReaders) {
         recordReader.close();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -148,6 +148,10 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, recordReader);
       driver.build();
+      _eventObserver.notifyProgress(pinotTaskConfig,
+          "transformation stats - incomplete:" + driver.getIncompleteRowsFound()
+              + ", dropped:" + driver.getSkippedRowsFound() + ", sanitized:"
+              + driver.getSanitizedRowsFound());
     }
 
     File refreshedSegmentFile = new File(workingDir, segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -149,9 +149,8 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
       driver.init(config, recordReader);
       driver.build();
       _eventObserver.notifyProgress(pinotTaskConfig,
-          "transformation stats - incomplete:" + driver.getIncompleteRowsFound()
-              + ", dropped:" + driver.getSkippedRowsFound() + ", sanitized:"
-              + driver.getSanitizedRowsFound());
+          "Segment processing stats - incomplete rows:" + driver.getIncompleteRowsFound() + ", dropped rows:"
+              + driver.getSkippedRowsFound() + ", sanitized rows:" + driver.getSanitizedRowsFound());
     }
 
     File refreshedSegmentFile = new File(workingDir, segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -104,6 +104,10 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, compactedRecordReader);
       driver.build();
+      _eventObserver.notifyProgress(pinotTaskConfig,
+          "transformation stats - incomplete:" + driver.getIncompleteRowsFound()
+              + ", dropped:" + driver.getSkippedRowsFound() + ", sanitized:"
+              + driver.getSanitizedRowsFound());
       totalDocsAfterCompaction = driver.getSegmentStats().getTotalDocCount();
     }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -105,9 +105,8 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
       driver.init(config, compactedRecordReader);
       driver.build();
       _eventObserver.notifyProgress(pinotTaskConfig,
-          "transformation stats - incomplete:" + driver.getIncompleteRowsFound()
-              + ", dropped:" + driver.getSkippedRowsFound() + ", sanitized:"
-              + driver.getSanitizedRowsFound());
+          "Segment processing stats - incomplete rows:" + driver.getIncompleteRowsFound() + ", dropped rows:"
+              + driver.getSkippedRowsFound() + ", sanitized rows:" + driver.getSanitizedRowsFound());
       totalDocsAfterCompaction = driver.getSegmentStats().getTotalDocCount();
     }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -145,9 +145,13 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     SegmentProcessorConfig segmentProcessorConfig = segmentProcessorConfigBuilder.build();
     List<File> outputSegmentDirs;
     _eventObserver.notifyProgress(_pinotTaskConfig, "Generating segments");
-    outputSegmentDirs = new SegmentProcessorFramework(segmentProcessorConfig, workingDir,
+    SegmentProcessorFramework framework = new SegmentProcessorFramework(segmentProcessorConfig, workingDir,
         recordReaderFileConfigs, Collections.emptyList(), new DefaultSegmentNumRowProvider(Integer.parseInt(
-        configs.get(MinionConstants.UpsertCompactMergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY)))).process();
+        configs.get(MinionConstants.UpsertCompactMergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY))));
+    outputSegmentDirs = framework.process();
+    _eventObserver.notifyProgress(_pinotTaskConfig,
+        "transformation stats - incomplete:" + framework.getIncompleteRowsFound() + ", dropped:" + framework
+            .getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
 
     long endMillis = System.currentTimeMillis();
     LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metrics.MinionMeter;
+import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.segment.local.realtime.converter.stats.RealtimeSegmentSegmentCreationDataSource;
 import org.apache.pinot.segment.local.segment.creator.RecordReaderSegmentCreationDataSource;
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
@@ -85,8 +87,6 @@ import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.pinot.common.metrics.MinionMeter;
-import org.apache.pinot.common.metrics.MinionMetrics;
 
 
 /**
@@ -278,7 +278,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           if (!_continueOnError) {
             throw new RuntimeException("Error occurred while reading row during indexing", e);
           } else {
-        _incompleteRowsFound++;
+            _incompleteRowsFound++;
             LOGGER.debug("Error occurred while reading row during indexing", e);
             continue;
           }


### PR DESCRIPTION
Minion tasks currently do not expose how many records were skipped during ingestion which is critical for prod systems. This PR adds this metric in the minions.