### PR TITLE
Adds server startup check meter

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -123,7 +123,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
 
   // how many message are there in the server's message queue in helix
   HELIX_MESSAGES_COUNT("count", true),
-  STARTUP_STATUS_CHECK_IN_PROGRESS("state", true);
+  STARTUP_STATUS_CHECK_IN_PROGRESS("state", true,
+      "Indicates whether the server startup status check is currently in progress");
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -122,7 +122,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   MAILBOX_SERVER_CHUNK_SIZE("bytes", true),
 
   // how many message are there in the server's message queue in helix
-  HELIX_MESSAGES_COUNT("count", true);
+  HELIX_MESSAGES_COUNT("count", true),
+  STARTUP_STATUS_CHECK_IN_PROGRESS("state", true);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -747,6 +747,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
       long endTimeMs =
           startTimeMs + _serverConf.getProperty(Server.CONFIG_OF_STARTUP_TIMEOUT_MS, Server.DEFAULT_STARTUP_TIMEOUT_MS);
       try {
+        serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 1);
         startupServiceStatusCheck(endTimeMs);
       } catch (Exception e) {
         LOGGER.error("Caught exception while checking service status. Stopping server.", e);
@@ -754,6 +755,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
         _adminApiApplication.stop();
         _helixManager.disconnect();
         throw e;
+      } finally {
+        serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 0);
       }
     }
 


### PR DESCRIPTION
Adds metric for Indicating whether the server startup status check is currently in progress or not.
This is to avoid repeatedly checking on logs.