### PR TITLE
add guava as dep in pinot-s3

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -54,6 +54,10 @@
       <version>${s3mock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
This is a small dep fix to specify the dependency in `pinot-s3` for guava. It is used in `S3PinotFS.java` and `S3Config.java`. Our own internal build started failing at compile time without this when we removed some shading.

before
```
mvn dependency:tree -pl  pinot-plugins/pinot-file-system/pinot-s3 -Dincludes=com.google.guava:guava
...
[INFO] --- dependency:3.8.1:tree (default-cli) @ pinot-s3 ---
[INFO] org.apache.pinot:pinot-s3:jar:1.4.0-SNAPSHOT
[INFO] \- org.apache.pinot:pinot-spi:jar:1.4.0-SNAPSHOT:provided
[INFO]    \- com.google.guava:guava:jar:33.4.0-jre:provided
```

after
```
[INFO] --- dependency:3.8.1:tree (default-cli) @ pinot-s3 ---
[INFO] org.apache.pinot:pinot-s3:jar:1.4.0-SNAPSHOT
[INFO] \- com.google.guava:guava:jar:33.4.0-jre:compile
```
