### PR TITLE
[multistage] Handle Column Less Tuples in BlockSplitter

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
@@ -67,7 +67,7 @@ public interface BlockSplitter {
       // Use estimated row size, this estimate is not accurate and is used to estimate numRowsPerChunk only.
       DataSchema dataSchema = block.getDataSchema();
       assert dataSchema != null;
-      int estimatedRowSizeInBytes = dataSchema.getColumnNames().length * MEDIAN_COLUMN_SIZE_BYTES;
+      int estimatedRowSizeInBytes = Math.max(1, dataSchema.getColumnNames().length * MEDIAN_COLUMN_SIZE_BYTES);
       int numRowsPerChunk = maxBlockSize / estimatedRowSizeInBytes;
       Preconditions.checkState(numRowsPerChunk > 0, "row size too large for query engine to handle, abort!");
 


### PR DESCRIPTION
Small change to fix broken support for column less tuples.

This issue was caught while I was working on #15958.

Not adding new tests for this since it will be covered by #15958.

Verified the fix with Colocated Join Quickstart:

```
SET useMultistageEngine=true;
SET usePhysicalOptimizer=true;

select COUNT(*) OVER() from userAttributes
```