### PR TITLE
Add a metric to count invalid json rows

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -210,6 +210,11 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   SEGMENT_REINGESTION_FAILURE("segments", false),
 
   /**
+   * Number of invalid json rows at the time of index close.
+   */
+  INVALID_JSON_ROWS("rows", false),
+
+  /**
    * Approximate heap bytes used by the mutable JSON index at the time of index close.
    */
   MUTABLE_JSON_INDEX_MEMORY_USAGE("bytes", false),


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds a counter for invalid JSON rows during add and reports it on index close\.

```mermaid
flowchart TD
  N0["MutableJsonIndexImpl#46;add #40;F2#41;"]:::stModified
  N1["Increment #95;invalidJsonRows #40;F2#41;"]:::stModified
  N2["MutableJsonIndexImpl#46;close #40;F2#41;"]:::stModified
  N3["Report INVALID#95;JSON#95;ROWS metric #40;F2#41;"]:::stModified
  N4["ServerMeter#46;INVALID#95;JSON#95;ROWS #40;F1#41;"]:::stAdded
  N5["Test verifies metric #40;F3#41;"]:::stAdded
  N0 -->|"if invalid json then increment"| N1
  N1 -->|"field value used in close"| N2
  N2 -->|"call addMeteredTableValue"| N3
  N3 -->|"pass enum value"| N4
  N5 -->|"verify call with expected count"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter\.java — [before](https://github.com/apache/pinot/blob/9e4bb2a80f82f63b3069de3ef879d270b886021e/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java) · [after](https://github.com/apache/pinot/blob/8ec62142d011eab5b57283e1b9b9ec4ad6b60ede/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl\.java — [before](https://github.com/apache/pinot/blob/9e4bb2a80f82f63b3069de3ef879d270b886021e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java) · [after](https://github.com/apache/pinot/blob/8ec62142d011eab5b57283e1b9b9ec4ad6b60ede/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java)
- F3: pinot\-segment\-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest\.java — [before](https://github.com/apache/pinot/blob/9e4bb2a80f82f63b3069de3ef879d270b886021e/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java) · [after](https://github.com/apache/pinot/blob/8ec62142d011eab5b57283e1b9b9ec4ad6b60ede/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjllNGJiMmE4MGY4MmY2M2IzMDY5ZGUzZWY4NzlkMjcwYjg4NjAyMWUiLCJjb250ZXh0X2hhc2giOiI0ZGIwOTRkY2EwYWFhNWIyY2RmNzc3ZjdiNTE5MWUxYjI1MGY0OTMwNTZkOWQ3OGM5NDJkYTBlYmQ3MWU5ZWRkIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDA1NzIzLCJoZWFkX3NoYSI6IjhlYzYyMTQyZDAxMWVhYjViNTcyODNlMWI5YjllYzRhZDZiNjBlZGUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5ZTRiYjJhODBmODJmNjNiMzA2OWRlM2VmODc5ZDI3MGI4ODYwMjFlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e59abeaee6897869659b2329b7996680b572a62d29f76f3de13972841357fbf2 -->
<!-- pinot-pr-flow:end -->

TLDB: Add a metric to count invalid json rows at the time closing the index. I meant to introduce a new instance level config field to set up the default value of skipInvalidJson but realized that it likely introduce inconsistency. Check details below.
 
Current default value of skipInvalidJson is false, meaning the ingestion will get stopped if the user input data contains invalid json and tried to build json index. Uber has an internal patch that flip the default value as we don't wanna production ingestion get stopped due to malformat json.

I meant to introduce a new instance level config field to specify the skipInvalidJson's default value. When instance level's default value is not null and table config's default value is null, we will use the instance level's default value as the final value of Json's IndexConfig.skipInvalidJson. This approach can be implemented inside the [IndexLoadConfig](https://sourcegraph.com/github.com/apache/pinot/-/blob/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java?L133-L140), which will be used to create the mutable segments.

```java
  private void init() {
    if (_instanceDataManagerConfig != null) {
      extractFromInstanceConfig();
    }
    if (_tableConfig != null) {
      extractFromTableConfigAndSchema();
    }
  }
```

However, I just realized that the spi interfaces being called outside of pinot cluster is not aware of the pinot instance level config and thus will introduce inconsistency for the default value of skipInvalidJson. Two typical spi library case that creates index config are listed below.

**Offline pipeline application**: segments are created outside of pinot cluster and then push to pinot.
``` java
var indexingConfig = new IndexingConfig(jsonIndexConfig, ...);
var tableConfig = new TableConfig(indexConfig, ...);
var segmentGeneratorConfig = SegmentGeneratorConfig(tableConfig, ...);
SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
driver.init(segmentGeneratorConfig);
driver.build();
```

**Table Format Conversion**
``` java
// tableConfig use the legacy jsonIndexColumns
IndexType.convertToNewFormat(TableConfig tableConfig, Schema schema)
    -> indexType.createDeserializer().deserialize(tableConfig, schema)
    -->   public ColumnConfigDeserializer<JsonIndexConfig> createDeserializer() {
            ColumnConfigDeserializer<JsonIndexConfig> fromIndexes =
                IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
            ColumnConfigDeserializer<JsonIndexConfig> fromJsonIndexConfigs =
                IndexConfigDeserializer.fromMap(tableConfig -> tableConfig.getIndexingConfig().getJsonIndexConfigs());
            ColumnConfigDeserializer<JsonIndexConfig> fromJsonIndexColumns =
                IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getJsonIndexColumns(),
                    (accum, column) -> accum.put(column, JsonIndexConfig.DEFAULT));
            return fromIndexes.withExclusiveAlternative(fromJsonIndexConfigs.withFallbackAlternative(fromJsonIndexColumns));
          }
```
The `TableConfigUtils.createTableConfigFromOldFormat` invokes this interface to transform table format.

Thus, give up the approach of using instance level config.



