### PR TITLE
Fix null join key matching in multi-stage hash joins

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
@@ -59,9 +60,12 @@ public class HashJoinOperator extends BaseJoinOperator {
   // TODO: Optimize this
   @Nullable
   private Map<Object, BitSet> _matchedRightRows;
+  // Store null key rows separately for RIGHT and FULL JOINs
+  @Nullable
+  private List<Object[]> _nullKeyRightRows;
 
   public HashJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
-      MultiStageOperator rightInput, JoinNode node) {
+                          MultiStageOperator rightInput, JoinNode node) {
     super(context, leftInput, leftSchema, rightInput, node);
     List<Integer> leftKeys = node.getLeftKeys();
     Preconditions.checkState(!leftKeys.isEmpty(), "Hash join operator requires join keys");
@@ -69,6 +73,8 @@ public class HashJoinOperator extends BaseJoinOperator {
     _rightKeySelector = KeySelectorFactory.getKeySelector(node.getRightKeys());
     _rightTable = createLookupTable(leftKeys, leftSchema);
     _matchedRightRows = needUnmatchedRightRows() ? new HashMap<>() : null;
+    // Initialize _nullKeyRightRows for both RIGHT and FULL JOINs
+    _nullKeyRightRows = (_joinType == JoinRelType.RIGHT || _joinType == JoinRelType.FULL) ? new ArrayList<>() : null;
   }
 
   private static LookupTable createLookupTable(List<Integer> joinKeys, DataSchema schema) {
@@ -98,8 +104,36 @@ public class HashJoinOperator extends BaseJoinOperator {
   protected void addRowsToRightTable(List<Object[]> rows) {
     assert _rightTable != null : "Right table should not be null when adding rows";
     for (Object[] row : rows) {
-      _rightTable.addRow(_rightKeySelector.getKey(row), row);
+      Object key = _rightKeySelector.getKey(row);
+      // Skip rows with null join keys - they should not participate in equi-joins per SQL standard
+      if (isNullKey(key)) {
+        // For RIGHT and FULL JOIN, we need to preserve null key rows for the final output
+        if (_nullKeyRightRows != null) {
+          _nullKeyRightRows.add(row);
+        }
+        continue;
+      }
+      _rightTable.addRow(key, row);
     }
+  }
+
+  /**
+   * Check if a join key contains null values. In SQL standard, null keys should not match in equi-joins.
+   **/
+  private boolean isNullKey(Object key) {
+    if (key == null) {
+      return true;
+    }
+    // For composite keys (Object[]), check if any component is null
+    if (key instanceof Object[]) {
+      Object[] keyArray = (Object[]) key;
+      for (Object component : keyArray) {
+        if (component == null) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   @Override
@@ -112,6 +146,7 @@ public class HashJoinOperator extends BaseJoinOperator {
   protected void onEosProduced() {
     _rightTable = null;
     _matchedRightRows = null;
+    _nullKeyRightRows = null;
   }
 
   @Override
@@ -132,6 +167,14 @@ public class HashJoinOperator extends BaseJoinOperator {
     }
   }
 
+  private boolean handleNullKey(Object key, Object[] leftRow, List<Object[]> rows) {
+    if (isNullKey(key)) {
+      handleUnmatchedLeftRow(leftRow, rows);
+      return true;
+    }
+    return false;
+  }
+
   private List<Object[]> buildJoinedDataBlockUniqueKeys(MseBlock.Data leftBlock) {
     assert _rightTable != null : "Right table should not be null when building joined rows";
     List<Object[]> leftRows = leftBlock.asRowHeap().getRows();
@@ -139,6 +182,10 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
+      // Skip rows with null join keys - they should not participate in equi-joins per SQL standard
+      if (handleNullKey(key, leftRow, rows)) {
+        continue;
+      }
       Object[] rightRow = (Object[]) _rightTable.lookup(key);
       if (rightRow == null) {
         handleUnmatchedLeftRow(leftRow, rows);
@@ -169,6 +216,10 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
+      // Skip rows with null join keys - they should not participate in equi-joins per SQL standard
+      if (handleNullKey(key, leftRow, rows)) {
+        continue;
+      }
       List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(key);
       if (rightRows == null) {
         handleUnmatchedLeftRow(leftRow, rows);
@@ -219,6 +270,10 @@ public class HashJoinOperator extends BaseJoinOperator {
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
       // SEMI-JOIN only checks existence of the key
+      // Skip rows with null join keys for SEMI-JOIN
+      if (isNullKey(key)) {
+        continue;
+      }
       if (_rightTable.containsKey(key)) {
         rows.add(leftRow);
       }
@@ -235,6 +290,11 @@ public class HashJoinOperator extends BaseJoinOperator {
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
       // ANTI-JOIN only checks non-existence of the key
+      // For ANTI-JOIN, rows with null keys should be included (null != anything)
+      if (isNullKey(key)) {
+        rows.add(leftRow);
+        continue;
+      }
       if (!_rightTable.containsKey(key)) {
         rows.add(leftRow);
       }
@@ -270,6 +330,12 @@ public class HashJoinOperator extends BaseJoinOperator {
             rows.add(joinRow(null, rightRows.get(unmatchedIndex++)));
           }
         }
+      }
+    }
+    // Add unmatched null key rows from right side for RIGHT and FULL JOIN
+    if (_nullKeyRightRows != null) {
+      for (Object[] nullKeyRow : _nullKeyRightRows) {
+        rows.add(joinRow(null, nullKeyRow));
       }
     }
     return rows;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
 import org.apache.pinot.query.planner.plannode.JoinNode;
@@ -38,7 +39,6 @@ import org.apache.pinot.query.runtime.operator.join.LongLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LookupTable;
 import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.core.data.table.Key;
 
 
 /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/ObjectLookupTable.java
@@ -33,6 +33,10 @@ public class ObjectLookupTable extends LookupTable {
 
   @Override
   public void addRow(@Nullable Object key, Object[] row) {
+    if (key == null) {
+      // Ignore null keys for SQL semantics
+      return;
+    }
     _lookupTable.compute(key, (k, v) -> computeNewValue(row, v));
   }
 
@@ -47,12 +51,18 @@ public class ObjectLookupTable extends LookupTable {
 
   @Override
   public boolean containsKey(@Nullable Object key) {
+    if (key == null) {
+      return false;  // Null keys are not contained per SQL semantics
+    }
     return _lookupTable.containsKey(key);
   }
 
   @Nullable
   @Override
   public Object lookup(@Nullable Object key) {
+    if (key == null) {
+      return null;  // Null keys always return null
+    }
     return _lookupTable.get(key);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -26,12 +26,10 @@ import javax.annotation.Nullable;
 
 public abstract class PrimitiveLookupTable extends LookupTable {
 
-  private Object _valueForNullKey;
-
   @Override
   public void addRow(@Nullable Object key, Object[] row) {
     if (key == null) {
-      _valueForNullKey = computeNewValue(row, _valueForNullKey);
+      // Do nothing: SQL semantics ignore null keys
       return;
     }
     addRowNotNullKey(key, row);
@@ -40,9 +38,6 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   @Override
   public void finish() {
     if (!_keysUnique) {
-      if (_valueForNullKey != null) {
-        _valueForNullKey = convertValueToList(_valueForNullKey);
-      }
       finishNotNullKey();
     }
   }
@@ -54,7 +49,8 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   @Override
   public boolean containsKey(@Nullable Object key) {
     if (key == null) {
-      return _valueForNullKey != null;
+      // SQL semantics: null never matches
+      return false;
     }
     return containsNotNullKey(key);
   }
@@ -65,7 +61,8 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   @Override
   public Object lookup(@Nullable Object key) {
     if (key == null) {
-      return _valueForNullKey;
+      // SQL semantics: null lookup returns null
+      return null;
     }
     return lookupNotNullKey(key);
   }
@@ -75,28 +72,7 @@ public abstract class PrimitiveLookupTable extends LookupTable {
   @SuppressWarnings("rawtypes")
   @Override
   public Set<Map.Entry<Object, Object>> entrySet() {
-    Set<Map.Entry<Object, Object>> notNullSet = notNullKeyEntrySet();
-    if (_valueForNullKey != null) {
-      Set<Map.Entry<Object, Object>> nullEntry = Set.of(new Map.Entry<>() {
-        @Override
-        public Object getKey() {
-          return null;
-        }
-
-        @Override
-        public Object getValue() {
-          return _valueForNullKey;
-        }
-
-        @Override
-        public Object setValue(Object value) {
-          throw new UnsupportedOperationException();
-        }
-      });
-      return Sets.union(notNullSet, nullEntry);
-    } else {
-      return notNullSet;
-    }
+    return notNullKeyEntrySet();
   }
 
   protected abstract Set<Map.Entry<Object, Object>> notNullKeyEntrySet();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/PrimitiveLookupTable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator.join;
 
-import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -685,11 +685,9 @@ public class HashJoinOperatorTest {
 
     // Composite key join on columns 1 and 2 (string_col and double_col)
     HashJoinOperator operator = getOperator(compositeSchema, resultSchema, JoinRelType.INNER,
-            List.of(1,2), List.of(1,2), List.of(), PlanNode.NodeHint.EMPTY);
-
+            List.of(1, 2), List.of(1, 2), List.of(), PlanNode.NodeHint.EMPTY);
 
     List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
-
     // Only the non-null key match should be returned
     assertEquals(resultRows.size(), 1);
     assertArrayEquals(resultRows.get(0), new Object[]{1, "Aa", 1.0, 1, "Aa", 1.0});

--- a/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
+++ b/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
@@ -1,0 +1,65 @@
+{
+  "left_join_null_filter_test": {
+    "tables": {
+      "t1": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "event_time", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      "t2": {
+        "schema": [
+          {"name": "key_col", "type": "STRING"},
+          {"name": "event_time", "type": "INT"}
+        ],
+        "inputs": [
+          ["b", 2],
+          ["a", 1],
+          ["c", 3],
+          ["a", 2],
+          ["c", 1],
+          ["b", 3],
+          ["d", 5]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "outputs": [
+          ["a", 1],
+          ["b", 2],
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "outputs": [
+          ["d", 4],
+          ["e", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "outputs": [
+          ["c", 3],
+          ["e", 5]
+        ]
+      },
+      {
+        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "outputs": [
+          ["e", 5]
+        ]
+      }
+    ]
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
+++ b/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
@@ -43,38 +43,32 @@
       {
         "description": "LEFT JOIN with null filter on key_col and event_time comparison",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL"
       },
       {
         "description": "LEFT JOIN with null filter on key_col and event_time >= comparison",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL"
       },
       {
         "description": "LEFT JOIN with null filter on key_col and event_time < comparison",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL"
       },
       {
         "description": "LEFT JOIN with null filter on key_col and event_time <= comparison",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL"
       },
       {
         "description": "LEFT JOIN with null filter on key_col and non-nullable event_time comparison",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.nn_event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.nn_event_time > {t2}.nn_event_time WHERE {t2}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.nn_event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.nn_event_time > {t2}.nn_event_time WHERE {t2}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.nn_event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.nn_event_time > {t2}.nn_event_time WHERE {t2}.key_col IS NULL"
       },
       {
         "description": "LEFT JOIN with null check on key_col",
         "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col WHERE {t1}.key_col IS NULL",
-        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col WHERE {t1}.key_col IS NULL",
-        "keepOutputRowOrder": true
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col WHERE {t1}.key_col IS NULL"
       }
     ]
   }

--- a/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
+++ b/pinot-query-runtime/src/test/resources/queries/LeftAntiJoins.json
@@ -1,64 +1,80 @@
 {
   "left_join_null_filter_test": {
+    "extraProps": {
+      "enableColumnBasedNullHandling": true
+    },
     "tables": {
       "t1": {
         "schema": [
-          {"name": "key_col", "type": "STRING"},
-          {"name": "event_time", "type": "INT"}
+          {"name": "key_col", "type": "STRING", "notNull": false},
+          {"name": "event_time", "type": "INT", "notNull": false},
+          {"name": "nn_event_time", "type": "INT", "notNull": true}
         ],
         "inputs": [
-          ["a", 1],
-          ["b", 2],
-          ["c", 3],
-          ["d", 4],
-          ["e", 5]
+          ["a", 1, 1],
+          ["b", 2, 2],
+          ["c", 3, 3],
+          ["d", 4, 4],
+          ["e", 5, 5],
+          [null, null, 0],
+          ["f", null, 6]
         ]
       },
       "t2": {
         "schema": [
-          {"name": "key_col", "type": "STRING"},
-          {"name": "event_time", "type": "INT"}
+          {"name": "key_col", "type": "STRING", "notNull": false},
+          {"name": "event_time", "type": "INT", "notNull": false},
+          {"name": "nn_event_time", "type": "INT", "notNull": true}
         ],
         "inputs": [
-          ["b", 2],
-          ["a", 1],
-          ["c", 3],
-          ["a", 2],
-          ["c", 1],
-          ["b", 3],
-          ["d", 5]
+          ["b", 2, 2],
+          ["a", 1, 1],
+          ["c", 3, 3],
+          ["a", 2, 2],
+          ["c", 1, 1],
+          ["b", 3, 3],
+          ["d", 5, 5],
+          [null, null, 0],
+          ["f", null, 6]
         ]
       }
     },
     "queries": [
       {
-        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "outputs": [
-          ["a", 1],
-          ["b", 2],
-          ["d", 4],
-          ["e", 5]
-        ]
+        "description": "LEFT JOIN with null filter on key_col and event_time comparison",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time > {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "keepOutputRowOrder": true
       },
       {
-        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "outputs": [
-          ["d", 4],
-          ["e", 5]
-        ]
+        "description": "LEFT JOIN with null filter on key_col and event_time >= comparison",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time >= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "keepOutputRowOrder": true
       },
       {
-        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "outputs": [
-          ["c", 3],
-          ["e", 5]
-        ]
+        "description": "LEFT JOIN with null filter on key_col and event_time < comparison",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time < {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "keepOutputRowOrder": true
       },
       {
-        "sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
-        "outputs": [
-          ["e", 5]
-        ]
+        "description": "LEFT JOIN with null filter on key_col and event_time <= comparison",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.event_time <= {t2}.event_time WHERE {t2}.key_col IS NULL",
+        "keepOutputRowOrder": true
+      },
+      {
+        "description": "LEFT JOIN with null filter on key_col and non-nullable event_time comparison",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.nn_event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.nn_event_time > {t2}.nn_event_time WHERE {t2}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.nn_event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col AND {t1}.nn_event_time > {t2}.nn_event_time WHERE {t2}.key_col IS NULL",
+        "keepOutputRowOrder": true
+      },
+      {
+        "description": "LEFT JOIN with null check on key_col",
+        "sql": "SET enableNullHandling=true; SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col WHERE {t1}.key_col IS NULL",
+        "h2Sql": "SELECT {t1}.key_col, {t1}.event_time FROM {t1} LEFT JOIN {t2} ON {t1}.key_col = {t2}.key_col WHERE {t1}.key_col IS NULL",
+        "keepOutputRowOrder": true
       }
     ]
   }


### PR DESCRIPTION
**Summary**
Title: Fix null join key matching in multi-stage hash joins

**Description:**
This PR addresses an issue in Apache Pinot's multi-stage hash join implementation where null join keys were incorrectly matching each other. The fix ensures that null keys are handled appropriately, preventing unintended matches and ensuring accurate query results.

**Changes:**

**Null Key Handling in Hash Join:**

Updated the HashJoinOperator to correctly handle null values in join keys. This ensures that rows with null join keys are properly matched during multi-stage hash joins.

**Impact:**

Resolves join inaccuracies involving null keys.

Enhances the reliability and correctness of multi-stage hash joins in Pinot.

**Type of change**
bugfix