### PR TITLE
Add multistage thread limiting configs at the broker and server level

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -369,7 +369,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     MultiStageBrokerRequestHandler multiStageBrokerRequestHandler = null;
     QueryDispatcher queryDispatcher = null;
     if (_brokerConf.getProperty(Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
-      _multiStageQueryThrottler = new MultiStageQueryThrottler();
+      _multiStageQueryThrottler = new MultiStageQueryThrottler(_brokerConf);
       _multiStageQueryThrottler.init(_spectatorHelixManager);
       // multi-stage request handler uses both Netty and GRPC ports.
       // worker requires both the "Netty port" for protocol transport; and "GRPC port" for mailbox transport.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
@@ -121,9 +121,10 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
     if (numQueryThreads > _semaphore.getTotalPermits()) {
       throw new RuntimeException(
           String.format("Can't dispatch query because the estimated number of server threads for this query is too "
-              + "large for the configured value of '"
-              + CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS
-              + "'. estimatedThreads=%d configuredLimit=%d", numQueryThreads, _semaphore.getTotalPermits()));
+              + "large for the configured value of '%s' or '%s'. estimatedThreads=%d configuredLimit=%d",
+                  CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS,
+                  CommonConstants.Broker.CONFIG_OF_MSE_MAX_SERVER_QUERY_THREADS,
+                  numQueryThreads, _semaphore.getTotalPermits()));
     }
 
     boolean result = _semaphore.tryAcquire(numQueryThreads, timeout, unit);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottler.java
@@ -120,9 +120,10 @@ public class MultiStageQueryThrottler implements ClusterChangeHandler {
 
     if (numQueryThreads > _semaphore.getTotalPermits()) {
       throw new RuntimeException(
-          "Can't dispatch query because the estimated number of server threads for this query is too large for the "
-              + "configured value of '" + CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS
-              + "'. Consider increasing the value of this configuration");
+          String.format("Can't dispatch query because the estimated number of server threads for this query is too "
+              + "large for the configured value of '"
+              + CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS
+              + "'. estimatedThreads=%d configuredLimit=%d", numQueryThreads, _semaphore.getTotalPermits()));
     }
 
     boolean result = _semaphore.tryAcquire(numQueryThreads, timeout, unit);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageQueryThrottlerTest.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.broker.requesthandler;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -68,7 +70,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testBasicAcquireRelease()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     Assert.assertTrue(_multiStageQueryThrottler.tryAcquire(1, 100, TimeUnit.MILLISECONDS));
@@ -83,7 +85,7 @@ public class MultiStageQueryThrottlerTest {
     when(_helixAdmin.getConfig(any(),
         eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
     ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "2"));
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     Assert.assertTrue(_multiStageQueryThrottler.tryAcquire(1, 100, TimeUnit.MILLISECONDS));
@@ -99,7 +101,7 @@ public class MultiStageQueryThrottlerTest {
     when(_helixAdmin.getConfig(any(),
         eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
     ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "-1"));
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     // If maxConcurrentQueries is <= 0, the throttling mechanism should be "disabled" and any attempt to acquire should
@@ -112,7 +114,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testIncreaseNumBrokers()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -140,7 +142,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testDecreaseNumBrokers()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -162,7 +164,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testIncreaseNumServers()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -185,7 +187,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testDecreaseNumServers()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -212,7 +214,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testIncreaseMaxServerQueryThreads()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -233,7 +235,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testDecreaseMaxServerQueryThreads()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     for (int i = 0; i < 2; i++) {
@@ -260,7 +262,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testEnabledToDisabledTransitionDisallowed()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     Assert.assertEquals(_multiStageQueryThrottler.availablePermits(), 4);
@@ -286,7 +288,7 @@ public class MultiStageQueryThrottlerTest {
     when(_helixAdmin.getConfig(any(),
         eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
     ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "-1"));
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     // If maxServerQueryThreads is <= 0, the throttling mechanism should be "disabled" and any attempt to acquire should
@@ -308,8 +310,74 @@ public class MultiStageQueryThrottlerTest {
   }
 
   @Test
+  public void testCalculateMaxServerQueryThreads() {
+    // Neither config is set, both use defaults
+    when(_helixAdmin.getConfig(any(),
+        eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
+    ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "-1"));
+
+    PinotConfiguration emptyConfig = new PinotConfiguration(); // No MSE_MAX_SERVER_QUERY_THREADS set
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(emptyConfig);
+    _multiStageQueryThrottler.init(_helixManager);
+
+    Assert.assertEquals(0, _multiStageQueryThrottler.calculateMaxServerQueryThreads(emptyConfig));
+
+    // Only cluster config is set
+    when(_helixAdmin.getConfig(any(),
+        eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
+    ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10"));
+
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(emptyConfig);
+    _multiStageQueryThrottler.init(_helixManager);
+
+    Assert.assertEquals(10, _multiStageQueryThrottler.calculateMaxServerQueryThreads(emptyConfig));
+
+    // Only broker config is set
+    when(_helixAdmin.getConfig(any(),
+        eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
+    ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "-1"));
+
+    Map<String, Object> brokerConfigMap = new HashMap<>();
+    brokerConfigMap.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "20");
+    PinotConfiguration brokerConfig = new PinotConfiguration(brokerConfigMap);
+
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(brokerConfig);
+    _multiStageQueryThrottler.init(_helixManager);
+
+    Assert.assertEquals(20, _multiStageQueryThrottler.calculateMaxServerQueryThreads(brokerConfig));
+
+    // Both configs are set, cluster config is lower
+    when(_helixAdmin.getConfig(any(),
+        eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
+    ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "15"));
+
+    Map<String, Object> brokerConfigMap2 = new HashMap<>();
+    brokerConfigMap2.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "25");
+    PinotConfiguration brokerConfig2 = new PinotConfiguration(brokerConfigMap2);
+
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(brokerConfig2);
+    _multiStageQueryThrottler.init(_helixManager);
+
+    Assert.assertEquals(15, _multiStageQueryThrottler.calculateMaxServerQueryThreads(brokerConfig2));
+
+    // Both configs are set, broker config is lower
+    when(_helixAdmin.getConfig(any(),
+        eq(Collections.singletonList(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS)))
+    ).thenReturn(Map.of(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "30"));
+
+    Map<String, Object> brokerConfigMap3 = new HashMap<>();
+    brokerConfigMap3.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "5");
+    PinotConfiguration brokerConfig3 = new PinotConfiguration(brokerConfigMap3);
+
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(brokerConfig3);
+    _multiStageQueryThrottler.init(_helixManager);
+
+    Assert.assertEquals(5, _multiStageQueryThrottler.calculateMaxServerQueryThreads(brokerConfig3));
+  }
+
+  @Test
   public void testLowMaxServerQueryThreads() {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     Assert.assertEquals(_multiStageQueryThrottler.availablePermits(), 4);
@@ -321,7 +389,7 @@ public class MultiStageQueryThrottlerTest {
   @Test
   public void testAcquireReleaseWithDifferentQuerySizes()
       throws Exception {
-    _multiStageQueryThrottler = new MultiStageQueryThrottler();
+    _multiStageQueryThrottler = new MultiStageQueryThrottler(new PinotConfiguration());
     _multiStageQueryThrottler.init(_helixManager);
 
     Assert.assertEquals(_multiStageQueryThrottler.availablePermits(), 4);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -195,6 +195,7 @@ public class QueryRunner {
 
     int hardLimit = HardLimitExecutor.getMultiStageExecutorHardLimit(config);
     if (hardLimit > 0) {
+      LOGGER.info("Setting hard limit for multi-stage executor to: hardLimit={}", hardLimit);
       _executorService = new HardLimitExecutor(hardLimit, _executorService);
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -382,6 +382,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_MSE_ENABLE_GROUP_TRIM = "pinot.broker.mse.enable.group.trim";
     public static final boolean DEFAULT_MSE_ENABLE_GROUP_TRIM = false;
 
+    public static final String CONFIG_OF_MSE_MAX_SERVER_QUERY_THREADS = "pinot.broker.mse.max.server.query.threads";
+    public static final int DEFAULT_MSE_MAX_SERVER_QUERY_THREADS = -1;
+
     // Configure the request handler type used by broker to handler inbound query request.
     // NOTE: the request handler type refers to the communication between Broker and Server.
     public static final String BROKER_REQUEST_HANDLER_TYPE = "pinot.broker.request.handler.type";
@@ -907,6 +910,9 @@ public class CommonConstants {
     public static final String MSE_CONFIG_PREFIX = QUERY_EXECUTOR_CONFIG_PREFIX + "." + MSE;
     public static final String CONFIG_OF_MSE_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         MSE_CONFIG_PREFIX + "." + MAX_INITIAL_RESULT_HOLDER_CAPACITY;
+    public static final String CONFIG_OF_MSE_MAX_EXECUTION_THREADS =
+        MSE_CONFIG_PREFIX + "." + MAX_EXECUTION_THREADS;
+    public static final int DEFAULT_MSE_MAX_EXECUTION_THREADS = -1;
 
     // For group-by queries with order-by clause, the tail groups are trimmed off to reduce the memory footprint. To
     // ensure the accuracy of the result, {@code max(limit * 5, minTrimSize)} groups are retained. When

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
@@ -18,9 +18,13 @@
  */
 package org.apache.pinot.spi.executor;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -58,5 +62,42 @@ public class HardLimitExecutorTest {
     } finally {
       ex.shutdownNow();
     }
+  }
+
+  @Test
+  public void testGetMultiStageExecutorHardLimit() {
+    // Only cluster config is set
+    Map<String, Object> configMap1 = new HashMap<>();
+    configMap1.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10");
+    configMap1.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_HARDLIMIT_FACTOR, "5");
+    PinotConfiguration config1 = new PinotConfiguration(configMap1);
+    assertEquals(50, HardLimitExecutor.getMultiStageExecutorHardLimit(config1));
+
+    // Only server config is set
+    Map<String, Object> configMap2 = new HashMap<>();
+    configMap2.put(CommonConstants.Server.CONFIG_OF_MSE_MAX_EXECUTION_THREADS, "30");
+    PinotConfiguration config2 = new PinotConfiguration(configMap2);
+    assertEquals(30, HardLimitExecutor.getMultiStageExecutorHardLimit(config2));
+
+    // Both configs are set, server is lower
+    Map<String, Object> configMap3 = new HashMap<>();
+    configMap3.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10");
+    configMap3.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_HARDLIMIT_FACTOR, "5");
+    configMap3.put(CommonConstants.Server.CONFIG_OF_MSE_MAX_EXECUTION_THREADS, "30");
+    PinotConfiguration config3 = new PinotConfiguration(configMap3);
+    assertEquals(30, HardLimitExecutor.getMultiStageExecutorHardLimit(config3));
+
+    // Both configs are set, cluster is lower
+    Map<String, Object> configMap4 = new HashMap<>();
+    configMap4.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "10");
+    configMap4.put(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_HARDLIMIT_FACTOR, "2");
+    configMap4.put(CommonConstants.Server.CONFIG_OF_MSE_MAX_EXECUTION_THREADS, "30");
+    PinotConfiguration config4 = new PinotConfiguration(configMap4);
+    assertEquals(20, HardLimitExecutor.getMultiStageExecutorHardLimit(config4));
+
+    // No configs set, should return non-positive
+    Map<String, Object> configMap5 = new HashMap<>();
+    PinotConfiguration config5 = new PinotConfiguration(configMap5);
+    assertEquals(-1, HardLimitExecutor.getMultiStageExecutorHardLimit(config5));
   }
 }


### PR DESCRIPTION
### Summary
Making existing functionality to control multistage thread limits at the broker and server that is configurable with cluster configs now configurable with broker and server configs. This adds support for thread limiting heterogeneous infra rather than a single value to apply across the entire cluster.

The previously existing cluster configs are:
- pinot.beta.multistage.engine.max.server.query.threads (broker limit)
- pinot.beta.multistage.engine.max.server.query.threads.hardlimit.factor (server limit)

and we are now adding:
- pinot.broker.mse.max.server.query.threads (broker limit)
- pinot.server.query.executor.mse.max.execution.threads (server limit)

### Comptability
This is backwards compatible since this is an opt-in feature. Limiting is only in effect when one of the configs is enabled. If both configs are enabled, the lower one is chosen.

This is not forwards compatible once opted-in to using either of the new configs. 

### Testing

1. Set brokers and server side limits to 100 using the new configs
2. Load tested
3. Observed expected limits being hit

![Screenshot 2025-06-11 at 11 51 11 AM](https://github.com/user-attachments/assets/523ac9aa-d355-4a95-8882-1a28654dcb2e)

Broker metric limited to under 222 (100 config * 20 servers / 9 brokers). Limits at ~170 since any further queries we were sending would cross the 222 limit.


![Screenshot 2025-06-11 at 11 51 49 AM](https://github.com/user-attachments/assets/d40358ac-8914-4000-b2af-a445dc13775a)

Server JVM thread count increases by ~130. With the extra 30% accounted for by thread overhead apart from just the threads performing query execution.