### PR TITLE
Add validations for MV columns: reject MV primary-keys for upsert/dedup, BIG_DECIMAL, and JSON

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -291,6 +291,35 @@ public class SchemaUtilsTest {
   }
 
   @Test
+  public void testValidateMultiValueFieldSpec() {
+    Schema pinotSchema;
+
+    pinotSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("myJsonCol", FieldSpec.DataType.JSON).build();
+
+    checkValidationFails(pinotSchema);
+
+    pinotSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("myBigDecimalCol", FieldSpec.DataType.BIG_DECIMAL).build();
+
+    checkValidationFails(pinotSchema);
+
+    pinotSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("myJsonCol", FieldSpec.DataType.JSON).build();
+
+    SchemaUtils.validate(pinotSchema);
+
+    pinotSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("myBigDecimalCol", FieldSpec.DataType.BIG_DECIMAL).build();
+
+    SchemaUtils.validate(pinotSchema);
+  }
+
+  @Test
   public void testValidateCaseInsensitive() {
     Schema pinotSchema = new Schema.SchemaBuilder()
         .addTime(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -147,9 +147,9 @@ public class SchemaUtils {
             .equals(FieldSpec.DataType.DOUBLE)) {
           validateDefaultIsNotNaN(fieldSpec);
         }
-        if (!fieldSpec.isSingleValueField()) {
-          validateMultiValueCompatibility(fieldSpec);
-        }
+      }
+      if (!fieldSpec.isSingleValueField()) {
+        validateMultiValueCompatibility(fieldSpec);
       }
     }
     Preconditions.checkState(Collections.disjoint(transformedColumns, argumentColumns),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -147,6 +147,9 @@ public class SchemaUtils {
             .equals(FieldSpec.DataType.DOUBLE)) {
           validateDefaultIsNotNaN(fieldSpec);
         }
+        if (!fieldSpec.isSingleValueField()) {
+          validateMultiValueCompatibility(fieldSpec);
+        }
       }
     }
     Preconditions.checkState(Collections.disjoint(transformedColumns, argumentColumns),
@@ -164,6 +167,16 @@ public class SchemaUtils {
     Preconditions.checkState(!fieldSpec.getDefaultNullValueString().equals("NaN"),
             "NaN as null default value is not managed yet for %s",
             fieldSpec.getName());
+  }
+
+  /**
+   * Validations for MV type columns
+   */
+  private static void validateMultiValueCompatibility(FieldSpec fieldSpec) {
+    Preconditions.checkState(!fieldSpec.getDataType().equals(FieldSpec.DataType.JSON),
+        "JSON columns cannot be of multi-value type");
+    Preconditions.checkState(!fieldSpec.getDataType().equals(FieldSpec.DataType.BIG_DECIMAL),
+        "BIG_DECIMAL columns cannot be of multi-value type");
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -717,8 +717,10 @@ public final class TableConfigUtils {
     // primary key columns are not of multi-value type
     for (String primaryKeyColumn : schema.getPrimaryKeyColumns()) {
       FieldSpec fieldSpec = schema.getFieldSpecFor(primaryKeyColumn);
-      Preconditions.checkState(fieldSpec.isSingleValueField(),
-          String.format("Upsert/Dedup primary key column: %s cannot be of multi-value type", primaryKeyColumn));
+      if (fieldSpec != null) {
+        Preconditions.checkState(fieldSpec.isSingleValueField(),
+            String.format("Upsert/Dedup primary key column: %s cannot be of multi-value type", primaryKeyColumn));
+      }
     }
     // replica group is configured for routing
     Preconditions.checkState(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -714,6 +714,12 @@ public final class TableConfigUtils {
     // primary key exists
     Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
         "Upsert/Dedup table must have primary key columns in the schema");
+    // primary key columns are not of multi-value type
+    for (String primaryKeyColumn : schema.getPrimaryKeyColumns()) {
+      FieldSpec fieldSpec = schema.getFieldSpecFor(primaryKeyColumn);
+      Preconditions.checkState(fieldSpec.isSingleValueField(),
+          String.format("Upsert/Dedup primary key column: %s cannot be of multi-value type", primaryKeyColumn));
+    }
     // replica group is configured for routing
     Preconditions.checkState(
         tableConfig.getRoutingConfig() != null && isRoutingStrategyAllowedForUpsert(tableConfig.getRoutingConfig()),


### PR DESCRIPTION
Add validations for MV columns to reject the following unsupported configurations:

- Primary key columns for upsert / dedup should not be of type MV - validation added to TableConfigUtils
- JSON columns should not be of type MV - validation added to SchemaUtils
- BIG_DECIMAL type columns should not be of type MV - validation added to SchemaUtils

Testing:

- Added tests to verify the above behavior