### PR TITLE
Add config  to use LegacyMd5Plugin in S3 client, which restores the pre-2.30.0 MD5 checksum behavior

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -84,6 +84,8 @@ public class S3Config {
   public static final String ANONYMOUS_CREDENTIALS_PROVIDER = "anonymousCredentialsProvider";
   public static final String REQUEST_CHECKSUM_CALCULATION = "requestChecksumCalculation";
   public static final String RESPONSE_CHECKSUM_VALIDATION = "responseChecksumValidation";
+  public static final String USE_LEGACY_MD5_PLUGIN = "useLegacyMd5Plugin";
+
 
   private final String _accessKey;
   private final String _secretKey;
@@ -109,6 +111,7 @@ public class S3Config {
   private final boolean _anonymousCredentialsProvider;
   private final RequestChecksumCalculation _requestChecksumCalculationWhenRequired;
   private final ResponseChecksumValidation _responseChecksumValidationWhenRequired;
+  private final boolean _useLegacyMd5Plugin;
 
   public S3Config(PinotConfiguration pinotConfig) {
     _disableAcl = pinotConfig.getProperty(DISABLE_ACL_CONFIG_KEY, DEFAULT_DISABLE_ACL);
@@ -122,6 +125,7 @@ public class S3Config {
         pinotConfig.getProperty(REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation.WHEN_REQUIRED.name()));
     _responseChecksumValidationWhenRequired = ResponseChecksumValidation.fromValue(
         pinotConfig.getProperty(RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation.WHEN_REQUIRED.name()));
+    _useLegacyMd5Plugin = Boolean.parseBoolean(pinotConfig.getProperty(USE_LEGACY_MD5_PLUGIN, "false"));
 
     _storageClass = pinotConfig.getProperty(STORAGE_CLASS);
     if (_storageClass != null) {
@@ -300,5 +304,9 @@ public class S3Config {
 
   public ResponseChecksumValidation getResponseChecksumValidationWhenRequired() {
     return _responseChecksumValidationWhenRequired;
+  }
+
+  public boolean useLegacyMd5Plugin() {
+    return _useLegacyMd5Plugin;
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -55,6 +55,7 @@ import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
@@ -176,6 +177,9 @@ public class S3PinotFS extends BasePinotFS {
       }
       if (s3Config.getResponseChecksumValidationWhenRequired() == ResponseChecksumValidation.WHEN_REQUIRED) {
         s3ClientBuilder.requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+      }
+      if (s3Config.useLegacyMd5Plugin()) {
+        s3ClientBuilder.addPlugin(LegacyMd5Plugin.create());
       }
 
       _s3Client = s3ClientBuilder.build();

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
@@ -67,4 +67,12 @@ public class S3ConfigTest {
     pinotConfig.setProperty("storageClass", "invalid-storage-class");
     S3Config cfg = new S3Config(pinotConfig);
   }
+
+  @Test
+  public void testLegacyMd5Plugin() {
+    PinotConfiguration pinotConfig = new PinotConfiguration();
+    pinotConfig.setProperty("useLegacyMd5Plugin", "true");
+    S3Config cfg = new S3Config(pinotConfig);
+    Assert.assertTrue(cfg.useLegacyMd5Plugin());
+  }
 }


### PR DESCRIPTION
We recently observed logs post s3 2.30.0  library upgrade like:
```
2025/05/22 10:21:27.371 ERROR [org.apache.pinot.controller.api.resources.PinotTableRestletResource] [grizzly-http-server-3] Missing required content hash for this request: Content-MD5 or x-amz-content-sha256 (Service: S3, Status Code: 400, Request ID: xxxxxx) (SDK Attempt Count: 1)
 
software.amazon.awssdk.services.s3.model.S3Exception: Missing required content hash for this request: Content-MD5 or x-amz-content-sha256 (Service: S3, Status Code: 400, Request ID: xxxxxxx) (SDK Attempt Count: 1)
       at software.amazon.awssdk.services.s3.model.S3Exception$BuilderImpl.build(S3Exception.java:113)
       at software.amazon.awssdk.services.s3.model.S3Exception$BuilderImpl.build(S3Exception.java:61)
       at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.retryPolicyDisallowedRetryException(RetryableStageHelper.java:168)
       at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:73)
       at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
```