### PR TITLE
Fix testRealtimeRebalancePreChecks integ-test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalanceIntegrationTest.java
@@ -597,7 +597,13 @@ public class TableRebalanceIntegrationTest extends BaseHybridClusterIntegrationT
         60_000L, "Failed to drop added server");
 
     // Add a schema change. Notice that this may affect other following tests
-    Schema schema = getSchema(getTableName());
+
+    Schema originalSchema = getSchema(getTableName());
+    Schema schema = new Schema();
+    schema.setSchemaName(getTableName());
+    for (FieldSpec fieldSpec : originalSchema.getAllFieldSpecs()) {
+      schema.addField(fieldSpec);
+    }
     schema.addField(new MetricFieldSpec("NewAddedIntMetricB", FieldSpec.DataType.INT, 1));
     updateSchema(schema);
     response = sendPostRequest(getRebalanceUrl(rebalanceConfig, TableType.REALTIME));
@@ -697,6 +703,7 @@ public class TableRebalanceIntegrationTest extends BaseHybridClusterIntegrationT
         aVoid -> getHelixResourceManager().dropInstance(serverStarter1.getInstanceId()).isSuccessful(),
         60_000L, "Failed to drop added server");
     updateTableConfig(originalTableConfig);
+    forceUpdateSchema(originalSchema);
   }
 
   @Test


### PR DESCRIPTION
This test seems to update the schema and table-config, it does revert the table config but doesn't revert the old schema, this seem to cause an issue when run in some odd sequence of tests 