### PR TITLE
Use the RebalanceDiskUtilizationThreshold instead of DiskUtilizationThreshold config for init() of the rebalance pre-checker

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -556,7 +556,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _diskUtilizationChecker = new DiskUtilizationChecker(_helixResourceManager, _config);
     _resourceUtilizationManager = new ResourceUtilizationManager(_config, _diskUtilizationChecker);
     _rebalancePreChecker = RebalancePreCheckerFactory.create(_config.getRebalancePreCheckerClass());
-    _rebalancePreChecker.init(_helixResourceManager, _executorService, _config.getDiskUtilizationThreshold());
+    _rebalancePreChecker.init(_helixResourceManager, _executorService, _config.getRebalanceDiskUtilizationThreshold());
     _rebalancerExecutorService = createExecutorService(_config.getControllerExecutorRebalanceNumThreads(),
         "rebalance-thread-%d");
     _tableRebalanceManager =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -98,7 +98,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
         checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
             preCheckContext.getTableSubTypeSizeDetails(), _diskUtilizationThreshold, true));
     // Check if all servers involved in the rebalance will have enough disk space after the rebalance.
-    // TODO: give this check a separate threshold other than the disk utilization threshold
+    // TODO: Add the option to take disk utilization threshold as a RebalanceConfig option and use that to override
+    //       the default config
     preCheckResult.put(DISK_UTILIZATION_AFTER_REBALANCE,
         checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
             preCheckContext.getTableSubTypeSizeDetails(), _diskUtilizationThreshold, false));


### PR DESCRIPTION
Use the RebalanceDiskUtilizationThreshold instead of DiskUtilizationThreshold config for init() of the rebalance pre-checker

Testing done: validated that the correct config is picked up from the debugger
Also ran all the rebalance unit tests and the integration test