### PR TITLE
Reduce fanout of intermediate stage

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -314,6 +314,9 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.Broker.DEFAULT_INFER_PARTITION_HINT);
     boolean defaultUseSpool = _config.getProperty(CommonConstants.Broker.CONFIG_OF_SPOOLS,
         CommonConstants.Broker.DEFAULT_OF_SPOOLS);
+    boolean defaultUseLeafServerForIntermediateStage = _config.getProperty(
+        CommonConstants.Broker.CONFIG_OF_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE,
+        CommonConstants.Broker.DEFAULT_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE);
     boolean defaultEnableGroupTrim = _config.getProperty(CommonConstants.Broker.CONFIG_OF_MSE_ENABLE_GROUP_TRIM,
         CommonConstants.Broker.DEFAULT_MSE_ENABLE_GROUP_TRIM);
     boolean defaultEnableDynamicFilteringSemiJoin = _config.getProperty(
@@ -331,6 +334,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         .isCaseSensitive(caseSensitive)
         .defaultInferPartitionHint(inferPartitionHint)
         .defaultUseSpools(defaultUseSpool)
+        .defaultUseLeafServerForIntermediateStage(defaultUseLeafServerForIntermediateStage)
         .defaultEnableGroupTrim(defaultEnableGroupTrim)
         .defaultEnableDynamicFilteringSemiJoin(defaultEnableDynamicFilteringSemiJoin)
         .build();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -393,21 +393,25 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isAccurateGroupByWithoutOrderBy(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(
-        queryOptions.getOrDefault(QueryOptionKey.ACCURATE_GROUP_BY_WITHOUT_ORDER_BY, "false"));
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.ACCURATE_GROUP_BY_WITHOUT_ORDER_BY));
   }
 
-  public static Boolean isUseMSEToFillEmptySchema(Map<String, String> queryOptions, boolean defaultValue) {
+  public static boolean isUseMSEToFillEmptySchema(Map<String, String> queryOptions, boolean defaultValue) {
     String useMSEToFillEmptySchema = queryOptions.get(QueryOptionKey.USE_MSE_TO_FILL_EMPTY_RESPONSE_SCHEMA);
     return useMSEToFillEmptySchema != null ? Boolean.parseBoolean(useMSEToFillEmptySchema) : defaultValue;
   }
 
   public static boolean isInferInvalidSegmentPartition(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.INFER_INVALID_SEGMENT_PARTITION, "false"));
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.INFER_INVALID_SEGMENT_PARTITION));
   }
 
   public static boolean isInferRealtimeSegmentPartition(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.INFER_REALTIME_SEGMENT_PARTITION, "false"));
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.INFER_REALTIME_SEGMENT_PARTITION));
+  }
+
+  public static boolean isUseLeafServerForIntermediateStage(Map<String, String> queryOptions, boolean defaultValue) {
+    String option = queryOptions.get(QueryOptionKey.USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE);
+    return option != null ? Boolean.parseBoolean(option) : defaultValue;
   }
 
   public static boolean isUsePhysicalOptimizer(Map<String, String> queryOptions) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -27,8 +27,9 @@ import org.apache.pinot.broker.broker.helix.BaseBrokerStarter;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.FailureDetector;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
@@ -68,6 +69,7 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
     super.overrideBrokerConf(brokerConf);
     brokerConf.setProperty(FailureDetector.CONFIG_OF_TYPE, FailureDetector.Type.CONNECTION.name());
+    brokerConf.setProperty(Broker.CONFIG_OF_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE, true);
   }
 
   @Test
@@ -80,13 +82,13 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     String clusterName = getHelixClusterName();
     String brokerId = brokerStarter.getInstanceId();
     IdealState brokerResourceIdealState =
-        _helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+        _helixAdmin.getResourceIdealState(clusterName, Helix.BROKER_RESOURCE_INSTANCE);
     for (Map<String, String> brokerAssignment : brokerResourceIdealState.getRecord().getMapFields().values()) {
       assertEquals(brokerAssignment.get(brokerId), BrokerResourceStateModel.ONLINE);
     }
     TestUtils.waitForCondition(aVoid -> {
       ExternalView brokerResourceExternalView =
-          _helixAdmin.getResourceExternalView(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+          _helixAdmin.getResourceExternalView(clusterName, Helix.BROKER_RESOURCE_INSTANCE);
       for (Map<String, String> brokerAssignment : brokerResourceExternalView.getRecord().getMapFields().values()) {
         if (!brokerAssignment.containsKey(brokerId)) {
           return false;
@@ -111,14 +113,13 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     sendPutRequest(_controllerRequestURLBuilder.forInstanceUpdateTags(brokerId, Collections.emptyList(), true));
 
     // Check if broker is removed from all the tables in broker resource
-    brokerResourceIdealState =
-        _helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+    brokerResourceIdealState = _helixAdmin.getResourceIdealState(clusterName, Helix.BROKER_RESOURCE_INSTANCE);
     for (Map<String, String> brokerAssignment : brokerResourceIdealState.getRecord().getMapFields().values()) {
       assertFalse(brokerAssignment.containsKey(brokerId));
     }
     TestUtils.waitForCondition(aVoid -> {
       ExternalView brokerResourceExternalView =
-          _helixAdmin.getResourceExternalView(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+          _helixAdmin.getResourceExternalView(clusterName, Helix.BROKER_RESOURCE_INSTANCE);
       for (Map<String, String> brokerAssignment : brokerResourceExternalView.getRecord().getMapFields().values()) {
         if (brokerAssignment.containsKey(brokerId)) {
           return false;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -552,6 +552,7 @@ public class QueryEnvironment {
 
   @Value.Immutable
   public interface Config {
+
     long getRequestId();
 
     String getDatabase();
@@ -592,6 +593,13 @@ public class QueryEnvironment {
     @Value.Default
     default boolean defaultUseSpools() {
       return CommonConstants.Broker.DEFAULT_OF_SPOOLS;
+    }
+
+    /// Whether to only use servers for leaf stages as the workers for the intermediate stages.
+    /// This is useful to control the fanout of the query and reduce data shuffling.
+    @Value.Default
+    default boolean defaultUseLeafServerForIntermediateStage() {
+      return CommonConstants.Broker.DEFAULT_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE;
     }
 
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -52,6 +52,7 @@ public class PlannerContext implements AutoCloseable {
   private final LogicalPlanner _relTraitPlanner;
 
   private final Map<String, String> _options;
+  private final QueryEnvironment.Config _envConfig;
   private final Map<String, String> _plannerOutput;
   private final SqlExplainFormat _sqlExplainFormat;
   @Nullable
@@ -66,6 +67,7 @@ public class PlannerContext implements AutoCloseable {
     _relTraitPlanner = new LogicalPlanner(traitProgram, Contexts.of(envConfig),
         Collections.singletonList(RelDistributionTraitDef.INSTANCE));
     _options = options;
+    _envConfig = envConfig;
     _plannerOutput = new HashMap<>();
     _sqlExplainFormat = sqlExplainFormat;
     _physicalPlannerContext = physicalPlannerContext;
@@ -89,6 +91,10 @@ public class PlannerContext implements AutoCloseable {
 
   public Map<String, String> getOptions() {
     return _options;
+  }
+
+  public QueryEnvironment.Config getEnvConfig() {
+    return _envConfig;
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -20,15 +20,18 @@ package org.apache.pinot.query.planner.physical;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import org.apache.calcite.runtime.PairList;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.query.context.PlannerContext;
 import org.apache.pinot.query.planner.PlanFragment;
 import org.apache.pinot.query.planner.plannode.PlanNode;
@@ -42,25 +45,38 @@ import org.slf4j.LoggerFactory;
 
 public class DispatchablePlanContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(DispatchablePlanContext.class);
+
   private final WorkerManager _workerManager;
-
   private final long _requestId;
-  private final Set<String> _tableNames;
-  private final PairList<Integer, String> _resultFields;
-
   private final PlannerContext _plannerContext;
-  private final Map<Integer, DispatchablePlanMetadata> _dispatchablePlanMetadataMap;
-  private final Map<Integer, PlanNode> _dispatchablePlanStageRootMap;
+  private final PairList<Integer, String> _resultFields;
+  private final Set<String> _tableNames;
+
+  private final Set<String> _nonLookupTables;
+  private final Set<QueryServerInstance> _leafServerInstances;
+
+  private final Map<Integer, DispatchablePlanMetadata> _dispatchablePlanMetadataMap = new HashMap<>();
+  private final Map<Integer, PlanNode> _dispatchablePlanStageRootMap = new HashMap<>();
+
 
   public DispatchablePlanContext(WorkerManager workerManager, long requestId, PlannerContext plannerContext,
       PairList<Integer, String> resultFields, Set<String> tableNames) {
     _workerManager = workerManager;
     _requestId = requestId;
     _plannerContext = plannerContext;
-    _dispatchablePlanMetadataMap = new HashMap<>();
-    _dispatchablePlanStageRootMap = new HashMap<>();
     _resultFields = resultFields;
     _tableNames = tableNames;
+
+    if (QueryOptionsUtils.isUseLeafServerForIntermediateStage(plannerContext.getOptions(),
+        plannerContext.getEnvConfig().defaultUseLeafServerForIntermediateStage())) {
+      // Use only leaf servers for intermediate stages
+      _leafServerInstances = new HashSet<>();
+      _nonLookupTables = null;
+    } else {
+      // Use all servers (excluding lookup tables) for intermediate stages
+      _leafServerInstances = null;
+      _nonLookupTables = Sets.newHashSetWithExpectedSize(tableNames.size());
+    }
   }
 
   public WorkerManager getWorkerManager() {
@@ -71,17 +87,36 @@ public class DispatchablePlanContext {
     return _requestId;
   }
 
-  // Returns all the table names.
-  public Set<String> getTableNames() {
-    return _tableNames;
+  public PlannerContext getPlannerContext() {
+    return _plannerContext;
   }
 
   public PairList<Integer, String> getResultFields() {
     return _resultFields;
   }
 
-  public PlannerContext getPlannerContext() {
-    return _plannerContext;
+  // Returns all the table names.
+  public Set<String> getTableNames() {
+    return _tableNames;
+  }
+
+  /// Returns `true` if we want to use servers for leaf stages as the workers for the intermediate stages.
+  public boolean isUseLeafServerForIntermediateStage() {
+    return _nonLookupTables == null;
+  }
+
+  /// Tracks non-lookup tables queried in leaf stages, which are used to determine the servers to use for intermediate
+  /// stages. Should be used only when leaf servers are NOT directly used for intermediate stages.
+  public Set<String> getNonLookupTables() {
+    assert !isUseLeafServerForIntermediateStage();
+    return _nonLookupTables;
+  }
+
+  /// Tracks servers that are used for leaf stages, which are used to determine the servers to use for intermediate
+  /// stages. Should be used only when leaf servers are directly used for intermediate stages.
+  public Set<QueryServerInstance> getLeafServerInstances() {
+    assert isUseLeafServerForIntermediateStage();
+    return _leafServerInstances;
   }
 
   public Map<Integer, DispatchablePlanMetadata> getDispatchablePlanMetadataMap() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -441,6 +441,12 @@ public class CommonConstants {
     public static final String CONFIG_OF_SPOOLS = "pinot.broker.multistage.spools";
     public static final boolean DEFAULT_OF_SPOOLS = false;
 
+    /// Whether to only use servers for leaf stages as the workers for the intermediate stages.
+    /// This value can always be overridden by [Request.QueryOptionKey#USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE].
+    public static final String CONFIG_OF_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE =
+        "pinot.broker.mse.use.leaf.server.for.intermediate.stage";
+    public static final boolean DEFAULT_USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE = false;
+
     public static final String CONFIG_OF_USE_FIXED_REPLICA = "pinot.broker.use.fixed.replica";
     public static final boolean DEFAULT_USE_FIXED_REPLICA = false;
 
@@ -658,6 +664,10 @@ public class CommonConstants {
         // When lite mode is enabled, if this flag is set, we will run all the non-leaf stage operators within the
         // broker itself. That way, the MSE queries will model the scatter gather pattern used by the V1 Engine.
         public static final String RUN_IN_BROKER = "runInBroker";
+
+        /// For MSE queries, when this option is set to true, only use servers for leaf stages as the workers for the
+        /// intermediate stages. This is useful to control the fanout of the query and reduce data shuffling.
+        public static final String USE_LEAF_SERVER_FOR_INTERMEDIATE_STAGE = "useLeafServerForIntermediateStage";
       }
 
       public static class QueryOptionValue {


### PR DESCRIPTION
Fix #15932 

Reduce the fanout of intermediate stage workers:
- Do not include tables used as lookup table when calculating the candidate servers for intermediate stage
- Add a config/query option to only use servers serving leaf stages as the candidate servers for intermediate stage
  - Can be enabled at broker level: `pinot.broker.mse.use.leaf.server.for.intermediate.stage`
  - Can be enabled at query level: `useLeafServerForIntermediateStage`