### PR TITLE
Misc fixes for virtual column support

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1382,10 +1382,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
 
     for (String columnName : segmentPhysicalColumns) {
       ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(columnName);
-      FieldSpec fieldSpecInSchema = schema.getFieldSpecFor(columnName);
       DataSource source = segment.getDataSource(columnName);
-      Preconditions.checkNotNull(columnMetadata);
-      Preconditions.checkNotNull(source);
+      assert columnMetadata != null && source != null;
+      FieldSpec fieldSpecInSchema = schema.getFieldSpecFor(columnName);
 
       // Column is deleted
       if (fieldSpecInSchema == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -324,7 +324,11 @@ public class StarTreeUtils {
       return null;
     }
     String column = lhs.getIdentifier();
-    DataSource dataSource = indexSegment.getDataSource(column);
+    DataSource dataSource = indexSegment.getDataSourceNullable(column);
+    if (dataSource == null) {
+      // Star-tree does not support non-existent column
+      return null;
+    }
     Dictionary dictionary = dataSource.getDictionary();
     if (dictionary == null) {
       // Star-tree does not support non-dictionary encoded dimension
@@ -388,7 +392,11 @@ public class StarTreeUtils {
         }
 
         String column = aggregationFunctionColumnPair.getColumn();
-        DataSource dataSource = indexSegment.getDataSource(column);
+        DataSource dataSource = indexSegment.getDataSourceNullable(column);
+        if (dataSource == null) {
+          LOGGER.debug("Cannot use star-tree index because aggregation column: '{}' does not exist", column);
+          return null;
+        }
         if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
           LOGGER.debug("Cannot use star-tree index because aggregation column: '{}' has null values", column);
           return null;
@@ -396,7 +404,11 @@ public class StarTreeUtils {
       }
 
       for (String column : predicateEvaluatorsMap.keySet()) {
-        DataSource dataSource = indexSegment.getDataSource(column);
+        DataSource dataSource = indexSegment.getDataSourceNullable(column);
+        if (dataSource == null) {
+          LOGGER.debug("Cannot use star-tree index because filter column: '{}' does not exist", column);
+          return null;
+        }
         if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
           LOGGER.debug("Cannot use star-tree index because filter column: '{}' has null values", column);
           return null;
@@ -410,7 +422,11 @@ public class StarTreeUtils {
         }
       }
       for (String column : groupByColumns) {
-        DataSource dataSource = indexSegment.getDataSource(column);
+        DataSource dataSource = indexSegment.getDataSourceNullable(column);
+        if (dataSource == null) {
+          LOGGER.debug("Cannot use star-tree index because group-by column: '{}' does not exist", column);
+          return null;
+        }
         if (dataSource.getNullValueVector() != null && !dataSource.getNullValueVector().getNullBitmap().isEmpty()) {
           LOGGER.debug("Cannot use star-tree index because group-by column: '{}' has null values", column);
           return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -42,7 +42,6 @@ public class PinotSegmentColumnReader implements Closeable {
 
   public PinotSegmentColumnReader(IndexSegment indexSegment, String column) {
     DataSource dataSource = indexSegment.getDataSource(column);
-    Preconditions.checkArgument(dataSource != null, "Failed to find data source for column: %s", column);
     _forwardIndexReader = dataSource.getForwardIndex();
     Preconditions.checkArgument(_forwardIndexReader != null, "Forward index disabled for column: %s", column);
     _forwardIndexReaderContext = _forwardIndexReader.createContext();


### PR DESCRIPTION
Fix some issues for the new virtual column feature introduced in #15956 and #15350:
- Rely on Helix messaging service to find the servers to send the `TableConfigSchemaRefreshMessage` instead of server tag because server tag is not always accurate (e.g. instance assignment config is not honored)
- Fix some usage of `getDataSource()` when the input column might not exist (fix MAP index and star-tree index handling)
- Add test in `OfflineClusterIntegrationTest` to verify the fix