### PR TITLE
Fix exception message in PinotDataType.BYTE.toTimestamp

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -157,7 +157,7 @@ public enum PinotDataType {
 
     @Override
     public Timestamp toTimestamp(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from BOOLEAN to TIMESTAMP");
+      throw new UnsupportedOperationException("Cannot convert value from BYTE to TIMESTAMP");
     }
 
     @Override


### PR DESCRIPTION
toTimestamp(Object) method of the BYTE enum constant within PinotDataType has a typo where the exception text reads “Cannot convert value from BOOLEAN to TIMESTAMP", updated message to say BYTE.

