### PR TITLE
Improve prune() performance of SinglePartitionColumnSegmentPruner

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SinglePartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SinglePartitionInfo.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.util.Objects;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+
+
+/**
+ * Representation for a single immutable combination of partitionColumn, partitionFunction,
+ * and partition. This is exactly like SegmentPartitionInfo except it only supports one partition.
+ */
+public class SinglePartitionInfo {
+  private final String _partitionColumn;
+  private final PartitionFunction _partitionFunction;
+  private final int _partition;
+
+  public SinglePartitionInfo(String partitionColumn, PartitionFunction partitionFunction, int partition) {
+    _partitionColumn = partitionColumn;
+    _partitionFunction = partitionFunction;
+    _partition = partition;
+  }
+
+  public String getPartitionColumn() {
+    return _partitionColumn;
+  }
+
+  public PartitionFunction getPartitionFunction() {
+    return _partitionFunction;
+  }
+
+  public int getPartition() {
+    return _partition;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    SinglePartitionInfo that = (SinglePartitionInfo) other;
+    return _partition == that._partition
+        && Objects.equals(_partitionColumn, that._partitionColumn)
+        && Objects.equals(_partitionFunction.getName(), that._partitionFunction.getName())
+        && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions()
+        && Objects.equals(_partitionFunction.getFunctionConfig(), that._partitionFunction.getFunctionConfig());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_partitionColumn, _partition, _partitionFunction.getName(),
+        _partitionFunction.getNumPartitions(), _partitionFunction.getFunctionConfig());
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkSinglePartitionPruner.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkSinglePartitionPruner.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionInfo;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionUtils;
+import org.apache.pinot.broker.routing.segmentpartition.SinglePartitionInfo;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.segment.spi.partition.ModuloPartitionFunction;
+import org.apache.pinot.segment.spi.partition.MurmurPartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.sql.FilterKind;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 1, time = 2)
+@Measurement(iterations = 1, time = 2)
+@State(Scope.Benchmark)
+public class BenchmarkSinglePartitionPruner {
+  // @Param({"8", "64", "256"})
+  @Param({"256"})
+  private int _numPartitions;
+  // @Param({"100", "1000", "10000", "10000"})
+  @Param({"1000", "10000", "20000"})
+  private int _numSegments;
+
+  @Param({"forward", "inverted"})
+  private String _pruneAlgorithm;
+
+  @Param({"murmur"})
+  private String _partitionFunction;
+
+  @Param({"true", "false"})
+  private boolean _badPartitioning;
+
+  private SegmentPruner _pruner;
+  private List<BrokerRequest> _queries;
+  private final Set<String> _segments = new HashSet<>();
+  private static final String QUERY_PREFIX = "SELECT * FROM testTable WHERE userId = ";
+
+  private static final String PARTITION_COLULMN = "userId";
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkSinglePartitionPruner.class.getSimpleName());
+    if (args.length > 0 && args[0].equals("jfr")) {
+      opt = opt.addProfiler(JavaFlightRecorderProfiler.class)
+          .jvmArgsAppend("-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints");
+    }
+    new Runner(opt.build()).run();
+  }
+
+  @Setup
+  public void setBrokerRequest() {
+    _queries = new ArrayList<>();
+    for (int i = 0; i < 500; i++) {
+      _queries.add(CalciteSqlCompiler.compileToBrokerRequest(QUERY_PREFIX + i));
+    }
+  }
+
+  @Setup
+  public void setupPruner() {
+    HashMap<String, SegmentPartitionInfo> segmentPartitions = new HashMap<>();
+    PartitionFunction partitionFunction;
+    if (_partitionFunction.equals("murmur")) {
+      partitionFunction = new MurmurPartitionFunction(_numPartitions);
+    } else {
+      partitionFunction = new ModuloPartitionFunction(_numPartitions);
+    }
+    for (int i = 0; i < _numSegments; i++) {
+      _segments.add("Segment_" + i);
+      Set<Integer> partitions = new HashSet<>(Set.of(_numSegments % _numPartitions));
+      if (_badPartitioning) {
+        for (int p = 0; p < _numPartitions; p++) {
+          partitions.add(p);
+        }
+      }
+      segmentPartitions.put(
+          "Segment_" + i,
+          new SegmentPartitionInfo(
+              PARTITION_COLULMN, partitionFunction, partitions
+          )
+      );
+    }
+
+    if (_pruneAlgorithm.equals("inverted")) {
+      _pruner = new InvertedSegmentPruner(PARTITION_COLULMN);
+    } else {
+      _pruner = new SinglePartitionColumnSegmentPruner(PARTITION_COLULMN);
+    }
+    _pruner.init(segmentPartitions);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OperationsPerInvocation(500)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void prune() {
+    for (BrokerRequest r : _queries) {
+      Set<String> result = _pruner.prune(r, _segments);
+      assert !result.isEmpty();
+    }
+  }
+}
+
+interface SegmentPruner {
+  Set<String> prune(BrokerRequest brokerRequest, Set<String> segments);
+
+  void init(Map<String, SegmentPartitionInfo> segmentPartitions);
+}
+
+class InvertedSegmentPruner implements SegmentPruner {
+  private final String _partitionColumn;
+  private final Map<SinglePartitionInfo, Set<String>> _partitionToSegmentMap = new ConcurrentHashMap<>();
+  private final Set<String> _unPartitionedSegments = ConcurrentHashMap.newKeySet();
+
+  public InvertedSegmentPruner(String partitionColumn) {
+    _partitionColumn = partitionColumn;
+  }
+
+  @Override
+  public void init(Map<String, SegmentPartitionInfo> segmentPartitions) {
+    segmentPartitions.forEach(this::addSegmentToPartitionIndex);
+  }
+
+  private void addSegmentToPartitionIndex(String segment, SegmentPartitionInfo partitionInfo) {
+    if (partitionInfo == null || partitionInfo.getPartitionColumn() == null) {
+      _unPartitionedSegments.add(segment);
+      return;
+    }
+    _unPartitionedSegments.remove(segment);
+    Set<SinglePartitionInfo> singlePartitionInfos = partitionInfo.getPartitions()
+        .stream()
+        .map(p -> new SinglePartitionInfo(partitionInfo.getPartitionColumn(), partitionInfo.getPartitionFunction(), p))
+        .collect(Collectors.toSet());
+      for (SinglePartitionInfo singlePartitionInfo : singlePartitionInfos) {
+        _partitionToSegmentMap.computeIfAbsent(singlePartitionInfo, k -> ConcurrentHashMap.newKeySet()).add(segment);
+      }
+      _partitionToSegmentMap.entrySet()
+          .stream()
+          .filter(entry -> !singlePartitionInfos.contains(entry.getKey()))
+          .forEach(e -> e.getValue().remove(segment));
+  }
+
+  @Override
+  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+    Expression filterExpression = brokerRequest.getPinotQuery().getFilterExpression();
+    if (filterExpression == null) {
+      return segments;
+    }
+    Set<String> selectedSegments = _partitionToSegmentMap.entrySet()
+        .stream()
+        .filter(entry -> isPartitionMatch(filterExpression, entry.getKey()))
+        .map(Map.Entry::getValue)
+        .flatMap(Set::stream)
+        .filter(segments::contains)
+        .collect(Collectors.toSet());
+    _unPartitionedSegments.stream().filter(segments::contains).forEach(selectedSegments::add);
+    return selectedSegments;
+  }
+
+  private boolean isPartitionMatch(Expression filterExpression, SinglePartitionInfo partitionInfo) {
+    Function function = filterExpression.getFunctionCall();
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+    List<Expression> operands = function.getOperands();
+    switch (filterKind) {
+      case AND:
+        for (Expression child : operands) {
+          if (!isPartitionMatch(child, partitionInfo)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (Expression child : operands) {
+          if (isPartitionMatch(child, partitionInfo)) {
+            return true;
+          }
+        }
+        return false;
+      case EQUALS: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          return partitionInfo.getPartition() == partitionInfo.getPartitionFunction()
+              .getPartition(RequestContextUtils.getStringValue(operands.get(1)));
+        } else {
+          return true;
+        }
+      }
+      case IN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          int numOperands = operands.size();
+          for (int i = 1; i < numOperands; i++) {
+            if (partitionInfo.getPartition() == (partitionInfo.getPartitionFunction()
+                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
+              return true;
+            }
+          }
+          return false;
+        } else {
+          return true;
+        }
+      }
+      default:
+        return true;
+    }
+  }
+}
+
+class SinglePartitionColumnSegmentPruner implements SegmentPruner {
+  private final String _partitionColumn;
+  private final Map<String, SegmentPartitionInfo> _partitionInfoMap = new ConcurrentHashMap<>();
+
+  public SinglePartitionColumnSegmentPruner(String partitionColumn) {
+    _partitionColumn = partitionColumn;
+  }
+
+  @Override
+  public void init(Map<String, SegmentPartitionInfo> segmentPartitions) {
+    _partitionInfoMap.putAll(segmentPartitions);
+  }
+
+  @Override
+  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+    Expression filterExpression = brokerRequest.getPinotQuery().getFilterExpression();
+    if (filterExpression == null) {
+      return segments;
+    }
+    Set<String> selectedSegments = new HashSet<>();
+    for (String segment : segments) {
+      SegmentPartitionInfo partitionInfo = _partitionInfoMap.get(segment);
+      if (partitionInfo == null || partitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO || isPartitionMatch(
+          filterExpression, partitionInfo)) {
+        selectedSegments.add(segment);
+      }
+    }
+    return selectedSegments;
+  }
+
+  private boolean isPartitionMatch(Expression filterExpression, SegmentPartitionInfo partitionInfo) {
+    Function function = filterExpression.getFunctionCall();
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+    List<Expression> operands = function.getOperands();
+    switch (filterKind) {
+      case AND:
+        for (Expression child : operands) {
+          if (!isPartitionMatch(child, partitionInfo)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (Expression child : operands) {
+          if (isPartitionMatch(child, partitionInfo)) {
+            return true;
+          }
+        }
+        return false;
+      case EQUALS: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
+              .getPartition(RequestContextUtils.getStringValue(operands.get(1))));
+        } else {
+          return true;
+        }
+      }
+      case IN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          int numOperands = operands.size();
+          for (int i = 1; i < numOperands; i++) {
+            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
+                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
+              return true;
+            }
+          }
+          return false;
+        } else {
+          return true;
+        }
+      }
+      default:
+        return true;
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Improved prune\(\) iterates over partition\-to\-segment map and filters by matching partition\.

```mermaid
flowchart TD
  N0["Get filterExpression #40;F2#41;"]:::stAdded
  N1["Check if filterExpression is null #40;F2#41;"]:::stAdded
  N2["Stream partitionToSegmentMap entries #40;F2#41;"]:::stAdded
  N3["Filter entries by isPartitionMatch #40;F2#41;"]:::stAdded
  N4["Map to segment sets #40;F2#41;"]:::stAdded
  N5["FlatMap to segment stream #40;F2#41;"]:::stAdded
  N6["Filter segments by input set #40;F2#41;"]:::stAdded
  N7["Collect to selectedSegments #40;F2#41;"]:::stAdded
  N8["Add unpartitioned segments in input #40;F2#41;"]:::stAdded
  N9["Return selectedSegments #40;F2#41;"]:::stAdded
  N0 --> N1
  N1 -->|"null"| N9
  N1 -->|"non#45;null"| N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 --> N6
  N6 --> N7
  N7 --> N8
  N8 --> N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner\.java — [before](https://github.com/apache/pinot/blob/078c47a63f62ff7a39248860a9cd803a9fdd503f/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java) · [after](https://github.com/apache/pinot/blob/22bdeffd39d3a9b6b97a17e689adb837e1f66d39/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjA3OGM0N2E2M2Y2MmZmN2EzOTI0ODg2MGE5Y2Q4MDNhOWZkZDUwM2YiLCJjb250ZXh0X2hhc2giOiJhYmIxNmUwZmJiZDcyMjAzYmExZmMzM2M5ZGU0YmQyMDMzMzczOTI3N2JmNGUwOTE4NWZlN2UyMDM1MmM2MTI0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjc3MTczLCJoZWFkX3NoYSI6IjIyYmRlZmZkMzlkM2E5YjZiOTdhMTdlNjg5YWRiODM3ZTFmNjZkMzkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmZDQ0OGY0NDI2NmNmYmVmODdlNTQ1Yzk5MzNjMTIwYTc0ZjIxZDE2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c749a6efca0e318010dbf49bd3a4a3494a62db7b55aa8b0dee2228620b7b84ee -->
<!-- pinot-pr-flow:end -->

Previously this class stored a map from `segmentName -> partitionDetails`. This works but means that during prune() we need to check to see if the partition is matching for each and every segment.

<img width="1247" alt="Screenshot 2025-06-12 at 2 22 17 PM" src="https://github.com/user-attachments/assets/047e3747-fec7-4fbd-a4df-716f44a957f2" />

In this case ~40% of the total broker cpu time is spent in `SinglePartitionColumnSegmentPruner::prune()`.

This change observes that generally the total number of partitions will be much smaller than the number of segments, so instead of mapping segment to partition config, invert this pattern and map a partition to a set of segments.

There's some interesting behavior to consider I think -- for example, a segment in both partitions 1 and 5 would be present in both the set for 1 and the set for 5.

In the "best" case, each segment participates in exactly 1 partition. This means that for equality we have to do a single set intersection with the input `Set<String> segments & Set<String> matchingPartition`.

* `numPartition` partition evaluations (note this can temporarily be higher than the number of partitions, for example if the number of partitions changed and a backfill/refresh was not done to update the metadata).
* One set intersection, comparing `matchingPartition` with `segments`.
* Generally `matchingPartition` size will be `1 / partitionCount * numSegments`

In the "worst" common case, consider a filter that matches every partition -- this will still do `numPartition` evaluations, but will also have to do more set intersections.

Finally, the "worst" case would be a very badly configured partitioning in which segments participate in every partition. We would still do `numPartition` evaluations and have set intersections done on each set of segments, but in this case there would be `numSegments` in each `Set` and `partition` sets => `numSegments * numPartitions` calls to `segments.contains`...

Will write some simple benchmarks to compare performance of `prune()`. I also wonder if we would see benefit from maintaining some setup like `Map<PartitionInfo, BloomFilter<String>>` instead of the exact pruning.

***
Based on some simplified benchmark focusing on _just_ the performance of `prune()`:

For:
* 256 partitions
* murmer partition algorithm
* A simple equality query
* All segments being pruned() (not a small subset)

| Benchmark | (_badPartitioning) | (_numSegments) | (_pruneAlgorithm) | Cnt | Score | Error | Units |
|---|---|---|---|---|---|---|---|
| .prune | true | 1000 | forward | 74 | 0.054 | 0.002 | ms/op |
| .prune:p0.00 | true | 1000 | forward | | 0.047 | | ms/op |
| .prune:p0.50 | true | 1000 | forward | | 0.054 | | ms/op |
| .prune:p0.90 | true | 1000 | forward | | 0.058 | | ms/op |
| .prune:p0.95 | true | 1000 | forward | | 0.060 | | ms/op |
| .prune:p0.99 | true | 1000 | forward | | 0.077 | | ms/op |
| .prune:p0.999 | true | 1000 | forward | | 0.077 | | ms/op |
| .prune:p0.9999 | true | 1000 | forward | | 0.077 | | ms/op |
| .prune:p1.00 | true | 1000 | forward | | 0.077 | | ms/op |
| .prune | true | 1000 | inverted | 125 | 0.032 | 0.001 | ms/op |
| .prune:p0.00 | true | 1000 | inverted | | 0.032 | | ms/op |
| .prune:p0.50 | true | 1000 | inverted | | 0.032 | | ms/op |
| .prune:p0.90 | true | 1000 | inverted | | 0.032 | | ms/op |
| .prune:p0.95 | true | 1000 | inverted | | 0.033 | | ms/op |
| .prune:p0.99 | true | 1000 | inverted | | 0.036 | | ms/op |
| .prune:p0.999 | true | 1000 | inverted | | 0.036 | | ms/op |
| .prune:p0.9999 | true | 1000 | inverted | | 0.036 | | ms/op |
| .prune:p1.00 | true | 1000 | inverted | | 0.036 | | ms/op |
| .prune | true | 10000 | forward | 3 | 1.621 | 0.151 | ms/op |
| .prune:p0.00 | true | 10000 | forward | | 1.612 | | ms/op |
| .prune:p0.50 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p0.90 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p0.95 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p0.99 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p0.999 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p0.9999 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune:p1.00 | true | 10000 | forward | | 1.626 | | ms/op |
| .prune | true | 10000 | inverted | 13 | 0.315 | 0.027 | ms/op |
| .prune:p0.00 | true | 10000 | inverted | | 0.293 | | ms/op |
| .prune:p0.50 | true | 10000 | inverted | | 0.303 | | ms/op |
| .prune:p0.90 | true | 10000 | inverted | | 0.357 | | ms/op |
| .prune:p0.95 | true | 10000 | inverted | | 0.370 | | ms/op |
| .prune:p0.99 | true | 10000 | inverted | | 0.370 | | ms/op |
| .prune:p0.999 | true | 10000 | inverted | | 0.370 | | ms/op |
| .prune:p0.9999 | true | 10000 | inverted | | 0.370 | | ms/op |
| .prune:p1.00 | true | 10000 | inverted | | 0.370 | | ms/op |
| .prune | true | 20000 | forward | 2 | 3.465 | | ms/op |
| .prune:p0.00 | true | 20000 | forward | | 3.457 | | ms/op |
| .prune:p0.50 | true | 20000 | forward | | 3.465 | | ms/op |
| .prune:p0.90 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune:p0.95 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune:p0.99 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune:p0.999 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune:p0.9999 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune:p1.00 | true | 20000 | forward | | 3.473 | | ms/op |
| .prune | true | 20000 | inverted | 7 | 0.612 | 0.021 | ms/op |
| .prune:p0.00 | true | 20000 | inverted | | 0.602 | | ms/op |
| .prune:p0.50 | true | 20000 | inverted | | 0.612 | | ms/op |
| .prune:p0.90 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune:p0.95 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune:p0.99 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune:p0.999 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune:p0.9999 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune:p1.00 | true | 20000 | inverted | | 0.630 | | ms/op |
| .prune | false | 1000 | forward | 153 | 0.026 | 0.001 | ms/op |
| .prune:p0.00 | false | 1000 | forward | | 0.025 | | ms/op |
| .prune:p0.50 | false | 1000 | forward | | 0.026 | | ms/op |
| .prune:p0.90 | false | 1000 | forward | | 0.027 | | ms/op |
| .prune:p0.95 | false | 1000 | forward | | 0.028 | | ms/op |
| .prune:p0.99 | false | 1000 | forward | | 0.055 | | ms/op |
| .prune:p0.999 | false | 1000 | forward | | 0.081 | | ms/op |
| .prune:p0.9999 | false | 1000 | forward | | 0.081 | | ms/op |
| .prune:p1.00 | false | 1000 | forward | | 0.081 | | ms/op |
| .prune | false | 1000 | inverted | 10428 | $\approx 10^{-3}$ | | ms/op |
| .prune:p0.00 | false | 1000 | inverted | | $\approx 10^{-3}$ | | ms/op |
| .prune:p0.50 | false | 1000 | inverted | | $\approx 10^{-3}$ | | ms/op |
| .prune:p0.90 | false | 1000 | inverted | | $\approx 10^{-3}$ | | ms/op |
| .prune:p0.95 | false | 1000 | inverted | | $\approx 10^{-3}$ | | ms/op |
| .prune:p0.99 | false | 1000 | inverted | | 0.001 | | ms/op |
| .prune:p0.999 | false | 1000 | inverted | | 0.001 | | ms/op |
| .prune:p0.9999 | false | 1000 | inverted | | 0.001 | | ms/op |
| .prune:p1.00 | false | 1000 | inverted | | 0.001 | | ms/op |
| .prune | false | 10000 | forward | 16 | 0.252 | 0.001 | ms/op |
| .prune:p0.00 | false | 10000 | forward | | 0.251 | | ms/op |
| .prune:p0.50 | false | 10000 | forward | | 0.252 | | ms/op |
| .prune:p0.90 | false | 10000 | forward | | 0.255 | | ms/op |
| .prune:p0.95 | false | 10000 | forward | | 0.257 | | ms/op |
| .prune:p0.99 | false | 10000 | forward | | 0.257 | | ms/op |
| .prune:p0.999 | false | 10000 | forward | | 0.257 | | ms/op |
| .prune:p0.9999 | false | 10000 | forward | | 0.257 | | ms/op |
| .prune:p1.00 | false | 10000 | forward | | 0.257 | | ms/op |
| .prune | false | 10000 | inverted | 6370 | 0.001 | 0.001 | ms/op |
| .prune:p0.00 | false | 10000 | inverted | | 0.001 | | ms/op |
| .prune:p0.50 | false | 10000 | inverted | | 0.001 | | ms/op |
| .prune:p0.90 | false | 10000 | inverted | | 0.001 | | ms/op |
| .prune:p0.95 | false | 10000 | inverted | | 0.001 | | ms/op |
| .prune:p0.99 | false | 10000 | inverted | | 0.001 | | ms/op |
| .prune:p0.999 | false | 10000 | inverted | | 0.002 | | ms/op |
| .prune:p0.9999 | false | 10000 | inverted | | 0.002 | | ms/op |
| .prune:p1.00 | false | 10000 | inverted | | 0.002 | | ms/op |
| .prune | false | 20000 | forward | 9 | 0.498 | 0.004 | ms/op |
| .prune:p0.00 | false | 20000 | forward | | 0.496 | | ms/op |
| .prune:p0.50 | false | 20000 | forward | | 0.497 | | ms/op |
| .prune:p0.90 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune:p0.95 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune:p0.99 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune:p0.999 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune:p0.9999 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune:p1.00 | false | 20000 | forward | | 0.503 | | ms/op |
| .prune | false | 20000 | inverted | 3593 | 0.001 | 0.001 | ms/op |
| .prune:p0.00 | false | 20000 | inverted | | 0.001 | | ms/op |
| .prune:p0.50 | false | 20000 | inverted | | 0.001 | | ms/op |
| .prune:p0.90 | false | 20000 | inverted | | 0.001 | | ms/op |
| .prune:p0.95 | false | 20000 | inverted | | 0.001 | | ms/op |
| .prune:p0.99 | false | 20000 | inverted | | 0.001 | | ms/op |
| .prune:p0.999 | false | 20000 | inverted | | 0.002 | | ms/op |
| .prune:p0.9999 | false | 20000 | inverted | | 0.003 | | ms/op |
| .prune:p1.00 | false | 20000 | inverted | | 0.003 | | ms/op |
