### PR TITLE
Enabled table configuration to decide whether to drop original field during unnest transformation

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
@@ -497,7 +497,7 @@ public class TableConfigSerDeUtilsTest {
     assertEquals(ingestionConfig.getComplexTypeConfig().getCollectionNotUnnestedToJson(),
             ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     assertEquals(ingestionConfig.getComplexTypeConfig().getPrefixesToRename(), Collections.emptyMap());
-    assertFalse(ingestionConfig.getComplexTypeConfig().isSkipOriginalFieldInUnnest());
+    assertFalse(ingestionConfig.getComplexTypeConfig().isRemoveUnnestedFields());
   }
 
   private void checkTierConfigList(TableConfig tableConfig) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -76,7 +76,6 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
-import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -544,7 +543,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     validate(tableConfig, schema);
     VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(schema, segmentName);
     setDefaultTimeValueIfInvalid(tableConfig, schema, zkMetadata);
-    setSkipOriginalFieldInUnnest(tableConfig);
 
     // Generates only one semaphore for every partition
     LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
@@ -953,20 +951,5 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private boolean isEnforceConsumptionInOrder() {
     StreamIngestionConfig streamIngestionConfig = getStreamIngestionConfig();
     return streamIngestionConfig != null && streamIngestionConfig.isEnforceConsumptionInOrder();
-  }
-
-  /**
-   * Sets the skipOriginalFieldInUnnest field using server level config if table level config is false.
-   */
-  private void setSkipOriginalFieldInUnnest(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() == null) {
-      return;
-    }
-    ComplexTypeConfig complexTypeConfig = tableConfig.getIngestionConfig().getComplexTypeConfig();
-    if (complexTypeConfig != null && !complexTypeConfig.isSkipOriginalFieldInUnnest()) {
-      complexTypeConfig.setSkipOriginalFieldInUnnest(_instanceDataManagerConfig.isSkipOriginalFieldInUnnest());
-      _logger.info("Setting skipOriginalFieldInUnnest for table: {} to {}", tableConfig.getTableName(),
-              _instanceDataManagerConfig.isSkipOriginalFieldInUnnest());
-    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonUnnestIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonUnnestIngestionFromAvroQueriesTest.java
@@ -280,7 +280,7 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
   }
 
   /** Create an AVRO file and then ingest it into Pinot while creating a JsonIndex. */
-  public void setUp(boolean skipOriginalFieldInUnnest)
+  public void setUp(boolean removeUnnestedFields)
           throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
     createInputFile();
@@ -290,7 +290,7 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
             List.of(new TransformConfig("eventTimeColumn", "eventTimeColumn.seconds * 1000"),
                     new TransformConfig("eventTimeColumn_10m", "round(eventTimeColumn, 60000)")));
     ingestionConfig.setComplexTypeConfig(new ComplexTypeConfig(
-            List.of(JSON_COLUMN), null, null, null, skipOriginalFieldInUnnest));
+            List.of(JSON_COLUMN), null, null, null, removeUnnestedFields));
     TableConfig tableConfig =
             new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setIngestionConfig(ingestionConfig)
                     .setJsonIndexColumns(List.of(JSON_COLUMN)).build();
@@ -311,7 +311,7 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
   }
 
   @Test
-  public void testComplexSelectOnJsonColumnAndSkipOriginalFieldsInUnnest() throws Exception {
+  public void testComplexSelectOnJsonColumnWithRemoveUnnestedFieldsSetAsTrue() throws Exception {
     setUp(true);
     List<String> expecteds = Arrays.asList(
         "[1, daffy duck, null, 1719390721, null, 1, 2, 1719390721000, 1719390720000]",
@@ -332,7 +332,7 @@ public class JsonUnnestIngestionFromAvroQueriesTest extends BaseQueriesTest {
   }
 
   @Test
-  public void testComplexSelectOnJsonColumnAndDoNotSkipOriginalFieldsInUnnest() throws Exception {
+  public void testComplexSelectOnJsonColumnWithRemoveUnnestedFieldsSetAsFalse() throws Exception {
     setUp(false);
     List<String> expecteds = Arrays.asList(
         "[1, daffy duck, [{\"data\":{\"a\":\"1\",\"b\":\"2\"},\"timestamp\":1719390721},{\"data\":{\"a\":\"2\","

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -322,6 +322,15 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
       Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
     }
+    // server level config honoured only when table level config is not set to true
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
+      boolean removeUnnestedFields = false;
+      removeUnnestedFields = tableConfig.getIngestionConfig().getComplexTypeConfig().isRemoveUnnestedFields();
+      if (!removeUnnestedFields) {
+        removeUnnestedFields = _instanceDataManagerConfig.isRemoveUnnestedFields();
+      }
+      tableConfig.getIngestionConfig().getComplexTypeConfig().setRemoveUnnestedFields(removeUnnestedFields);
+    }
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
     Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
     TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -333,8 +333,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public boolean isSkipOriginalFieldInUnnest() {
-    return _serverConfig.getProperty(REALTIME_COMPLEX_CONFIG_SKIP_ORIGINAL_FIELD_IN_UNNEST,
-            DEFAULT_REALTIME_COMPLEX_CONFIG_SKIP_ORIGINAL_FIELD_IN_UNNEST);
+  public boolean isRemoveUnnestedFields() {
+    return _serverConfig.getProperty(CONFIG_OF_COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS,
+            DEFAULT_COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -87,5 +87,5 @@ public interface InstanceDataManagerConfig {
 
   boolean isUploadSegmentToDeepStore();
 
-  boolean isSkipOriginalFieldInUnnest();
+  boolean isRemoveUnnestedFields();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -48,20 +48,20 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Map of <prefix, replacement> so matching fields are renamed to start with the replacement")
   private final Map<String, String> _prefixesToRename;
 
-  @JsonPropertyDescription("Skip original fields in unnest")
-  private boolean _skipOriginalFieldInUnnest;
+  @JsonPropertyDescription("Whether to remove unnested fields")
+  private boolean _removeUnnestedFields;
 
   @JsonCreator
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
       @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson,
       @JsonProperty("prefixesToRename") @Nullable Map<String, String> prefixesToRename,
-      @JsonProperty("skipOriginalFieldInUnnest") boolean skipOriginalFieldInUnnest) {
+      @JsonProperty("removeUnnestedFields") boolean removeUnnestedFields) {
     _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
     _prefixesToRename = prefixesToRename;
-    _skipOriginalFieldInUnnest = skipOriginalFieldInUnnest;
+    _removeUnnestedFields = removeUnnestedFields;
   }
 
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
@@ -91,11 +91,11 @@ public class ComplexTypeConfig extends BaseJsonConfig {
     return _prefixesToRename;
   }
 
-  public void setSkipOriginalFieldInUnnest(boolean skipOriginalFieldInUnnest) {
-    _skipOriginalFieldInUnnest = skipOriginalFieldInUnnest;
+  public void setRemoveUnnestedFields(boolean removeUnnestedFields) {
+    _removeUnnestedFields = removeUnnestedFields;
   }
 
-  public boolean isSkipOriginalFieldInUnnest() {
-    return _skipOriginalFieldInUnnest;
+  public boolean isRemoveUnnestedFields() {
+    return _removeUnnestedFields;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1008,11 +1008,6 @@ public class CommonConstants {
     public static final String CONFIG_OF_RELOAD_CONSUMING_SEGMENT =
         INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "." + RELOAD_CONSUMING_SEGMENT;
     public static final boolean DEFAULT_RELOAD_CONSUMING_SEGMENT = true;
-    public static final String REALTIME_COMPLEX_CONFIG_SKIP_ORIGINAL_FIELD_IN_UNNEST =
-            "realtime.complex.config.skipOriginalFieldInUnnest";
-    public static final String CONFIG_OF_REALTIME_COMPLEX_CONFIG_SKIP_ORIGINAL_FIELD_IN_UNNEST =
-        INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "." + REALTIME_OFFHEAP_ALLOCATION;
-    public static final boolean DEFAULT_REALTIME_COMPLEX_CONFIG_SKIP_ORIGINAL_FIELD_IN_UNNEST = false;
 
     // Query logger related configs
     public static final String CONFIG_OF_QUERY_LOG_MAX_RATE = "pinot.server.query.log.maxRatePerSecond";
@@ -1292,6 +1287,12 @@ public class CommonConstants {
     public static final String CONFIG_OF_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS =
         "pinot.server.messagesCount.refreshIntervalSeconds";
     public static final int DEFAULT_MESSAGES_COUNT_REFRESH_INTERVAL_SECONDS = 30;
+
+    public static final String COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS =
+            "complex.type.transformation.remove.unnestedFields";
+    public static final String CONFIG_OF_COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS =
+            INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "." + COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS;
+    public static final boolean DEFAULT_COMPLEX_TYPE_TRANSFORMATION_REMOVE_UNNESTED_FIELDS = false;
 
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";


### PR DESCRIPTION
Related to #15665

This PR introduces a new configuration field under the Complex Type transformation to control whether the original array field should be retained in the output after applying the UNNEST transformation.

In previous use cases (notably related to [#13490](https://github.com/apache/pinot/pull/13490)), we observed increased GC overhead on Pinot server nodes for tables leveraging Complex Type transformations. This enhancement allows fine-grained control — enabling the retention of original fields for selected tables — thereby minimising memory impact and improving operational flexibility.

### Added configuration:
Introduced boolean field `skipOriginalFieldInUnnest` in `ComplexTypeConfig`  
- `false` -  Do not skip original fields in array object (by default)
- `true` - Skip original fields in array object 
```
"ingestionConfig": {
    "complexTypeConfig": {
      "fieldsToUnnest": [
        .......
      ],
      "skipOriginalFieldInUnnest": true   # Default : false               ---> Added New Field
    }
    ......
  },
```
To allow setting this field to `true` for a larger set of tables, a server level configuration can be used which will override the value of `skipOriginalFieldInUnnest` field only when `skipOriginalFieldInUnnest` is set to `false` (Server level config will be ignored in all other cases)

### Impact on Existing Users:
Previously, original fields were not retained in the array object after the unnest operation. PR #13490 introduced support for preserving these fields by default for all tables using complex type transformation, which led to increased GC pressure. This PR retains the behaviour of #13490 as default. 

There will be no impact on any existing users relying on this configuration as `skipOriginalFieldInUnnest` is `false` by default. 

In case users observe high GC for their datasets, they must explicitly set the configuration - `skipOriginalFieldInUnnest` as `true` at table-level to skip original fields during unnest operation. They can also utilise the server level configuration.