### PR TITLE
Add reset segment operation to UI

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -325,6 +325,29 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
     setConfirmDialog(true);
   };
 
+  const handleResetSegmentClick = () => {
+    setDialogDetails({
+      title: 'Reset Segment',
+      content: 'Are you sure want to reset this segment?',
+      successCb: () => handleResetOp(),
+    });
+    setConfirmDialog(true);
+  };
+
+  const handleResetOp = async () => {
+    const result = await PinotMethodUtils.resetSegmentOp(
+      tableName,
+      segmentName
+    );
+    if (result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
+      fetchData();
+    } else {
+      dispatch({ type: 'error', message: result.error, show: true });
+    }
+    closeDialog();
+  };
+
   const handleReloadOp = async () => {
     const result = await PinotMethodUtils.reloadSegmentOp(
       tableName,
@@ -375,6 +398,15 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
                 enableTooltip={true}
               >
                 Reload Segment
+              </CustomButton>
+              <CustomButton
+                onClick={() => {
+                  handleResetSegmentClick();
+                }}
+                tooltipTitle="Reset the segment by disabling and enabling it"
+                enableTooltip={true}
+              >
+                Reset Segment
               </CustomButton>
             </div>
           </SimpleAccordion>

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -335,17 +335,23 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
   };
 
   const handleResetOp = async () => {
-    const result = await PinotMethodUtils.resetSegmentOp(
-      tableName,
-      segmentName
-    );
-    if (result.status) {
-      dispatch({ type: 'success', message: result.status, show: true });
-      fetchData();
-    } else {
-      dispatch({ type: 'error', message: result.error, show: true });
+    try {
+      const result = await PinotMethodUtils.resetSegmentOp(
+        tableName,
+        segmentName
+      );
+      if (result.status) {
+        dispatch({ type: 'success', message: result.status, show: true });
+        fetchData();
+      } else {
+        dispatch({ type: 'error', message: result.error, show: true });
+      }
+    } catch (error) {
+      console.error('Error resetting segment:', error);
+      dispatch({ type: 'error', message: 'Failed to reset segment. Please try again later.', show: true });
+    } finally {
+      closeDialog();
     }
-    closeDialog();
   };
 
   const handleReloadOp = async () => {

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -328,7 +328,7 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
   const handleResetSegmentClick = () => {
     setDialogDetails({
       title: 'Reset Segment',
-      content: 'Are you sure want to reset this segment?',
+      content: 'Are you sure you want to reset this segment?',
       successCb: () => handleResetOp(),
     });
     setConfirmDialog(true);

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -265,6 +265,9 @@ export const getServerListOfTenant = (name: string): Promise<AxiosResponse<Serve
 export const reloadSegment = (tableName: string, instanceName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.post(`/segments/${tableName}/${instanceName}/reload`, null, {headers});
 
+export const resetSegment = (tableName: string, segmentName: string): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.post(`/segments/${tableName}/${segmentName}/reset`, null, {headers});
+
 export const reloadAllSegments = (tableName: string, tableType: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.post(`/segments/${tableName}/reload?type=${tableType}`, null, {headers});
 

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -80,6 +80,7 @@ import {
   getBrokerListOfTenant,
   getServerListOfTenant,
   deleteSegment,
+  resetSegment,
   putTable,
   putSchema,
   deleteTable,
@@ -989,6 +990,12 @@ const reloadStatusOp = (tableName, tableType) => {
   });
 }
 
+const resetSegmentOp = (tableName, segmentName) => {
+  return resetSegment(tableName, segmentName).then((response) => {
+    return response.data;
+  });
+};
+
 const deleteSegmentOp = (tableName, segmentName) => {
   return deleteSegment(tableName, segmentName).then((response)=>{
     return response.data;
@@ -1382,6 +1389,7 @@ export default {
   getTaskProgressData,
   getTaskGeneratorDebugData,
   deleteSegmentOp,
+  resetSegmentOp,
   reloadSegmentOp,
   reloadStatusOp,
   reloadAllSegmentsOp,


### PR DESCRIPTION
This pull request introduces a new feature to reset a segment in the Pinot Controller UI. The changes include adding a "Reset Segment" button to the `SegmentDetails` page, implementing the corresponding API call, and handling the reset operation in the frontend logic.

### Frontend Changes:
* **New "Reset Segment" Button**: Added a `CustomButton` labeled "Reset Segment" to the `SegmentDetails` page, with a tooltip explaining its functionality. Clicking the button triggers the reset operation. (`pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx`, [pinot-controller/src/main/resources/app/pages/SegmentDetails.tsxR402-R410](diffhunk://#diff-23536ffd8faea49c12bd00541a968335b946315b037944e1512b1bf844a8c3caR402-R410))
* **Reset Segment Logic**: Introduced a `handleResetSegmentClick` function to display a confirmation dialog and a `handleResetOp` function to perform the reset operation, handle success/error messages, and refresh the data. (`pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx`, [pinot-controller/src/main/resources/app/pages/SegmentDetails.tsxR328-R350](diffhunk://#diff-23536ffd8faea49c12bd00541a968335b946315b037944e1512b1bf844a8c3caR328-R350))

### API Integration:
* **Reset Segment API Call**: Added a `resetSegment` function in `requests/index.ts` to make a POST request to the backend for resetting a segment. (`pinot-controller/src/main/resources/app/requests/index.ts`, [pinot-controller/src/main/resources/app/requests/index.tsR268-R270](diffhunk://#diff-b13897d73dad61f05e92f4bb1b1c27b1f602329ae0797dcbbb9d44d06d6cdca4R268-R270))

### Utility Enhancements:
* **Utility Method for Reset**: Added a `resetSegmentOp` method to `PinotMethodUtils` to wrap the `resetSegment` API call and return the response data. (`pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts`, [[1]](diffhunk://#diff-15df1cdd7056ee59b518965ce03484b9033929df4d271ab1d90ac035cef6ae3bR993-R998) [[2]](diffhunk://#diff-15df1cdd7056ee59b518965ce03484b9033929df4d271ab1d90ac035cef6ae3bR1392)
* **Import Update**: Included the `resetSegment` function in the imports of `PinotMethodUtils`. (`pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts`, [pinot-controller/src/main/resources/app/utils/PinotMethodUtils.tsR83](diffhunk://#diff-15df1cdd7056ee59b518965ce03484b9033929df4d271ab1d90ac035cef6ae3bR83))


https://github.com/user-attachments/assets/78c48568-1b4c-47d2-b467-fe3cb8839653