### PR TITLE
Add bad data handling for some IndexCreator::add() functions to skip record or add dummy record

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
@@ -521,7 +521,7 @@ public class ResourceManagerAccountingTest {
     FileUtils.forceMkdir(indexDir);
     String colName = "col";
     try (JsonIndexCreator offHeapIndexCreator = new OffHeapJsonIndexCreator(indexDir, colName, "myTable_OFFLINE",
-        new JsonIndexConfig());
+        false, new JsonIndexConfig());
         MutableJsonIndexImpl mutableJsonIndex = new MutableJsonIndexImpl(new JsonIndexConfig(), "table__0__1", "col")) {
       // build json indexes
       for (int i = 0; i < 1000000; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
@@ -520,7 +520,8 @@ public class ResourceManagerAccountingTest {
     File indexDir = new File(FileUtils.getTempDirectory(), "testJsonIndexExtractMapOOM");
     FileUtils.forceMkdir(indexDir);
     String colName = "col";
-    try (JsonIndexCreator offHeapIndexCreator = new OffHeapJsonIndexCreator(indexDir, colName, new JsonIndexConfig());
+    try (JsonIndexCreator offHeapIndexCreator = new OffHeapJsonIndexCreator(indexDir, colName, "myTable_OFFLINE",
+        new JsonIndexConfig());
         MutableJsonIndexImpl mutableJsonIndex = new MutableJsonIndexImpl(new JsonIndexConfig(), "table__0__1", "col")) {
       // build json indexes
       for (int i = 0; i < 1000000; i++) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -27,16 +27,14 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.segment.index.h3.H3IndexType;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.H3Utils;
+import org.apache.pinot.segment.local.utils.MetricUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.GeoSpatialIndexCreator;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
@@ -120,10 +118,8 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
   @Override
   public void add(@Nullable Geometry geometry)
       throws IOException {
-    if (_continueOnError && (geometry == null || !(geometry instanceof Point))) {
-      String metricKeyName =
-          _tableNameWithType + "-" + H3IndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
-      ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+    if (_continueOnError && !(geometry instanceof Point)) {
+      MetricUtils.updateIndexingErrorMetric(_tableNameWithType, H3IndexType.INDEX_DISPLAY_NAME);
       _nextDocId++;
       return;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
@@ -61,9 +61,10 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
 
   private long _postingListChunkOffset;
 
-  public OffHeapH3IndexCreator(File indexDir, String columnName, String tableNameWithType, H3IndexResolution resolution)
+  public OffHeapH3IndexCreator(File indexDir, String columnName, String tableNameWithType, boolean continueOnError,
+      H3IndexResolution resolution)
       throws IOException {
-    super(indexDir, columnName, tableNameWithType, resolution);
+    super(indexDir, columnName, tableNameWithType, continueOnError, resolution);
     _postingListFile = new File(_tempDir, POSTING_LIST_FILE_NAME);
     _postingListOutputStream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_postingListFile)));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OnHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OnHeapH3IndexCreator.java
@@ -34,9 +34,10 @@ import org.roaringbitmap.RoaringBitmapWriter;
  */
 public class OnHeapH3IndexCreator extends BaseH3IndexCreator {
 
-  public OnHeapH3IndexCreator(File indexDir, String columnName, String tableNameWithType, H3IndexResolution resolution)
+  public OnHeapH3IndexCreator(File indexDir, String columnName, String tableNameWithType, boolean continueOnError,
+      H3IndexResolution resolution)
       throws IOException {
-    super(indexDir, columnName, tableNameWithType, resolution);
+    super(indexDir, columnName, tableNameWithType, continueOnError, resolution);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
@@ -102,7 +102,7 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
   }
 
   @Override
-  public void add(Object value)
+  public void add(Map value)
       throws IOException {
     String valueToAdd;
     try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
@@ -98,7 +98,15 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
   @Override
   public void add(String jsonString)
       throws IOException {
-    addFlattenedRecords(JsonUtils.flatten(jsonString, _jsonIndexConfig));
+    List<Map<String, String>> flattenedRecord = JsonUtils.flatten(jsonString, _jsonIndexConfig);
+    if (flattenedRecord.equals(JsonUtils.SKIPPED_FLATTENED_RECORD)) {
+      // The default SKIPPED_FLATTENED_RECORD was returned, this can only happen if the original record could not be
+      // flattened, so update a metric
+      String metricKeyName =
+          _tableNameWithType + "-" + JsonIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
+      ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+    }
+    addFlattenedRecords(flattenedRecord);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OffHeapJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OffHeapJsonIndexCreator.java
@@ -70,10 +70,10 @@ public class OffHeapJsonIndexCreator extends BaseJsonIndexCreator {
   private int _numPostingListsInLastChunk;
   private int _numPostingLists;
 
-  public OffHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType,
+  public OffHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType, boolean continueOnError,
       JsonIndexConfig jsonIndexConfig)
       throws IOException {
-    super(indexDir, columnName, tableNameWithType, jsonIndexConfig);
+    super(indexDir, columnName, tableNameWithType, continueOnError, jsonIndexConfig);
     _postingListFile = new File(_tempDir, POSTING_LIST_FILE_NAME);
     _postingListOutputStream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_postingListFile)));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OffHeapJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OffHeapJsonIndexCreator.java
@@ -70,9 +70,10 @@ public class OffHeapJsonIndexCreator extends BaseJsonIndexCreator {
   private int _numPostingListsInLastChunk;
   private int _numPostingLists;
 
-  public OffHeapJsonIndexCreator(File indexDir, String columnName, JsonIndexConfig jsonIndexConfig)
+  public OffHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType,
+      JsonIndexConfig jsonIndexConfig)
       throws IOException {
-    super(indexDir, columnName, jsonIndexConfig);
+    super(indexDir, columnName, tableNameWithType, jsonIndexConfig);
     _postingListFile = new File(_tempDir, POSTING_LIST_FILE_NAME);
     _postingListOutputStream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_postingListFile)));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OnHeapJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OnHeapJsonIndexCreator.java
@@ -39,9 +39,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class OnHeapJsonIndexCreator extends BaseJsonIndexCreator {
 
-  public OnHeapJsonIndexCreator(File indexDir, String columnName, JsonIndexConfig jsonIndexConfig)
+  public OnHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType,
+      JsonIndexConfig jsonIndexConfig)
       throws IOException {
-    super(indexDir, columnName, jsonIndexConfig);
+    super(indexDir, columnName, tableNameWithType, jsonIndexConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OnHeapJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/OnHeapJsonIndexCreator.java
@@ -39,10 +39,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class OnHeapJsonIndexCreator extends BaseJsonIndexCreator {
 
-  public OnHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType,
+  public OnHeapJsonIndexCreator(File indexDir, String columnName, String tableNameWithType, boolean continueOnError,
       JsonIndexConfig jsonIndexConfig)
       throws IOException {
-    super(indexDir, columnName, tableNameWithType, jsonIndexConfig);
+    super(indexDir, columnName, tableNameWithType, continueOnError, jsonIndexConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
@@ -78,7 +78,7 @@ public class LuceneFSTIndexCreator implements FSTIndexCreator {
       for (_dictId = 0; _dictId < sortedEntries.length; _dictId++) {
         try {
           _fstBuilder.addEntry(sortedEntries[_dictId], _dictId);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
           // Caught exception while trying to add, update metric and skip the document
           String metricKeyName =
               _tableNameWithType + "-" + FstIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
@@ -99,7 +99,7 @@ public class LuceneFSTIndexCreator implements FSTIndexCreator {
   public void add(String document) {
     try {
       _fstBuilder.addEntry(document, _dictId);
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       // Caught exception while trying to add, update metric and skip the document
       String metricKeyName =
           _tableNameWithType + "-" + FstIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
@@ -22,12 +22,10 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Locale;
 import org.apache.lucene.store.OutputStreamDataOutput;
 import org.apache.lucene.util.fst.FST;
-import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.segment.index.fst.FstIndexType;
+import org.apache.pinot.segment.local.utils.MetricUtils;
 import org.apache.pinot.segment.local.utils.fst.FSTBuilder;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
@@ -87,9 +85,7 @@ public class LuceneFSTIndexCreator implements FSTIndexCreator {
         } catch (Exception ex) {
           if (_continueOnError) {
             // Caught exception while trying to add, update metric and skip the document
-            String metricKeyName =
-                _tableNameWithType + "-" + FstIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
-            ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+            MetricUtils.updateIndexingErrorMetric(_tableNameWithType, FstIndexType.INDEX_DISPLAY_NAME);
           } else {
             LOGGER.error("Caught exception while trying to add to FST index for table: {}, column: {}",
                 tableNameWithType, columnName, ex);
@@ -115,9 +111,7 @@ public class LuceneFSTIndexCreator implements FSTIndexCreator {
     } catch (Exception ex) {
       if (_continueOnError) {
         // Caught exception while trying to add, update metric and skip the document
-        String metricKeyName =
-            _tableNameWithType + "-" + FstIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
-        ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+        MetricUtils.updateIndexingErrorMetric(_tableNameWithType, FstIndexType.INDEX_DISPLAY_NAME);
       } else {
         LOGGER.error("Caught exception while trying to add to FST index for table: {}, column: {}",
             _tableNameWithType, _columnName, ex);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
@@ -26,19 +26,17 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitmapInvertedIndexWriter;
 import org.apache.pinot.segment.local.segment.index.text.AbstractTextIndexCreator;
 import org.apache.pinot.segment.local.segment.index.text.CaseAwareStandardAnalyzer;
 import org.apache.pinot.segment.local.segment.index.text.TextIndexType;
+import org.apache.pinot.segment.local.utils.MetricUtils;
 import org.apache.pinot.segment.local.utils.nativefst.FST;
 import org.apache.pinot.segment.local.utils.nativefst.FSTHeader;
 import org.apache.pinot.segment.local.utils.nativefst.builder.FSTBuilder;
@@ -108,9 +106,7 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
     } catch (RuntimeException e) {
       if (_continueOnError) {
         // Caught exception while trying to add, update metric and skip the document
-        String metricKeyName =
-            _tableNameWithType + "-" + TextIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
-        ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+        MetricUtils.updateIndexingErrorMetric(_tableNameWithType, TextIndexType.INDEX_DISPLAY_NAME);
       } else {
         LOGGER.error("Caught exception while trying to add to native text index for table: {}, column: {}",
             _tableNameWithType, _columnName, e);
@@ -129,9 +125,7 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
     } catch (RuntimeException e) {
       if (_continueOnError) {
         // Caught exception while trying to add, update metric and skip the document
-        String metricKeyName =
-            _tableNameWithType + "-" + TextIndexType.INDEX_DISPLAY_NAME.toUpperCase(Locale.US) + "-indexingError";
-        ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+        MetricUtils.updateIndexingErrorMetric(_tableNameWithType, TextIndexType.INDEX_DISPLAY_NAME);
       } else {
         LOGGER.error("Caught exception while trying to add to native text index for table: {}, column: {}",
             _tableNameWithType, _columnName, e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
@@ -109,9 +109,9 @@ public class H3IndexType extends AbstractIndexType<H3IndexConfig, H3IndexReader,
     H3IndexResolution resolution = Objects.requireNonNull(indexConfig).getResolution();
     return context.isOnHeap()
         ? new OnHeapH3IndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
-        context.getTableNameWithType(), resolution)
+        context.getTableNameWithType(), context.isContinueOnError(), resolution)
         : new OffHeapH3IndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
-            context.getTableNameWithType(), resolution);
+            context.getTableNameWithType(), context.isContinueOnError(), resolution);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -115,9 +115,9 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
     Preconditions.checkState(storedType == DataType.STRING || storedType == DataType.MAP,
         "Json index is currently only supported on STRING columns");
     return context.isOnHeap() ? new OnHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
-        context.getTableNameWithType(), indexConfig)
+        context.getTableNameWithType(), context.isContinueOnError(), indexConfig)
         : new OffHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
-            context.getTableNameWithType(), indexConfig);
+            context.getTableNameWithType(), context.isContinueOnError(), indexConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -115,8 +115,9 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
     Preconditions.checkState(storedType == DataType.STRING || storedType == DataType.MAP,
         "Json index is currently only supported on STRING columns");
     return context.isOnHeap() ? new OnHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
-        indexConfig)
-        : new OffHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(), indexConfig);
+        context.getTableNameWithType(), indexConfig)
+        : new OffHeapJsonIndexCreator(context.getIndexDir(), context.getFieldSpec().getName(),
+            context.getTableNameWithType(), indexConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -116,7 +116,8 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
     Preconditions.checkState(context.getFieldSpec().getDataType().getStoredType() == FieldSpec.DataType.STRING,
         "Text index is currently only supported on STRING type columns");
     if (indexConfig.getFstType() == FSTType.NATIVE) {
-      return new NativeTextIndexCreator(context.getFieldSpec().getName(), context.getIndexDir());
+      return new NativeTextIndexCreator(context.getFieldSpec().getName(), context.getTableNameWithType(),
+          context.getIndexDir());
     } else {
       return new LuceneTextIndexCreator(context, indexConfig);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -117,7 +117,7 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
         "Text index is currently only supported on STRING type columns");
     if (indexConfig.getFstType() == FSTType.NATIVE) {
       return new NativeTextIndexCreator(context.getFieldSpec().getName(), context.getTableNameWithType(),
-          context.getIndexDir());
+          context.isContinueOnError(), context.getIndexDir());
     } else {
       return new LuceneTextIndexCreator(context, indexConfig);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/MetricUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/MetricUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.utils;
 
 import java.util.Locale;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/MetricUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/MetricUtils.java
@@ -1,0 +1,22 @@
+package org.apache.pinot.segment.local.utils;
+
+import java.util.Locale;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
+
+
+/**
+ * Utils for metrics
+ */
+public class MetricUtils {
+
+
+  private MetricUtils() {
+  }
+
+  public static void updateIndexingErrorMetric(String tableNameWithType, String indexDisplayName) {
+    String metricKeyName =
+        tableNameWithType + "-" + indexDisplayName.toUpperCase(Locale.US) + "-indexingError";
+    ServerMetrics.get().addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
@@ -398,8 +398,8 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
   private void createIndex(boolean createOnHeap, JsonIndexConfig jsonIndexConfig, String[] records)
       throws IOException {
     try (JsonIndexCreator indexCreator = createOnHeap
-        ? new OnHeapJsonIndexCreator(INDEX_DIR, ON_HEAP_COLUMN_NAME, jsonIndexConfig)
-        : new OffHeapJsonIndexCreator(INDEX_DIR, OFF_HEAP_COLUMN_NAME, jsonIndexConfig)) {
+        ? new OnHeapJsonIndexCreator(INDEX_DIR, ON_HEAP_COLUMN_NAME, "myTable_OFFLINE", jsonIndexConfig)
+        : new OffHeapJsonIndexCreator(INDEX_DIR, OFF_HEAP_COLUMN_NAME, "myTable_OFFLINE", jsonIndexConfig)) {
       for (String record : records) {
         indexCreator.add(record);
       }
@@ -453,7 +453,8 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
     };
 
     String colName = "col";
-    try (JsonIndexCreator offHeapCreator = new OffHeapJsonIndexCreator(INDEX_DIR, colName, getIndexConfig());
+    try (JsonIndexCreator offHeapCreator = new OffHeapJsonIndexCreator(INDEX_DIR, colName, "myTable_OFFLINE",
+        getIndexConfig());
         MutableJsonIndexImpl mutableIndex = new MutableJsonIndexImpl(getIndexConfig(), "table__0__1", "col")) {
       for (String record : records) {
         offHeapCreator.add(record);
@@ -522,7 +523,8 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
     // @formatter: on
 
     String colName = "col";
-    try (JsonIndexCreator offHeapCreator = new OffHeapJsonIndexCreator(INDEX_DIR, colName, getIndexConfig());
+    try (JsonIndexCreator offHeapCreator = new OffHeapJsonIndexCreator(INDEX_DIR, colName, "myTable_OFFLINE",
+        getIndexConfig());
         MutableJsonIndexImpl mutableIndex = new MutableJsonIndexImpl(getIndexConfig(), "table__0__1", "col")) {
       for (String record : records) {
         offHeapCreator.add(record);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
@@ -26,7 +26,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.HnswVectorIndexCreator;
 import org.apache.pinot.segment.local.segment.index.readers.vector.HnswVectorIndexReader;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
@@ -35,28 +35,20 @@ import org.testng.annotations.Test;
 public class HnswVectorIndexCreatorTest {
   private static final File INDEX_DIR =
       new File(FileUtils.getTempDirectory(), HnswVectorIndexCreatorTest.class.toString());
+  private VectorIndexConfig _config;
 
   @BeforeMethod
   public void setUp()
       throws IOException {
     FileUtils.forceMkdir(INDEX_DIR);
-  }
 
-  @AfterMethod
-  public void tearDown()
-      throws IOException {
-    FileUtils.deleteDirectory(INDEX_DIR);
-  }
-
-  @Test
-  public void testIndexWriterReader()
-      throws IOException {
     Map<String, String> properties = new HashMap<>();
+
     properties.put("vectorIndexType", "HNSW");
     properties.put("vectorDimension", "1536");
 
-    VectorIndexConfig config = new VectorIndexConfig(properties);
-    try (HnswVectorIndexCreator creator = new HnswVectorIndexCreator("foo", INDEX_DIR, config)) {
+    _config = new VectorIndexConfig(properties);
+    try (HnswVectorIndexCreator creator = new HnswVectorIndexCreator("foo", INDEX_DIR, _config)) {
       float[] values1 = new float[] {5.0F, 42.0F, 54.33333F, 42.24F, 1001.045F};
       creator.add(values1);
       float[] values2 = new float[] {42.0F, 23423.0F, 42431.32532F, 6785676.3242F, 42.3F};
@@ -67,28 +59,37 @@ public class HnswVectorIndexCreatorTest {
       creator.add(values4);
       creator.seal();
     }
+  }
 
-    // Use TextIndex reader to validate that reads work
-    try (HnswVectorIndexReader reader = new HnswVectorIndexReader("foo", INDEX_DIR, 4, config)) {
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testIndexWriterReaderWithTop3()
+      throws IOException {
+    // Use VectorIndex reader to validate that reads work
+    try (HnswVectorIndexReader reader = new HnswVectorIndexReader("foo", INDEX_DIR, 4, _config)) {
       int[] matchedDocIds = reader.getDocIds(new float[]{5.0F, 42.0F, 54.33333F, 42.24F, 3413.4F}, 3).toArray();
+      // Expect to get 3 matching docIds since topK = 3 is used
       Assert.assertEquals(matchedDocIds.length, 3);
       Assert.assertEquals(matchedDocIds[0], 0);
       Assert.assertEquals(matchedDocIds[1], 2);
       Assert.assertEquals(matchedDocIds[1], 2);
+    }
+  }
 
-      matchedDocIds = reader.getDocIds(new float[]{1.0F, 2.0F, 3.0F, 4.0F, 5.0F}, 1).toArray();
+  @Test
+  public void testIndexWriterReaderWithTop1()
+      throws IOException {
+    // Use VectorIndex reader to validate that reads work
+    try (HnswVectorIndexReader reader = new HnswVectorIndexReader("foo", INDEX_DIR, 4, _config)) {
+      int[] matchedDocIds = reader.getDocIds(new float[]{1.0F, 2.0F, 3.0F, 4.0F, 5.0F}, 1).toArray();
+      // Expect to get 1 matching docId since topK = 1 is used
       Assert.assertEquals(matchedDocIds.length, 1);
       Assert.assertEquals(matchedDocIds[0], 2);
-
-      matchedDocIds = reader.getDocIds(new float[]{42.678F, 23423423.0F, 42431.32523432F, 6723485.3242F, 41.3F}, 1)
-          .toArray();
-      Assert.assertEquals(matchedDocIds.length, 1);
-      Assert.assertEquals(matchedDocIds[0], 3);
-
-      matchedDocIds = reader.getDocIds(new float[]{42.0F, 23423.0F, 42431.32532F, 6785676.3242F, 42.3F}, 1)
-          .toArray();
-      Assert.assertEquals(matchedDocIds.length, 1);
-      Assert.assertEquals(matchedDocIds[0], 1);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.vector.HnswVectorIndexCreator;
+import org.apache.pinot.segment.local.segment.index.readers.vector.HnswVectorIndexReader;
+import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class HnswVectorIndexCreatorTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), HnswVectorIndexCreatorTest.class.toString());
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testIndexWriterReader()
+      throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("vectorIndexType", "HNSW");
+    properties.put("vectorDimension", "1536");
+
+    VectorIndexConfig config = new VectorIndexConfig(properties);
+    try (HnswVectorIndexCreator creator = new HnswVectorIndexCreator("foo", INDEX_DIR, config)) {
+      float[] values1 = new float[] {5.0F, 42.0F, 54.33333F, 42.24F, 1001.045F};
+      creator.add(values1);
+      float[] values2 = new float[] {42.0F, 23423.0F, 42431.32532F, 6785676.3242F, 42.3F};
+      creator.add(values2);
+      float[] values3 = new float[] {1.0F, 2.0F, 3.0F, 4.0F, 5.0F};
+      creator.add(values3);
+      float[] values4 = new float[] {42.678F, 23423423.0F, 42431.32523432F, 6723485.3242F, 42342.3F};
+      creator.add(values4);
+      creator.seal();
+    }
+
+    // Use TextIndex reader to validate that reads work
+    try (HnswVectorIndexReader reader = new HnswVectorIndexReader("foo", INDEX_DIR, 4, config)) {
+      int[] matchedDocIds = reader.getDocIds(new float[]{5.0F, 42.0F, 54.33333F, 42.24F, 3413.4F}, 3).toArray();
+      Assert.assertEquals(matchedDocIds.length, 3);
+      Assert.assertEquals(matchedDocIds[0], 0);
+      Assert.assertEquals(matchedDocIds[1], 2);
+      Assert.assertEquals(matchedDocIds[1], 2);
+
+      matchedDocIds = reader.getDocIds(new float[]{1.0F, 2.0F, 3.0F, 4.0F, 5.0F}, 1).toArray();
+      Assert.assertEquals(matchedDocIds.length, 1);
+      Assert.assertEquals(matchedDocIds[0], 2);
+
+      matchedDocIds = reader.getDocIds(new float[]{42.678F, 23423423.0F, 42431.32523432F, 6723485.3242F, 41.3F}, 1)
+          .toArray();
+      Assert.assertEquals(matchedDocIds.length, 1);
+      Assert.assertEquals(matchedDocIds[0], 3);
+
+      matchedDocIds = reader.getDocIds(new float[]{42.0F, 23423.0F, 42431.32532F, 6785676.3242F, 42.3F}, 1)
+          .toArray();
+      Assert.assertEquals(matchedDocIds.length, 1);
+      Assert.assertEquals(matchedDocIds[0], 1);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
@@ -62,7 +62,8 @@ public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRu
     uniqueValues[1] = "hello-world123";
     uniqueValues[2] = "still";
 
-    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues);
+    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", "myTable_OFFLINE",
+        uniqueValues);
     creator.seal();
     File fstFile = new File(INDEX_DIR, "testFSTColumn" + LUCENE_V912_FST_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer pinotDataBuffer =
@@ -94,8 +95,8 @@ public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRu
     FSTBuilder fstBuilder = Mockito.spy(new FSTBuilder());
     // For the word "still" throw an exception so it is not indexed
     doThrow(IOException.class).when(fstBuilder).addEntry(eq("still"), anyInt());
-    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues,
-        fstBuilder);
+    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", "myTable_OFFLINE",
+        uniqueValues, fstBuilder);
     creator.seal();
     File fstFile = new File(INDEX_DIR, "testFSTColumn" + LUCENE_V912_FST_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer pinotDataBuffer =

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
@@ -25,15 +25,18 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.PinotBuffersAfterMethodCheckRule;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.text.LuceneFSTIndexCreator;
 import org.apache.pinot.segment.local.segment.index.readers.LuceneFSTIndexReader;
+import org.apache.pinot.segment.local.utils.fst.FSTBuilder;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.LUCENE_V912_FST_INDEX_FILE_EXTENSION;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 
 
 public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRule {
@@ -59,9 +62,7 @@ public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRu
     uniqueValues[1] = "hello-world123";
     uniqueValues[2] = "still";
 
-    FieldSpec fieldSpec = new DimensionFieldSpec("testFSTColumn", FieldSpec.DataType.STRING, true);
-    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(
-        INDEX_DIR, "testFSTColumn", uniqueValues);
+    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues);
     creator.seal();
     File fstFile = new File(INDEX_DIR, "testFSTColumn" + LUCENE_V912_FST_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer pinotDataBuffer =
@@ -69,12 +70,49 @@ public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRu
         LuceneFSTIndexReader reader = new LuceneFSTIndexReader(pinotDataBuffer)) {
 
       int[] matchedDictIds = reader.getDictIds("hello.*").toArray();
-      Assert.assertEquals(2, matchedDictIds.length);
-      Assert.assertEquals(0, matchedDictIds[0]);
-      Assert.assertEquals(1, matchedDictIds[1]);
+      Assert.assertEquals(matchedDictIds.length, 2);
+      Assert.assertEquals(matchedDictIds[0], 0);
+      Assert.assertEquals(matchedDictIds[1], 1);
 
       matchedDictIds = reader.getDictIds(".*llo").toArray();
-      Assert.assertEquals(0, matchedDictIds.length);
+      Assert.assertEquals(matchedDictIds.length, 0);
+
+      matchedDictIds = reader.getDictIds("st.*").toArray();
+      Assert.assertEquals(matchedDictIds.length, 1);
+      Assert.assertEquals(matchedDictIds[0], 2);
+    }
+  }
+
+  @Test
+  public void testIndexWriterReaderWithAddExceptions()
+      throws IOException {
+    String[] uniqueValues = new String[3];
+    uniqueValues[0] = "hello-world";
+    uniqueValues[1] = "hello-world123";
+    uniqueValues[2] = "still";
+
+    FSTBuilder fstBuilder = Mockito.spy(new FSTBuilder());
+    // For the word "still" throw an exception so it is not indexed
+    doThrow(IOException.class).when(fstBuilder).addEntry(eq("still"), anyInt());
+    LuceneFSTIndexCreator creator = new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues,
+        fstBuilder);
+    creator.seal();
+    File fstFile = new File(INDEX_DIR, "testFSTColumn" + LUCENE_V912_FST_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.mapFile(fstFile, true, 0, fstFile.length(), ByteOrder.BIG_ENDIAN, "fstIndexFile");
+        LuceneFSTIndexReader reader = new LuceneFSTIndexReader(pinotDataBuffer)) {
+
+      int[] matchedDictIds = reader.getDictIds("hello.*").toArray();
+      Assert.assertEquals(matchedDictIds.length, 2);
+      Assert.assertEquals(matchedDictIds[0], 0);
+      Assert.assertEquals(matchedDictIds[1], 1);
+
+      matchedDictIds = reader.getDictIds(".*llo").toArray();
+      Assert.assertEquals(matchedDictIds.length, 0);
+
+      // Validate that nothing matches st.*
+      matchedDictIds = reader.getDictIds("st.*").toArray();
+      Assert.assertEquals(matchedDictIds.length, 0);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneFSTIndexCreatorTest.java
@@ -128,7 +128,7 @@ public class LuceneFSTIndexCreatorTest implements PinotBuffersAfterMethodCheckRu
     FSTBuilder fstBuilder = Mockito.spy(new FSTBuilder());
     // For the word "still" throw an exception so it is not indexed
     doThrow(IOException.class).when(fstBuilder).addEntry(eq("still"), anyInt());
-    Assert.assertThrows(IOException.class, () -> new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn", "myTable_OFFLINE",
-        false, uniqueValues, fstBuilder));
+    Assert.assertThrows(IOException.class, () -> new LuceneFSTIndexCreator(INDEX_DIR, "testFSTColumn",
+        "myTable_OFFLINE", false, uniqueValues, fstBuilder));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneTextIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/LuceneTextIndexCreatorTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.text.LuceneTextIndexCreator;
+import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class LuceneTextIndexCreatorTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), LuceneTextIndexCreatorTest.class.toString());
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testIndexWriterReader()
+      throws IOException {
+    TextIndexConfig config = new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, null,
+        null, null, false, false, 0, false, null);
+    try (LuceneTextIndexCreator creator = new LuceneTextIndexCreator("foo", INDEX_DIR, true, false, null, null,
+            config)) {
+      creator.add("{\"clean\":\"this\"}");
+      creator.add("{\"retain\":\"this\"}");
+      creator.add("{\"keep\":\"this\"}");
+      creator.add("{\"hold\":\"this\"}");
+      creator.add("{\"clean\":\"that\"}");
+      creator.seal();
+    }
+
+    // Use TextIndex reader to validate that reads work
+    try (LuceneTextIndexReader reader = new LuceneTextIndexReader("foo", INDEX_DIR, 5, new HashMap<>())) {
+      int[] matchedDocIds = reader.getDocIds("clean").toArray();
+      Assert.assertEquals(matchedDocIds.length, 2);
+      Assert.assertEquals(matchedDocIds[0], 0);
+      Assert.assertEquals(matchedDocIds[1], 4);
+
+      matchedDocIds = reader.getDocIds("hold").toArray();
+      Assert.assertEquals(matchedDocIds.length, 1);
+      Assert.assertEquals(matchedDocIds[0], 3);
+
+      matchedDocIds = reader.getDocIds("retain").toArray();
+      Assert.assertEquals(matchedDocIds.length, 1);
+      Assert.assertEquals(matchedDocIds[0], 1);
+
+      matchedDocIds = reader.getDocIds("retain|keep").toArray();
+      Assert.assertEquals(matchedDocIds.length, 2);
+      Assert.assertEquals(matchedDocIds[0], 1);
+      Assert.assertEquals(matchedDocIds[1], 2);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeTextIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeTextIndexCreatorTest.java
@@ -59,7 +59,7 @@ public class NativeTextIndexCreatorTest implements PinotBuffersAfterMethodCheckR
     uniqueValues[2] = "still";
     uniqueValues[3] = "zoobar";
 
-    try (NativeTextIndexCreator creator = new NativeTextIndexCreator("testFSTColumn", INDEX_DIR)) {
+    try (NativeTextIndexCreator creator = new NativeTextIndexCreator("testFSTColumn", "myTable_OFFLINE", INDEX_DIR)) {
       for (int i = 0; i < 4; i++) {
         creator.add(uniqueValues[i]);
       }
@@ -103,7 +103,8 @@ public class NativeTextIndexCreatorTest implements PinotBuffersAfterMethodCheckR
     uniqueValues[2] = "hello-world";
     uniqueValues[3] = "hello-world123";
 
-    try (NativeTextIndexCreator creator = spy(new NativeTextIndexCreator("testFSTColumn", INDEX_DIR))) {
+    try (NativeTextIndexCreator creator = spy(new NativeTextIndexCreator("testFSTColumn", "myTable_OFFLINE",
+        INDEX_DIR))) {
       // Add a couple of words so they show up in the index
       for (int i = 0; i < 2; i++) {
         creator.add(uniqueValues[i]);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -178,7 +178,7 @@ public class FilePerIndexDirectoryTest implements PinotBuffersAfterMethodCheckRu
       throws IOException {
     // See https://github.com/apache/pinot/issues/11529
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        NativeTextIndexCreator fooCreator = new NativeTextIndexCreator("foo", TEMP_DIR)) {
+        NativeTextIndexCreator fooCreator = new NativeTextIndexCreator("foo", "myTable_OFFLINE", TEMP_DIR)) {
 
       fooCreator.add("{\"clean\":\"this\"}");
       fooCreator.seal();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -178,7 +178,7 @@ public class FilePerIndexDirectoryTest implements PinotBuffersAfterMethodCheckRu
       throws IOException {
     // See https://github.com/apache/pinot/issues/11529
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        NativeTextIndexCreator fooCreator = new NativeTextIndexCreator("foo", "myTable_OFFLINE", TEMP_DIR)) {
+        NativeTextIndexCreator fooCreator = new NativeTextIndexCreator("foo", "myTable_OFFLINE", false, TEMP_DIR)) {
 
       fooCreator.add("{\"clean\":\"this\"}");
       fooCreator.seal();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/FSTIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/FSTIndexCreator.java
@@ -40,7 +40,8 @@ public interface FSTIndexCreator extends IndexCreator {
   /**
    * Adds the next document.
    */
-  void add(String document);
+  void add(String document)
+      throws IOException;
 
   /**
    * Adds a set of documents to the index

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
@@ -35,7 +35,7 @@ public interface JsonIndexCreator extends IndexCreator {
   default void add(Object value, int dictId)
       throws IOException {
     if (value instanceof Map) {
-      add(value);
+      add((Map) value);
     } else {
       add((String) value);
     }
@@ -54,7 +54,7 @@ public interface JsonIndexCreator extends IndexCreator {
   /**
    * Adds the next json value for Map type
    */
-  void add(Object jsonMap)
+  void add(Map jsonMap)
     throws IOException;
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.IndexCreator;
-import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -36,7 +35,7 @@ public interface JsonIndexCreator extends IndexCreator {
   default void add(Object value, int dictId)
       throws IOException {
     if (value instanceof Map) {
-      add(JsonUtils.objectToString(value));
+      add(value);
     } else {
       add((String) value);
     }
@@ -51,6 +50,12 @@ public interface JsonIndexCreator extends IndexCreator {
    */
   void add(String jsonString)
       throws IOException;
+
+  /**
+   * Adds the next json value for Map type
+   */
+  void add(Object jsonMap)
+    throws IOException;
 
   /**
    * Seals the index and flushes it to disk.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -734,19 +734,16 @@ public class JsonUtils {
   public static List<Map<String, String>> flatten(String jsonString, JsonIndexConfig jsonIndexConfig)
       throws IOException {
     JsonNode jsonNode;
-    List<Map<String, String>> flattenedJson;
     try {
       jsonNode = JsonUtils.stringToJsonNode(jsonString);
-      flattenedJson = JsonUtils.flatten(jsonNode, jsonIndexConfig);
-    } catch (JsonProcessingException | IllegalArgumentException e) {
-      // IllegalArgumentException is a catch-all Exception from 'JsonUtils.flatten()' for scenarios other than OOM
+      return JsonUtils.flatten(jsonNode, jsonIndexConfig);
+    } catch (Exception e) {
       if (jsonIndexConfig.getSkipInvalidJson()) {
         return SKIPPED_FLATTENED_RECORD;
       } else {
         throw e;
       }
     }
-    return flattenedJson;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -79,7 +79,7 @@ public class JsonUtils {
   public static final String ARRAY_INDEX_KEY = ".$index";
   public static final String SKIPPED_VALUE_REPLACEMENT = "$SKIPPED$";
   public static final int MAX_COMBINATIONS = 100_000;
-  private static final List<Map<String, String>> SKIPPED_FLATTENED_RECORD =
+  public static final List<Map<String, String>> SKIPPED_FLATTENED_RECORD =
       Collections.singletonList(Collections.singletonMap(VALUE_KEY, SKIPPED_VALUE_REPLACEMENT));
 
   // For querying
@@ -743,7 +743,17 @@ public class JsonUtils {
         throw e;
       }
     }
-    return JsonUtils.flatten(jsonNode, jsonIndexConfig);
+
+    try {
+      return JsonUtils.flatten(jsonNode, jsonIndexConfig);
+    } catch (IllegalArgumentException e) {
+      // IllegalArgumentException is a catch-all Exception from 'JsonUtils.flatten()' for scenarios other than OOM
+      if (jsonIndexConfig.getSkipInvalidJson()) {
+        return SKIPPED_FLATTENED_RECORD;
+      } else {
+        throw e;
+      }
+    }
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -734,19 +734,11 @@ public class JsonUtils {
   public static List<Map<String, String>> flatten(String jsonString, JsonIndexConfig jsonIndexConfig)
       throws IOException {
     JsonNode jsonNode;
+    List<Map<String, String>> flattenedJson;
     try {
       jsonNode = JsonUtils.stringToJsonNode(jsonString);
-    } catch (JsonProcessingException e) {
-      if (jsonIndexConfig.getSkipInvalidJson()) {
-        return SKIPPED_FLATTENED_RECORD;
-      } else {
-        throw e;
-      }
-    }
-
-    try {
-      return JsonUtils.flatten(jsonNode, jsonIndexConfig);
-    } catch (IllegalArgumentException e) {
+      flattenedJson = JsonUtils.flatten(jsonNode, jsonIndexConfig);
+    } catch (JsonProcessingException | IllegalArgumentException e) {
       // IllegalArgumentException is a catch-all Exception from 'JsonUtils.flatten()' for scenarios other than OOM
       if (jsonIndexConfig.getSkipInvalidJson()) {
         return SKIPPED_FLATTENED_RECORD;
@@ -754,6 +746,7 @@ public class JsonUtils {
         throw e;
       }
     }
+    return flattenedJson;
   }
 
   /**


### PR DESCRIPTION
This PR is a continuation on the theme of: https://github.com/apache/pinot/pull/16002

This PR adds handling for potential bad data for some of the `IndexCreator::add()` functions if `continueOnError` is enabled:

- LuceneFSTIndexCreator - adds handling in the constructor and add() to catch exceptions and skip (Lucene can throw exception: https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/util/fst/FSTCompiler.html)
- NativeTextIndexCreator - adds handling in add() to catch exceptions and skip
- BaseJsonIndexCreator - adds more handling for JSON processing exceptions and reuses the skip flag for returning a default SKIPPED record
- BaseH3IndexCreator - updated to use the `continueOnError` flag

Also added some test files for the following (these indexes haven't been changed):

- HnswVectorIndexCreatorTest
- LuceneTextIndexCreatorTest

Testing:

- Added some tests for LuceneFSTIndexCreator, NativeTextIndexCreator, and ran the existing tests for JSON (hard to add tests for the exact scenarios)


Some complications to address skip or add default value for `HnswVectorIndexCreator` and `LuceneTextIndexCreator`:

- They use: https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/index/IndexWriter.html#addDocument(java.lang.Iterable) which can throw exceptions for some system level issues, which may not be easy to handle
- The index readers need a correct (smaller or equal to) numDocs as input, otherwise its creation fails due to overflow in number of docs. Thus we cannot just skip these records