### PR TITLE
Allow setting wildcard and useAND default operator for all query parsers

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -169,11 +169,10 @@ public class LuceneTextIndexReader implements TextIndexReader {
       QueryParserBase parser = _queryParserClassConstructor.newInstance(_column, _analyzer);
       // Phrase search with prefix/suffix matching may have leading *. E.g., `*pache pinot` which can be stripped by
       // the query parser. To support the feature, we need to explicitly set the config to be true.
-      if (_queryParserClass.equals("org.apache.lucene.queryparser.classic.QueryParser")
-              && _enablePrefixSuffixMatchingInPhraseQueries) {
+      if (_enablePrefixSuffixMatchingInPhraseQueries) {
         parser.setAllowLeadingWildcard(true);
       }
-      if (_queryParserClass.equals("org.apache.lucene.queryparser.classic.QueryParser") && _useANDForMultiTermQueries) {
+      if (_useANDForMultiTermQueries) {
         parser.setDefaultOperator(QueryParser.Operator.AND);
       }
       Query query = parser.parse(searchQuery);


### PR DESCRIPTION
# Allow setting wildcard and useANDForMultiTermTextIndexQueries flag to default AND operator for all query parsers

## Configuration
The following configuration options are available in the text index config:

```json
"fieldConfigList": [
      {
        "name": "propsJson",
        "encodingType": "RAW",
        "indexes": {
          "forward": {
            "compressionCodec": "ZSTANDARD",
            "rawIndexWriterVersion": 4,
            "deriveNumDocsPerChunk": false
          },
          "text": {
            "deriveNumDocsPerChunk": false,
            "rawIndexWriterVersion": 4,
            "useANDForMultiTermTextIndexQueries": true
            "enablePrefixSuffixMatchingInPhraseQueries": true,
            "stopWordExclude": "and, or, (, ), \\, /,  -, +, =, {, }, [, ], \", ', <, >, ?",
            "luceneAnalyzerClass": "org.apache.lucene.analysis.standard.StandardAnalyzer",
            "luceneQueryParserClass": "org.apache.lucene.queryparser.complexPhrase.ComplexPhraseQueryParser"
          }
        },
        "tierOverwrites": null
      }
    ],
```


## Testing
- Manually Validated the query with different query Parser Types
