### PR TITLE
Make ThreadResourceUsageProvider a Helper/Utility Class.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -34,7 +34,7 @@ import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
-import org.apache.pinot.spi.accounting.ThreadResourceContext;
+import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -416,7 +416,7 @@ public class DataTableImplV4 implements DataTable {
   @Override
   public byte[] toBytes()
       throws IOException {
-    ThreadResourceContext resourceContext = new ThreadResourceContext();
+    ThreadResourceSnapshot resourceContext = new ThreadResourceSnapshot();
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
@@ -428,7 +428,7 @@ public class DataTableImplV4 implements DataTable {
     // backward compatibility.
     if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(),
-          String.valueOf(resourceContext.getCpuTimeNanos()));
+          String.valueOf(resourceContext.getCpuTimeNs()));
     }
     if (ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_MEM_ALLOCATED_BYTES.getName(),

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -425,7 +425,6 @@ public class DataTableImplV4 implements DataTable {
     // Add table serialization time and memory metadata if thread timer is enabled.
     // TODO: The check on cpu time and memory measurement is not needed. We can remove it. But keeping it around for
     // backward compatibility.
-    resourceSnapshot.takeSnapshot();
     if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(),
           String.valueOf(resourceSnapshot.getCpuTimeNs()));

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -422,10 +422,10 @@ public class DataTableImplV4 implements DataTable {
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
     writeLeadingSections(dataOutputStream);
 
-    resourceSnapshot.close();
     // Add table serialization time and memory metadata if thread timer is enabled.
     // TODO: The check on cpu time and memory measurement is not needed. We can remove it. But keeping it around for
     // backward compatibility.
+    resourceSnapshot.takeSnapshot();
     if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(),
           String.valueOf(resourceSnapshot.getCpuTimeNs()));

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -416,23 +416,23 @@ public class DataTableImplV4 implements DataTable {
   @Override
   public byte[] toBytes()
       throws IOException {
-    ThreadResourceSnapshot resourceContext = new ThreadResourceSnapshot();
+    ThreadResourceSnapshot resourceSnapshot = new ThreadResourceSnapshot();
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
     writeLeadingSections(dataOutputStream);
 
-    resourceContext.close();
+    resourceSnapshot.close();
     // Add table serialization time and memory metadata if thread timer is enabled.
     // TODO: The check on cpu time and memory measurement is not needed. We can remove it. But keeping it around for
     // backward compatibility.
     if (ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(),
-          String.valueOf(resourceContext.getCpuTimeNs()));
+          String.valueOf(resourceSnapshot.getCpuTimeNs()));
     }
     if (ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
       getMetadata().put(MetadataKey.RESPONSE_SER_MEM_ALLOCATED_BYTES.getName(),
-          String.valueOf(resourceContext.getAllocatedBytes()));
+          String.valueOf(resourceSnapshot.getAllocatedBytes()));
     }
 
     // Write metadata: length followed by actual metadata bytes.

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
@@ -43,6 +43,10 @@ public class CPUMemThreadLevelAccountingObjects {
     volatile long _currentThreadCPUTimeSampleMS = 0;
     volatile long _currentThreadMemoryAllocationSampleBytes = 0;
 
+    // reference point for start time/bytes
+    long _startTimeNs;
+    long _startBytesAllocated;
+
     // previous query_id, task_id of the thread, this field should only be accessed by the accountant
     TaskEntry _previousThreadTaskStatus = null;
     // previous cpu time and memory allocation of the thread

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/CPUMemThreadLevelAccountingObjects.java
@@ -120,8 +120,13 @@ public class CPUMemThreadLevelAccountingObjects {
       _threadResourceSnapshot.reset();
     }
 
+    /**
+     * Note that the precision does not match the name of the variable.
+     * _currentThreadCPUTimeSampleMS is in nanoseconds, but the variable name suggests milliseconds.
+     * This is to maintain backward compatibility. It replaces code that set the value in nanoseconds.
+     */
     public void updateCpuSnapshot() {
-      _currentThreadCPUTimeSampleMS = _threadResourceSnapshot.getCpuTimeNs() / 1_000_000; // convert to ms
+      _currentThreadCPUTimeSampleMS = _threadResourceSnapshot.getCpuTimeNs();
     }
 
     public void updateMemorySnapshot() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -290,8 +290,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     @SuppressWarnings("ConstantConditions")
     public void sampleThreadCPUTime() {
       if (_isThreadCPUSamplingEnabled) {
-        _threadLocalEntry.get()._currentThreadCPUTimeSampleMS =
-            ThreadResourceUsageProvider.getCurrentThreadCpuTime() - _threadLocalEntry.get()._startTimeNs;
+        _threadLocalEntry.get().updateCpuSnapshot();
       }
     }
 
@@ -302,16 +301,13 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     @SuppressWarnings("ConstantConditions")
     public void sampleThreadBytesAllocated() {
       if (_isThreadMemorySamplingEnabled) {
-        _threadLocalEntry.get()._currentThreadMemoryAllocationSampleBytes =
-            ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() - _threadLocalEntry.get()._startBytesAllocated;
+        _threadLocalEntry.get().updateMemorySnapshot();
       }
     }
 
     @Override
     public void setupRunner(@Nullable String queryId, int taskId, ThreadExecutionContext.TaskType taskType) {
       _threadLocalEntry.get()._errorStatus.set(null);
-      _threadLocalEntry.get()._startTimeNs = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
-      _threadLocalEntry.get()._startBytesAllocated = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
       if (queryId != null) {
         _threadLocalEntry.get()
             .setThreadTaskStatus(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType, Thread.currentThread());
@@ -322,8 +318,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     public void setupWorker(int taskId, ThreadExecutionContext.TaskType taskType,
         @Nullable ThreadExecutionContext parentContext) {
       _threadLocalEntry.get()._errorStatus.set(null);
-      _threadLocalEntry.get()._startTimeNs = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
-      _threadLocalEntry.get()._startBytesAllocated = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
       if (parentContext != null && parentContext.getQueryId() != null && parentContext.getAnchorThread() != null) {
         _threadLocalEntry.get().setThreadTaskStatus(parentContext.getQueryId(), taskId, parentContext.getTaskType(),
             parentContext.getAnchorThread());

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -330,11 +330,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       return _threadLocalEntry.get().getCurrentThreadTaskStatus();
     }
 
-    @Override
-    @Deprecated
-    public void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
-    }
-
     public CPUMemThreadLevelAccountingObjects.ThreadEntry getThreadEntry() {
       return _threadLocalEntry.get();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -271,6 +271,11 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     @Override
+    @Deprecated
+    public void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
+    }
+
+    @Override
     public void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long memoryAllocatedBytes) {
       if (_isThreadCPUSamplingEnabled) {
         _concurrentTaskCPUStatsAggregator.compute(queryId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -287,6 +287,10 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       }
     }
 
+    @Override
+    @Deprecated
+    public void updateQueryUsageConcurrently(String queryId) {
+    }
 
     /**
      * The thread would need to do {@code setThreadResourceUsageProvider} first upon it is scheduled.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -106,7 +106,7 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
     BaseResultsBlock resultsBlock = getCombinedResults();
 
-    resourceSnapshot.close();
+    resourceSnapshot.takeSnapshot();
     long mainThreadCpuTimeNs = resourceSnapshot.getCpuTimeNs();
     long mainThreadMemAllocatedBytes = resourceSnapshot.getAllocatedBytes();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -30,7 +30,7 @@ import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.SegmentContext;
-import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
+import org.apache.pinot.spi.accounting.ThreadResourceContext;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
@@ -102,13 +102,13 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
   protected BaseResultsBlock getBaseBlock() {
     long startWallClockTimeNs = System.nanoTime();
-    ThreadResourceUsageProvider mainThreadResourceUsageProvider = new ThreadResourceUsageProvider();
+    ThreadResourceContext resourceContext = new ThreadResourceContext();
 
     BaseResultsBlock resultsBlock = getCombinedResults();
 
-    // No-ops if CPU time measurement and/or memory allocation measurements are not enabled.
-    long mainThreadCpuTimeNs = mainThreadResourceUsageProvider.getThreadTimeNs();
-    long mainThreadMemAllocatedBytes = mainThreadResourceUsageProvider.getThreadAllocatedBytes();
+    resourceContext.close();
+    long mainThreadCpuTimeNs = resourceContext.getCpuTimeNanos();
+    long mainThreadMemAllocatedBytes = resourceContext.getAllocatedBytes();
 
     long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -102,13 +102,13 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
   protected BaseResultsBlock getBaseBlock() {
     long startWallClockTimeNs = System.nanoTime();
-    ThreadResourceSnapshot resourceContext = new ThreadResourceSnapshot();
+    ThreadResourceSnapshot resourceSnapshot = new ThreadResourceSnapshot();
 
     BaseResultsBlock resultsBlock = getCombinedResults();
 
-    resourceContext.close();
-    long mainThreadCpuTimeNs = resourceContext.getCpuTimeNs();
-    long mainThreadMemAllocatedBytes = resourceContext.getAllocatedBytes();
+    resourceSnapshot.close();
+    long mainThreadCpuTimeNs = resourceSnapshot.getCpuTimeNs();
+    long mainThreadMemAllocatedBytes = resourceSnapshot.getAllocatedBytes();
 
     long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -106,7 +106,6 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
     BaseResultsBlock resultsBlock = getCombinedResults();
 
-    resourceSnapshot.takeSnapshot();
     long mainThreadCpuTimeNs = resourceSnapshot.getCpuTimeNs();
     long mainThreadMemAllocatedBytes = resourceSnapshot.getAllocatedBytes();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -30,7 +30,7 @@ import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.SegmentContext;
-import org.apache.pinot.spi.accounting.ThreadResourceContext;
+import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
@@ -102,12 +102,12 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
   protected BaseResultsBlock getBaseBlock() {
     long startWallClockTimeNs = System.nanoTime();
-    ThreadResourceContext resourceContext = new ThreadResourceContext();
+    ThreadResourceSnapshot resourceContext = new ThreadResourceSnapshot();
 
     BaseResultsBlock resultsBlock = getCombinedResults();
 
     resourceContext.close();
-    long mainThreadCpuTimeNs = resourceContext.getCpuTimeNanos();
+    long mainThreadCpuTimeNs = resourceContext.getCpuTimeNs();
     long mainThreadMemAllocatedBytes = resourceContext.getAllocatedBytes();
 
     long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -114,7 +114,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
             Tracing.ThreadAccountantOps.clear();
             return;
           }
-          try (resourceSnapshot) {
+          try {
             processSegments();
           } catch (EarlyTerminationException e) {
             // Early-terminated by interruption (canceled by the main thread)
@@ -132,10 +132,12 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
           } finally {
             onProcessSegmentsFinish();
             _phaser.arriveAndDeregister();
-            _totalWorkerThreadCpuTimeNs.getAndAdd(resourceSnapshot.getCpuTimeNs());
-            _totalWorkerThreadMemAllocatedBytes.getAndAdd(resourceSnapshot.getAllocatedBytes());
             Tracing.ThreadAccountantOps.clear();
           }
+
+          resourceSnapshot.takeSnapshot();
+          _totalWorkerThreadCpuTimeNs.getAndAdd(resourceSnapshot.getCpuTimeNs());
+          _totalWorkerThreadMemAllocatedBytes.getAndAdd(resourceSnapshot.getAllocatedBytes());
         }
       });
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -34,7 +34,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.util.QueryMultiThreadingUtils;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.accounting.ThreadResourceContext;
+import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
@@ -103,7 +103,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
       _futures[i] = _executorService.submit(new TraceRunnable() {
         @Override
         public void runJob() {
-          ThreadResourceContext resourceContext = new ThreadResourceContext();
+          ThreadResourceSnapshot resourceContext = new ThreadResourceSnapshot();
           Tracing.ThreadAccountantOps.setupWorker(taskId, parentContext);
 
           // Register the task to the phaser
@@ -132,7 +132,7 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
           } finally {
             onProcessSegmentsFinish();
             _phaser.arriveAndDeregister();
-            _totalWorkerThreadCpuTimeNs.getAndAdd(resourceContext.getCpuTimeNanos());
+            _totalWorkerThreadCpuTimeNs.getAndAdd(resourceContext.getCpuTimeNs());
             _totalWorkerThreadMemAllocatedBytes.getAndAdd(resourceContext.getAllocatedBytes());
             Tracing.ThreadAccountantOps.clear();
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -135,7 +135,6 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
             Tracing.ThreadAccountantOps.clear();
           }
 
-          resourceSnapshot.takeSnapshot();
           _totalWorkerThreadCpuTimeNs.getAndAdd(resourceSnapshot.getCpuTimeNs());
           _totalWorkerThreadMemAllocatedBytes.getAndAdd(resourceSnapshot.getAllocatedBytes());
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
@@ -72,7 +72,6 @@ public class DataTableHandler extends SimpleChannelInboundHandler<ByteBuf> {
       _queryRouter.receiveDataTable(_serverRoutingInstance, dataTable, responseSize,
           (int) (System.currentTimeMillis() - deserializationStartTimeMs));
       long requestID = Long.parseLong(dataTable.getMetadata().get(DataTable.MetadataKey.REQUEST_ID.getName()));
-      resourceSnapshot.takeSnapshot();
       Tracing.ThreadAccountantOps.updateQueryUsageConcurrently(String.valueOf(requestID),
           resourceSnapshot.getCpuTimeNs(), resourceSnapshot.getAllocatedBytes());
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
@@ -72,7 +72,7 @@ public class DataTableHandler extends SimpleChannelInboundHandler<ByteBuf> {
       _queryRouter.receiveDataTable(_serverRoutingInstance, dataTable, responseSize,
           (int) (System.currentTimeMillis() - deserializationStartTimeMs));
       long requestID = Long.parseLong(dataTable.getMetadata().get(DataTable.MetadataKey.REQUEST_ID.getName()));
-      resourceSnapshot.close();
+      resourceSnapshot.takeSnapshot();
       Tracing.ThreadAccountantOps.updateQueryUsageConcurrently(String.valueOf(requestID),
           resourceSnapshot.getCpuTimeNs(), resourceSnapshot.getAllocatedBytes());
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.accounting.ThreadResourceContext;
 import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,16 +63,16 @@ public class DataTableHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
-    Tracing.ThreadAccountantOps.setThreadResourceUsageProvider();
     int responseSize = msg.readableBytes();
     _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_BYTES_RECEIVED, responseSize);
-    try {
+    try (ThreadResourceContext resourceContext = new ThreadResourceContext()) {
       long deserializationStartTimeMs = System.currentTimeMillis();
       DataTable dataTable = DataTableFactory.getDataTable(msg.nioBuffer());
       _queryRouter.receiveDataTable(_serverRoutingInstance, dataTable, responseSize,
           (int) (System.currentTimeMillis() - deserializationStartTimeMs));
       long requestID = Long.parseLong(dataTable.getMetadata().get(DataTable.MetadataKey.REQUEST_ID.getName()));
-      Tracing.ThreadAccountantOps.updateQueryUsageConcurrently(String.valueOf(requestID));
+      Tracing.ThreadAccountantOps.updateQueryUsageConcurrently(String.valueOf(requestID),
+          resourceContext.getCpuTimeNanos(), resourceContext.getAllocatedBytes());
     } catch (Exception e) {
       LOGGER.error("Caught exception while deserializing data table of size: {} from server: {}", responseSize,
           _serverRoutingInstance, e);

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
@@ -54,7 +54,7 @@ public class TestThreadMXBean {
       long[] ll = new long[10000];
       ll[2] = 4;
       LOGGER.trace(String.valueOf(ll[2]));
-      threadResourceSnapshot.close();
+      threadResourceSnapshot.takeSnapshot();
       long result = threadResourceSnapshot.getCpuTimeNs();
       Assert.assertTrue(result >= 80000 && result <= 85000);
     }
@@ -83,7 +83,7 @@ public class TestThreadMXBean {
         for (int i = 0; i < 100000; i++) {
           concurrentHashMap.put(i, i);
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         a.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -92,7 +92,7 @@ public class TestThreadMXBean {
         for (int i = 100000; i < 200000; i++) {
           concurrentHashMap.put(i, i);
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         b.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -101,7 +101,7 @@ public class TestThreadMXBean {
         for (int i = 0; i < 200000; i++) {
           concurrentHashMap2.put(i, i);
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         c.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -110,7 +110,7 @@ public class TestThreadMXBean {
       } catch (InterruptedException ignored) {
       }
 
-      threadResourceSnapshot0.close();
+      threadResourceSnapshot0.takeSnapshot();
       long d = threadResourceSnapshot0.getAllocatedBytes();
       long threadAllocatedBytes = a.get() + b.get() + c.get() + d;
       float heapUsedBytes = (float) memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
@@ -144,7 +144,7 @@ public class TestThreadMXBean {
         for (int i = 0; i < 100; i++) {
           concurrentHashMap.put(i, new NestedArray());
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         a.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -153,7 +153,7 @@ public class TestThreadMXBean {
         for (int i = 100; i < 200; i++) {
           concurrentHashMap.put(i, new NestedArray());
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         b.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -162,7 +162,7 @@ public class TestThreadMXBean {
         for (int i = 0; i < 200; i++) {
           concurrentHashMap2.put(i, new NestedArray());
         }
-        threadResourceSnapshot.close();
+        threadResourceSnapshot.takeSnapshot();
         c.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -171,7 +171,7 @@ public class TestThreadMXBean {
       } catch (InterruptedException ignored) {
       }
 
-      threadResourceSnapshot0.close();
+      threadResourceSnapshot0.takeSnapshot();
       long d = threadResourceSnapshot0.getAllocatedBytes();
       long threadAllocatedBytes = a.get() + b.get() + c.get() + d;
       float heapUsedBytes = (float) memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
@@ -198,7 +198,7 @@ public class TestThreadMXBean {
     }
     System.gc();
     long heapResult = memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
-    threadResourceSnapshot0.close();
+    threadResourceSnapshot0.takeSnapshot();
     long result = threadResourceSnapshot0.getAllocatedBytes();
     LOGGER.info("Measured thread allocated bytes {}, heap used bytes {}",
         result, heapResult);

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
@@ -55,7 +55,7 @@ public class TestThreadMXBean {
       ll[2] = 4;
       LOGGER.trace(String.valueOf(ll[2]));
       threadResourceSnapshot.takeSnapshot();
-      long result = threadResourceSnapshot.getCpuTimeNs();
+      long result = threadResourceSnapshot.getAllocatedBytes();
       Assert.assertTrue(result >= 80000 && result <= 85000);
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
@@ -54,7 +54,6 @@ public class TestThreadMXBean {
       long[] ll = new long[10000];
       ll[2] = 4;
       LOGGER.trace(String.valueOf(ll[2]));
-      threadResourceSnapshot.takeSnapshot();
       long result = threadResourceSnapshot.getAllocatedBytes();
       Assert.assertTrue(result >= 80000 && result <= 85000);
     }
@@ -83,7 +82,6 @@ public class TestThreadMXBean {
         for (int i = 0; i < 100000; i++) {
           concurrentHashMap.put(i, i);
         }
-        threadResourceSnapshot.takeSnapshot();
         a.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -92,7 +90,6 @@ public class TestThreadMXBean {
         for (int i = 100000; i < 200000; i++) {
           concurrentHashMap.put(i, i);
         }
-        threadResourceSnapshot.takeSnapshot();
         b.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -101,7 +98,6 @@ public class TestThreadMXBean {
         for (int i = 0; i < 200000; i++) {
           concurrentHashMap2.put(i, i);
         }
-        threadResourceSnapshot.takeSnapshot();
         c.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -110,7 +106,6 @@ public class TestThreadMXBean {
       } catch (InterruptedException ignored) {
       }
 
-      threadResourceSnapshot0.takeSnapshot();
       long d = threadResourceSnapshot0.getAllocatedBytes();
       long threadAllocatedBytes = a.get() + b.get() + c.get() + d;
       float heapUsedBytes = (float) memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
@@ -144,7 +139,6 @@ public class TestThreadMXBean {
         for (int i = 0; i < 100; i++) {
           concurrentHashMap.put(i, new NestedArray());
         }
-        threadResourceSnapshot.takeSnapshot();
         a.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -153,7 +147,6 @@ public class TestThreadMXBean {
         for (int i = 100; i < 200; i++) {
           concurrentHashMap.put(i, new NestedArray());
         }
-        threadResourceSnapshot.takeSnapshot();
         b.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -162,7 +155,6 @@ public class TestThreadMXBean {
         for (int i = 0; i < 200; i++) {
           concurrentHashMap2.put(i, new NestedArray());
         }
-        threadResourceSnapshot.takeSnapshot();
         c.set(threadResourceSnapshot.getAllocatedBytes());
       });
 
@@ -171,7 +163,6 @@ public class TestThreadMXBean {
       } catch (InterruptedException ignored) {
       }
 
-      threadResourceSnapshot0.takeSnapshot();
       long d = threadResourceSnapshot0.getAllocatedBytes();
       long threadAllocatedBytes = a.get() + b.get() + c.get() + d;
       float heapUsedBytes = (float) memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
@@ -198,7 +189,6 @@ public class TestThreadMXBean {
     }
     System.gc();
     long heapResult = memoryMXBean.getHeapMemoryUsage().getUsed() - heapPrev;
-    threadResourceSnapshot0.takeSnapshot();
     long result = threadResourceSnapshot0.getAllocatedBytes();
     LOGGER.info("Measured thread allocated bytes {}, heap used bytes {}",
         result, heapResult);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadResourceUsageProvider.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadResourceUsageProvider.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.perf;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -65,24 +66,24 @@ public class BenchmarkThreadResourceUsageProvider {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchThreadMXBeanThreadCPUTime(MyState myState, Blackhole bh) {
-    bh.consume(myState._threadResourceUsageProvider.getThreadTimeNs());
+    bh.consume(myState._threadResourceSnapshot.getCpuTimeNs());
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchThreadMXBeanMem(MyState myState, Blackhole bh) {
-    bh.consume(myState._threadResourceUsageProvider.getThreadAllocatedBytes());
+    bh.consume(myState._threadResourceSnapshot.getAllocatedBytes());
   }
 
   @State(Scope.Benchmark)
   public static class MyState {
-    ThreadResourceUsageProvider _threadResourceUsageProvider;
+    ThreadResourceSnapshot _threadResourceSnapshot;
     long[] _allocation;
 
     @Setup(Level.Iteration)
     public void doSetup() {
-      _threadResourceUsageProvider = new ThreadResourceUsageProvider();
+      _threadResourceSnapshot = new ThreadResourceSnapshot();
     }
 
     @Setup(Level.Invocation)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceContext.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.accounting;
+
+public class ThreadResourceContext implements AutoCloseable {
+  private final long _startCpuTime;
+  private final long _startAllocatedBytes;
+
+  private long _endCpuTime;
+  private long _endAllocatedBytes;
+  private boolean _closed = false;
+
+  /**
+   * Creates a new tracker and takes initial snapshots.
+   */
+  public ThreadResourceContext() {
+    _startCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
+    _startAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
+  }
+
+  /**
+   * Gets the CPU time used so far in nanoseconds.
+   * Takes a current snapshot if not yet closed.
+   */
+  public long getCpuTimeNanos() {
+    updateCurrentSnapshot();
+    return _endCpuTime - _startCpuTime;
+  }
+
+  /**
+   * Gets the memory allocated so far in bytes.
+   * Takes a current snapshot if not yet closed.
+   */
+  public long getAllocatedBytes() {
+    updateCurrentSnapshot();
+    return _endAllocatedBytes - _startAllocatedBytes;
+  }
+
+  /**
+   * Updates the current snapshot if not already closed.
+   */
+  private void updateCurrentSnapshot() {
+    if (!_closed) {
+      _endCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
+      _endAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
+    }
+  }
+
+  /**
+   * Takes final snapshots and marks the tracker as closed.
+   * This is automatically called when used in try-with-resources.
+   */
+  @Override
+  public void close() {
+    if (!_closed) {
+      updateCurrentSnapshot();
+      _closed = true;
+    }
+  }
+
+  /**
+   * Returns true if this tracker has been closed.
+   */
+  public boolean isClosed() {
+    return _closed;
+  }
+
+  @Override
+  public String toString() {
+    return "ThreadResourceContext{" + "cpuTime=" + (_endCpuTime - _startCpuTime) + ", allocatedBytes="
+        + (_endAllocatedBytes - _startAllocatedBytes) + ", closed=" + _closed + '}';
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
@@ -18,6 +18,12 @@
  */
 package org.apache.pinot.spi.accounting;
 
+/**
+ * ThreadResourceSnapshot is a utility class that helps to track the CPU time and memory allocated.
+ * {@link ThreadResourceUsageProvider} provides cumulative CPU time and memory allocated for the current thread.
+ * This class uses that provider to snapshot start & end values for a task executed by that thread.
+ * It also implements {@link AutoCloseable} to allow usage in try-with-resources blocks,
+ */
 public class ThreadResourceSnapshot implements AutoCloseable {
   private long _startCpuTime;
   private long _startAllocatedBytes;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
@@ -21,14 +21,11 @@ package org.apache.pinot.spi.accounting;
 /**
  * ThreadResourceSnapshot is a utility class that helps to track the CPU time and memory allocated.
  * {@link ThreadResourceUsageProvider} provides cumulative CPU time and memory allocated for the current thread.
- * This class uses that provider to snapshot start & end values for a task executed by that thread.
+ * This class uses that provider to snapshot start for a task executed by that thread.
  */
 public class ThreadResourceSnapshot {
   private long _startCpuTime;
   private long _startAllocatedBytes;
-
-  private long _endCpuTime;
-  private long _endAllocatedBytes;
 
   /**
    * Creates a new tracker and takes initial snapshots.
@@ -40,37 +37,27 @@ public class ThreadResourceSnapshot {
   public void reset() {
     _startCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
     _startAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
-    _endCpuTime = _startCpuTime;
-    _endAllocatedBytes = _startAllocatedBytes;
   }
 
   /**
    * Gets the CPU time used so far in nanoseconds.
-   * Takes a current snapshot if not yet closed.
+   * This is the difference between the current CPU time and the start CPU time.
    */
   public long getCpuTimeNs() {
-    return _endCpuTime - _startCpuTime;
+    return ThreadResourceUsageProvider.getCurrentThreadCpuTime() - _startCpuTime;
   }
 
   /**
    * Gets the memory allocated so far in bytes.
-   * Takes a current snapshot if not yet closed.
+   * This is the difference between the current allocated bytes and the start allocated bytes.
    */
   public long getAllocatedBytes() {
-    return _endAllocatedBytes - _startAllocatedBytes;
-  }
-
-  /**
-   * Updates the current snapshot if not already closed.
-   */
-  public void takeSnapshot() {
-    _endCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
-    _endAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
+    return ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() - _startAllocatedBytes;
   }
 
   @Override
   public String toString() {
-    return "ThreadResourceSnapshot{" + "cpuTime=" + (_endCpuTime - _startCpuTime) + ", allocatedBytes="
-        + (_endAllocatedBytes - _startAllocatedBytes) + '}';
+    return "ThreadResourceSnapshot{" + "cpuTime=" + (getCpuTimeNs()) + ", allocatedBytes="
+        + (getAllocatedBytes()) + '}';
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
@@ -22,15 +22,13 @@ package org.apache.pinot.spi.accounting;
  * ThreadResourceSnapshot is a utility class that helps to track the CPU time and memory allocated.
  * {@link ThreadResourceUsageProvider} provides cumulative CPU time and memory allocated for the current thread.
  * This class uses that provider to snapshot start & end values for a task executed by that thread.
- * It also implements {@link AutoCloseable} to allow usage in try-with-resources blocks,
  */
-public class ThreadResourceSnapshot implements AutoCloseable {
+public class ThreadResourceSnapshot {
   private long _startCpuTime;
   private long _startAllocatedBytes;
 
   private long _endCpuTime;
   private long _endAllocatedBytes;
-  private boolean _closed = false;
 
   /**
    * Creates a new tracker and takes initial snapshots.
@@ -51,7 +49,6 @@ public class ThreadResourceSnapshot implements AutoCloseable {
    * Takes a current snapshot if not yet closed.
    */
   public long getCpuTimeNs() {
-    updateCurrentSnapshot();
     return _endCpuTime - _startCpuTime;
   }
 
@@ -60,42 +57,20 @@ public class ThreadResourceSnapshot implements AutoCloseable {
    * Takes a current snapshot if not yet closed.
    */
   public long getAllocatedBytes() {
-    updateCurrentSnapshot();
     return _endAllocatedBytes - _startAllocatedBytes;
   }
 
   /**
    * Updates the current snapshot if not already closed.
    */
-  private void updateCurrentSnapshot() {
-    if (!_closed) {
-      _endCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
-      _endAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
-    }
-  }
-
-  /**
-   * Takes final snapshots and marks the tracker as closed.
-   * This is automatically called when used in try-with-resources.
-   */
-  @Override
-  public void close() {
-    if (!_closed) {
-      updateCurrentSnapshot();
-      _closed = true;
-    }
-  }
-
-  /**
-   * Returns true if this tracker has been closed.
-   */
-  public boolean isClosed() {
-    return _closed;
+  public void takeSnapshot() {
+    _endCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
+    _endAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
   }
 
   @Override
   public String toString() {
     return "ThreadResourceSnapshot{" + "cpuTime=" + (_endCpuTime - _startCpuTime) + ", allocatedBytes="
-        + (_endAllocatedBytes - _startAllocatedBytes) + ", closed=" + _closed + '}';
+        + (_endAllocatedBytes - _startAllocatedBytes) + '}';
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceSnapshot.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.spi.accounting;
 
-public class ThreadResourceContext implements AutoCloseable {
-  private final long _startCpuTime;
-  private final long _startAllocatedBytes;
+public class ThreadResourceSnapshot implements AutoCloseable {
+  private long _startCpuTime;
+  private long _startAllocatedBytes;
 
   private long _endCpuTime;
   private long _endAllocatedBytes;
@@ -29,16 +29,22 @@ public class ThreadResourceContext implements AutoCloseable {
   /**
    * Creates a new tracker and takes initial snapshots.
    */
-  public ThreadResourceContext() {
+  public ThreadResourceSnapshot() {
+    reset();
+  }
+
+  public void reset() {
     _startCpuTime = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
     _startAllocatedBytes = ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes();
+    _endCpuTime = _startCpuTime;
+    _endAllocatedBytes = _startAllocatedBytes;
   }
 
   /**
    * Gets the CPU time used so far in nanoseconds.
    * Takes a current snapshot if not yet closed.
    */
-  public long getCpuTimeNanos() {
+  public long getCpuTimeNs() {
     updateCurrentSnapshot();
     return _endCpuTime - _startCpuTime;
   }
@@ -83,7 +89,7 @@ public class ThreadResourceContext implements AutoCloseable {
 
   @Override
   public String toString() {
-    return "ThreadResourceContext{" + "cpuTime=" + (_endCpuTime - _startCpuTime) + ", allocatedBytes="
+    return "ThreadResourceSnapshot{" + "cpuTime=" + (_endCpuTime - _startCpuTime) + ", allocatedBytes="
         + (_endAllocatedBytes - _startAllocatedBytes) + ", closed=" + _closed + '}';
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -71,8 +71,7 @@ public interface ThreadResourceUsageAccountant {
    * set resource usage provider
    */
   @Deprecated
-  default void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
-  }
+  void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider);
 
   /**
    * call to sample usage

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -70,6 +70,7 @@ public interface ThreadResourceUsageAccountant {
   /**
    * set resource usage provider
    */
+  @Deprecated
   void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider);
 
   /**
@@ -87,7 +88,12 @@ public interface ThreadResourceUsageAccountant {
    * ser/de threads where the thread execution context cannot be setup before hands as
    * queryId/taskId is unknown and the execution process is hard to instrument
    */
-  void updateQueryUsageConcurrently(String queryId);
+  void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes);
+
+  @Deprecated
+  default void updateQueryUsageConcurrently(String queryId) {
+    updateQueryUsageConcurrently(queryId, 0, 0);
+  }
 
   /**
    * start the periodical task

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -71,7 +71,8 @@ public interface ThreadResourceUsageAccountant {
    * set resource usage provider
    */
   @Deprecated
-  void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider);
+  default void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
+  }
 
   /**
    * call to sample usage

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -91,9 +91,7 @@ public interface ThreadResourceUsageAccountant {
   void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes);
 
   @Deprecated
-  default void updateQueryUsageConcurrently(String queryId) {
-    updateQueryUsageConcurrently(queryId, 0, 0);
-  }
+  void updateQueryUsageConcurrently(String queryId);
 
   /**
    * start the periodical task

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
@@ -54,6 +54,16 @@ public class ThreadResourceUsageProvider {
   private ThreadResourceUsageProvider() {
   }
 
+  @Deprecated
+  public long getThreadTimeNs() {
+    return 0;
+  }
+
+  @Deprecated
+  public long getThreadAllocatedBytes() {
+    return 0;
+  }
+
   public static long getCurrentThreadCpuTime() {
     return _isThreadCpuTimeMeasurementEnabled ? MX_BEAN.getCurrentThreadCpuTime() : 0;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
@@ -51,9 +51,6 @@ public class ThreadResourceUsageProvider {
   private static boolean _isThreadCpuTimeMeasurementEnabled = false;
   private static boolean _isThreadMemoryMeasurementEnabled = false;
 
-  private ThreadResourceUsageProvider() {
-  }
-
   @Deprecated
   public long getThreadTimeNs() {
     return 0;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
@@ -51,22 +51,21 @@ public class ThreadResourceUsageProvider {
   private static boolean _isThreadCpuTimeMeasurementEnabled = false;
   private static boolean _isThreadMemoryMeasurementEnabled = false;
 
-  // reference point for start time/bytes
-  private final long _startTimeNs;
-  private final long _startBytesAllocated;
+  private ThreadResourceUsageProvider() {
+  }
 
-  public ThreadResourceUsageProvider() {
-    _startTimeNs = _isThreadCpuTimeMeasurementEnabled ? MX_BEAN.getCurrentThreadCpuTime() : -1;
+  public static long getCurrentThreadCpuTime() {
+    return _isThreadCpuTimeMeasurementEnabled ? MX_BEAN.getCurrentThreadCpuTime() : 0;
+  }
 
-    long startBytesAllocated1;
+  public static long getCurrentThreadAllocatedBytes() {
     try {
-      startBytesAllocated1 = _isThreadMemoryMeasurementEnabled
-          ? (long) SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD.invoke(MX_BEAN, Thread.currentThread().getId()) : -1;
+      return _isThreadMemoryMeasurementEnabled ? (long) SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD
+          .invoke(MX_BEAN, Thread.currentThread().getId()) : 0;
     } catch (IllegalAccessException | InvocationTargetException e) {
-      startBytesAllocated1 = -1;
-      LOGGER.error("Exception happened during the invocation of getting initial bytes allocated", e);
+      LOGGER.error("Exception happened during the invocation of getting current bytes allocated", e);
+      return 0;
     }
-    _startBytesAllocated = startBytesAllocated1;
   }
 
   public static boolean isThreadCpuTimeMeasurementEnabled() {
@@ -98,20 +97,6 @@ public class ThreadResourceUsageProvider {
       }
     }
     _isThreadMemoryMeasurementEnabled = enable && IS_THREAD_ALLOCATED_MEMORY_SUPPORTED && isThreadAllocateMemoryEnabled;
-  }
-
-  public long getThreadTimeNs() {
-    return _isThreadCpuTimeMeasurementEnabled ? MX_BEAN.getCurrentThreadCpuTime() - _startTimeNs : 0;
-  }
-
-  public long getThreadAllocatedBytes() {
-    try {
-      return _isThreadMemoryMeasurementEnabled ? (long) SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD
-          .invoke(MX_BEAN, Thread.currentThread().getId()) - _startBytesAllocated : 0;
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      LOGGER.error("Exception happened during the invocation of getting initial bytes allocated", e);
-      return 0;
-    }
   }
 
   //initialize the com.sun.management.ThreadMXBean related variables using reflection

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -30,7 +30,6 @@ import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
-import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.EarlyTerminationException;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -326,6 +326,10 @@ public class Tracing {
       sample();
     }
 
+    @Deprecated
+    public static void updateQueryUsageConcurrently(String queryId) {
+    }
+
     public static void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes) {
       Tracing.getThreadAccountant().updateQueryUsageConcurrently(queryId, cpuTimeNs, allocatedBytes);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -198,6 +198,12 @@ public class Tracing {
     }
 
     @Override
+    @Deprecated
+    public void updateQueryUsageConcurrently(String queryId) {
+      // No-op for default accountant
+    }
+
+    @Override
     public void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes) {
       // No-op for default accountant
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -191,10 +191,6 @@ public class Tracing {
     }
 
     @Override
-    public void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
-    }
-
-    @Override
     public void sampleUsage() {
     }
 
@@ -331,7 +327,6 @@ public class Tracing {
 
     @Deprecated
     public static void setThreadResourceUsageProvider() {
-      Tracing.getThreadAccountant().setThreadResourceUsageProvider(null);
     }
 
     // Check for thread interruption, every time after merging 8192 keys

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
@@ -195,6 +196,11 @@ public class Tracing {
 
     @Override
     public void sampleUsageMSE() {
+    }
+
+    @Override
+    @Deprecated
+    public void setThreadResourceUsageProvider(ThreadResourceUsageProvider threadResourceUsageProvider) {
     }
 
     @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -203,7 +203,8 @@ public class Tracing {
     }
 
     @Override
-    public void updateQueryUsageConcurrently(String queryId) {
+    public void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes) {
+      // No-op for default accountant
     }
 
     @Override
@@ -256,7 +257,6 @@ public class Tracing {
     }
 
     public static void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType) {
-      Tracing.getThreadAccountant().setThreadResourceUsageProvider(new ThreadResourceUsageProvider());
       Tracing.getThreadAccountant().setupRunner(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType);
     }
 
@@ -276,7 +276,6 @@ public class Tracing {
      */
     public static void setupWorker(int taskId, ThreadExecutionContext.TaskType taskType,
         @Nullable ThreadExecutionContext threadExecutionContext) {
-      Tracing.getThreadAccountant().setThreadResourceUsageProvider(new ThreadResourceUsageProvider());
       Tracing.getThreadAccountant().setupWorker(taskId, taskType, threadExecutionContext);
     }
 
@@ -326,12 +325,13 @@ public class Tracing {
       sample();
     }
 
-    public static void updateQueryUsageConcurrently(String queryId) {
-      Tracing.getThreadAccountant().updateQueryUsageConcurrently(queryId);
+    public static void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes) {
+      Tracing.getThreadAccountant().updateQueryUsageConcurrently(queryId, cpuTimeNs, allocatedBytes);
     }
 
+    @Deprecated
     public static void setThreadResourceUsageProvider() {
-      Tracing.getThreadAccountant().setThreadResourceUsageProvider(new ThreadResourceUsageProvider());
+      Tracing.getThreadAccountant().setThreadResourceUsageProvider(null);
     }
 
     // Check for thread interruption, every time after merging 8192 keys


### PR DESCRIPTION
`ThreadResourceUsageProvider` has two functions:
* Provide utility functions to capture thread cpu and allocated bytes. 
* Snapshot start values for cpu and allocated bytes since the mxbean functions provide cumulative values.

The dual functionality complicated its usage in `PerQueryCpuMemAccountant`. A `ThreadResourceUsageProvider` object has to be stored in a thread local to remember the initial resource values. When a thread is assigned a task this thread local also has to be initialized. Else queries will fail with NPE. #15045 is an example.

This PR splits the functionality into
* `ThreadResourceUsageProvider` is now a pure utility class with only static functions
* `ThreadResourceSnapshot` maintains start values.

With these changes, the thread-local for `ThreadResourceUsageProvider` has been removed. The snapshot of resources is stored in the `ThreadEntry` thread-local itself. So a class of issues have been eliminated along with yet another thread-local. 

Closes #16042 
