### PR TITLE
Reuse Kafka admin client for better performance

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
@@ -56,6 +56,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   protected final Consumer<String, Bytes> _consumer;
   protected final TopicPartition _topicPartition;
   protected final Properties _consumerProp;
+  protected final AdminClient _adminClient;
 
   public KafkaPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig, int partition) {
     _config = new KafkaPartitionLevelStreamConfig(streamConfig);
@@ -67,6 +68,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     _consumer = createConsumer(_consumerProp);
     _topicPartition = new TopicPartition(_topic, _partition);
     _consumer.assign(Collections.singletonList(_topicPartition));
+    _adminClient = createAdminClient();
   }
 
   private Properties buildProperties(StreamConfig streamConfig) {
@@ -116,6 +118,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   public void close()
       throws IOException {
     _consumer.close();
+    _adminClient.close();
   }
 
   @VisibleForTesting

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -100,7 +100,7 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   @Override
   public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     Preconditions.checkNotNull(offsetCriteria);
-    try (AdminClient adminClient = createAdminClient()) {
+    try {
       // Build the offset spec request for this partition
       Map<TopicPartition, OffsetSpec> request = new HashMap<>();
       if (offsetCriteria.isLargest()) {
@@ -117,13 +117,13 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
         throw new IllegalArgumentException("Unknown offset criteria: " + offsetCriteria);
       }
       // Query via AdminClient (thread-safe)
-      ListOffsetsResult result = adminClient.listOffsets(request);
+      ListOffsetsResult result = _adminClient.listOffsets(request);
       Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> offsets =
           result.all().get(timeoutMillis, TimeUnit.MILLISECONDS);
       if (!isValidOffsetInfo(offsets) && (offsetCriteria.isTimestamp() || offsetCriteria.isPeriod())) {
         // fetch endOffsets as fallback
         request.put(_topicPartition, OffsetSpec.latest());
-        result = adminClient.listOffsets(request);
+        result = _adminClient.listOffsets(request);
         offsets = result.all().get(timeoutMillis, TimeUnit.MILLISECONDS);
         LOGGER.warn(
             "initial offset type is {} and its value evaluates to null hence proceeding with offset {} " + "for "

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -55,6 +55,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   protected final Consumer<String, Bytes> _consumer;
   protected final TopicPartition _topicPartition;
   protected final Properties _consumerProp;
+  protected final AdminClient _adminClient;
 
   public KafkaPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig, int partition) {
     _config = new KafkaPartitionLevelStreamConfig(streamConfig);
@@ -66,6 +67,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     _consumer = createConsumer(_consumerProp);
     _topicPartition = new TopicPartition(_topic, _partition);
     _consumer.assign(Collections.singletonList(_topicPartition));
+    _adminClient = createAdminClient();
   }
 
   private Properties buildProperties(StreamConfig streamConfig) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -100,7 +100,7 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   @Override
   public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     Preconditions.checkNotNull(offsetCriteria);
-    try (AdminClient adminClient = createAdminClient()) {
+    try {
       // Build the offset spec request for this partition
       Map<TopicPartition, OffsetSpec> request = new HashMap<>();
       if (offsetCriteria.isLargest()) {
@@ -117,13 +117,13 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
         throw new IllegalArgumentException("Unknown offset criteria: " + offsetCriteria);
       }
       // Query via AdminClient (thread-safe)
-      ListOffsetsResult result = adminClient.listOffsets(request);
+      ListOffsetsResult result = _adminClient.listOffsets(request);
       Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> offsets =
           result.all().get(timeoutMillis, TimeUnit.MILLISECONDS);
       if (!isValidOffsetInfo(offsets) && (offsetCriteria.isTimestamp() || offsetCriteria.isPeriod())) {
         // fetch endOffsets as fallback
         request.put(_topicPartition, OffsetSpec.latest());
-        result = adminClient.listOffsets(request);
+        result = _adminClient.listOffsets(request);
         offsets = result.all().get(timeoutMillis, TimeUnit.MILLISECONDS);
         LOGGER.warn(
             "initial offset type is {} and its value evaluates to null hence proceeding with offset {} " + "for "


### PR DESCRIPTION
**Existing code with Kafka Admin client**

```
listOffsetsResult for topic pullRequestMergedEvents partition 0 and offset smallest took 9407ms

listOffsetsResult for topic pullRequestMergedEvents partition 1 and offset smallest took 10592ms

listOffsetsResult for topic pullRequestMergedEvents partition 2 and offset smallest took 9364ms

listOffsetsResult for topic pullRequestMergedEvents partition 3 and offset smallest took 7994ms
```

**With this PR**

```
listOffsetsResult for topic pullRequestMergedEvents partition 0 and offset smallest took 7669ms 

listOffsetsResult for topic pullRequestMergedEvents partition 1 and offset smallest took 6664ms

listOffsetsResult for topic pullRequestMergedEvents partition 2 and offset smallest took 6815ms 

listOffsetsResult for topic pullRequestMergedEvents partition 3 and offset smallest took 7628ms 
```

This will also lead to lower log generations. The logs are flooded with lines like these on every creation 

```
2025/06/20 03:16:18.903 WARN [AdminClientConfig] [foo_bar] The configuration 'key.deserializer' was supplied but isn't a known config.
2025/06/20 03:16:18.903 WARN [AdminClientConfig] [foo_bar] The configuration 'realtime.segment.flush.threshold.rows' was supplied but isn't a known config.
2025/06/20 03:16:18.903 WARN [AdminClientConfig] [foo_bar] The configuration 'value.deserializer' was supplied but isn't a known config.
```
