### PR TITLE
Fix up the schema validation to perform most validations for virtual columns as well

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -117,36 +117,36 @@ public class SchemaUtils {
     Set<String> argumentColumns = new HashSet<>();
     Set<String> primaryKeyColumnCandidates = new HashSet<>();
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(!StringUtils.containsWhitespace(column),
+          "The column name \"%s\" should not contain blank space.", column);
       if (!fieldSpec.isVirtualColumn()) {
-        String column = fieldSpec.getName();
-        Preconditions.checkState(!StringUtils.containsWhitespace(column),
-            "The column name \"%s\" should not contain blank space.", column);
         primaryKeyColumnCandidates.add(column);
-        String transformFunction = fieldSpec.getTransformFunction();
-        if (transformFunction != null) {
-          try {
-            List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec).getArguments();
-            Preconditions.checkState(!arguments.contains(column),
-                "The arguments of transform function %s should not contain the destination column %s",
-                transformFunction, column);
-            transformedColumns.add(column);
-            argumentColumns.addAll(arguments);
-          } catch (Exception e) {
-            throw new IllegalStateException(
-                "Exception in getting arguments for transform function '" + transformFunction + "' for column '"
-                    + column + "'", e);
-          }
+      }
+      String transformFunction = fieldSpec.getTransformFunction();
+      if (transformFunction != null) {
+        try {
+          List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec).getArguments();
+          Preconditions.checkState(!arguments.contains(column),
+              "The arguments of transform function %s should not contain the destination column %s",
+              transformFunction, column);
+          transformedColumns.add(column);
+          argumentColumns.addAll(arguments);
+        } catch (Exception e) {
+          throw new IllegalStateException(
+              "Exception in getting arguments for transform function '" + transformFunction + "' for column '"
+                  + column + "'", e);
         }
-        if (fieldSpec.getFieldType() == FieldSpec.FieldType.TIME) {
-          validateTimeFieldSpec((TimeFieldSpec) fieldSpec);
-        }
-        if (fieldSpec.getFieldType() == FieldSpec.FieldType.DATE_TIME) {
-          validateDateTimeFieldSpec((DateTimeFieldSpec) fieldSpec);
-        }
-        if (fieldSpec.getDataType().equals(FieldSpec.DataType.FLOAT) || fieldSpec.getDataType()
-            .equals(FieldSpec.DataType.DOUBLE)) {
-          validateDefaultIsNotNaN(fieldSpec);
-        }
+      }
+      if (fieldSpec.getFieldType() == FieldSpec.FieldType.TIME) {
+        validateTimeFieldSpec((TimeFieldSpec) fieldSpec);
+      }
+      if (fieldSpec.getFieldType() == FieldSpec.FieldType.DATE_TIME) {
+        validateDateTimeFieldSpec((DateTimeFieldSpec) fieldSpec);
+      }
+      if (fieldSpec.getDataType().equals(FieldSpec.DataType.FLOAT) || fieldSpec.getDataType()
+          .equals(FieldSpec.DataType.DOUBLE)) {
+        validateDefaultIsNotNaN(fieldSpec);
       }
       if (!fieldSpec.isSingleValueField()) {
         validateMultiValueCompatibility(fieldSpec);


### PR DESCRIPTION
Follow-up for https://github.com/apache/pinot/pull/16079 where the ask was to also do most of the schema validations for virtual columns as well. Left out the part where the primary key candidates are constructed as primary key should not be set up for a virtual column